### PR TITLE
Harmony 979 - Add HPAs (horizontal pod autoscalers)

### DIFF
--- a/bin/deploy-hpa
+++ b/bin/deploy-hpa
@@ -19,7 +19,6 @@ envsubst < $file | kubectl apply -f - -n harmony
 # create the other autoscalers
 for service in ${LOCALLY_DEPLOYED_SERVICES//,/ }
 do
-  # set up enviornment variables for service
   export SERVICE_NAME=${service}
   envsubst < $file | kubectl apply -f - -n harmony
 done

--- a/bin/deploy-hpa
+++ b/bin/deploy-hpa
@@ -10,6 +10,9 @@ fi
 set +a
 eval "$env_save"
 
+# ensure that prometheus and the prometheus adapter have started
+. ./bin/deploy-prometheus
+
 file="config/hpa.yaml"
 
 # create the query-cmr autoscaler

--- a/bin/deploy-hpa
+++ b/bin/deploy-hpa
@@ -13,7 +13,6 @@ eval "$env_save"
 file="config/hpa.yaml"
 
 # create the query-cmr autoscaler
-echo "Deploying HPA for query-cmr"
 export SERVICE_NAME="query-cmr"
 envsubst < $file | kubectl apply -f - -n harmony
 
@@ -22,6 +21,5 @@ for service in ${LOCALLY_DEPLOYED_SERVICES//,/ }
 do
   # set up enviornment variables for service
   export SERVICE_NAME=${service}
-  echo "Deploying HPA for $service"
   envsubst < $file | kubectl apply -f - -n harmony
 done

--- a/bin/deploy-hpa
+++ b/bin/deploy-hpa
@@ -1,0 +1,27 @@
+#!/bin/bash
+# deploy horizontal pod autoscalers for locally deployed services and query-cmr
+
+env_save=$(export -p)
+set -a
+source "env-defaults"
+if [ -f ".env" ]; then
+source ".env"
+fi
+set +a
+eval "$env_save"
+
+file="config/hpa.yaml"
+
+# create the query-cmr autoscaler
+echo "Deploying HPA for query-cmr"
+export SERVICE_NAME="query-cmr"
+envsubst < $file | kubectl apply -f - -n harmony
+
+# create the other autoscalers
+for service in ${LOCALLY_DEPLOYED_SERVICES//,/ }
+do
+  # set up enviornment variables for service
+  export SERVICE_NAME=${service}
+  echo "Deploying HPA for $service"
+  envsubst < $file | kubectl apply -f - -n harmony
+done

--- a/config/hpa.yaml
+++ b/config/hpa.yaml
@@ -4,6 +4,23 @@ metadata:
   name: $SERVICE_NAME
   namespace: harmony
 spec:
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: 5
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 5
+    scaleUp:
+      stabilizationWindowSeconds: 0
+      policies:
+      - type: Percent
+        value: 100
+        periodSeconds: 5
+      - type: Pods
+        value: 4
+        periodSeconds: 5
+      selectPolicy: Max
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
@@ -11,10 +28,15 @@ spec:
   minReplicas: $HPA_MIN_REPLICAS
   maxReplicas: $HPA_MAX_REPLICAS
   metrics:
-  - type: Pods
-    pods:
+  - type: Object
+    object:
+      describedObject:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: $SERVICE_NAME
       target:
         type: AverageValue
         averageValue: $HPA_TARGET_VALUE
       metric:
-        name: num_ready_work_items_avg
+        name: num_ready_work_items
+        selector: {matchLabels: {name: $SERVICE_NAME}}

--- a/config/hpa.yaml
+++ b/config/hpa.yaml
@@ -1,0 +1,20 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: $SERVICE_NAME
+  namespace: harmony
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: $SERVICE_NAME 
+  minReplicas: $HPA_MIN_REPLICAS
+  maxReplicas: $HPA_MAX_REPLICAS
+  metrics:
+  - type: Pods
+    pods:
+      target:
+        type: AverageValue
+        averageValue: $HPA_TARGET_VALUE
+      metric:
+        name: num_ready_work_items_avg

--- a/config/hpa.yaml
+++ b/config/hpa.yaml
@@ -4,23 +4,6 @@ metadata:
   name: $SERVICE_NAME
   namespace: harmony
 spec:
-  behavior:
-    scaleDown:
-      stabilizationWindowSeconds: 5
-      policies:
-      - type: Percent
-        value: 100
-        periodSeconds: 5
-    scaleUp:
-      stabilizationWindowSeconds: 0
-      policies:
-      - type: Percent
-        value: 100
-        periodSeconds: 5
-      - type: Pods
-        value: 4
-        periodSeconds: 5
-      selectPolicy: Max
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/config/hpa.yaml
+++ b/config/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: $SERVICE_NAME

--- a/config/prometheus-adapter-helm-values.yaml
+++ b/config/prometheus-adapter-helm-values.yaml
@@ -11,7 +11,8 @@ rules:
       overrides:
         kubernetes_namespace: {resource: "namespace"}
         kubernetes_pod_name: {resource: "pod"}
+        name: {group: "apps", resource: "deployment"}
     name:
       matches: "num_ready_work_items"
-      as: "num_ready_work_items_avg"
-    metricsQuery: 'avg_over_time(<<.Series>>{<<.LabelMatchers>>}[2m])'
+      as: "num_ready_work_items"
+    metricsQuery: '<<.Series>>{<<.LabelMatchers>>}'

--- a/env-defaults
+++ b/env-defaults
@@ -349,8 +349,11 @@ PROMETHEUS_POD_MANAGER_SCRAPE_INTERVAL=15s
 ###########################################################################
 
 HPA_MIN_REPLICAS=1
-HPA_MAX_REPLICAS=4
-HPA_TARGET_VALUE=100
+HPA_MAX_REPLICAS=10
+
+# See https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/#Quantity
+# for an explanation of the "m" suffix 
+HPA_TARGET_VALUE=10000m
 
 #############################################################################
 #                        OAuth 2 (Earthdata Login)                          #

--- a/env-defaults
+++ b/env-defaults
@@ -341,6 +341,17 @@ PROMETHEUS_LIMITS_EPHEMERAL_STORAGE=500Mi
 PROMETHEUS_PROMETHEUS_SCRAPE_INTERVAL=15s
 PROMETHEUS_POD_MANAGER_SCRAPE_INTERVAL=15s
 
+###########################################################################
+#             Horizontal Pod Autoscaling Config                           #
+#                                                                         #
+# Variables that are used to configure scaling for service pods           #
+#                                                                         #
+###########################################################################
+
+HPA_MIN_REPLICAS=1
+HPA_MAX_REPLICAS=4
+HPA_TARGET_VALUE=100
+
 #############################################################################
 #                        OAuth 2 (Earthdata Login)                          #
 #                                                                           #


### PR DESCRIPTION
This allows us to use the HPAs locally. (The corresponding CICD PR will be forthcoming.) To test this out locally:

- start Harmony as usual
- `bin/deploy-prometheus`
- `bin/deploy-hpa` (deploys HPA for each LOCALLY_DEPLOYED_SERVICES and query-cmr)
- try a request, e.g. http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=100
- `kubectl describe hpa harmony-service-example -n harmony` or something similar in order to see the scaling in action
- optionally `kubectl port-forward pod/prometheus-6f8dccc575-lsqjs 9090:9090 -n monitoring` (substituting your Prometheus pod name) in order to view the graph of num_ready_work_items over time, using a PromQL query like `num_ready_work_items{name="harmony-service-example"}`

The HPAs are configured with an env variable HPA_TARGET_VALUE to target an average value of 10,000m or 10 work items per pod in a service. For deployed environments we'll probably want that number to be higher.

In prometheus-adapter-helm-values.yaml, I removed the avg_over_time function in favor of k8s built in mechanism (`stabilizationWindowSeconds`) to prevent thrashing (or flapping) https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#stabilization-window. From what I understand, they have set `stabilizationWindowSeconds` to a sensible default, but we can change that as desired using the `behavior` portion of the YAML spec. For simplicity sake I would vote that we start with 1 mechanism for preventing thrashing, but I'm happy to use avg_over_time instead if others think that'd work better.

If you use kubectl to describe the HPA, you should see something like this in the event logs, indicating that the HPA has scaled up the service and then scaled down the service:

```
Normal   SuccessfulRescale             6m28s                horizontal-pod-autoscaler  New size: 5; reason: external metric num_ready_work_items(&LabelSelector{MatchLabels:map[string]string{name: harmony-service-example,},MatchExpressions:[]LabelSelectorRequirement{},}) above target
Normal   SuccessfulRescale             5m28s                horizontal-pod-autoscaler  New size: 8; reason: external metric num_ready_work_items(&LabelSelector{MatchLabels:map[string]string{name: harmony-service-example,},MatchExpressions:[]LabelSelectorRequirement{},}) above target
Normal   SuccessfulRescale             4m28s (x3 over 18h)  horizontal-pod-autoscaler  New size: 6; reason: All metrics below target
Normal   SuccessfulRescale             3m28s (x2 over 15h)  horizontal-pod-autoscaler  New size: 3; reason: All metrics below target
Normal   SuccessfulRescale             2m28s (x6 over 19h)  horizontal-pod-autoscaler  New size: 1; reason: All metrics below target
```

The scaling algorithm works using this formula:
```
desiredReplicas = ceil[currentReplicas * ( currentMetricValue / desiredMetricValue )]
```
In our case, `currentMetricValue = num_ready_work_items / currentPodCount`, and `desiredMetricValue = 10`:

When you `kubectl describe` the HPA, it will display this metric:
```
Metrics:                                                                                ( current / target )
  "num_ready_work_items" on Deployment/harmony-service-example (target average value):  15400m / 10
```
In this case 15400m means that the HPA calculated that there are 15 work items per pod (15,400m / 10,000m), and it will keep scaling up or down until the ceil of this ratio = 1.

Due to the default scaling behavior, in practice the HPA will only scale up by maximum increments of 4 pods (https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#default-behavior).