### PR TITLE
DAS-1432 - Ensure the unchained NetCDF-to-Zarr service concatenates by default

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -208,6 +208,7 @@ https://cmr.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
+        operations: ['reformat', 'concatenate']
 
   - name: harmony/service-example
     data_operation_version: '0.14.0'
@@ -865,6 +866,7 @@ https://cmr.uat.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
+        operations: ['reformat', 'concatenate']
 
   # CHAINED SERVICES BELOW HERE
   - name: harmony/podaac-l2-subsetter-netcdf-to-zarr


### PR DESCRIPTION
## Jira Issue ID
[DAS-1432](https://bugs.earthdata.nasa.gov/browse/DAS-1432)

## Description
This ticket adds the operations to the NetCDF-to-Zarr step for the unchained service. This will ensure that a single request is sent to the backend service for all granules, rather than one per granule.

## Local Test Steps
* Update your local Harmony instance to use this version of the `services.yml`.
* Update your NetCDF-to-Zarr service Docker image to the latest from `main`.
* Restart the Harmony backend services to use the updated NetCDF-to-Zarr service image.
* Run the following request:

```
http://localhost:3000/C1225808238-GES_DISC/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&maxResults=3&format=application%2Fx-zarr&granuleId=G1242670752-GES_DISC&granuleId=G1242640604-GES_DISC
```
You should retrieve a single Zarr output from your request, not one per granule. The name will be `C1225808238-GES_DISC_merged.zarr`.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing (no updates needed, but all passed locally)
* [ ] ~Documentation updated (if needed)~ (no documentation updates needed)