### PR TITLE
Added necessary collections under asf gdal service UAT for PODAAC testing

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -300,6 +300,10 @@ https://cmr.uat.earthdata.nasa.gov:
       - C1215139640-GES_DISC
       - C1215802932-GES_DISC
       - C1221312185-GES_DISC
+      - C1239324659-POCUMULUS
+      - C1239379702-POCLOUD
+      - C1238618571-POCUMULUS
+      - C1238621141-POCLOUD
     capabilities:
       subsetting:
         shape: true


### PR DESCRIPTION
Similar to: https://github.com/nasa/harmony/pull/61#pullrequestreview-732177519

### Description
In a joint effort with Joe Roberts, PODAAC is looking to deliver browse image generation using the asf gdal subsetter and needs to add the following collections to the service.

ECCO	C1239324659-POCUMULUS
ECCO	C1239379702-POCLOUD

MUR	C1238618571-POCUMULUS
MUR	C1238621141-POCLOUD

### Overview of work done

I have added these collections to the harmony/config/services.yml under the asf gdal service for UAT.

