### PR TITLE
HARMONY-826: Clarify install, enforce node version and guard against GDAL_DATA

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You must select "401" as the application type for Harmony to work correctly with
 
 Required:
 * A local copy of this repository.  Using `git clone` is strongly recommended
-* Node.js version 12.  We recommend installing [NVM](https://github.com/nvm-sh/nvm) to add and manage node versions
+* Node.js version 12.  We strongly recommend installing [NVM](https://github.com/nvm-sh/nvm) to add and manage node versions.
 * Mac OSX, Linux, or similar command line tooling.  Harmony is tested to run on OSX >= 10.14 and Amazon Linux 2.  Command-line instructions and bash helper files under [bin/](bin/) are tested on OSX >= 10.14.
 * [git](https://git-scm.com) - Used to clone this repository
 * A running [Docker Desktop](https://www.docker.com/products/developer-tools) or daemon instance - Used to invoke docker-based services
@@ -76,20 +76,24 @@ If you have not yet cloned the Harmony repository, run
 $ git clone https://github.com/nasa/harmony.git
 ```
 
-Ensure node is available and is the correct version, 12.x.x
+Ensure node is available and is the correct version, 12.x.y, where "x" >= 14.
 
 ```
 $ node --version
-v12.15.0
+v12.22.1
 ```
 
 If it is not the correct version and you are using NVM, install it and ensure your `PATH` is up-to-date by running:
 
 ```
-$ nvm use && nvm install
+$ nvm install && nvm use && node --version
+...
+<NVM output>
+...
+v12.22.1
 ```
 
-Then verify the version again as above.
+Be sure to **verify the version on the final line** to make sure the NVM binary appears first in your `PATH`.
 
 From the harmony project root, install library dependencies:
 ```

--- a/app/util/env.ts
+++ b/app/util/env.ts
@@ -2,6 +2,14 @@ import _ from 'lodash';
 import * as dotenv from 'dotenv';
 import * as winston from 'winston';
 
+if (Object.prototype.hasOwnProperty.call(process.env, 'GDAL_DATA')) {
+  winston.warn('Found a GDAL_DATA environment variable.  This is usually from an external GDAL '
+    + 'installation and can interfere with CRS parsing in Harmony, so we will ignore it. '
+    + 'If you need to override the GDAL_DATA location for Harmony, provide a GDAL_DATA key in '
+    + 'your .env file.');
+  delete process.env.GDAL_DATA;
+}
+
 if (dotenv.config().error) {
   winston.warn('Did not read a .env file');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13618,6 +13618,49 @@
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
+    "strict-npm-engines": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/strict-npm-engines/-/strict-npm-engines-0.0.1.tgz",
+      "integrity": "sha512-s+dyVC+DBlm5kQlDHdvra0oymB9OvXsGn0s8xxJOTUrBQ5BMwiM+ixhd13FN8IXspwvT7F5D8tPk+KCmXxr4Xg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "read-pkg": "^5.1.1",
+        "semver": "^6.1.1"
+      },
+      "dependencies": {
+        "parse-json": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+          "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-even-better-errors": "^2.3.0",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
     "string-similarity": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "Data services frontend",
   "main": "index.js",
   "scripts": {
-    "test": "eslint --ext .ts --ignore-pattern tasks . && nyc mocha && npm audit && lerna run test",
+    "test": "strict-npm-engines && eslint --ext .ts --ignore-pattern tasks . && nyc mocha && npm audit && lerna run test",
     "test-fast": "TS_NODE_TRANSPILE_ONLY=true mocha",
     "coverage": "nyc mocha",
     "start": "ts-node -r tsconfig-paths/register app/server.ts",
-    "start-dev": "ts-node-dev --no-notify -r tsconfig-paths/register --watch app/views --respawn app/server",
+    "start-dev": "strict-npm-engines && ts-node-dev --no-notify -r tsconfig-paths/register --watch app/views --respawn app/server",
     "start-dev-fast": "TS_NODE_TRANSPILE_ONLY=true ts-node-dev --no-notify -r tsconfig-paths/register --respawn app/server",
     "build-image": "bin/build-image",
     "push-image": "bin/push-image",
@@ -26,7 +26,8 @@
     "Cumulus"
   ],
   "engines": {
-    "node": "^12.14.1"
+    "node": "^12.14.1",
+    "npm": ">=6"
   },
   "nyc": {
     "all": true,
@@ -149,6 +150,7 @@
     "eslint-plugin-node": "^9.2.0",
     "eslint-plugin-tsdoc": "^0.2.5",
     "fast-check": "^2.7.0",
+    "javascript-typescript-langserver": "^2.11.3",
     "lerna": "^3.22.1",
     "mocha": "^7.2.0",
     "mocha-junit-reporter": "^1.23.3",
@@ -159,9 +161,9 @@
     "nyc": "^15.1.0",
     "replay": "^2.4.0",
     "sinon": "^7.5.0",
+    "strict-npm-engines": "0.0.1",
     "superagent": "^5.3.1",
     "supertest": "^4.0.2",
-    "ts-node-dev": "^1.0.0-pre.50",
-    "javascript-typescript-langserver": "^2.11.3"
+    "ts-node-dev": "^1.0.0-pre.50"
   }
 }


### PR DESCRIPTION
Fixes some small issues new devs were seeing:

1. The README for NVM had an inverted command (use before install) and the recommendation to re-check node version wasn't clear enough.  A dev encountered issues with an incorrect PATH setup even though NVM looked correct
2. Node version isn't enforced at all, which meant an incorrect node version could cause subtle problems
3. If GDAL_DATA is set in the environment, it's likely to cause issues with the gdal installed by our NPM module.  I added a warning when this happens along with instructions to override.

To test item 2, run `npm install` and `nvm use 12.4.0` (or any node version you have installed below v12.14.1), then run `npm test` and `npm run start-dev`  It should error out.
To see the GDAL warning behavior:
No GDAL_DATA set:
```
ts-node -e 'require("./app/util/env"); console.log(require("gdal").SpatialReference.fromUserInput("EPSG:4326").toProj4())'
```

GDAL_DATA set.  This would fail before this change but now prints a warning and succeeds:
```
GDAL_DATA=/tmp ts-node -e 'require("./app/util/env"); console.log(require("gdal").SpatialReference.fromUserInput("EPSG:4326").toProj4())'
```

You can set GDAL_DATA to some non-gdal dir in .env and rerun either of the above commands, causing a failure