### PR TITLE
HARMONY-1076: Add migration to add foreign key constraint between work_items and workflow_steps

### DIFF
--- a/db/migrations/20220301141810_add_work_item_foreign_keys.js
+++ b/db/migrations/20220301141810_add_work_item_foreign_keys.js
@@ -1,0 +1,14 @@
+
+exports.up = function(knex) {
+  return knex.schema.table('work_items', (t) => {
+    t.foreign(['jobID','workflowStepIndex'])
+      .references(['jobID','stepIndex'])
+      .inTable('workflow_steps');
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table('work_items', (t) => {
+    t.dropForeign(['jobID','workflowStepIndex']);
+  });
+};

--- a/docs/fair-queueing.md
+++ b/docs/fair-queueing.md
@@ -6,6 +6,7 @@
 - [Introduction](#introduction)
 - [Background](#background)
 - [The Algorithm](#the-algorithm)
+
 ## Introduction
 Harmony supports two goals with regard to processing work for users. These are referred to
 collectively as _fair queueing_:

--- a/docs/fair-queueing.md
+++ b/docs/fair-queueing.md
@@ -3,16 +3,17 @@
 **IMPORTANT! This documentation concerns features under active development. The algorithm described here may undergo changes in the future.**
 
 ## Table of Contents<!-- omit in toc -->
-
-
-# Introduction
+- [Introduction](#introduction)
+- [Background](#background)
+- [The Algorithm](#the-algorithm)
+## Introduction
 Harmony supports two goals with regard to processing work for users. These are referred to
 collectively as _fair queueing_:
 
 * When a user performs a Harmony request and no other users are currently in the system, Harmony provides all available resources to that user
 * When a user performs a Harmony request and other users currently have requests pending in the system, Harmony shares available resources evenly between the user requests (prioritizing synchronous calls)
 
-# Background
+## Background
 Harmony orchestrates multiple services that can be invoked on data. These services
 can be chained together (where appropriate) to form complex workflows involving both
 sequential services chains in which the output of one service becomes the input of the
@@ -26,7 +27,7 @@ Fair queueing is the process by which Harmony decides which work item to send to
 requesting work. More generally, it answers the question, "of the users needing work 
 performed by a given service, which user should go next?". 
  
-# The Algorithm
+## The Algorithm
 The steps to perform fair queueing in harmony can be summarized as follows:
 
 When a worker requests a work item for a given service


### PR DESCRIPTION
Tested locally with postgres and in a sandbox deployment. I also ran the following query to verify that we don't already have any work_items rows violating the new foreign key constraint in SIT/UAT/Prod.

```sql
select * from work_items w left join workflow_steps ws on "w"."jobID" = "ws"."jobID" and "w"."workflowStepIndex" = "ws"."stepIndex" where ws.id is null;
```

If you want to test this locally, check out the branch and the migration using `knex`. Then for an existing job ID try to insert a row into work_items that does not have a matching workflow_step row:

```sql
insert into work_items values(<some unused work_item_id>,<some real job id>,1000,'','foo','ready','',now(),now());
```

1000 above is just a really high workflowStepIndex that should not exist.
