### PR TITLE
GDDS-269: Adding GES DISC UMM-S entries for l2-subsetter in UAT and PROD

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -238,6 +238,7 @@ https://cmr.earthdata.nasa.gov:
           STAGING_PATH: public/podaac/l2-subsetter
     umm_s:
       - S1962070864-POCLOUD
+      - S2214242245-GES_DISC
     collections:
       - C1940473819-POCLOUD
       - C1940475563-POCLOUD
@@ -517,6 +518,7 @@ https://cmr.uat.earthdata.nasa.gov:
           STAGING_PATH: public/podaac/l2-subsetter
     umm_s:
       - S1234899453-POCLOUD
+      - S1242721133-GES_DISC
     collections:
       - C1234208436-POCLOUD
       - C1234208437-POCLOUD


### PR DESCRIPTION
Links to UMM-S entries are in the comments of https://bugs.earthdata.nasa.gov/browse/GDDS-269
This should take care of enabling any new collections with the Harmony l2-subsetting service. 