### PR TITLE
HARMONY-925: Updates to workload drivers to execute both argo and turbo requests

### DIFF
--- a/workload/locustfile.py
+++ b/workload/locustfile.py
@@ -4,27 +4,61 @@ from harmony.common import BaseHarmonyUser
 
 
 class HarmonyUatUser(BaseHarmonyUser):
+
+    def _harmony_service_example_bbox_variable_reformat(self, turbo=False):
+      name = 'Harmony Service Example: Bbox, Variable, and reformat'
+      collection = 'C1233800302-EEDTEST'
+      variable = 'blue_var'
+      params = {
+          'subset': [
+              'lat(20:60)',
+              'lon(-140:-50)'
+          ],
+          'granuleId': 'G1233800343-EEDTEST',
+          'outputCrs': 'EPSG:4326',
+          'format': 'image/png'
+      }
+      if turbo:
+        params['turbo'] = 'true'
+
+      self.client.get(
+          self.coverages_root.format(
+              collection=collection,
+              variable=variable),
+          params=params,
+          name=f'Turbo: {name}' if turbo else f'Argo: {name}')
+
     @tag('harmony-service-example', 'sync', 'variable', 'bbox', 'reproject', 'png')
     @task(2)
     def harmony_service_example_bbox_variable_reformat(self):
-        collection = 'C1233800302-EEDTEST'
-        variable = 'blue_var'
-        params = {
-            'subset': [
-                'lat(20:60)',
-                'lon(-140:-50)'
-            ],
-            'granuleId': 'G1233800343-EEDTEST',
-            'outputCrs': 'EPSG:4326',
-            'format': 'image/png'
-        }
+      self._harmony_service_example_bbox_variable_reformat()
 
-        self.client.get(
-            self.coverages_root.format(
-                collection=collection,
-                variable=variable),
-            params=params,
-            name='Harmony Service Example: Bbox, Variable, and reformat')
+    @tag('harmony-service-example', 'sync', 'variable', 'bbox', 'reproject', 'png', 'turbo')
+    @task(2)
+    def harmony_service_example_bbox_variable_reformat_turbo(self):
+      self._harmony_service_example_bbox_variable_reformat(True)
+
+    # @tag('harmony-service-example', 'sync', 'variable', 'bbox', 'reproject', 'png')
+    # @task(2)
+    # def harmony_service_example_bbox_variable_reformat(self):
+    #     collection = 'C1233800302-EEDTEST'
+    #     variable = 'blue_var'
+    #     params = {
+    #         'subset': [
+    #             'lat(20:60)',
+    #             'lon(-140:-50)'
+    #         ],
+    #         'granuleId': 'G1233800343-EEDTEST',
+    #         'outputCrs': 'EPSG:4326',
+    #         'format': 'image/png'
+    #     }
+
+    #     self.client.get(
+    #         self.coverages_root.format(
+    #             collection=collection,
+    #             variable=variable),
+    #         params=params,
+    #         name='Harmony Service Example: Bbox, Variable, and reformat')
 
     @tag('swot-repr', 'sync', 'reproject', 'netcdf4')
     @task(2)
@@ -45,64 +79,143 @@ class HarmonyUatUser(BaseHarmonyUser):
             params=params,
             name='SWOT Reprojection: Europe scale extent')
 
-    @tag('podaac-ps3', 'shapefile', 'sync', 'temporal', 'netcdf4')
+    # @tag('harmony-service-example', 'sync', 'variable', 'bbox', 'reproject', 'png', 'turbo')
+    # @task(2)
+    # def harmony_service_example_bbox_variable_reformat_turbo(self):
+    #     collection = 'C1233800302-EEDTEST'
+    #     variable = 'blue_var'
+    #     params = {
+    #         'subset': [
+    #             'lat(20:60)',
+    #             'lon(-140:-50)'
+    #         ],
+    #         'granuleId': 'G1233800343-EEDTEST',
+    #         'outputCrs': 'EPSG:4326',
+    #         'format': 'image/png',
+    #         'turbo': 'true'
+    #     }
+
+    #     self.client.get(
+    #         self.coverages_root.format(
+    #             collection=collection,
+    #             variable=variable),
+    #         params=params,
+    #         name='Turbo: Harmony Service Example: Bbox, Variable, and reformat')
+
+    @tag('swot-repr', 'sync', 'reproject', 'netcdf4', 'turbo')
     @task(2)
