### PR TITLE
Harmony 960 wait for all inputs to aggregation

### DIFF
--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -7,7 +7,7 @@ import { readCatalogItems } from '../util/stac';
 import HarmonyRequest from '../models/harmony-request';
 import { Job, JobStatus } from '../models/job';
 import JobLink from '../models/job-link';
-import WorkItem, { getNextWorkItem, WorkItemStatus, updateWorkItemStatus, getWorkItemById, workItemCountForStep } from '../models/work-item';
+import WorkItem, { getNextWorkItem, WorkItemStatus, updateWorkItemStatus, getWorkItemById, workItemCountForStep, WORK_ITEM_SUCCESS_STATUSES } from '../models/work-item';
 import WorkflowStep, { getWorkflowStepByJobIdStepIndex } from '../models/workflow-steps';
 
 const MAX_TRY_COUNT = 1;
@@ -118,6 +118,7 @@ async function createNextWorkItems(
     return createAggregatingWorkItem(tx, currentWorkItem, nextStep, results);
   } else {
     // Create a new work item for each result using the next step
+    // FIXME Do this as a bulk insertion when working NO GRANULES LIMIT TICKET (HARMONY-276)
     for await (const result of results) {
       const newWorkItem = new WorkItem({
         jobID: currentWorkItem.jobID,
@@ -190,7 +191,7 @@ export async function updateWorkItem(req: HarmonyRequest, res: Response): Promis
         tx,
         workItem.jobID,
         workItem.workflowStepIndex,
-        WorkItemStatus.SUCCESSFUL,
+        WORK_ITEM_SUCCESS_STATUSES,
       );
       const thisStep = await getWorkflowStepByJobIdStepIndex(
         tx,

--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -7,7 +7,7 @@ import { readCatalogItems } from '../util/stac';
 import HarmonyRequest from '../models/harmony-request';
 import { Job, JobStatus } from '../models/job';
 import JobLink from '../models/job-link';
-import WorkItem, { getNextWorkItem, WorkItemStatus, updateWorkItemStatus, getWorkItemById, workItemCountForStep, WORK_ITEM_SUCCESS_STATUSES } from '../models/work-item';
+import WorkItem, { getNextWorkItem, WorkItemStatus, updateWorkItemStatus, getWorkItemById, workItemCountForStep, SUCCESSFUL_WORK_ITEM_STATUSES } from '../models/work-item';
 import WorkflowStep, { getWorkflowStepByJobIdStepIndex } from '../models/workflow-steps';
 
 const MAX_TRY_COUNT = 1;
@@ -191,7 +191,7 @@ export async function updateWorkItem(req: HarmonyRequest, res: Response): Promis
         tx,
         workItem.jobID,
         workItem.workflowStepIndex,
-        WORK_ITEM_SUCCESS_STATUSES,
+        SUCCESSFUL_WORK_ITEM_STATUSES,
       );
       const thisStep = await getWorkflowStepByJobIdStepIndex(
         tx,

--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -81,6 +81,7 @@ async function _handleWorkItemResults(
 }
 
 /**
+ * Creates a work item that uses all the output of the previous step.
  * 
  * @param tx - The database transaction
  * @param currentWorkItem - The current work item

--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -81,26 +81,53 @@ async function _handleWorkItemResults(
 }
 
 /**
+ * 
+ * @param tx - The database transaction
+ * @param currentWorkItem - The current work item
+ * @param nextStep - the next step in the workflow
+ * @param results - an array of paths to STAC catalogs
+ */
+async function createAggregatingWorkItem(
+  tx: Transaction, currentWorkItem: WorkItem, nextStep: WorkflowStep, results: string[],
+): Promise<void> {
+  // TODO use ALL outputs from the prior step here (HARMONY-961)
+  // just use the first result of the current output for now
+  const newWorkItem = new WorkItem({
+    jobID: currentWorkItem.jobID,
+    serviceID: nextStep.serviceID,
+    status: WorkItemStatus.READY,
+    stacCatalogLocation: results[0],
+    workflowStepIndex: nextStep.stepIndex,
+  });
+
+  await newWorkItem.save(tx);
+}
+
+/**
  * Creates the next work items for the workflow based on the results of the current step
  * @param tx - The database transaction
  * @param currentWorkItem - The current work item
  * @param nextStep - the next step in the workflow
  * @param results - an array of paths to STAC catalogs
  */
-async function _createNextWorkItems(
+async function createNextWorkItems(
   tx: Transaction, currentWorkItem: WorkItem, nextStep: WorkflowStep, results: string[],
 ): Promise<void> {
-  // Create a new work item for each result using the next step
-  for await (const result of results) {
-    const newWorkItem = new WorkItem({
-      jobID: currentWorkItem.jobID,
-      serviceID: nextStep.serviceID,
-      status: WorkItemStatus.READY,
-      stacCatalogLocation: result,
-      workflowStepIndex: nextStep.stepIndex,
-    });
+  if (nextStep.hasAggregatedOutput) {
+    return createAggregatingWorkItem(tx, currentWorkItem, nextStep, results);
+  } else {
+    // Create a new work item for each result using the next step
+    for await (const result of results) {
+      const newWorkItem = new WorkItem({
+        jobID: currentWorkItem.jobID,
+        serviceID: nextStep.serviceID,
+        status: WorkItemStatus.READY,
+        stacCatalogLocation: result,
+        workflowStepIndex: nextStep.stepIndex,
+      });
 
-    await newWorkItem.save(tx);
+      await newWorkItem.save(tx);
+    }
   }
 
   // If the current step is the query-cmr service and the number of work items for the next
@@ -158,25 +185,29 @@ export async function updateWorkItem(req: HarmonyRequest, res: Response): Promis
         workItem.workflowStepIndex + 1,
       );
 
+      const successWorkItemCount = await workItemCountForStep(
+        tx,
+        workItem.jobID,
+        workItem.workflowStepIndex,
+        WorkItemStatus.SUCCESSFUL,
+      );
+      const thisStep = await getWorkflowStepByJobIdStepIndex(
+        tx,
+        workItem.jobID,
+        workItem.workflowStepIndex,
+      );
+
       if (nextStep) {
-        await _createNextWorkItems(tx, workItem, nextStep, results);
+        // if we have completed all the work items for this step or if the next step does not
+        // aggregate then create a work item for the next step
+        if (successWorkItemCount === thisStep.workItemCount || !nextStep.hasAggregatedOutput) {
+          await createNextWorkItems(tx, workItem, nextStep, results);
+        }
       } else {
         // 1. add job links for the results
         await _handleWorkItemResults(tx, job, results, logger);
         // 2. If the number of work items with status 'successful' equals 'workItemCount'
         //    for the current step (which is the last) then set the job status to 'complete'.
-        const successWorkItemCount = await workItemCountForStep(
-          tx,
-          workItem.jobID,
-          workItem.workflowStepIndex,
-          WorkItemStatus.SUCCESSFUL,
-        );
-        const thisStep = await getWorkflowStepByJobIdStepIndex(
-          tx,
-          workItem.jobID,
-          workItem.workflowStepIndex,
-        );
-
         job.completeBatch(thisStep.workItemCount);
         if (successWorkItemCount === thisStep.workItemCount) {
           await completeJob(tx, job, JobStatus.SUCCESSFUL, logger);

--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -314,7 +314,7 @@ export default abstract class BaseService<ServiceParamType> {
   }
 
   /**
-   * Return the number of work items that should be created for a give step
+   * Return the number of work items that should be created for a given step
    * 
    * @param step - workflow service step
    * @returns  the number of work items for the given step

--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -314,6 +314,23 @@ export default abstract class BaseService<ServiceParamType> {
   }
 
   /**
+   * Return the number of work items that should be created for a give step
+   * 
+   * @param step - workflow service step
+   * @returns  the number of work items for the given step
+   */
+  protected _workItemCountForStep(step: ServiceStep): number {
+    const regex = /query\-cmr/;
+    // query-cmr number of work items is a function of the page size and total granules
+    if (step.image.match(regex)) {
+      return Math.ceil(this.numInputGranules / env.cmrMaxPageSize);
+    } else if (stepHasAggregatedOutput(step)) {
+      return 1;
+    }
+    return this.numInputGranules;
+  }
+
+  /**
    * Creates the workflow steps objects for this request
    *
    * @returns The created WorkItem for the query CMR job
@@ -330,7 +347,7 @@ export default abstract class BaseService<ServiceParamType> {
             jobID: this.operation.requestId,
             serviceID: serviceImageToId(step.image),
             stepIndex: i,
-            workItemCount: this.numInputGranules,
+            workItemCount: this._workItemCountForStep(step),
             operation: this.operation.serialize(
               this.config.data_operation_version,
               step.operations || [],

--- a/test/workflow-orchestration.ts
+++ b/test/workflow-orchestration.ts
@@ -61,7 +61,7 @@ describe('When a workflow contains an aggregating step', async function () {
 
   describe('and a work item for the first step is completed', async function () {
     describe('and it is not the last work item for the step', async function () {
-      it('the next step has no work available', async function () {
+      it('does not supply work for the next step', async function () {
 
         const nextStepWorkResponse = await getWorkForService(this.backend, aggregateService);
         expect(nextStepWorkResponse.statusCode).to.equal(404);
@@ -69,7 +69,7 @@ describe('When a workflow contains an aggregating step', async function () {
     });
 
     describe('and it is the last work item for the step', async function () {
-      it('the next step has exactly one work item available', async function () {
+      it('supplies exactly one work item for the next step', async function () {
         const savedWorkItemResp = await getWorkForService(this.backend, 'foo');
         const savedWorkItem = JSON.parse(savedWorkItemResp.text);
         savedWorkItem.status = WorkItemStatus.SUCCESSFUL;

--- a/test/workflow-orchestration.ts
+++ b/test/workflow-orchestration.ts
@@ -22,25 +22,27 @@ describe('When a workflow contains an aggregating step', async function () {
     await buildWorkflowStep({
       jobID: job.jobID,
       serviceID: 'foo',
-      stepIndex: 0,
+      stepIndex: 1,
       workItemCount: 2,
     }).save(db);
 
     await buildWorkflowStep({
       jobID: job.jobID,
       serviceID: aggregateService,
-      stepIndex: 1,
+      stepIndex: 2,
       hasAggregatedOutput: true,
     }).save(db);
 
     await buildWorkItem({
       jobID: job.jobID,
       serviceID: 'foo',
+      workflowStepIndex: 1,
     }).save(db);
 
     await buildWorkItem({
       jobID: job.jobID,
       serviceID: 'foo',
+      workflowStepIndex: 1,
     }).save(db);
     const savedWorkItemResp = await getWorkForService(this.backend, 'foo');
     const savedWorkItem = JSON.parse(savedWorkItemResp.text);
@@ -54,7 +56,6 @@ describe('When a workflow contains an aggregating step', async function () {
   });
 
   this.afterEach(async function () {
-    // await knex('work_items').whereIn('id', [1, 2]).del();
     await db.table('work_items').del();
   });
 

--- a/test/workflow-orchestration.ts
+++ b/test/workflow-orchestration.ts
@@ -6,7 +6,89 @@ import { Job, JobStatus } from '../app/models/job';
 import { hookRedirect } from './helpers/hooks';
 import { hookRangesetRequest } from './helpers/ogc-api-coverages';
 import hookServersStartStop from './helpers/servers';
-import { getWorkForService, hookGetWorkForService, updateWorkItem } from './helpers/work-items';
+import { buildWorkItem, getWorkForService, hookGetWorkForService, updateWorkItem } from './helpers/work-items';
+import { buildWorkflowStep } from './helpers/workflow-steps';
+import { buildJob } from './helpers/jobs';
+
+describe('When a workflow contains an aggregating step', async function () {
+  const aggregateService = 'bar';
+  hookServersStartStop();
+
+  beforeEach(async function () {
+    const job = buildJob();
+    await job.save(db);
+    this.jobID = job.jobID;
+
+    await buildWorkflowStep({
+      jobID: job.jobID,
+      serviceID: 'foo',
+      stepIndex: 0,
+      workItemCount: 2,
+    }).save(db);
+
+    await buildWorkflowStep({
+      jobID: job.jobID,
+      serviceID: aggregateService,
+      stepIndex: 1,
+      hasAggregatedOutput: true,
+    }).save(db);
+
+    await buildWorkItem({
+      jobID: job.jobID,
+      serviceID: 'foo',
+    }).save(db);
+
+    await buildWorkItem({
+      jobID: job.jobID,
+      serviceID: 'foo',
+    }).save(db);
+    const savedWorkItemResp = await getWorkForService(this.backend, 'foo');
+    const savedWorkItem = JSON.parse(savedWorkItemResp.text);
+    savedWorkItem.status = WorkItemStatus.SUCCESSFUL;
+    savedWorkItem.results = [
+      'test/resources/worker-response-sample/catalog0.json',
+      'test/resources/worker-response-sample/catalog1.json',
+      'test/resources/worker-response-sample/catalog2.json',
+    ];
+    await updateWorkItem(this.backend, savedWorkItem);
+  });
+
+  this.afterEach(async function () {
+    // await knex('work_items').whereIn('id', [1, 2]).del();
+    await db.table('work_items').del();
+  });
+
+  describe('and a work item for the first step is completed', async function () {
+    describe('and it is not the last work item for the step', async function () {
+      it('the next step has no work available', async function () {
+
+        const nextStepWorkResponse = await getWorkForService(this.backend, aggregateService);
+        expect(nextStepWorkResponse.statusCode).to.equal(404);
+      });
+    });
+
+    describe('and it is the last work item for the step', async function () {
+      it('the next step has exactly one work item available', async function () {
+        const savedWorkItemResp = await getWorkForService(this.backend, 'foo');
+        const savedWorkItem = JSON.parse(savedWorkItemResp.text);
+        savedWorkItem.status = WorkItemStatus.SUCCESSFUL;
+        savedWorkItem.results = [
+          'test/resources/worker-response-sample/catalog0.json',
+          'test/resources/worker-response-sample/catalog1.json',
+          'test/resources/worker-response-sample/catalog2.json',
+        ];
+        await updateWorkItem(this.backend, savedWorkItem);
+
+        // one work item available
+        const nextStepWorkResponse = await getWorkForService(this.backend, aggregateService);
+        expect(nextStepWorkResponse.statusCode).to.equal(200);
+
+        const secondNextStepWorkResponse = await getWorkForService(this.backend, aggregateService);
+        expect(secondNextStepWorkResponse.statusCode).to.equal(404);
+      });
+    });
+  });
+});
 
 describe('Workflow chaining for a collection configured for swot reprojection and netcdf-to-zarr', function () {
   const collection = 'C1233800302-EEDTEST';


### PR DESCRIPTION
This ticket has a single AC:

- When a step in a job is marked as an aggregated output job, Harmony does not invoke it until all prior steps complete

The work item that is generated for the aggregation step currently does not use all the output from the preceding step (although it does wait for all the output). That is the subject of HARMONY-961.