### PR TITLE
DAS-1208 - Add UMM-S concept IDs for HOSS, Variable Subsetter and MaskFill

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -449,6 +449,8 @@ https://cmr.uat.earthdata.nasa.gov:
         env:
           <<: *default-argo-env
           STAGING_PATH: public/sds/variable-subsetter
+    umm_s:
+      - S1237976118-EEDTEST
     collections:
       - C1234714691-EEDTEST  # ATL03 UAT
       - C1234714698-EEDTEST  # ATL08 UAT
@@ -475,6 +477,8 @@ https://cmr.uat.earthdata.nasa.gov:
         env:
           <<: *default-argo-env
           STAGING_PATH: public/sds/HOSS
+    umm_s:
+      - S1240682712-EEDTEST
     collections:
       - C1238392622-EEDTEST  # RSSMIF16D test collection UAT
       - C1222931739-GHRC_CLOUD  # RSSMIF16D UAT
@@ -502,6 +506,8 @@ https://cmr.uat.earthdata.nasa.gov:
         env:
           <<: *default-argo-env
           STAGING_PATH: public/sds/maskfill
+    umm_s:
+      - S1240151795-EEDTEST
     collections:
       - C1240150677-EEDTEST  # SPL4CMDL test collection
     capabilities:


### PR DESCRIPTION
This PR adds the UMM-S concept IDs for the services maintained by the Data Services team.

We'll use the GES DISC GPM_3IMERGHH and M2T1NXSLV (MERRA-2) collections as tests for the UMM-S/UMM-C mechanism. When that all works nicely, I'll probably submit a later PR to scrub the UMM-C entries from `services.yml` for our services that have the UMM-S/UMM-C association (which is most, if not all, of them).