### PR TITLE
HARMONY-1005: Fix query CMR manual invocation example errors

### DIFF
--- a/tasks/query-cmr/README.md
+++ b/tasks/query-cmr/README.md
@@ -13,7 +13,7 @@ To build and run in Docker:
 
 ```
 npm run build
-npm run docker-example -- --harmony-input "$(cat example/message.json)" --query example/query.json -o temp
+npm run docker-example -- --harmony-input '$(cat example/message.json)' --query example/query.json -o temp
 ```
 
 To test:

--- a/tasks/query-cmr/package.json
+++ b/tasks/query-cmr/package.json
@@ -8,7 +8,7 @@
     "test-fast": "TS_NODE_TRANSPILE_ONLY=true mocha",
     "lint": "eslint --ext .ts .",
     "coverage": "nyc mocha",
-    "docker-example": "docker run --rm -it --env SHARED_SECRET_KEY=foo -v $(pwd)/example:/app/example -v $(pwd)/temp:/app/temp harmonyservices/query-cmr:${VERSION:-latest}",
+    "docker-example": "docker run --rm -it --env SHARED_SECRET_KEY=foo --env CMR_ENDPOINT='https://cmr.uat.earthdata.nasa.gov' -v $(pwd)/example:/app/example -v $(pwd)/temp:/app/temp harmonyservices/query-cmr:${VERSION:-latest}",
     "build": "tsc && docker build -t harmonyservices/query-cmr:${VERSION:-latest} .",
     "publish": "docker push harmonyservices/query-cmr:${VERSION:-latest}"
   },


### PR DESCRIPTION
Switching '$(cat example/message.json)' to single quoting fixed the JSON parse error, which was due to some double escaping of the JSON input.

(If there's a better way to do this in bash please enlighten me.) 

Passing `--env CMR_ENDPOINT='https://cmr.uat.earthdata.nasa.gov'` to the docker run command fixed the "Only absolute URLs are supported" error because the env variable was simply blank.