-    def podaac_shapefile(self):
-        collection = 'C1234530533-EEDTEST'
+    def swot_repr_europe(self):
+        collection = 'C1233860183-EEDTEST'
         variable = 'all'
-        shapefile_location = '../docs/notebook_helpers/test_in-polygon.shp.zip'
-        self.client.post(
-            self.coverages_root.format(
-                collection=collection,
-                variable=variable
-            ),
-            data={'subset': 'time("2009-01-09T00:00:00Z":"2009-01-09T01:00:00Z")'},
-            files={'shapefile': ('test_in-polygon.shp.zip',
-                                 open(shapefile_location, 'rb'), 'application/shapefile+zip')},
-            name='PODAAC Shapefile Subsetter')
-
-    @tag('podaac-l2ss', 'bbox', 'sync', 'netcdf4', 'agu', 'variable')
-    @task(5)
-    def podaac_l2ss_sync_variable(self):
-        collection = 'C1234208438-POCLOUD'
-        variable = 'mean_sea_surface'
         params = {
-            'maxResults': 1,
-            'subset': [
-                'lon(-160:160)',
-                'lat(-80:80)'
-            ]
+            'granuleId': 'G1233860486-EEDTEST',
+            'outputCrs': '+proj=lcc +lat_1=43 +lat_2=62 +lat_0=30 +lon_0=10 +x_0=0 +y_0=0 +ellps=intl +units=m no_defs',
+            'interpolation': 'near',
+            'scaleExtent': '-7000000,1000000,8000000,8000000',
+            'turbo': 'true'
         }
+
         self.client.get(
             self.coverages_root.format(
                 collection=collection,
-                variable=variable
-            ),
+                variable=variable),
             params=params,
-            name='PODAAC L2SS mean sea surface'
-        )
+            name='Turbo: SWOT Reprojection: Europe scale extent')
 
-    @tag('asf-gdal', 'sync', 'bbox', 'variable', 'temporal', 'hierarchical-variable', 'netcdf4')
+    @tag('netcdf-to-zarr', 'async', 'zarr', 'turbo')
     @task(2)
-    def asf_gdal(self):
-        collection = 'C1225776654-ASF'
-        variable = urllib.parse.quote('science/grids/data/amplitude', safe='')
+    def swot_repr_europe(self):
+        collection = 'harmony_example_l2'
+        variable = 'all'
         params = {
-            'granuleId': 'G1235282694-ASF',
-            'subset': [
-                'lon(37:40)',
-                'lat(23:24)',
-                'time("2014-10-30T15:00:00Z":"2014-10-30T15:59:00Z")'
-            ]
+            'format': 'application/x-zarr',
+            'maxResults': '10',
+            'turbo': 'true'
         }
+
         self.client.get(
             self.coverages_root.format(
                 collection=collection,
-                variable=variable
-            ),
+                variable=variable),
             params=params,
