### PR TITLE
Add collections to uat podaac/l2-subsetter-concise

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -589,6 +589,11 @@ https://cmr.uat.earthdata.nasa.gov:
       - C1234208436-POCLOUD
       - C1234208437-POCLOUD
       - C1234208438-POCLOUD
+      - C1234724470-POCLOUD
+      - C1234724471-POCLOUD
+      - C1238621102-POCLOUD
+      - C1234071416-POCLOUD
+      - C1238658052-POCLOUD
     capabilities:
       concatenation: true
       subsetting:


### PR DESCRIPTION
This PR adds POCLOUD collections to the uat podaac/l2-subsetter-concise service.