### PR TITLE
HARMONY-873: Remove _json_links column from the jobs table.

### DIFF
--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -446,8 +446,7 @@ export class Job extends Record {
     const { links, originalStatus } = this;
     delete this.links;
     delete this.originalStatus;
-    // Remove the _json_links field once we've dropped the column
-    await super.save(transaction, { ...this, _json_links: [] });
+    await super.save(transaction);
     const promises = [];
     for (const link of links) {
       // Note we will not update existing links in the database - only add new ones

--- a/db/db.sql
+++ b/db/db.sql
@@ -9,8 +9,6 @@ CREATE TABLE `jobs` (
   `message` varchar(4096) not null,
   `progress` integer not null,
   `batchesCompleted` integer not null,
-  -- Remove _json_links in a later migration once we've confirmed links are populated
-  `_json_links` json not null,
   `createdAt` datetime not null,
   `updatedAt` datetime not null,
   `request` varchar(4096) not null default 'unknown',

--- a/db/migrations/20210621095351_remove_json_links_from_jobs.js
+++ b/db/migrations/20210621095351_remove_json_links_from_jobs.js
@@ -1,0 +1,12 @@
+exports.up = function(knex) {
+  return knex.schema.alterTable('jobs', (t) => {
+    t.dropColumn('_json_links');
+  });
+};
+
+exports.down = function(knex) {
+  // Just recreate the column, do not try to repopulate the field
+  return knex.schema.alterTable('jobs', (t) => {
+    t.json('_json_links');
+  });
+};


### PR DESCRIPTION
Tested by deploying to a sandbox account. Verified that the database column is gone and jobs listings and jobs status calls come back the same as before. Also no problems submitting requests resulting in new jobs.