### PR TITLE
HARMONY-1091: Fixes cases where fair queueing is choosing a user with a canceled job as waiting for work for a service

### DIFF
--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -43,6 +43,7 @@ export enum JobStatus {
   CANCELED = 'canceled',
 }
 
+export const activeJobStatuses = [JobStatus.ACCEPTED, JobStatus.RUNNING];
 export const terminalStates = [JobStatus.SUCCESSFUL, JobStatus.FAILED, JobStatus.CANCELED];
 
 export interface JobRecord {

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import logger from '../util/log';
 import db, { Transaction } from '../util/db';
 import DataOperation from './data-operation';
-import { Job, JobStatus } from './job';
+import { activeJobStatuses, Job, JobStatus } from './job';
 import Record from './record';
 import WorkflowStep from './workflow-steps';
 
@@ -126,10 +126,11 @@ export async function getNextWorkItem(
 ): Promise<WorkItem> {
   let workItemData;
   try {
-    const subQuery =
+    const subQueryForUsersRequestingService =
       tx(Job.table)
         .select('username')
         .join(`${WorkItem.table} as w`, `${Job.table}.jobID`, 'w.jobID')
+        .whereIn(`${Job.table}.status`, activeJobStatuses)
         .where({ 'w.status': 'ready', serviceID });
     // lock rows in the jobs table for users requesting this service - needed as a workaround
     // for postgres limitation (https://stackoverflow.com/questions/5272412/group-by-in-update-from-clause)
@@ -137,7 +138,7 @@ export async function getNextWorkItem(
       .forUpdate()
       .join(WorkItem.table, `${Job.table}.jobID`, '=', `${WorkItem.table}.jobID`)
       .select(['username', 'serviceID', `${WorkItem.table}.serviceID`])
-      .whereIn('username', subQuery);
+      .whereIn('username', subQueryForUsersRequestingService);
 
     if (db.client.config.client === 'pg') {
       jobQuery = jobQuery.skipLocked();
@@ -149,7 +150,7 @@ export async function getNextWorkItem(
       .join(WorkItem.table, `${Job.table}.jobID`, '=', `${WorkItem.table}.jobID`)
       .select(['username'])
       .max(`${Job.table}.updatedAt`, { as: 'm' })
-      .whereIn('username', subQuery)
+      .whereIn('username', subQueryForUsersRequestingService)
       .groupBy('username')
       .orderBy('m', 'asc')
       .first();
@@ -163,7 +164,7 @@ export async function getNextWorkItem(
             .on('w.workflowStepIndex', '=', 'wf.stepIndex');
         })
         .select(...tableFields, 'wf.operation')
-        .whereIn('j.status', ['running', 'accepted'])
+        .whereIn('j.status', activeJobStatuses)
         .where('w.status', '=', 'ready')
         .where('w.serviceID', '=', serviceID)
         .where('j.username', '=', userData.username)
@@ -192,6 +193,7 @@ export async function getNextWorkItem(
     }
   } catch (e) {
     logger.error(`Error getting next work item for service [${serviceID}]`);
+    logger.error(e);
     throw e;
   }
 
@@ -505,7 +507,7 @@ export async function workItemCountByServiceIDAndStatus(
 
 /**
  * Get the scroll-id for a job if it has one
- * 
+ *
  * @param tx - the transaction to use for querying
  * @param jobID - the JobID
  * @returns A promise containing a scroll-id or null if the job does not use query-cmr

--- a/test/work-items/fair-queueing.ts
+++ b/test/work-items/fair-queueing.ts
@@ -30,6 +30,8 @@ const jobData = [
   ['job8', 'Bill', 'successful', true, 12355],
   // this job is not for the 'foo' service so it should not have its work items returned
   ['job9', 'John', 'accepted', true, 12340],
+  // this job has been canceled so even a work item with a ready status should be ignored
+  ['job10', 'Jane', 'canceled', true, 12200],
 ];
 
 const workflowStepData = [
@@ -43,6 +45,7 @@ const workflowStepData = [
   ['job7', 'foo', '[]'],
   ['job8', 'foo', '[]'],
   ['job9', 'bar', '[]'],
+  ['job10', 'foo', '[]'],
 ];
 
 const workItemData = [
@@ -56,6 +59,7 @@ const workItemData = [
   ['job7', 'foo', 'ready', 12349],
   ['job8', 'foo', 'successful', 12355],
   ['job9', 'bar', 'ready', 12340],
+  ['job10', 'foo', 'ready', 12200],
 ];
 
 describe('Fair Queueing', function () {


### PR DESCRIPTION
Do not consider a user as waiting for work on a service if the job associated with any 'ready' work items is in a terminal state. Fixes an issue when jobs are canceled, but not all work items were marked as canceled.

During our regression tests we perform a cancel, and for some reason when we cancel a request it does not always mark all of the work items for that job as canceled (separate bug). This makes sure that if a job is canceled we ignore any work items for that job regardless of their status.