### PR TITLE
Harmony 1106

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "harmony",
       "version": "0.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -10811,9 +10812,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -20413,7 +20414,9 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "requires": {}
+      "requires": {
+        "ajv": "^8.0.0"
+      }
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -25858,9 +25861,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minimist-options": {
       "version": "4.1.0",

--- a/tasks/giovanni-adapter/app/cli.ts
+++ b/tasks/giovanni-adapter/app/cli.ts
@@ -101,7 +101,7 @@ export default async function main(args: string[]): Promise<void> {
   const stacItemFilename = path.join(options.harmonyMetadataDir, stacItemRelativeFilename);
   const time_start = operation.temporal.start;
   const time_end = operation.temporal.end;
-  const properties = { start_datetime: time_start, end_datetime: time_end, datetime: null };
+  const properties = { start_datetime: time_start, end_datetime: time_end };
   const [lon, lat] = operation.spatialPoint;
   const bbox: BoundingBox = [lon, lat, lon, lat];
   const assets = {

--- a/tasks/giovanni-adapter/app/cli.ts
+++ b/tasks/giovanni-adapter/app/cli.ts
@@ -99,6 +99,9 @@ export default async function main(args: string[]): Promise<void> {
     'title': 'giovanni stac item',
   });
   const stacItemFilename = path.join(options.harmonyMetadataDir, stacItemRelativeFilename);
+  const time_start = operation.temporal.start;
+  const time_end = operation.temporal.end;
+  const properties = { start_datetime: time_start, end_datetime: time_end, datetime: null };
   const [lon, lat] = operation.spatialPoint;
   const bbox: BoundingBox = [lon, lat, lon, lat];
   const assets = {
@@ -111,6 +114,7 @@ export default async function main(args: string[]): Promise<void> {
     },
   };
   const item = new StacItem({
+    properties,
     bbox,
     assets,
   });

--- a/tasks/giovanni-adapter/app/stac/item.ts
+++ b/tasks/giovanni-adapter/app/stac/item.ts
@@ -40,7 +40,7 @@ export default class Item implements StacItem {
     this.links = [];
     this.properties = {};
     Object.assign(this, properties);
-    assert(!!this.bbox || !!this.geometry, 'Item point, bbox or geometry is required');
+    assert(!!this.bbox || !!this.geometry, 'Item bbox or geometry is required');
   }
 
   /**

--- a/tasks/giovanni-adapter/package-lock.json
+++ b/tasks/giovanni-adapter/package-lock.json
@@ -3103,9 +3103,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mocha": {
@@ -7008,9 +7008,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mocha": {

--- a/tasks/giovanni-adapter/test/cli.ts
+++ b/tasks/giovanni-adapter/test/cli.ts
@@ -99,6 +99,16 @@ describe('cli', function () {
         expect(fs.existsSync(index)).to.be.true;
         expect(JSON.parse(fs.readFileSync(index, 'utf-8')).description).to.equal('Giovanni adapter service');
       });
+
+      it('outputs the result data to item.json in the directory', function () {
+        const item = path.join(tmpDir, 'item.json');
+        expect(fs.existsSync(item)).to.be.true;
+        const itemContext = JSON.parse(fs.readFileSync(item, 'utf-8'));
+        expect(itemContext.bbox).to.eql([ 0.76, -3.8, 0.76, -3.8 ]);
+        expect(itemContext.properties.start_datetime).to.equal('2020-01-01T00:00:00.000Z');
+        expect(itemContext.properties.end_datetime).to.equal('2020-01-01T03:00:00.000Z');
+        expect(itemContext.assets['Giovanni URL'].href).to.equal('https://api.giovanni.earthdata.nasa.gov/proxy-timeseries?data=GPM_3IMERGHH_06_precipitationCal&location=%5B-3.8%2C0.76%5D&time=2020-01-01T00%3A00%3A00.000Z%2F2020-01-01T03%3A00%3A00.000Z');
+      });
     });
 
     describe('when the output directory does not exist', function () {

--- a/tasks/query-cmr/package-lock.json
+++ b/tasks/query-cmr/package-lock.json
@@ -3103,9 +3103,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mocha": {
@@ -7008,9 +7008,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mocha": {

--- a/tasks/service-runner/package-lock.json
+++ b/tasks/service-runner/package-lock.json
@@ -3118,9 +3118,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/minipass": {
       "version": "2.9.0",
@@ -7601,9 +7601,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "minipass": {
       "version": "2.9.0",


### PR DESCRIPTION
## Jira Issue ID
1106

## Description
This PR fixed a minor issue in `giovanni-adapter` (adding the time properties in the stac item) which was found when testing it in sandbox.

## Local Test Steps
A giovanni request (e.g. the following) should return the giovanni URL successfully.
```
curl -Ln -bj "http://localhost:3000/C1225808238-GES_DISC/ogc-api-coverages/1.0.0/collections/%2FGrid%2FIRprecipitation/coverage/rangeset?format=text%2Fcsv&point=0.76,-3.8&subset=time%28%222020-01-01T00%3A00%3A00Z%22%3A%222020-01-01T03%3A00%3A00Z%22%29&forceAsync=true"
```

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)