### PR TITLE
DAS-1371 - Use error message from error.json in service-runner, if present.

### DIFF
--- a/tasks/service-runner/test/fixtures/error-messages/error.json
+++ b/tasks/service-runner/test/fixtures/error-messages/error.json
@@ -1,0 +1,1 @@
+{"error": "Service error message", "category": "Service"}

--- a/tasks/service-runner/test/service-runner.ts
+++ b/tasks/service-runner/test/service-runner.ts
@@ -44,30 +44,38 @@ const nonErrorLog = `
 }
 `;
 
+const workItemWithErrorJson = './test/fixtures/error-messages';
+const workItemWithoutErrorJson = './test/fixtures/empty-dir';
 const emptyLog = '';
 
 describe('Service Runner', function () {
   describe('_getErrorMessage()', function () {
+    describe('when there is an error.json file associated with the WorkItem', function () {
+      const errorMessage = _getErrorMessage(errorLog, workItemWithErrorJson);
+      it('returns the error message from error.json', function () {
+        expect(errorMessage).equal('Service error message');
+      });
+    });
     describe('when the error log has ERROR level entries', function () {
-      const errorMessage = _getErrorMessage(errorLog);
+      const errorMessage = _getErrorMessage(errorLog, workItemWithoutErrorJson);
       it('returns the first error log entry', function () {
         expect(errorMessage).equal('bad stuff');
       });
     });
     describe('when the error log has no ERROR level entries', function () {
-      const errorMessage = _getErrorMessage(nonErrorLog);
+      const errorMessage = _getErrorMessage(nonErrorLog, workItemWithoutErrorJson);
       it('returns "unknown error"', function () {
         expect(errorMessage).equal('Unknown error');
       });
     });
     describe('when the error log is empty', function () {
-      const errorMessage = _getErrorMessage(emptyLog);
+      const errorMessage = _getErrorMessage(emptyLog, workItemWithoutErrorJson);
       it('returns "unknown error"', function () {
         expect(errorMessage).equal('Unknown error');
       });
     });
     describe('when the error log is null', function () {
-      const errorMessage = _getErrorMessage(null);
+      const errorMessage = _getErrorMessage(null, workItemWithoutErrorJson);
       it('returns "unknown error"', function () {
         expect(errorMessage).equal('Unknown error');
       });


### PR DESCRIPTION
This PR follows on from work being done within HOSS to ensure error messages are well handled. In that work, we found that Harmony has a bit of an issue with logging messages that include curly braces. This is a particular issue for OPeNDAP error messages:

* OPeNDAP returns error messages that include curly braces, (e.g.: `{\n            font-size: 24px;\n            font-weight: bold;\n        }`)
* `harmony-service-lib-py` [logs all error messages to STDOUT](https://github.com/nasa/harmony-service-lib-py/blob/main/harmony/http.py#L361).
* `harmony-service-lib-py` then swallows the OPeNDAP error message, so the backend service can't access it.
* When the backend service fails, `harmony-service-lib-py` [creates `error.json` in the `WorkItem` directory](https://github.com/nasa/harmony-service-lib-py/blob/main/harmony/cli.py#L132).
* The Harmony service-runner currently [searches through STDOUT for matches to the regular expression `\{.*\}`](https://github.com/nasa/harmony/blob/main/tasks/service-runner/app/service/service-runner.ts#L57). This will include things like the part of the OPeNDAP message quoted above.
* The service-runner tries to use `JSON.parse()` on the match to the regular expression that is within the OPeNDAP error message.
* This causes a JSON parsing error. In this case it would be `Unexpected token \ in JSON at position 1`.

In this PR, the `_getErrorMessage` function is updated to first check for the `error.json` output from `harmony-service-lib-py`. This should contain a single JSON log entry. If this file is present, the contents will be used to generate the final output error message. If the file is absent, the previous logic of scanning the STDOUT log messages is used as before.