### PR TITLE
Harmony 1030

### DIFF
--- a/app/middleware/cmr-granule-locator.ts
+++ b/app/middleware/cmr-granule-locator.ts
@@ -278,7 +278,7 @@ async function cmrGranuleLocatorArgo(
 export default async function cmrGranuleLocator(
   req: HarmonyRequest, res: ServerResponse, next: NextFunction,
 ): Promise<void> {
-  if (req.query.turbo === 'true') {
+  if (req.query.turbo === 'true' && !(req.context.serviceConfig.name === 'noOpService')) {
     await cmrGranuleLocatorNew(req, res, next);
   } else {
     await cmrGranuleLocatorArgo(req, res, next);

--- a/test/ogc-api-coverages/get-coverage-rangeset.ts
+++ b/test/ogc-api-coverages/get-coverage-rangeset.ts
@@ -932,7 +932,7 @@ describe('OGC API Coverages - getCoverageRangeset with a collection not configur
 
   hookServersStartStop();
 
-  // TODO Added for HARMONY-976. Remove this when working HARMONY-968
+  // TODO Added for HARMONY-1030. Remove this when working HARMONY-968
   describe('when running in turbo mode', function () {
     hookRangesetRequest(version, collection, 'all', { username: 'joe', query: { turbo: true } });
     it('returns a 200 successful response', function () {

--- a/test/ogc-api-coverages/get-coverage-rangeset.ts
+++ b/test/ogc-api-coverages/get-coverage-rangeset.ts
@@ -932,6 +932,46 @@ describe('OGC API Coverages - getCoverageRangeset with a collection not configur
 
   hookServersStartStop();
 
+  // TODO Added for HARMONY-976. Remove this when working HARMONY-968
+  describe('when running in turbo mode', function () {
+    hookRangesetRequest(version, collection, 'all', { username: 'joe', query: { turbo: true } });
+    it('returns a 200 successful response', function () {
+      expect(this.res.status).to.equal(200);
+    });
+    it('returns a JSON body in the format of a job status without a job ID', function () {
+      const job = JSON.parse(this.res.text);
+      expect(Object.keys(job)).to.eql(expectedNoOpJobKeys);
+    });
+    it('returns a successful status', function () {
+      const job = JSON.parse(this.res.text);
+      expect(job.status).to.eql('successful');
+    });
+    it('returns 100 for progress', function () {
+      const job = JSON.parse(this.res.text);
+      expect(job.progress).to.eql(100);
+    });
+    it('returns the number of CMR hits as the number of input granules', function () {
+      const job = JSON.parse(this.res.text);
+      expect(job.numInputGranules).to.eql(39);
+    });
+    it('returns a message when results are truncated', function () {
+      const job = JSON.parse(this.res.text);
+      expect(job.message).to.eql('Returning direct download links because no operations can be performed on C446474-ORNL_DAAC.');
+    });
+    it('returns granule links', function () {
+      const job = JSON.parse(this.res.text);
+      expect(job.links.length).to.equal(39);
+    });
+    it('granule links include a title of the granuleId', function () {
+      const job = JSON.parse(this.res.text);
+      expect(job.links[0].title).to.equal('G1239610894-ORNL_DAAC');
+    });
+    it('granule links include a download link', function () {
+      const job = JSON.parse(this.res.text);
+      expect(job.links[0].href).to.not.equal(undefined);
+    });
+  });
+
   describe('when provided a valid set of parameters', function () {
     hookRangesetRequest(version, collection, 'all', { username: 'joe' });
 


### PR DESCRIPTION
Use argo granule locator instead of turbo for no-op service even if turbo mode is requested. This is necessary because the no-op service cannot handle the scroll-id sent by the new granule locator.