### PR TITLE
Harmony 251 - Add google analytics to public Harmony pages (documentation, landing page)

### DIFF
--- a/app/routers/router.ts
+++ b/app/routers/router.ts
@@ -186,7 +186,7 @@ export default function router({ skipEarthdataLogin = 'false' }: RouterConfig): 
 
   result.get('/', landingPage);
   result.get('/versions', getVersions);
-  result.use('/docs/api', swaggerUi.serve, swaggerUi.setup(yaml.load(ogcCoverageApi.openApiContent)));
+  result.use('/docs/api', swaggerUi.serve, swaggerUi.setup(yaml.load(ogcCoverageApi.openApiContent), {customJs: '/analytics-tag.js'}));
   result.get(collectionPrefix('(wms|eoss|ogc-api-coverages)'), service(serviceInvoker));
   result.post(collectionPrefix('(ogc-api-coverages)'), service(serviceInvoker));
   result.get('/jobs', getJobsListing);

--- a/app/routers/router.ts
+++ b/app/routers/router.ts
@@ -186,7 +186,7 @@ export default function router({ skipEarthdataLogin = 'false' }: RouterConfig): 
 
   result.get('/', landingPage);
   result.get('/versions', getVersions);
-  result.use('/docs/api', swaggerUi.serve, swaggerUi.setup(yaml.load(ogcCoverageApi.openApiContent), {customJs: '/analytics-tag.js'}));
+  result.use('/docs/api', swaggerUi.serve, swaggerUi.setup(yaml.load(ogcCoverageApi.openApiContent), { customJs: '/analytics-tag.js' }));
   result.get(collectionPrefix('(wms|eoss|ogc-api-coverages)'), service(serviceInvoker));
   result.post(collectionPrefix('(ogc-api-coverages)'), service(serviceInvoker));
   result.get('/jobs', getJobsListing);

--- a/app/views/index.mustache.html
+++ b/app/views/index.mustache.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="eui.min.css">
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/5.0.0-alpha1/js/bootstrap.min.js" integrity="sha384-oesi62hOLfzrys4LxRF63OJCXdXDipiYWBnvTl9Y9/TRlw5xlKIEHpNyvvDShgf/" crossorigin="anonymous"></script>
-    <script language="javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=GSFC"></script>
+    <script language="javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=GSFC&dclink=true"></script>
     <title>Harmony</title>
     <style>
         footer a {

--- a/app/views/index.mustache.html
+++ b/app/views/index.mustache.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="eui.min.css">
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/5.0.0-alpha1/js/bootstrap.min.js" integrity="sha384-oesi62hOLfzrys4LxRF63OJCXdXDipiYWBnvTl9Y9/TRlw5xlKIEHpNyvvDShgf/" crossorigin="anonymous"></script>
+    <script language="javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=GSFC"></script>
     <title>Harmony</title>
     <style>
         footer a {

--- a/public/analytics-tag.js
+++ b/public/analytics-tag.js
@@ -1,0 +1,6 @@
+// google analytics tracking
+// appending this to the head since we can't modify the Swagger-generated HTML directly
+var script = document.createElement('script');
+script.src = "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=GSFC&dclink=true";
+script.id = "_fed_an_ua_tag"
+document.getElementsByTagName('head')[0].appendChild(script);

--- a/public/analytics-tag.js
+++ b/public/analytics-tag.js
@@ -1,6 +1,6 @@
 // google analytics tracking
 // appending this to the head since we can't modify the Swagger-generated HTML directly
-var script = document.createElement('script');
-script.src = "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=GSFC&dclink=true";
-script.id = "_fed_an_ua_tag"
-document.getElementsByTagName('head')[0].appendChild(script);
+var dapFederatedAnalyticsScript = document.createElement('script');
+dapFederatedAnalyticsScript.src = "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=GSFC&dclink=true";
+dapFederatedAnalyticsScript.id = "_fed_an_ua_tag"
+document.getElementsByTagName('head')[0].appendChild(dapFederatedAnalyticsScript);

--- a/public/analytics-tag.js
+++ b/public/analytics-tag.js
@@ -1,6 +1,9 @@
 // google analytics tracking
 // appending this to the head since we can't modify the Swagger-generated HTML directly
-var dapFederatedAnalyticsScript = document.createElement('script');
-dapFederatedAnalyticsScript.src = "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=GSFC&dclink=true";
-dapFederatedAnalyticsScript.id = "_fed_an_ua_tag"
-document.getElementsByTagName('head')[0].appendChild(dapFederatedAnalyticsScript);
+(function(){
+  var dapFederatedAnalyticsScript = document.createElement('script');
+  dapFederatedAnalyticsScript.src = "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=GSFC&dclink=true";
+  dapFederatedAnalyticsScript.id = "_fed_an_ua_tag";
+  dapFederatedAnalyticsScript.type = 'text/javascript';
+  document.getElementsByTagName('head')[0].appendChild(dapFederatedAnalyticsScript);
+})();

--- a/public/notebook-example.html
+++ b/public/notebook-example.html
@@ -6,7 +6,7 @@
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.10/require.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
-
+<script language="javascript" id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=GSFC&dclink=true"></script>
 
 
 <style type="text/css">
@@ -12944,7 +12944,7 @@ ul.typeahead-list  > li > a.pull-right {
 .terminal-app #terminado-container {
   margin-top: 20px;
 }
-/*# sourceMappingURL=style.min.css.map */
+
     </style>
 <style type="text/css">
     pre { line-height: 125%; margin: 0; }
@@ -13050,8 +13050,6 @@ div#notebook {
 }
 </style>
 
-<!-- Custom stylesheet, it must be in the same directory as the html file -->
-<link rel="stylesheet" href="custom.css">
 
 <!-- Loading mathjax macro -->
 <!-- Load mathjax -->


### PR DESCRIPTION
After talking to the main Goddard POC for google analytics and gaining access to the main dashboard, I added the analytics script to the following html pages:

- index
- documentation
- notebook example

Chrome inspector showed a 200 response (and no errors) from the request that pulls in the tracking JS. Statistics may take up to a day to show up from what I can tell, so I'll take a look at the dashboard tomorrow to see if things propagate properly.  Not sure if localhost will be tracked though(?), so we may need to deploy to SIT & UAT to validate further. 