### PR TITLE
Added UMM-S concept IDs for PODAAC L2 subsetter

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -210,6 +210,8 @@ https://cmr.earthdata.nasa.gov:
         env:
           <<: *default-argo-env
           STAGING_PATH: public/podaac/l2-subsetter
+    umm_s:
+      - S1962070864-POCLOUD
     collections:
       - C1940473819-POCLOUD
       - C1940475563-POCLOUD
@@ -350,6 +352,8 @@ https://cmr.uat.earthdata.nasa.gov:
         env:
           <<: *default-argo-env
           STAGING_PATH: public/podaac/l2-subsetter
+    umm_s:
+      - S1234899453-POCLOUD
     collections:
       - C1234208436-POCLOUD
       - C1234208437-POCLOUD


### PR DESCRIPTION
L2 subsetter prod UMM-S: [S1962070864-POCLOUD](https://cmr.earthdata.nasa.gov/search/services.umm_json?concept_id=S1962070864-POCLOUD)

L2 subsetter uat UMM-S: [S1234899453-POCLOUD](https://cmr.uat.earthdata.nasa.gov/search/services.umm_json?concept_id=S1234899453-POCLOUD)