-            name='ASF GDAL'
-        )
+            name='Turbo: netcdf-to-zarr: up to 10 granules')
+
+    @tag('chain-swot-repr-netcdf-to-zarr', 'async', 'zarr', 'reproject', 'turbo', 'chain')
+    @task(2)
+    def swot_repr_europe(self):
+        collection = 'harmony_example_l2'
+        variable = 'all'
+        params = {
+            'format': 'application/x-zarr',
+            'maxResults': '10',
+            'turbo': 'true'
+        }
+
+        self.client.get(
+            self.coverages_root.format(
+                collection=collection,
+                variable=variable),
+            params=params,
+            name='Turbo: netcdf-to-zarr: up to 10 granules')
+
+    # @tag('podaac-ps3', 'shapefile', 'sync', 'temporal', 'netcdf4')
+    # @task(2)
+    # def podaac_shapefile(self):
+    #     collection = 'C1234530533-EEDTEST'
+    #     variable = 'all'
+    #     shapefile_location = '../docs/notebook_helpers/test_in-polygon.shp.zip'
+    #     self.client.post(
+    #         self.coverages_root.format(
+    #             collection=collection,
+    #             variable=variable
+    #         ),
+    #         data={'subset': 'time("2009-01-09T00:00:00Z":"2009-01-09T01:00:00Z")'},
+    #         files={'shapefile': ('test_in-polygon.shp.zip',
+    #                              open(shapefile_location, 'rb'), 'application/shapefile+zip')},
+    #         name='PODAAC Shapefile Subsetter')
+
+    # @tag('podaac-l2ss', 'bbox', 'sync', 'netcdf4', 'agu', 'variable')
+    # @task(5)
+    # def podaac_l2ss_sync_variable(self):
+    #     collection = 'C1234208438-POCLOUD'
+    #     variable = 'mean_sea_surface'
+    #     params = {
+    #         'maxResults': 1,
+    #         'subset': [
+    #             'lon(-160:160)',
+    #             'lat(-80:80)'
+    #         ]
+    #     }
+    #     self.client.get(
+    #         self.coverages_root.format(
+    #             collection=collection,
+    #             variable=variable
+    #         ),
+    #         params=params,
+    #         name='PODAAC L2SS mean sea surface'
+    # )
+
+    # @tag('asf-gdal', 'sync', 'bbox', 'variable', 'temporal', 'hierarchical-variable', 'netcdf4')
+    # @task(2)
+    # def asf_gdal(self):
+    #     collection = 'C1225776654-ASF'
+    #     variable = urllib.parse.quote('science/grids/data/amplitude', safe='')
+    #     params = {
+    #         'granuleId': 'G1235282694-ASF',
+    #         'subset': [
+    #             'lon(37:40)',
+    #             'lat(23:24)',
+    #             'time("2014-10-30T15:00:00Z":"2014-10-30T15:59:00Z")'
+    #         ]
+    #     }
+    #     self.client.get(
+    #         self.coverages_root.format(
+    #             collection=collection,
+    #             variable=variable
+    #         ),
+    #         params=params,
+    #         name='ASF GDAL'
+    #     )
 
     @tag('var-subsetter', 'sync', 'variable', 'hierarchical-variable', 'netcdf4')
     @task(2)
@@ -121,49 +234,49 @@ class HarmonyUatUser(BaseHarmonyUser):
             name='Variable subsetter'
         )
 
-    @tag('podaac-l2ss', 'bbox', 'async', 'netcdf4')
-    @task(5)
-    def podaac_l2ss_async(self):
-        collection = 'C1234208436-POCLOUD'
-        variable = 'all'
-        params = {
-            'maxResults': 2,
-            'subset': [
-                'lon(-160:160)',
-                'lat(-80:80)'
-            ]
-        }
-        response = self.client.get(
-            self.coverages_root.format(
-                collection=collection,
-                variable=variable
-            ),
-            params=params,
-            name='PODAAC L2SS Async'
-        )
-        self.wait_for_job_completion(response)
+    # @tag('podaac-l2ss', 'bbox', 'async', 'netcdf4')
+    # @task(5)
+    # def podaac_l2ss_async(self):
+    #     collection = 'C1234208436-POCLOUD'
+    #     variable = 'all'
+    #     params = {
+    #         'maxResults': 2,
+    #         'subset': [
+    #             'lon(-160:160)',
+    #             'lat(-80:80)'
+    #         ]
+    #     }
+    #     response = self.client.get(
+    #         self.coverages_root.format(
+    #             collection=collection,
+    #             variable=variable
+    #         ),
+    #         params=params,
+    #         name='PODAAC L2SS Async'
+    #     )
+    #     self.wait_for_job_completion(response)
 
