### PR TITLE
Harmony 1054 pod counts

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -35,18 +35,9 @@ that is scraped by Prometheus, `num_ready_work_items`, which is the number of wo
 given service that are in the 'READY' state (i.e., available to be worked but not yet being worked).
 It can be accessed via the Prometheus UI.
 
-Additionally, Harmony deploys the [Prometheus Adapter](https://github.com/kubernetes-sigs/prometheus-adapter)
-to generate a custom metric based on the average value of `num_ready_work_items` over a two minute
-window. This metric, `num_ready_work_items_avg`, is used by the 
-[Horizontal Pod Autoscaler (HPA)](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
-to scale the number of pods for a given service up or down in response to load. 
-
-It is not available in the Prometheus UI, but can be accessed
-using `kubectl` as follows:
-
-```
-kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1/namespaces/harmony/pods/*/num_ready_work_items_avg" [--kubeconfig <config file>]
-```
+Harmony deploys the [Prometheus Adapter](https://github.com/kubernetes-sigs/prometheus-adapter)
+to make this metric available to the [Horizontal Pod Autoscaler (HPA)](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+to scale the number of pods for a given service up or down in response to load.
 
 #### Monitoring the Number of Pods for Each Service
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1,0 +1,65 @@
+# Procedures for Maintaining a Harmony Kubernetes Cluster
+
+This document provides instructions for the ongoing maintenance of a running Harmony cluster.
+
+## Monitoring
+
+Monitoring a running Harmony cluster is done using a combination of custom logging 
+(sent to CloudWatch when run on AWS) and the tools described here.
+
+### Prometheus
+
+The `deploy-prometheus` script in  the `bin` directory of this repository can be used to deploy
+[Prometheus](https://prometheus.io/) into the Harmony Kubernetes cluster along with the 
+[kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) service which provides 
+useful metrics related to pods and the state of the cluster. The Prometheus UI can be accessed
+by forwarding the service's port (9090) to a local machine as follows (all `kubectl` commands
+listed in this document use either the default context or the one specified by the optional
+`--kubeconfig` paramter):
+
+1. get the pod identifier for Prometheus
+```
+kubectl get pods -n monitoring [--kubeconfig <config file>]
+```
+2. forward port `9090` from the pod to your local machine
+```
+kubectl port-forward <Prometheus Pod ID> 9090:9090 -n monitoring [--kubeconfig <config file>]
+```
+
+After which you can access the Prometheus UI in web browser at `http://localhost:9090`.
+
+#### Metrics
+
+Harmony services workers provide a [metric](https://prometheus.io/docs/concepts/data_model/) 
+that is scraped by Prometheus, `num_ready_work_items`, which is the number of work items for a 
+given service that are in the 'READY' state (i.e., available to be worked but not yet being worked).
+It can be accessed via the Prometheus UI.
+
+Additionally, Harmony deploys the [Prometheus Adapter](https://github.com/kubernetes-sigs/prometheus-adapter)
+to generate a custom metric based on the average value of `num_ready_work_items` over a two minute
+window. This metric, `num_ready_work_items_avg`, is used by the 
+[Horizontal Pod Autoscaler (HPA)](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+to scale the number of pods for a given service up or down in response to load. 
+
+It is not available in the Prometheus UI, but can be accessed
+using `kubectl` as follows:
+
+```
+kubectl get --raw "/apis/custom.metrics.k8s.io/v1beta1/namespaces/harmony/pods/*/num_ready_work_items_avg" [--kubeconfig <config file>]
+```
+
+#### Monitoring the Number of Pods for Each Service
+
+The following Prometheus query (promQL) can be used to get the current number of running pods
+for each deployed service.
+
+```
+sum(
+count(kube_pod_status_phase{phase="Running", namespace="harmony"}) by (pod)
+*
+on (pod) group_left(label_name) sum (kube_pod_labels{namespace="harmony",label_name=~".*"}) without (namespace)
+) by (label_name)
+```
+
+The `".*"` for the `label_name` can be replaced with a service name to get the count for just that 
+service, e.g, `"harmony-service-example"`.

--- a/bin/delete-prometheus
+++ b/bin/delete-prometheus
@@ -8,10 +8,7 @@ set +a
 eval "$env_save"
 
 # Delete kube-state-metrics service
-kubectl delete deployment kube-state-metrics -n monitoring
-kubectl delete service kube-state-metrics -n monitoring
-kubectl delete clusterrolebinding kube-state-metrics
-kubectl delete clusterrole kube-state-metrics
+kubectl delete -f ./config/kube-state-metrics
 
 # Delete prometheus adapter
 PROMETHEUS_NAMESPACE=monitoring

--- a/bin/delete-prometheus
+++ b/bin/delete-prometheus
@@ -7,6 +7,12 @@ source ".env"
 set +a
 eval "$env_save"
 
+# Delete kube-state-metrics service
+kubectl delete deployment kube-state-metrics -n monitoring
+kubectl delete service kube-state-metrics -n monitoring
+kubectl delete clusterrolebinding kube-state-metrics
+kubectl delete clusterrole kube-state-metrics
+
 # Delete prometheus adapter
 PROMETHEUS_NAMESPACE=monitoring
 PROMETHEUS_ADAPTER_HELM_NAME=harmony-prometheus-adapter
@@ -14,3 +20,4 @@ helm delete ${PROMETHEUS_ADAPTER_HELM_NAME} -n ${PROMETHEUS_NAMESPACE}
 
 # Delete prometheus
 envsubst < "config/prometheus.yaml" | kubectl delete -f -
+

--- a/bin/deploy-prometheus
+++ b/bin/deploy-prometheus
@@ -38,6 +38,9 @@ else
                     -n ${PROMETHEUS_NAMESPACE} \
                     ${PROMETHEUS_ADAPTER_HELM_NAME} \
                     prometheus-community/prometheus-adapter
-
 fi
+
+# Deploy kube-state-metrics service to support monitoring
+echo "deploying kube-state-metrics service"
+kubectl apply -f ./config/kube-state-metrics
 

--- a/config/kube-state-metrics/cluster-role-binding.yaml
+++ b/config/kube-state-metrics/cluster-role-binding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.3.0
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: monitoring

--- a/config/kube-state-metrics/cluster-role.yaml
+++ b/config/kube-state-metrics/cluster-role.yaml
@@ -1,0 +1,109 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.3.0
+  name: kube-state-metrics
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  - ingresses
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - list
+  - watch

--- a/config/kube-state-metrics/deployment.yaml
+++ b/config/kube-state-metrics/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.3.0
+  name: kube-state-metrics
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/version: 2.3.0
+    spec:
+      automountServiceAccountToken: true
+      containers:
+      - resources:
+          limits:
+            cpu: 128m
+            memory: 250Mi
+        args:
+        - --resources=pods
+        - --metric-labels-allowlist=pods=[name,app]
+        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        name: kube-state-metrics
+        ports:
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 8081
+          name: telemetry
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        securityContext:
+          runAsUser: 65534
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: kube-state-metrics

--- a/config/kube-state-metrics/service-account.yaml
+++ b/config/kube-state-metrics/service-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.3.0
+  name: kube-state-metrics
+  namespace: monitoring

--- a/config/kube-state-metrics/service.yaml
+++ b/config/kube-state-metrics/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.3.0
+  name: kube-state-metrics
+  namespace: monitoring
+spec:
+  clusterIP: None
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
+  selector:
+    app.kubernetes.io/name: kube-state-metrics

--- a/config/prometheus.yaml
+++ b/config/prometheus.yaml
@@ -82,6 +82,9 @@ data:
         - source_labels: [__meta_kubernetes_pod_name]
           action: replace
           target_label: kubernetes_pod_name
+      - job_name: 'kube-state-metrics'
+        static_configs: 
+        - targets: ['kube-state-metrics:8080']
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This PR adds the deployment of the `kube-state-metrics` service to the `deploy-prometheus` script to provide a lot of metrics convenient to monitoring the cluster/pods. An OPERATIONS.md file provides a starting point for documenting
general operating procedures not specific to our Harmony deployments. 

Specifically, this PR makes it possible to determine the number of running pods for each service (AC for HARMONY-1054).
This can be verified as follows:

1. deploy this branch to the sandbox
2. get the pod identifier for Prometheus
```
kubectl get pods -n monitoring [--kubeconfig <config file>]
```
3. forward port `9090` from the pod to your local machine
```
kubectl port-forward <Prometheus Pod ID> 9090:9090 -n monitoring [--kubeconfig <config file>]
```
4. Execute the following promQL in the UI
```
sum(
count(kube_pod_status_phase{phase="Running", namespace="harmony"}) by (pod)
*
on (pod) group_left(label_name) sum (kube_pod_labels{namespace="harmony",label_name=~".*"}) without (namespace)
) by (label_name)
```

You can replace ".*" in the query with a service name to get the metrics for a single service.