### PR TITLE
HARMONY-1086: Fix URL formation error handling

### DIFF
--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -49,6 +49,8 @@ export async function getJobs(
           const path = url.pathname + url.search;
           return path;
         } catch (e) {
+          req.context.logger.error(`Could not form a valid URL from job.request: ${this.request}`);
+          req.context.logger.error(e);
           return this.request;
         }
       },

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -44,9 +44,13 @@ export async function getJobs(
       version,
       jobBadge() { return badgeClasses[this.status]; },
       jobUrl() {
-        const url = new URL(this.request);
-        const path = url.pathname + url.search;
-        return path;
+        try {
+          const url = new URL(this.request);
+          const path = url.pathname + url.search;
+          return path;
+        } catch (e) {
+          return this.request;
+        }
       },
       jobCreatedAt() { return this.createdAt.getTime(); },
       links: [

--- a/env-defaults
+++ b/env-defaults
@@ -89,7 +89,7 @@ DEFAULT_RESULT_PAGE_SIZE=2000
 DEFAULT_JOB_LIST_PAGE_SIZE=10
 
 # Maximum number of results in a page
-MAX_PAGE_SIZE=10000
+MAX_PAGE_SIZE=2000
 
 # Number of granules allowed for a synchronous request. When the request exceeds
 # this number it will be processed asynchronously. If a service provides a

--- a/test/jobs/job-status-pagination.ts
+++ b/test/jobs/job-status-pagination.ts
@@ -120,7 +120,7 @@ describe('Individual job status route - pagination', function () {
         const response = JSON.parse(this.res.text);
         expect(response).to.eql({
           code: 'harmony.RequestValidationError',
-          description: 'Error: Parameter "limit" is invalid. Must be an integer greater than or equal to 0 and less than or equal to 10000.',
+          description: 'Error: Parameter "limit" is invalid. Must be an integer greater than or equal to 0 and less than or equal to 2000.',
         });
       });
     });
@@ -135,7 +135,7 @@ describe('Individual job status route - pagination', function () {
         const response = JSON.parse(this.res.text);
         expect(response).to.eql({
           code: 'harmony.RequestValidationError',
-          description: 'Error: Parameter "limit" is invalid. Must be an integer greater than or equal to 0 and less than or equal to 10000.',
+          description: 'Error: Parameter "limit" is invalid. Must be an integer greater than or equal to 0 and less than or equal to 2000.',
         });
       });
     });

--- a/test/jobs/jobs-listing.ts
+++ b/test/jobs/jobs-listing.ts
@@ -208,7 +208,7 @@ describe('Jobs listing route', function () {
           expect(this.res.statusCode).to.equal(400);
           expect(error).to.eql({
             code: 'harmony.RequestValidationError',
-            description: 'Error: Parameter "limit" is invalid. Must be an integer greater than or equal to 0 and less than or equal to 10000.',
+            description: 'Error: Parameter "limit" is invalid. Must be an integer greater than or equal to 0 and less than or equal to 2000.',
           });
         });
       });
@@ -220,7 +220,7 @@ describe('Jobs listing route', function () {
           expect(this.res.statusCode).to.equal(400);
           expect(error).to.eql({
             code: 'harmony.RequestValidationError',
-            description: 'Error: Parameter "limit" is invalid. Must be an integer greater than or equal to 0 and less than or equal to 10000.',
+            description: 'Error: Parameter "limit" is invalid. Must be an integer greater than or equal to 0 and less than or equal to 2000.',
           });
         });
       });
@@ -232,7 +232,7 @@ describe('Jobs listing route', function () {
           expect(this.res.statusCode).to.equal(400);
           expect(error).to.eql({
             code: 'harmony.RequestValidationError',
-            description: 'Error: Parameter "limit" is invalid. Must be an integer greater than or equal to 0 and less than or equal to 10000.',
+            description: 'Error: Parameter "limit" is invalid. Must be an integer greater than or equal to 0 and less than or equal to 2000.',
           });
         });
       });

--- a/test/stac/stac-pagination.ts
+++ b/test/stac/stac-pagination.ts
@@ -135,7 +135,7 @@ describe('STAC - pagination', function () {
         const response = JSON.parse(this.res.text);
         expect(response).to.eql({
           code: 'harmony.RequestValidationError',
-          description: 'Error: Parameter "limit" is invalid. Must be an integer greater than or equal to 0 and less than or equal to 10000.',
+          description: 'Error: Parameter "limit" is invalid. Must be an integer greater than or equal to 0 and less than or equal to 2000.',
         });
       });
     });
@@ -150,7 +150,7 @@ describe('STAC - pagination', function () {
         const response = JSON.parse(this.res.text);
         expect(response).to.eql({
           code: 'harmony.RequestValidationError',
-          description: 'Error: Parameter "limit" is invalid. Must be an integer greater than or equal to 0 and less than or equal to 10000.',
+          description: 'Error: Parameter "limit" is invalid. Must be an integer greater than or equal to 0 and less than or equal to 2000.',
         });
       });
     });


### PR DESCRIPTION
I verified manually that this doesn't break anything, but wasn't able to add a test for this because there is validation logic that prevents me from adding a job with a malformed request url.