-    @tag('podaac-l2ss', 'bbox', 'async', 'netcdf4', 'temporal', 'agu')
-    @task(1)
-    def podaac_l2ss_async_spatial_temporal(self):
-        collection = 'C1234724471-POCLOUD'
-        variable = 'all'
-        params = {
-            'subset': [
-                'lat(81.7:83)',
-                'lon(-62.8:-56.4)',
-                'time("2019-06-22T00:00:00Z":"2019-06-22T23:59:59Z")'
-            ]
-        }
-        response = self.client.get(
-            self.coverages_root.format(
-                collection=collection,
-                variable=variable
-            ),
-            params=params,
-            name='PODAAC L2SS Async Spatial and Temporal'
-        )
-        self.wait_for_job_completion(response)
+    # @tag('podaac-l2ss', 'bbox', 'async', 'netcdf4', 'temporal', 'agu')
+    # @task(1)
+    # def podaac_l2ss_async_spatial_temporal(self):
+    #     collection = 'C1234724471-POCLOUD'
+    #     variable = 'all'
+    #     params = {
+    #         'subset': [
+    #             'lat(81.7:83)',
+    #             'lon(-62.8:-56.4)',
+    #             'time("2019-06-22T00:00:00Z":"2019-06-22T23:59:59Z")'
+    #         ]
+    #     }
+    #     response = self.client.get(
+    #         self.coverages_root.format(
+    #             collection=collection,
+    #             variable=variable
+    #         ),
+    #         params=params,
+    #         name='PODAAC L2SS Async Spatial and Temporal'
+    #     )
+    #     self.wait_for_job_completion(response)
 
     @tag('netcdf-to-zarr', 'async', 'zarr', 'agu')
     @task(1)
@@ -200,5 +313,26 @@ class HarmonyUatUser(BaseHarmonyUser):
             ),
             params=params,
             name='NetCDF to Zarr temporal subset'
+        )
+        self.wait_for_job_completion(response)
+
+
+    @tag('netcdf-to-zarr', 'async', 'zarr', 'turbo', 'memory', 'slow')
+    @task(1)
+    def netcdf_to_zarr_temporal(self):
+        collection = 'C1238621141-POCLOUD'
+        variable = 'all'
+        params = {
+            'format': 'application/x-zarr',
+            'maxResults': '1',
+            'turbo': 'true'
+        }
+        response = self.client.get(
+            self.coverages_root.format(
+                collection=collection,
+                variable=variable
+            ),
+            params=params,
+            name='NetCDF to Zarr large granules'
         )
         self.wait_for_job_completion(response)

--- a/workload/locustfile.py
+++ b/workload/locustfile.py
@@ -1,11 +1,6 @@
-from locust import task, tag, events
-from time import time
+from locust import task, tag
 import urllib.parse
-import logging
-from pprint import pprint
-from harmony.common import BaseHarmonyUser, manual_report
-# , manual_report
-
+from harmony.common import BaseHarmonyUser
 
 class HarmonyUatUser(BaseHarmonyUser):
 
@@ -22,18 +17,10 @@ class HarmonyUatUser(BaseHarmonyUser):
             'outputCrs': 'EPSG:4326',
             'format': 'image/png'
         }
-        if turbo:
-            params['turbo'] = 'true'
-
-        self.client.get(
-            self.coverages_root.format(
-                collection=collection,
-                variable=variable),
-            params=params,
-            name=f'Turbo: {name}' if turbo else f'Argo: {name}')
+        self._sync_request(name, collection, variable, params, turbo, 1)
 
     def _swot_repr_europe(self, turbo=False):
-        name='SWOT Reprojection: Europe scale extent'
+        name = 'SWOT Reprojection: Europe scale extent'
         collection = 'C1233860183-EEDTEST'
         variable = 'all'
         params = {
@@ -42,40 +29,20 @@ class HarmonyUatUser(BaseHarmonyUser):
             'interpolation': 'near',
             'scaleExtent': '-7000000,1000000,8000000,8000000'
         }
-        if turbo:
-          params['turbo'] = 'true'
-
-        self.client.get(
-            self.coverages_root.format(
-                collection=collection,
-                variable=variable),
-            params=params,
-            name=f'Turbo: {name}' if turbo else f'Argo: {name}')
+        self._sync_request(name, collection, variable, params, turbo, 2)
 
     def _netcdf_to_zarr_10_granules(self, turbo=False):
         name = 'NetCDF-to-Zarr: 10 granules'
