### PR TITLE
HARMONY-931: Finish setting up PODAAC L2 Subsetter as a turbo service.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -203,7 +203,7 @@ https://cmr.earthdata.nasa.gov:
       reprojection: true
 
   - name: podaac/l2-subsetter
-    data_operation_version: '0.9.0'
+    data_operation_version: '0.11.0'
     type:
       <<: *default-argo-config
       params:
@@ -245,6 +245,10 @@ https://cmr.earthdata.nasa.gov:
       output_formats:
         - application/netcdf # Incorrect mime-type, remove when no longer needed
         - application/x-netcdf4
+    steps:
+      - image: !Env ${CMR_GRANULE_LOCATOR_IMAGE}
+      - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
+
 
 https://cmr.uat.earthdata.nasa.gov:
 
@@ -355,7 +359,7 @@ https://cmr.uat.earthdata.nasa.gov:
       - image: !Env ${HARMONY_SERVICE_EXAMPLE_IMAGE}
 
   - name: podaac/l2-subsetter
-    data_operation_version: '0.9.0'
+    data_operation_version: '0.11.0'
     type:
       <<: *default-argo-config
       params:


### PR DESCRIPTION
To test locally with the l2 subsetter - add podaac-l2-subsetter to the list of deployed services (`LOCALLY_DEPLOYED_SERVICES` in .env).

I tested locally and in my own sandbox with the following request:
http://localhost:3000/C1238538241-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-45%3A45)&subset=lon(0%3A180)&maxResults=1&turbo=true

Note few changes were required because in prior PRs services.yml had been updated to allow turbo in some of the podaac-l2-subsetter service chains. 