### PR TITLE
DAS-1097 - Update history_json schema description for derived_from attribute

### DIFF
--- a/app/schemas/history/0.1.0/history-v0.1.0.json
+++ b/app/schemas/history/0.1.0/history-v0.1.0.json
@@ -15,7 +15,7 @@
                "format": "date-time"
             },
             "derived_from": {
-               "description": "List of source data files used in the creation of this data file",
+               "description": "List of source data files used in the creation of this data file. E.g., pystac.Item.asset.href where asset role == data from the Harmony processing request. Preferably including science data filename information vs. an obscure temporary file link.",
                "type": [ "array", "string" ],
                "items": { "type": "string" }
             },


### PR DESCRIPTION
This PR updates the description for the `derived_from` attribute of the `history_json` schema (v0.1.0). This is an update to the existing schema version as it doesn't change any of the attributes of the schema itself.