### PR TITLE
DAS-1086 - Activate HOSS for the GHRC RSSMIF16D collection.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -442,9 +442,10 @@ https://cmr.uat.earthdata.nasa.gov:
           <<: *default-argo-env
           STAGING_PATH: public/sds/variable-subsetter
     collections:
-      - C1234714691-EEDTEST  # ATL03
-      - C1234714698-EEDTEST  # ATL08
-      - C1238392622-EEDTEST  # RSSMIF16
+      - C1234714691-EEDTEST  # ATL03 UAT
+      - C1234714698-EEDTEST  # ATL08 UAT
+      - C1238392622-EEDTEST  # RSSMIF16D test collection UAT
+      - C1222931739-GHRC_CLOUD  # RSSMIF16D UAT
     capabilities:
       subsetting:
         variable: true


### PR DESCRIPTION
This PR updates the collections associated with the `sds/variable-subsetter` Docker image to also include the UAT RSSMIF16D collections within the GHRC cloud provider.

Note, the Harmony OPeNDAP SubSetter (HOSS) is essentially a code branch within the `sds/variable-subsetter` Docker image. If a bounding box is included in the message parameters, it will be given the full HOSS treatment (to also perform a spatial subset). Otherwise the subsetter will perform as previously and only behave as a variable subsetter.

The different uses are separated by different UMM-S records, one of which allows a bounding box, the other does not. This prevents requests including a bounding box being made against granules from non-geographically gridded collections.