-        full_name = f'Turbo: {name}' if turbo else f'Argo: {name}'
         collection = 'harmony_example_l2'
         variable = 'all'
         params = {
             'format': 'application/x-zarr',
             'maxResults': '10'
         }
-        if turbo:
-          params['turbo'] = 'true'
-
-        start_time = time()
-        response = self.client.get(
-            self.coverages_root.format(
-                collection=collection,
-                variable=variable),
-            params=params,
-            name='ignore')
-        self.wait_for_job_completion(response, full_name, start_time)
+        self._async_request(name, collection, variable, params, turbo, 3)
 
     def _chain_swot_repr_europe_to_zarr(self, turbo=False):
         name = 'Chain SWOT Reprojection to NetCDF-to-Zarr'
-        full_name = f'Turbo: {name}' if turbo else f'Argo: {name}'
         collection = 'harmony_example_l2'
         variable = 'all'
         params = {
@@ -85,88 +52,75 @@ class HarmonyUatUser(BaseHarmonyUser):
             'scaleExtent': '-7000000,1000000,8000000,8000000',
             'format': 'application/x-zarr'
         }
-        if turbo:
-          params['turbo'] = 'true'
-
-        start_time = time()
-        response = self.client.get(
-            self.coverages_root.format(
-                collection=collection,
-                variable=variable),
-            params=params,
-            name='ignore')
-        self.wait_for_job_completion(response, full_name, start_time)
+        self._async_request(name, collection, variable, params, turbo, 4)
 
     def _netcdf_to_zarr_large_granule(self, turbo=False):
-        name='NetCDF to Zarr large granules'
-        full_name = f'Turbo: {name}' if turbo else f'Argo: {name}'
+        name = 'NetCDF to Zarr single large granule'
         collection = 'C1238621141-POCLOUD'
         variable = 'all'
         params = {
             'format': 'application/x-zarr',
             'maxResults': '1',
-            'turbo': 'true'
         }
-        if turbo:
-          params['turbo'] = 'true'
+        self._async_request(name, collection, variable, params, turbo, 5)
 
-        start_time = time()
-        response = self.client.get(
-            self.coverages_root.format(
-                collection=collection,
-                variable=variable
-            ),
-            params=params,
-            name='ignore')
-        self.wait_for_job_completion(response, full_name, start_time)
+    def _asf_gdal(self, turbo=False):
+        name = 'ASF GDAL'
+        collection = 'C1225776654-ASF'
+        variable = urllib.parse.quote('science/grids/data/amplitude', safe='')
+        params = {
+            'granuleId': 'G1235282694-ASF',
+            'subset': [
+                'lon(37:40)',
+                'lat(23:24)',
+                'time("2014-10-30T15:00:00Z":"2014-10-30T15:59:00Z")'
+            ]
+        }
+        self._sync_request(name, collection, variable, params, turbo, 6)
 
-    @tag('thetest2')
-    @task(2)
-    # @manual_report('manual report test')
-    # def the_test(self, turbo=False):
-    def the_test2(self):
-        name='The test: service-example'
-        full_name = f'Turbo: {name}' if turbo else f'Argo: {name}'
-        collection = 'C1233800302-EEDTEST'
-        variable = 'blue_var'
+    def _podaac_l2ss_sync_variable(self, turbo=False):
+        name = 'PODAAC L2SS mean sea surface'
+        collection = 'C1234208438-POCLOUD'
+        variable = 'mean_sea_surface'
+        params = {
+            'maxResults': 1,
+            'subset': [
+                'lon(-160:160)',
+                'lat(-80:80)'
+            ]
+        }
+        self._sync_request(name, collection, variable, params, turbo, 7)
+
+    def _var_subsetter(self, turbo=False):
+        name = 'Variable subsetter'
+        collection = 'C1234714698-EEDTEST'
+        variable = urllib.parse.quote('/gt1l/land_segments/canopy/h_canopy', safe='')
+        params = {
+            'granuleid': 'G1238479514-EEDTEST'
+        }
+        self._sync_request(name, collection, variable, params, turbo, 8)
+
+    def _podaac_l2ss_async_spatial_temporal(self, turbo=False):
+        name = 'PODAAC L2SS Async Spatial and Temporal'
+        collection = 'C1234724471-POCLOUD'
+        variable = 'all'
         params = {
             'subset': [
-                'lat(20:60)',
-                'lon(-140:-50)'
-            ],
-            'granuleId': 'G1233800343-EEDTEST',
-            'outputCrs': 'EPSG:4326',
-            'format': 'image/png',
-            'forceAsync': 'true',
-            'turbo': 'true'
+                'lat(81.7:83)',
+                'lon(-62.8:-56.4)',
+                'time("2019-06-22T00:00:00Z":"2019-06-22T23:59:59Z")'
+            ]
         }
