### PR TITLE
DAS-1097 - Update history_json schema to allow parameters attribute to be an object

### DIFF
--- a/app/schemas/history/0.1.0/history-v0.1.0.json
+++ b/app/schemas/history/0.1.0/history-v0.1.0.json
@@ -34,7 +34,7 @@
             },
             "parameters": {
                "description": "The list of parameters to the program when generating this data file",
-               "type": [ "array", "string" ],
+               "type": [ "array", "string", "object" ],
                "items": { "type": "string" }
             },
             "program_ref": {


### PR DESCRIPTION
This PR makes a change to the `history_json` v0.1.0 schema to allow the parameters attribute to be a raw object (with unspecified properties) as proposed by David Auty. Because it only extends the options (and so is entirely backwards compatible) it has been proposed that the current semantic version (0.1.0) is overwritten, rather than a new version added.

I'm hopeful that this is the last change to the schema in the short term, and definitely hope it's the last update to v0.1.0.