### PR TITLE
Added S6 collections to UAT l2 subsetter

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -301,6 +301,13 @@ https://cmr.uat.earthdata.nasa.gov:
       - C1238543220-POCLOUD
       - C1238543223-POCLOUD
       - C1238538240-POCLOUD
+      - C1238538225-POCLOUD
+      - C1238538224-POCLOUD
+      - C1238538231-POCLOUD
+      - C1238538230-POCLOUD
+      - C1238538233-POCLOUD
+      - C1238538232-POCLOUD
+      - C1238538241-POCLOUD
     capabilities:
       subsetting:
         bbox: true


### PR DESCRIPTION
Added sentinel 6 L2 collections (that contain groups) to podaac/l2-subsetter:

| Collection short name | Concept ID | 
|---|---|
|JASON_CS_S6A_L2_ALT_HR_RED_OST_NRT_F | C1238538225-POCLOUD|
|JASON_CS_S6A_L2_ALT_HR_STD_OST_NRT_F | C1238538224-POCLOUD|
|JASON_CS_S6A_L2_ALT_HR_RED_OST_STC_F | C1238538231-POCLOUD|
|JASON_CS_S6A_L2_ALT_HR_STD_OST_STC_F | C1238538230-POCLOUD|
|JASON_CS_S6A_L2_ALT_LR_RED_OST_NRT_F | C1238538233-POCLOUD|
|JASON_CS_S6A_L2_ALT_LR_STD_OST_NRT_F | C1238538232-POCLOUD|
|JASON_CS_S6A_L2_ALT_LR_RED_OST_STC_F | C1238538241-POCLOUD|
