### PR TITLE
Harmony 451 fair queueing

### DIFF
--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -28,7 +28,7 @@ const serializedJobFields = [
   'username', 'status', 'message', 'progress', 'createdAt', 'updatedAt', 'links', 'request', 'numInputGranules', 'jobID',
 ];
 
-const jobRecordFields = [
+export const jobRecordFields = [
   'username', 'status', 'message', 'progress', 'createdAt', 'updatedAt', 'request', 'numInputGranules',
   'jobID', 'requestId', 'batchesCompleted', 'isAsync',
 ];

--- a/app/models/record.ts
+++ b/app/models/record.ts
@@ -2,7 +2,7 @@
 import logger from '../util/log';
 import db, { Transaction } from '../util/db';
 
-interface RecordConstructor extends Function {
+export interface RecordConstructor extends Function {
   table: string;
 }
 

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -145,6 +145,8 @@ export async function getNextWorkItem(
         .whereIn('j.status', ['running', 'accepted'])
         .where('w.status', '=', 'ready')
         .where('w.serviceID', '=', serviceID)
+        // Had to use `whereRaw` here because `where` tried to tread `wf.stepIndex` as a
+        // column name instead of a table alias + column name
         .whereRaw('w.workflowStepIndex = wf.stepIndex')
         .where('j.username', '=', userData.username)
         .orderBy('j.isAsync', 'asc')

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -106,7 +106,7 @@ export default class WorkItem extends Record implements WorkItemRecord {
   }
 }
 
-const tableFields = serializedFields.map((field) => `${WorkItem.table}.${field}`);
+const tableFields = serializedFields.map((field) => `w.${field}`);
 
 /**
  * Returns the next work item to process for a service
@@ -121,26 +121,46 @@ export async function getNextWorkItem(
 ): Promise<WorkItem> {
   let workItemData;
   try {
-    workItemData = await tx(WorkItem.table)
+    const subQuery =
+      tx(Job.table)
+        .select('username')
+        .join(`${WorkItem.table} as w`, `${Job.table}.jobID`, 'w.jobID')
+        .where({ 'w.status': 'ready', serviceID });
+    const userData = await tx(Job.table)
       .forUpdate()
-      .select(...tableFields, `${WorkflowStep.table}.operation`)
-      .join(WorkflowStep.table, function () {
-        this
-          .on(`${WorkflowStep.table}.stepIndex`, `${WorkItem.table}.workflowStepIndex`)
-          .on(`${WorkflowStep.table}.jobID`, `${WorkItem.table}.jobID`);
-      })
-      .join(Job.table, `${WorkItem.table}.jobID`, '=', `${Job.table}.jobID`)
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      .where({ 'work_items.serviceID': serviceID, 'work_items.status': WorkItemStatus.READY })
-      .whereIn('jobs.status', [JobStatus.RUNNING, JobStatus.ACCEPTED])
-      .orderBy([`${WorkItem.table}.id`])
+      .join(WorkItem.table, `${Job.table}.jobID`, '=', `${WorkItem.table}.jobID`)
+      .select(['username', 'serviceID', `${WorkItem.table}.serviceID`])
+      .max(`${Job.table}.updatedAt`, { as: 'm' })
+      .whereIn('username', subQuery)
+      .groupBy('username')
+      .orderBy('m', 'asc')
       .first();
+    if (userData?.username) {
+      workItemData = await tx(`${WorkItem.table} as w`)
+        .forUpdate()
+        .join(`${Job.table} as j`, 'w.jobID', 'j.jobID')
+        .join(`${WorkflowStep.table} as wf`, 'w.jobID', 'wf.jobID')
+        .select(...tableFields, 'wf.operation')
+        .whereIn('j.status', ['running', 'accepted'])
+        .where('w.status', '=', 'ready')
+        .where('w.serviceID', '=', serviceID)
+        .whereRaw('w.workflowStepIndex = wf.stepIndex')
+        .where('j.username', '=', userData.username)
+        .orderBy('j.updatedAt', 'asc')
+        .first();
 
-    if (workItemData) {
-      workItemData.operation = JSON.parse(workItemData.operation);
-      await tx(WorkItem.table)
-        .update({ status: WorkItemStatus.RUNNING, updatedAt: new Date() })
-        .where({ id: workItemData.id });
+      if (workItemData) {
+        workItemData.operation = JSON.parse(workItemData.operation);
+        await tx(WorkItem.table)
+          .update({ status: WorkItemStatus.RUNNING, updatedAt: new Date() })
+          .where({ id: workItemData.id });
+        // need to update the job otherwise long running jobs won't count against 
+        // the user's priority
+        await tx(Job.table)
+          .update({ updatedAt: new Date() })
+          .where({ jobID: workItemData.jobID });
+      }
+
     }
   } catch (e) {
     logger.error(`Error getting next work item for service [${serviceID}]`);
@@ -313,8 +333,8 @@ export async function getWorkItemIdsByJobUpdateAgeAndStatus(
   jobStatus: JobStatus[],
 ): Promise<number[]> {
   const pastDate = subMinutes(new Date(), notUpdatedForMinutes);
-  const workItemIds = (await tx(WorkItem.table)
-    .innerJoin(Job.table, `${WorkItem.table}.jobID`, '=', `${Job.table}.jobID`)
+  const workItemIds = (await tx(`${WorkItem.table} as w`)
+    .innerJoin(Job.table, 'w.jobID', '=', `${Job.table}.jobID`)
     .select(...tableFields)
     .where(`${Job.table}.updatedAt`, '<', pastDate)
     .whereIn(`${Job.table}.status`, jobStatus))

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -52,6 +52,12 @@ export interface WorkItemRecord {
 
   // The location of the resulting STAC catalog(s) (not serialized)
   results?: string[];
+
+  // The last time the record was updated
+  updatedAt: Date;
+
+  // When the item was created
+  createdAt: Date;
 }
 
 /**
@@ -137,7 +143,7 @@ export async function getNextWorkItem(
         .where({ id: workItemData.id });
     }
   } catch (e) {
-    logger.error('Error getting next work item');
+    logger.error(`Error getting next work item for service [${serviceID}]`);
     throw e;
   }
 

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -106,6 +106,7 @@ export default class WorkItem extends Record implements WorkItemRecord {
   }
 }
 
+// 'w' here is the alias for the 'work_items' table
 const tableFields = serializedFields.map((field) => `w.${field}`);
 
 /**

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -146,6 +146,7 @@ export async function getNextWorkItem(
         .where('w.serviceID', '=', serviceID)
         .whereRaw('w.workflowStepIndex = wf.stepIndex')
         .where('j.username', '=', userData.username)
+        .orderBy('j.isAsync', 'asc')
         .orderBy('j.updatedAt', 'asc')
         .first();
 

--- a/docs/fair-queueing.md
+++ b/docs/fair-queueing.md
@@ -1,0 +1,49 @@
+# Fair Queueing <!-- omit in toc -->
+
+**IMPORTANT! This documentation concerns features under active development. The algorithm described here may undergo changes in the future.**
+
+## Table of Contents<!-- omit in toc -->
+
+
+# Introduction
+Harmony supports two goals with regard to processing work for users. These are referred to
+collectively as _fair queueing_:
+
+* When a user performs a Harmony request and no other users are currently in the system, Harmony provides all available resources to that user
+* When a user performs a Harmony request and other users currently have requests pending in the system, Harmony shares available resources evenly between the user requests (prioritizing synchronous calls)
+
+# Background
+Harmony orchestrates multiple services that can be invoked on data. These services
+can be chained together (where appropriate) to form complex workflows involving both
+sequential services chains in which the output of one service becomes the input of the
+next service, as well as output aggregation where a services receives the output from
+multiple services as its input.
+
+Workers for each service are run as pods in a Kubernetes cluster. These workers
+request a unit of work (a 'work item') from the Harmony backend, process the associated work item, save the results in S3, then send a status update to the Harmony backend.
+
+Fair queueing is the process by which Harmony decides which work item to send to a service
+requesting work. More generally, it answers the question, "of the users needing work 
+performed by a given service, which user should go next?". 
+ 
+# The Algorithm
+The steps to perform fair queuing in harmony can be summarized as follows:
+
+When a worker requests a work item for a given service
+
+1. Identify all the users actively requesting work to be done on the service
+2. From the list of identified users, determine which user had work performed (for any service) least recently
+3. From that user's list of jobs (only those invoking the service) identify the job that has been worked least recently and return a work item for that job for the given service
+4. Update the work item and job timestamps in the database to indicate work being done at the current point in time
+
+All of the above are done inside a database transaction with locking to prevent a
+work item from being issued more than once.
+
+Note that this satisfies the first requirement as there will only be one user identified in step 1. Note also that this satisfies the second requirement including prioritizing 
+synchronous calls in the following way:
+
+Consider the case where a user has a long running asynchronous job involving many work 
+items for a given service. If a user then executes a synchronous request, the job
+associated with this request will become the oldest job with respect to
+step three above as soon as one of the running service workers completes a work item. 
+So the work item associated with the synchronous request will get processed next.

--- a/docs/fair-queueing.md
+++ b/docs/fair-queueing.md
@@ -33,17 +33,10 @@ When a worker requests a work item for a given service
 
 1. Identify all the users actively requesting work to be done on the service
 2. From the list of identified users, determine which user had work performed (for any service) least recently
-3. From that user's list of jobs (only those invoking the service) identify the job that has been worked least recently and return a work item for that job for the given service
+3. From that user's list of jobs (only those invoking the service) sort the jobs by the `isAsync` column to favor synchronous jobs, then sort by the `updatedAt` column to identify the job that has been worked least recently - return a work item for that job for the given service
 4. Update the work item and job timestamps in the database to indicate work being done at the current point in time
 
 All of the above are done inside a database transaction with locking to prevent a
 work item from being issued more than once.
 
-Note that this satisfies the first requirement as there will only be one user identified in step 1. Note also that this satisfies the second requirement including prioritizing 
-synchronous calls in the following way:
-
-Consider the case where a user has a long running asynchronous job involving many work 
-items for a given service. If a user then executes a synchronous request, the job
-associated with this request will become the oldest job with respect to
-step three above as soon as one of the running service workers completes a work item. 
-So the work item associated with the synchronous request will get processed next.
+Note that this implicitly satisfies the first requirement as there will only be one user identified in step 1. Note also that this satisfies the second requirement including prioritizing synchronous calls.

--- a/docs/fair-queueing.md
+++ b/docs/fair-queueing.md
@@ -27,7 +27,7 @@ requesting work. More generally, it answers the question, "of the users needing 
 performed by a given service, which user should go next?". 
  
 # The Algorithm
-The steps to perform fair queuing in harmony can be summarized as follows:
+The steps to perform fair queueing in harmony can be summarized as follows:
 
 When a worker requests a work item for a given service
 

--- a/test/helpers/hooks.ts
+++ b/test/helpers/hooks.ts
@@ -82,14 +82,18 @@ export function hookRequest(
  * and setting the result to this.res
  *
  * @param requestFn - The request function to execute
+ * @param beforeFn - The mocha `before` function to use, i.e. `before` or `beforeEach`
+ * @param afterFn - The mocha `after` function to use, i.e. `after` or `afterEach`
  */
 export function hookBackendRequest(
   requestFn: Function, options = { },
+  beforeFn = before,
+  afterFn = after,
 ): void {
-  before(async function () {
+  beforeFn(async function () {
     this.res = await requestFn(this.backend, options);
   });
-  after(function () {
+  afterFn(function () {
     delete this.res;
   });
 }

--- a/test/helpers/jobs.ts
+++ b/test/helpers/jobs.ts
@@ -41,8 +41,9 @@ export function makePartialJobRecord(data): Partial<JobRecord> {
     jobID: data[0],
     username: data[1],
     status: data[2],
-    createdAt: data[3],
-    updatedAt: data[3],
+    isAsync: data[3],
+    createdAt: data[4],
+    updatedAt: data[4],
     numInputGranules: 1,
     collectionIds: [],
   };

--- a/test/helpers/work-items.ts
+++ b/test/helpers/work-items.ts
@@ -192,8 +192,6 @@ export function getWorkForService(app: Application, serviceID: string): Test {
 
 export const hookGetWorkForService = hookBackendRequest.bind(this, getWorkForService);
 
-
-
 /**
  * Create fake output STAC catalogs/items to mock the execution of a service
  * 

--- a/test/helpers/work-items.ts
+++ b/test/helpers/work-items.ts
@@ -5,11 +5,12 @@ import { promises as fs } from 'fs';
 import request, { Test } from 'supertest';
 import _ from 'lodash';
 import WorkItem, { WorkItemRecord, WorkItemStatus } from '../../app/models/work-item';
-import db from '../../app/util/db';
+import db, { Transaction } from '../../app/util/db';
 import env from '../../app/util/env';
 import { truncateAll } from './db';
 import { hookBackendRequest } from './hooks';
 import { buildWorkflowStep, hookWorkflowStepCreation, hookWorkflowStepCreationEach } from './workflow-steps';
+import { RecordConstructor } from '../../app/models/record';
 
 export const exampleWorkItemProps = {
   jobID: '1',
@@ -19,6 +20,21 @@ export const exampleWorkItemProps = {
 } as WorkItemRecord;
 
 /**
+ * Create a partial WorkItemRecord from an array of data
+ * @param data - The array of data containing the WorkItemRecord elements
+ * @returns a record containing the supplied elements
+ */
+export function makePartialWorkItemRecord(data): Partial<WorkItemRecord> {
+  return {
+    jobID: data[0],
+    serviceID: data[1],
+    status: data[2],
+    updatedAt: data[3],
+    createdAt: data[3],
+  };
+}
+
+/**
  *  Creates a work item with default values for fields that are not passed in
  *
  * @param fields - fields to use for the work item record
@@ -26,6 +42,26 @@ export const exampleWorkItemProps = {
  */
 export function buildWorkItem(fields: Partial<WorkItemRecord> = {}): WorkItem {
   return new WorkItem({ ...exampleWorkItemProps, ...fields });
+}
+
+/**
+ * Save a work item without validating or updating createdAt/updatedAt
+ * @param tx - The transaction to use for saving the job
+ * @param fields - The fields to save to the database, defaults to example values
+ * @returns The saved work item
+ * @throws Error - if the save to the database fails
+ */
+export async function rawSaveWorkItem(tx: Transaction, fields: Partial<WorkItemRecord> = {}): Promise<WorkItem> {
+  const workItem = buildWorkItem(fields);
+  let stmt = tx((workItem.constructor as RecordConstructor).table)
+    .insert(workItem);
+  if (db.client.config.client === 'pg') {
+    stmt = stmt.returning('id'); // Postgres requires this to return the id of the inserted record
+  }
+
+  [workItem.id] = await stmt;
+
+  return workItem;
 }
 
 /**

--- a/test/helpers/workflow-steps.ts
+++ b/test/helpers/workflow-steps.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach } from 'mocha';
 import WorkflowStep, { WorkflowStepRecord } from '../../app/models/workflow-steps';
-import db from '../../app/util/db';
+import db, { Transaction } from '../../app/util/db';
 import { truncateAll } from './db';
 import { parseSchemaFile } from './data-operation';
 import DataOperation, { CURRENT_SCHEMA_VERSION } from '../../app/models/data-operation';
+import { RecordConstructor } from '../../app/models/record';
 
 export const validOperation = new DataOperation(parseSchemaFile('valid-operation-input.json')).serialize(CURRENT_SCHEMA_VERSION);
 
@@ -16,6 +17,19 @@ const exampleProps = {
 } as WorkflowStepRecord;
 
 /**
+ * Create a partial WorkFlowStepRecord from an array of data
+ * @param data - The array of data containing the WorkItemRecord elements
+ * @returns a record containing the supplied elements
+ */
+export function makePartialWorkflowStepRecord(data): Partial<WorkflowStepRecord> {
+  return {
+    jobID: data[0],
+    serviceID: data[1],
+    operation: data[2],
+  };
+}
+
+/**
  *  Creates a workflow step with default values for fields that are not passed in
  *
  * @param fields - fields to use for the workflow step record
@@ -23,6 +37,28 @@ const exampleProps = {
  */
 export function buildWorkflowStep(fields: Partial<WorkflowStepRecord> = {}): WorkflowStep {
   return new WorkflowStep({ ...exampleProps, ...fields });
+}
+
+/**
+ * Save a workflow step using a partial record
+ * @param tx - The transaction to use for saving the job
+ * @param fields - The fields to save to the database, defaults to example values
+ * @returns The saved workflow step
+ * @throws Error - if the save to the database fails
+ */
+export async function rawSaveWorkflowStep(tx: Transaction, fields: Partial<WorkflowStepRecord> = {}): Promise<WorkflowStep> {
+  const workflowStep = buildWorkflowStep(fields);
+  workflowStep.createdAt = new Date();
+  workflowStep.updatedAt = workflowStep.createdAt;
+  let stmt = tx((workflowStep.constructor as RecordConstructor).table)
+    .insert(workflowStep);
+  if (db.client.config.client === 'pg') {
+    stmt = stmt.returning('id'); // Postgres requires this to return the id of the inserted record
+  }
+
+  [workflowStep.id] = await stmt;
+
+  return workflowStep;
 }
 
 /**

--- a/test/work-items/fair-queueing.ts
+++ b/test/work-items/fair-queueing.ts
@@ -48,8 +48,6 @@ const workItemData = [
   ['job9', 'bar', 'ready', 12340],
 ];
 
-
-
 describe('Fair Queueing', function () {
 
   const jobRecords = jobData.map(makePartialJobRecord);

--- a/test/work-items/fair-queueing.ts
+++ b/test/work-items/fair-queueing.ts
@@ -1,0 +1,85 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { JobRecord } from '../../app/models/job';
+import { WorkItemRecord } from '../../app/models/work-item';
+import hookServersStartStop from '../helpers/servers';
+import db from '../../app/util/db';
+import { hookGetWorkForService, makePartialWorkItemRecord, rawSaveWorkItem } from '../helpers/work-items';
+import { makePartialJobRecord, rawSaveJob } from '../helpers/jobs';
+import { makePartialWorkflowStepRecord, rawSaveWorkflowStep } from '../helpers/workflow-steps';
+import { truncateAll } from '../helpers/db';
+
+const jobData = [
+  // jobID, username, status, updatedAt
+  ['job1', 'Bob', 'running', 12345],
+  ['job2', 'Bob', 'accepted', 12352],
+  ['job3', 'Bob', 'accepted', 12344],
+  ['job4', 'Joe', 'running', 12345],
+  ['job5', 'Joe', 'accepted', 12350],
+  ['job6', 'Bill', 'running', 12347],
+  ['job7', 'Bill', 'accepted', 12348],
+  ['job8', 'Bill', 'successful', 12355],
+  ['job8', 'John', 'accepted', 12340],
+];
+
+const workflowStepData = [
+  // jobID, serviceID, operation
+  ['job1', 'foo', '[]'],
+  ['job2', 'bar', '[]'],
+  ['job3', 'foo', '[]'],
+  ['job4', 'foo', '[]'],
+  ['job5', 'bar', '[]'],
+  ['job6', 'foo', '[]'],
+  ['job7', 'foo', '[]'],
+  ['job8', 'foo', '[]'],
+  ['job9', 'bar', '[]'],
+];
+
+const workItemData = [
+  // jobID, serviceID, status, updatedAt
+  ['job1', 'foo', 'ready', 12345],
+  ['job2', 'bar', 'ready', 12352],
+  ['job3', 'foo', 'ready', 12347],
+  ['job4', 'foo', 'ready', 12345],
+  ['job5', 'bar', 'ready', 12350],
+  ['job6', 'foo', 'ready', 12348],
+  ['job7', 'foo', 'ready', 12349],
+  ['job8', 'foo', 'successful', 12355],
+  ['job9', 'bar', 'ready', 12340],
+];
+
+
+
+describe('Fair Queueing', function () {
+
+  const jobRecords = jobData.map(makePartialJobRecord);
+  const workflowStepRecords = workflowStepData.map(makePartialWorkflowStepRecord);
+  const workItemRecords = workItemData.map(makePartialWorkItemRecord);
+
+  hookServersStartStop({ skipEarthdataLogin: true });
+
+  describe('when getting a work item', function () {
+
+    before(async () => {
+      await Promise.all(jobRecords.map(async (rec: Partial<JobRecord>) => {
+        await rawSaveJob(db, rec);
+      }));
+      await Promise.all(workflowStepRecords.map(async (rec: Partial<JobRecord>) => {
+        await rawSaveWorkflowStep(db, rec);
+      }));
+      await Promise.all(workItemRecords.map(async (rec: WorkItemRecord) => {
+        await rawSaveWorkItem(db, rec);
+      }));
+    });
+
+    after(truncateAll);
+
+    describe('when one user has waited longer than other users to have work done', function () {
+      hookGetWorkForService('foo');
+
+      it('returns the work item for the oldest worked job for that user', function () {
+        expect(this.res.body.jobID).to.equal('job4');
+      });
+    });
+  });
+});

--- a/test/work-items/work-backends.ts
+++ b/test/work-items/work-backends.ts
@@ -1,14 +1,14 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { v4 as uuid } from 'uuid';
-import { Job, JobRecord, JobStatus } from '../app/models/job';
-import { WorkItemRecord, WorkItemStatus, getWorkItemById } from '../app/models/work-item';
-import { WorkflowStepRecord } from '../app/models/workflow-steps';
-import hookServersStartStop from './helpers/servers';
-import db from '../app/util/db';
-import { hookJobCreation } from './helpers/jobs';
-import { hookGetWorkForService, hookWorkItemCreation, hookWorkItemUpdate, hookWorkflowStepAndItemCreation } from './helpers/work-items';
-import { hookWorkflowStepCreation, validOperation } from './helpers/workflow-steps';
+import { Job, JobRecord, JobStatus } from '../../app/models/job';
+import { WorkItemRecord, WorkItemStatus, getWorkItemById } from '../../app/models/work-item';
+import { WorkflowStepRecord } from '../../app/models/workflow-steps';
+import hookServersStartStop from '../helpers/servers';
+import db from '../../app/util/db';
+import { hookJobCreation } from '../helpers/jobs';
+import { hookGetWorkForService, hookWorkItemCreation, hookWorkItemUpdate, hookWorkflowStepAndItemCreation } from '../helpers/work-items';
+import { hookWorkflowStepCreation, validOperation } from '../helpers/workflow-steps';
 
 describe('Work Backends', function () {
   const requestId = uuid().toString();


### PR DESCRIPTION
Changes to the `getNextWorkItem` function to implement new queries that support fair queueing. Only added one test since other tests already confirm base functionality. How to test:

Test case 1 (single user):

1. Issue a long running (asynchronous) query.
2. Issue a synchronous (or at least short running) query for the same services.

The shorter job should finish first.

Test case 2 (multiuser):

1. Have user 1 issue a long running query (or multiple queries)
2. Have user 2 issue a short running query

Verify that user 2 job completes before long running jobs

Test case 3 (multiuser):

1. Have user 1 issue multiple (asynchronous) queries for a given service
2. Simultaneously have user 2 issue the same queries

Verify that both users' jobs complete about the same time.