-        turbo = True
+        self._async_request(name, collection, variable, params, turbo, 9)
 
-        # if turbo:
-        #   params['turbo'] = 'true'
-        start_time = time()
-        response = self.client.get(
-            self.coverages_root.format(
-                collection=collection,
-                variable=variable
-            ),
-            params=params,
-            name='ignore')
-            # initial_request_time = response.elapsed
-            # initial_request_time = response['response_time']
-            # logging.info('Response is: %s', response)
-            # pprint(vars(response))
-
-            # async_wait_time_start = time.perf_counter()
-        self.wait_for_job_completion(response, full_name, start_time)
-        # events.request.fire(
-        #     context=self.context,
-        #     request_type='async_job',
-        #     name='The custom thing',
-        #     response_time=(time() - start_time) * 1000,
-        #     response_length=0,
-        #     exception=None,
-        # )
+    def _netcdf_to_zarr_single_granule(self, turbo=False):
+        name='NetCDF to Zarr single granule'
+        collection = 'C1234082763-POCLOUD'
+        variable = 'all'
+        params = {
+            'maxResults': 1
+        }
+        self._async_request(name, collection, variable, params, turbo, 10)
 
     ############################################
     # Locust tasks
@@ -211,6 +165,72 @@ class HarmonyUatUser(BaseHarmonyUser):
     def chain_swot_repr_europe_to_zarr_turbo(self):
         self._chain_swot_repr_europe_to_zarr(True)
 
+    # Unable to download from ASF site in sandbox and SIT now
+    @tag('asf-gdal', 'sync', 'bbox', 'variable', 'temporal', 'hierarchical-variable', 'netcdf4', 'uat-only', 'argo')
+    @task(2)
+    def asf_gdal_argo(self):
+        self._asf_gdal()
+
+    # Unable to download from ASF site in sandbox and SIT now
+    @tag('asf-gdal', 'sync', 'bbox', 'variable', 'temporal', 'hierarchical-variable', 'netcdf4', 'uat-only', 'turbo')
+    @task(2)
+    def asf_gdal_argo(self):
+        self._asf_gdal(True)
+
+    @tag('var-subsetter', 'sync', 'variable', 'hierarchical-variable', 'netcdf4', 'argo')
+    @task(2)
+    def var_subsetter_argo(self):
+        self._var_subsetter()
+
+    # Service does not support turbo yet
+    # @tag('var-subsetter', 'sync', 'variable', 'hierarchical-variable', 'netcdf4', 'turbo')
+    # @task(2)
+    # def var_subsetter_turbo(self):
+    #     self._var_subsetter(True)
+
+    @tag('podaac-l2ss', 'bbox', 'sync', 'netcdf4', 'agu', 'variable', 'argo')
+    @task(2)
+    def podaac_l2ss_sync_variable_argo(self):
+        self._podaac_l2ss_sync_variable()
+
+    # Service does not support turbo yet
+    # @tag('podaac-l2ss', 'bbox', 'sync', 'netcdf4', 'agu', 'variable', 'turbo')
+    # @task(2)
+    # def podaac_l2ss_sync_variable_turbo(self):
+    #     self._podaac_l2ss_sync_variable(True)
+
+    @tag('podaac-l2ss', 'bbox', 'async', 'netcdf4', 'temporal', 'agu', 'argo')
+    @task(2)
+    def podaac_l2ss_async_spatial_temporal_argo(self):
+        self._podaac_l2ss_async_spatial_temporal()
+
+    # Service does not support turbo yet
+    # @tag('podaac-l2ss', 'bbox', 'async', 'netcdf4', 'temporal', 'agu', 'turbo')
+    # @task(2)
+    # def podaac_l2ss_async_spatial_temporal_turbo(self):
+    #     self._podaac_l2ss_async_spatial_temporal(True)
+
+    @tag('netcdf-to-zarr', 'async', 'zarr', 'agu', 'argo')
+    @task(2)
+    def netcdf_to_zarr_single_granule_argo(self):
+        self._netcdf_to_zarr_single_granule()
+
+    @tag('netcdf-to-zarr', 'async', 'zarr', 'agu', 'turbo')
+    @task(2)
+    def netcdf_to_zarr_single_granule_turbo(self):
+        self._netcdf_to_zarr_single_granule(True)
+
+    @tag('netcdf-to-zarr', 'async', 'zarr', 'argo', 'memory', 'slow')
+    @task(1)
+    def netcdf_to_zarr_large_granule_argo(self):
+        self._netcdf_to_zarr_large_granule()
+
+    @tag('netcdf-to-zarr', 'async', 'zarr', 'turbo', 'memory', 'slow')
+    @task(1)
+    def netcdf_to_zarr_large_granule_turbo(self):
+        self._netcdf_to_zarr_large_granule(True)
+
+    ## Shapefile request is currently not working
     # @tag('podaac-ps3', 'shapefile', 'sync', 'temporal', 'netcdf4')
     # @task(2)
     # def podaac_shapefile(self):
