### PR TITLE
HARMONY-1082: Add more specific routing to return 404s for bad URLs

### DIFF
--- a/app/routers/router.ts
+++ b/app/routers/router.ts
@@ -192,8 +192,9 @@ export default function router({ skipEarthdataLogin = 'false' }: RouterConfig): 
   result.get('/', landingPage);
   result.get('/versions', getVersions);
   result.use('/docs/api', swaggerUi.serve, swaggerUi.setup(yaml.load(ogcCoverageApi.openApiContent), { customJs: '/js/docs/analytics-tag.js' }));
-  result.get(collectionPrefix('(wms|eoss|ogc-api-coverages)'), service(serviceInvoker));
-  result.post(collectionPrefix('(ogc-api-coverages)'), service(serviceInvoker));
+  result.get(collectionPrefix('(wms|eoss)'), service(serviceInvoker));
+  result.get(/^.*?\/ogc-api-coverages\/.*?\/collections\/.*?\/coverage\/rangeset/, service(serviceInvoker));
+  result.post(/^.*?\/ogc-api-coverages\/.*?\/collections\/.*?\/coverage\/rangeset/, service(serviceInvoker));
   result.get('/jobs', getJobsListing);
   result.get('/jobs/:jobID', getJobStatus);
   result.post('/jobs/:jobID/cancel', cancelJob);

--- a/test/routing.ts
+++ b/test/routing.ts
@@ -11,6 +11,8 @@ describe('Routing', function () {
   const invalidCollection = 'C1234-MISSING';
   const invalidCollection2 = 'C4568-MISSING';
   const validCollection = 'C1233800302-EEDTEST';
+  const version = '1.0.0';
+  const variable = 'red_var';
 
   hookServersStartStop();
 
@@ -64,6 +66,26 @@ describe('Routing', function () {
     condition: 'accessing an invalid top-level route',
     path: '/invalid-route',
     message: 'The requested page was not found.',
+  });
+
+  describeErrorCondition({
+    condition: 'not including coverages/variables in the URL path',
+    path: `/${validCollection}/ogc-api-coverages/${version}/collections/coverage/rangeset`,
+    message: {
+      code: 'harmony.NotFoundError',
+      description: 'Error: The requested page was not found.',
+    },
+    html: false,
+  });
+
+  describeErrorCondition({
+    condition: 'not including `coverage` in the URL path',
+    path: `/${validCollection}/ogc-api-coverages/${version}/${variable}/rangeset`,
+    message: {
+      code: 'harmony.NotFoundError',
+      description: 'Error: The requested page was not found.',
+    },
+    html: false,
   });
 
   describe('/schemas', function () {


### PR DESCRIPTION
I made the acceptable routes a bit more specific to prevent bad URLs from being processed as service requests. They now
return a 404. This can be tested with the following (missing variable):

```
curl -Ln -bj "http://localhost:3000/C1234208436-POCLOUD/ogc-api-coverages/1.0.0/collections/coverage/rangeset?forceAsync=true&subset=lat(-20:0)&subset=lon(-80:0)&maxResults=1&format=application/x-zarr"
```