### PR TITLE
Harmony 899: Service entry for harmony-netcdf-to-zarr + swotrepr

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -641,7 +641,6 @@ https://cmr.uat.earthdata.nasa.gov:
       # DO NOT UNCOMMENT THE FOLLOWING LINE - this collection is added via UMM-S and is left here
       # to prevent re-adding. This is needed for tests related to HARMONY-875
       # - C1233800302-EEDTEST
-      - C1233860183-EEDTEST
       - C1234410736-POCLOUD
       - C1234082763-POCLOUD
       - C1234071416-POCLOUD

--- a/config/services.yml
+++ b/config/services.yml
@@ -634,7 +634,8 @@ https://cmr.uat.earthdata.nasa.gov:
           <<: *default-argo-env
           STAGING_PATH: public/harmony/netcdf-to-zarr
     umm_s:
-      - S1237980031-EEDTEST
+      - S1237980031-EEDTEST # Just NetCDF-to-Zarr
+      - S1240999847-EEDTEST # NetCDF-to-Zarr + swotrepr
     collections:
       - C1234088182-EEDTEST
       # DO NOT UNCOMMENT THE FOLLOWING LINE - this collection is added via UMM-S and is left here
@@ -742,6 +743,8 @@ https://cmr.uat.earthdata.nasa.gov:
         env:
           <<: *default-argo-env
           STAGING_PATH: public/harmony/swot-repr-netcdf-to-zarr
+    umm_s:
+      - S1240999847-EEDTEST
     collections:
       - C1233800302-EEDTEST
       - C1234724470-POCLOUD

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "request": "^2.88.2",
         "request-promise": "^4.2.5",
         "serve-favicon": "^2.5.0",
-        "shpjs": "^3.5.0",
+        "shpjs": "^4.0.2",
         "simple-oauth2": "git+https://github.com/bilts/simple-oauth2.git#fix-encoding",
         "source-map-support": "^0.5.19",
         "sqlite3": "^4.2.0",
@@ -10862,11 +10862,36 @@
       }
     },
     "node_modules/jszip": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
-      "integrity": "sha1-uI86ey5noqBIFSmCx6N1bZxIKPA=",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
       "dependencies": {
-        "pako": "~1.0.2"
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/just-extend": {
@@ -16159,6 +16184,14 @@
       "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
       "dev": true
     },
+    "node_modules/set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -16269,11 +16302,11 @@
       }
     },
     "node_modules/shpjs": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
-      "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-4.0.2.tgz",
+      "integrity": "sha512-yiyc7FyOCnVeF6UiJmKMxg5P/x0MQIUnH3m+OhFb2eic39WZo40b7jxh+zkhj309kA2Hh2t5La+kFv8Im94C3g==",
       "dependencies": {
-        "jszip": "^2.4.0",
+        "jszip": "^3.5.0",
         "lie": "^3.0.1",
         "lru-cache": "^2.7.0",
         "parsedbf": "^1.1.0",
@@ -18807,9 +18840,9 @@
       }
     },
     "node_modules/url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
@@ -28152,11 +28185,38 @@
       }
     },
     "jszip": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-2.6.1.tgz",
-      "integrity": "sha1-uI86ey5noqBIFSmCx6N1bZxIKPA=",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.7.1.tgz",
+      "integrity": "sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==",
       "requires": {
-        "pako": "~1.0.2"
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "set-immediate-shim": "~1.0.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
       }
     },
     "just-extend": {
@@ -32360,6 +32420,11 @@
       "integrity": "sha512-edRH8mBKEWNVIVMKejNnuJxleqYE/ZSdcT8/Nem9/mmosx12pctd80s2Oy00KNZzrogMZS5mauK2/ymL1bvlvg==",
       "dev": true
     },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
+    },
     "set-value": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
@@ -32444,11 +32509,11 @@
       }
     },
     "shpjs": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-3.6.3.tgz",
-      "integrity": "sha512-wcR2S3WL/7RnEIm+YO+H/mZR9z9FCV46op+SZt+W5PtPs26Omb9U93f+EPI1DOpNKBuAIrWjHWh0SxlnBahJkg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shpjs/-/shpjs-4.0.2.tgz",
+      "integrity": "sha512-yiyc7FyOCnVeF6UiJmKMxg5P/x0MQIUnH3m+OhFb2eic39WZo40b7jxh+zkhj309kA2Hh2t5La+kFv8Im94C3g==",
       "requires": {
-        "jszip": "^2.4.0",
+        "jszip": "^3.5.0",
         "lie": "^3.0.1",
         "lru-cache": "^2.7.0",
         "parsedbf": "^1.1.0",
@@ -34445,9 +34510,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
-      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "request": "^2.88.2",
     "request-promise": "^4.2.5",
     "serve-favicon": "^2.5.0",
-    "shpjs": "^3.5.0",
+    "shpjs": "^4.0.2",
     "simple-oauth2": "git+https://github.com/bilts/simple-oauth2.git#fix-encoding",
     "source-map-support": "^0.5.19",
     "sqlite3": "^4.2.0",


### PR DESCRIPTION
To test:

Run this and verify it calls the swotrepr + harmony-netcdf-to-zarr chain (just verify service selection and terminate, unless you have swotrepr in your local install):
http://localhost:3000/harmony_example_l2/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?format=application%2Fx-zarr&outputCrs=EPSG%3A4326

Run this and verify it calls the harmony-netcdf-to-zarr service un-chained in the argo console:
http://localhost:3000/harmony_example_l2/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?format=application%2Fx-zarr