@@ -226,157 +246,4 @@ class HarmonyUatUser(BaseHarmonyUser):
     #         files={'shapefile': ('test_in-polygon.shp.zip',
     #                              open(shapefile_location, 'rb'), 'application/shapefile+zip')},
     #         name='PODAAC Shapefile Subsetter')
-
-    # @tag('podaac-l2ss', 'bbox', 'sync', 'netcdf4', 'agu', 'variable')
-    # @task(5)
-    # def podaac_l2ss_sync_variable(self):
-    #     collection = 'C1234208438-POCLOUD'
-    #     variable = 'mean_sea_surface'
-    #     params = {
-    #         'maxResults': 1,
-    #         'subset': [
-    #             'lon(-160:160)',
-    #             'lat(-80:80)'
-    #         ]
-    #     }
-    #     self.client.get(
-    #         self.coverages_root.format(
-    #             collection=collection,
-    #             variable=variable
-    #         ),
-    #         params=params,
-    #         name='PODAAC L2SS mean sea surface'
-    # )
-
-    # @tag('asf-gdal', 'sync', 'bbox', 'variable', 'temporal', 'hierarchical-variable', 'netcdf4')
-    # @task(2)
-    # def asf_gdal(self):
-    #     collection = 'C1225776654-ASF'
-    #     variable = urllib.parse.quote('science/grids/data/amplitude', safe='')
-    #     params = {
-    #         'granuleId': 'G1235282694-ASF',
-    #         'subset': [
-    #             'lon(37:40)',
-    #             'lat(23:24)',
-    #             'time("2014-10-30T15:00:00Z":"2014-10-30T15:59:00Z")'
-    #         ]
-    #     }
-    #     self.client.get(
-    #         self.coverages_root.format(
-    #             collection=collection,
-    #             variable=variable
-    #         ),
-    #         params=params,
-    #         name='ASF GDAL'
-    #     )
-
-    # @tag('var-subsetter', 'sync', 'variable', 'hierarchical-variable', 'netcdf4')
-    # @task(2)
-    # def var_subsetter(self):
-    #     collection = 'C1234714698-EEDTEST'
-    #     variable = urllib.parse.quote('/gt1l/land_segments/canopy/h_canopy', safe='')
-    #     params = {
-    #         'granuleid': 'G1238479514-EEDTEST'
-    #     }
-    #     self.client.get(
-    #         self.coverages_root.format(
-    #             collection=collection,
-    #             variable=variable
-    #         ),
-    #         params=params,
-    #         name='Variable subsetter'
-    # )
-
-    # @tag('podaac-l2ss', 'bbox', 'async', 'netcdf4')
-    # @task(5)
-    # def podaac_l2ss_async(self):
-    #     collection = 'C1234208436-POCLOUD'
-    #     variable = 'all'
-    #     params = {
-    #         'maxResults': 2,
-    #         'subset': [
-    #             'lon(-160:160)',
-    #             'lat(-80:80)'
-    #         ]
-    #     }
-    #     response = self.client.get(
-    #         self.coverages_root.format(
-    #             collection=collection,
-    #             variable=variable
-    #         ),
-    #         params=params,
-    #         name='PODAAC L2SS Async'
-    #     )
-    #     self.wait_for_job_completion(response)
-
-    # @tag('podaac-l2ss', 'bbox', 'async', 'netcdf4', 'temporal', 'agu')
-    # @task(1)
-    # def podaac_l2ss_async_spatial_temporal(self):
-    #     collection = 'C1234724471-POCLOUD'
-    #     variable = 'all'
-    #     params = {
-    #         'subset': [
-    #             'lat(81.7:83)',
-    #             'lon(-62.8:-56.4)',
-    #             'time("2019-06-22T00:00:00Z":"2019-06-22T23:59:59Z")'
-    #         ]
-    #     }
-    #     response = self.client.get(
-    #         self.coverages_root.format(
-    #             collection=collection,
-    #             variable=variable
-    #         ),
-    #         params=params,
-    #         name='PODAAC L2SS Async Spatial and Temporal'
-    #     )
-    #     self.wait_for_job_completion(response)
-
-    # @tag('netcdf-to-zarr', 'async', 'zarr', 'agu')
-    # @task(1)
-    # def netcdf_to_zarr_single_granule(self):
-    #     collection = 'C1234082763-POCLOUD'
-    #     variable = 'all'
-    #     params = {
-    #         'maxResults': 1
-    #     }
-    #     response = self.client.get(
-    #         self.coverages_root.format(
-    #             collection=collection,
-    #             variable=variable
-    #         ),
-    #         params=params,
-    #         name='NetCDF to Zarr single granule'
-    #     )
-    #     self.wait_for_job_completion(response)
-
-    # @tag('netcdf-to-zarr', 'async', 'zarr', 'agu', 'temporal')
-    # @task(1)
-    # def netcdf_to_zarr_temporal(self):
-    #     collection = 'C1234410736-POCLOUD'
-    #     variable = 'all'
-    #     params = {
-    #         'subset': [
-    #           'time("2020-01-01T00:00:00.000Z":"2020-01-02T00:00:00.000Z")'
-    #         ]
-    #     }
-    #     response = self.client.get(
-    #         self.coverages_root.format(
-    #             collection=collection,
-    #             variable=variable
-    #         ),
-    #         params=params,
-    #         name='NetCDF to Zarr temporal subset'
-    #     )
-    #     self.wait_for_job_completion(response)
-
-
-    @tag('netcdf-to-zarr', 'async', 'zarr', 'argo', 'memory', 'slow')
-    @task(1)
-    def netcdf_to_zarr_large_granule_argo(self):
-        self._netcdf_to_zarr_large_granule()
-
-    @tag('netcdf-to-zarr', 'async', 'zarr', 'turbo', 'memory', 'slow')
-    @task(1)
-    def netcdf_to_zarr_large_granule_turbo(self):
-        self._netcdf_to_zarr_large_granule(True)
 

--- a/workload/requirements.txt
+++ b/workload/requirements.txt
@@ -1,4 +1,4 @@
-locust ~= 1.3.1
+locust ~= 2.2.3
 pysocks ~= 1.7.1
 pandas ~= 1.1.4
 plotly-express ~= 0.4.1


### PR DESCRIPTION
Here's a screenshot of the locust results with 25 concurrent users running against my sandbox with:

```
locust --exclude-tags uat-only
```
![image](https://user-images.githubusercontent.com/4248343/134706888-8a6e1f04-beb2-41c2-8f84-42b9a948431c.png)

We'll plan to address auto-scaling pods based on the load of the individual services, but otherwise no issues related to turbo were observed.

Note this PR also makes it possible to track the performance of asynchronous requests by adding a manual 'async_job' metric event.