### PR TITLE
Added POCLOUD VIIRS collections to podaac/l2-subsetter

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -203,6 +203,11 @@ https://cmr.earthdata.nasa.gov:
       - C1940466008-POCLOUD
       - C1968979997-POCLOUD
       - C1968979762-POCLOUD
+      - C1996880450-POCLOUD
+      - C1996881456-POCLOUD
+      - C1996881636-POCLOUD
+      - C1996880725-POCLOUD
+      - C1996881807-POCLOUD
     capabilities:
       subsetting:
         bbox: true
@@ -300,6 +305,7 @@ https://cmr.uat.earthdata.nasa.gov:
       - C1238543220-POCLOUD
       - C1238543223-POCLOUD
       - C1238538240-POCLOUD
+      - C1238621102-POCLOUD
     capabilities:
       subsetting:
         bbox: true


### PR DESCRIPTION
Jira ticket: [PODAAC-3238](https://jira.jpl.nasa.gov/browse/PODAAC-3238)

Added the following VIIRS POCLOUD datasets to ops and uat l2 subsetter

| Dataset                                                                                                                                                           | OPS Concept ID      | UAT Concept ID      |
|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|---------------------|
| GHRSST Level 2P OSPO dataset v2.61 from VIIRS on the NOAA-20 satellite (GDS v2)                                                                                   | C1996880450-POCLOUD | C1238621102-POCLOUD |
| GHRSST Level 2P Global Sea Surface Skin Temperature from the Visible and Infrared Imager/Radiometer Suite (VIIRS) on the Suomi-NPP satellite (GDS2)               | C1996881456-POCLOUD |                     |
| GHRSST Level 2P 1 m Depth Global Sea Surface Temperature version 3.0 from the Visible Infrared Imaging Radiometer Suite (VIIRS) on the Suomi NPP satellite (GDS2) | C1996881636-POCLOUD |                     |
| GHRSST Level 2P OSPO dataset v2.61 from VIIRS on S-NPP Satellite (GDS v2)                                                                                         | C1996880725-POCLOUD |                     |
| GHRSST Level 2P 1 m Depth Global Sea Surface Temperature from VIIRS on Suomi NPP (GDS2) V1                                                                        | C1996881807-POCLOUD |                     |

I tested one granule from each collection with the subsetter and the result was as expected.