### PR TITLE
HARMONY=976: Add 'publish' to github actions for service-runner

### DIFF
--- a/tasks/service-runner/package.json
+++ b/tasks/service-runner/package.json
@@ -9,7 +9,8 @@
     "test-fast": "TS_NODE_TRANSPILE_ONLY=true mocha --timeout 5000",
     "lint": "eslint --ext .ts .",
     "coverage": "nyc mocha --timeout 5000",
-    "build": "tsc && docker build --tag harmonyservices/service-runner:${VERSION:-latest} ."
+    "build": "tsc && docker build --tag harmonyservices/service-runner:${VERSION:-latest} .",
+    "publish": "docker push harmonyservices/service-runner:${VERSION:-latest}"
   },
   "engines": {
     "node": "^12.14.1",


### PR DESCRIPTION
Simple change to add a publish action to package.json for the service runner so we can publish it to DockerHub