### PR TITLE
HARMONY-855: Update netcdf-to-zarr batch size to 20 and set k8s request and limits for the netcdf-to-zarr service

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -57,7 +57,8 @@ https://cmr.earthdata.nasa.gov:
       reprojection: true
 
   - name: harmony/netcdf-to-zarr
-    data_operation_version: '0.9.0'
+    data_operation_version: '0.10.0'
+    batch_size: 20
     type:
       <<: *default-argo-config
       params:
@@ -578,6 +579,7 @@ https://cmr.uat.earthdata.nasa.gov:
 
   - name: harmony/netcdf-to-zarr
     data_operation_version: '0.10.0'
+    batch_size: 20
     type:
       <<: *default-argo-config
       params:
@@ -652,6 +654,7 @@ https://cmr.uat.earthdata.nasa.gov:
   # CHAINED SERVICES BELOW HERE
   - name: harmony/podaac-l2-subsetter-netcdf-to-zarr
     data_operation_version: '0.9.0'
+    batch_size: 20
     type:
       <<: *default-argo-config
       params:

--- a/config/workflow-templates/harmony-netcdf-to-zarr.yaml
+++ b/config/workflow-templates/harmony-netcdf-to-zarr.yaml
@@ -83,8 +83,8 @@ spec:
           ]
         resources:
           limits:
-            memory: 2048Mi
             cpu: 1000m
+            memory: 2048Mi
           requests:
             cpu: 100m
             memory: 1024Mi

--- a/config/workflow-templates/harmony-netcdf-to-zarr.yaml
+++ b/config/workflow-templates/harmony-netcdf-to-zarr.yaml
@@ -81,6 +81,13 @@ spec:
             "--harmony-metadata-dir",
             "{{outputs.artifacts.metadata.path}}"
           ]
+        resources:
+          limits:
+            memory: 2048Mi
+            cpu: 1000m
+          requests:
+            cpu: 100m
+            memory: 1024Mi
         envFrom:
           - configMapRef:
               name: harmony-env


### PR DESCRIPTION
Tested out in a sandbox environment with the following configuration:

2 c5.xlarge nodes (recommend changing from c5.large to c5.xlarge in each of our envs)

Submitted 20 requests each with 60 granules:
<sandbox_endpoint>/C1238621141-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?format=application%2Fx-zarr&maxResults=60

The requests correctly batched to 20 granules per batch. I saw 10 batches executed in parallel across the requests (never more than 2 batches at a time per workflow). The rest of the pods remained in a pending state because they could not reserve enough memory effectively queueing requests. I've seen a couple requests completing successfully so far with each batch taking no more than an hour and 15 minutes (plenty of room before the 4 hour timeout).

I'll check tomorrow morning to make sure the queued requests eventually complete successfully (and that the queueing doesn't affect timeout).

So far I've only made changes to netcdf-to-zarr, but we should make similar changes to all of the services as we have more time to perform testing. We'll perform those changes as part of HARMONY-839.
