### PR TITLE
Added collections to asf gdal subsetter be used by PODAAC for browse image generation

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -43,6 +43,10 @@ https://cmr.earthdata.nasa.gov:
       - C1214354031-ASF
       - C1808440897-ASF
       - C2011599335-ASF
+      - C1239324659-POCUMULUS
+      - C1239379702-POCLOUD
+      - C1238618571-POCUMULUS
+      - C1238621141-POCLOUD
     capabilities:
       subsetting:
         shape: true


### PR DESCRIPTION
### Description
In a joint effort with Joe Roberts, PODAAC is looking to deliver browse image generation using the asf gdal subsetter and needs to add the following collections to the service.

ECCO	C1239324659-POCUMULUS
ECCO	C1239379702-POCLOUD

MUR	C1238618571-POCUMULUS
MUR	C1238621141-POCLOUD

### Overview of work done

I have added these collections to the harmony/config/services.yml under the asf gdal service.

