### PR TITLE
HARMONY-1057: Prevent prometheus pod from being evicted due to running out of ephemeral storage.

### DIFF
--- a/bin/deploy-prometheus
+++ b/bin/deploy-prometheus
@@ -40,6 +40,9 @@ else
                     prometheus-community/prometheus-adapter
 fi
 
+# Force prometheus to restart to ensure configuration changes are always applied immediately
+kubectl -n monitoring rollout restart deployment prometheus
+
 # Deploy kube-state-metrics service to support monitoring
 echo "deploying kube-state-metrics service"
 kubectl apply -f ./config/kube-state-metrics

--- a/config/prometheus.yaml
+++ b/config/prometheus.yaml
@@ -83,7 +83,7 @@ data:
           action: replace
           target_label: kubernetes_pod_name
       - job_name: 'kube-state-metrics'
-        static_configs: 
+        static_configs:
         - targets: ['kube-state-metrics:8080']
 ---
 apiVersion: apps/v1
@@ -111,7 +111,7 @@ spec:
       serviceAccountName: prometheus
       containers:
       - name: prometheus
-        image: quay.io/prometheus/prometheus:v2.0.0
+        image: quay.io/prometheus/prometheus:v2.33.1
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -123,9 +123,10 @@ spec:
             memory: $PROMETHEUS_LIMITS_MEMORY
             cpu: $PROMETHEUS_LIMITS_CPU
         args:
-          - '--storage.tsdb.retention=6h'
-          - '--storage.tsdb.path=/prometheus'
-          - '--config.file=/etc/prometheus/prometheus.yml'
+          - "--storage.tsdb.retention.time=$PROMETHEUS_RETENTION_TIME"
+          - "--storage.tsdb.retention.size=$PROMETHEUS_RETENTION_SIZE"
+          - "--storage.tsdb.path=/prometheus"
+          - "--config.file=/etc/prometheus/prometheus.yml"
         command:
         - /bin/prometheus
         ports:

--- a/env-defaults
+++ b/env-defaults
@@ -334,12 +334,20 @@ HOST_VOLUME_PATH=
 
 PROMETHEUS_REQUESTS_CPU=128m
 PROMETHEUS_REQUESTS_MEMORY=150Mi
-PROMETHEUS_REQUESTS_EPHEMERAL_STORAGE=300Mi
+PROMETHEUS_REQUESTS_EPHEMERAL_STORAGE=600Mi
 PROMETHEUS_LIMITS_CPU=128m
-PROMETHEUS_LIMITS_MEMORY=300Mi
-PROMETHEUS_LIMITS_EPHEMERAL_STORAGE=500Mi
+PROMETHEUS_LIMITS_MEMORY=600Mi
+PROMETHEUS_LIMITS_EPHEMERAL_STORAGE=2000Mi
 PROMETHEUS_PROMETHEUS_SCRAPE_INTERVAL=15s
 PROMETHEUS_POD_MANAGER_SCRAPE_INTERVAL=15s
+
+# See https://prometheus.io/docs/prometheus/latest/storage/ for details on retention metrics.
+# How long to keep prometheus metrics before cleaning up
+PROMETHEUS_RETENTION_TIME=180d
+# Maximum amount of space to use for Prometheus metrics before deleting oldest metrics
+# Be sure to set this value to less than PROMETHEUS_LIMITS_EPHEMERAL_STORAGE otherwise the
+# pod may be evicted due to running out of ephemeral space.
+PROMETHEUS_RETENTION_SIZE=1750MB
 
 ###########################################################################
 #             Horizontal Pod Autoscaling Config                           #
@@ -352,7 +360,7 @@ HPA_MIN_REPLICAS=1
 HPA_MAX_REPLICAS=10
 
 # See https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/#Quantity
-# for an explanation of the "m" suffix 
+# for an explanation of the "m" suffix
 HPA_TARGET_VALUE=10000m
 
 #############################################################################


### PR DESCRIPTION
I took a look at how quickly space was being consumed by prometheus and found that it was under 0.5MB per hour or 12MB per day. There are peaks every couple hours with the bulk of the space being used by the write ahead log which gets allocated in 128MB segments. Our defaults were to only allow 500MB of storage which resulted in the pod getting evicted (I suspect when some prometheus internal activity caused the write ahead log to allocate an additional segment).

I set the defaults to allow up to 2GB of ephemeral storage and added configuration to delete the oldest metrics when we reached 1750MB in size, which should prevent us from ever having the pod evicted due to running out of ephemeral storage.

Note I also bumped up the retention time from the current 6h to a configurable value which I defaulted to 180 days. In practice we won't ever have 180 days of metrics, a new pod will be created on every deployment resulting in the metrics being reset as long as we're using ephemeral storage. Also if we ever reach the max allowed size it will delete the oldest metrics to stay under the size.

This PR also fixes HARMONY-1075 to ensure prometheus configuration changes are picked up on deployment.

I tested out the changes in my own sandbox account.