### PR TITLE
HARMONY-1089: Fix deadlocks with database queries and remove unnecessary locking

### DIFF
--- a/app/models/job-link.ts
+++ b/app/models/job-link.ts
@@ -1,6 +1,6 @@
 import { ILengthAwarePagination } from 'knex-paginate'; // For types only
 import _ from 'lodash';
-import { Transaction } from '../util/db';
+import db, { Transaction } from '../util/db';
 import { removeEmptyProperties } from '../util/object';
 import Record from './record';
 
@@ -184,7 +184,7 @@ export async function getLinksForJob(
   rel?: string,
   requireSpatioTemporal = false,
 ): Promise<{ data: JobLink[]; pagination: ILengthAwarePagination }> {
-  const result = await transaction('job_links').select()
+  let query = transaction('job_links').select()
     .where({ jobID })
     .orderBy(['id'])
     .modify((queryBuilder) => {
@@ -199,9 +199,14 @@ export async function getLinksForJob(
           .whereNotNull('temporalEnd');
       }
     })
-    .forUpdate()
-    .skipLocked()
-    .paginate({ currentPage, perPage, isLengthAware: true });
+    .forUpdate();
+
+  if (db.client.config.client === 'pg') {
+    query = query.skipLocked();
+  }
+
+  const result = await query.paginate({ currentPage, perPage, isLengthAware: true });
+
   const links = result.data.map((j) => new JobLink(j));
   return { data: links, pagination: result.pagination };
 }

--- a/app/models/job-link.ts
+++ b/app/models/job-link.ts
@@ -200,6 +200,7 @@ export async function getLinksForJob(
       }
     })
     .forUpdate()
+    .skipLocked()
     .paginate({ currentPage, perPage, isLengthAware: true });
   const links = result.data.map((j) => new JobLink(j));
   return { data: links, pagination: result.pagination };

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -7,7 +7,7 @@ import { ConflictError } from '../util/errors';
 import { createPublicPermalink } from '../frontends/service-results';
 import { truncateString } from '../util/string';
 import Record from './record';
-import db, { Transaction } from '../util/db';
+import { Transaction } from '../util/db';
 import JobLink, { getLinksForJob, JobLinkOrRecord } from './job-link';
 
 import env = require('../util/env');

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -7,7 +7,7 @@ import { ConflictError } from '../util/errors';
 import { createPublicPermalink } from '../frontends/service-results';
 import { truncateString } from '../util/string';
 import Record from './record';
-import { Transaction } from '../util/db';
+import db, { Transaction } from '../util/db';
 import JobLink, { getLinksForJob, JobLinkOrRecord } from './job-link';
 
 import env = require('../util/env');
@@ -273,7 +273,7 @@ export class Job extends Record implements JobRecord {
     currentPage = 0,
     perPage = env.defaultResultPageSize,
   ): Promise<{ job: Job; pagination: ILengthAwarePagination }> {
-    const result = await transaction('jobs').select().where({ requestId }).forUpdate();
+    const result = await transaction('jobs').select().where({ requestId });
     const job = result.length === 0 ? null : new Job(result[0]);
     let paginationInfo;
     if (job) {


### PR DESCRIPTION
Worked with James and ran a few workload tests in my own sandbox and verified this fixes poor performance and timeouts I had been seeing with polling. In addition we identified deadlocks that we fixed, and identified some slow queries when trying to pull back jobs by request ID and resolved those.

I had to do some clunky things with knex because sqlite does not support skipLocked like Postgres does.