### PR TITLE
HARMONY-1096: Fail a job if the work item update would cause an orphaned job in the running state

### DIFF
--- a/fixtures/cmr.uat.earthdata.nasa.gov-443/164806533329363129
+++ b/fixtures/cmr.uat.earthdata.nasa.gov-443/164806533329363129
@@ -1,0 +1,21 @@
+POST /search/clear-scroll
+accept: application/json
+content-type: application/json
+accept-encoding: gzip,deflate
+body: {\"scroll_id\":\"911852008\"}
+
+HTTP/1.1 204 No Content
+connection: close
+date: Wed, 23 Mar 2022 19:55:33 GMT
+cmr-request-id: a9b013fd-76a4-472b-ae9e-668bb303d9cb
+x-request-id: eU9f9Lmb6gLAMDYGDVa8ymYDS0Neo_pFadUWTXsBdeDLuveSW4OHow==
+strict-transport-security: max-age=31536000
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+server: ServerTokens ProductOnly
+x-cache: Miss from cloudfront
+via: 1.1 1bd7d779bed244375679d82e1821cc3c.cloudfront.net (CloudFront)
+x-amz-cf-pop: IAD89-P2
+x-amz-cf-id: eU9f9Lmb6gLAMDYGDVa8ymYDS0Neo_pFadUWTXsBdeDLuveSW4OHow==
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "swagger-ui-express": "^4.1.4",
         "tmp": "^0.2.1",
         "tmp-promise": "^3.0.3",
-        "ts-node": "^10.4.0",
+        "ts-node": "^10.7.0",
         "tsconfig-paths": "^3.9.0",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1",
@@ -16090,9 +16090,9 @@
       "integrity": "sha512-XvB+OdKSJ708Dmf9ore4Uf/q62AYDTzFcAdxc8KNML1mmAWywRFVt/dn1KYJH8Agt5UJNujfM3znU5PxgAzA2w=="
     },
     "node_modules/ts-node": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "dependencies": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
@@ -16105,11 +16105,13 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.0",
         "yn": "3.1.1"
       },
       "bin": {
         "ts-node": "dist/bin.js",
         "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
         "ts-node-script": "dist/bin-script.js",
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
@@ -16673,6 +16675,11 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA=="
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -30051,9 +30058,9 @@
       "integrity": "sha512-XvB+OdKSJ708Dmf9ore4Uf/q62AYDTzFcAdxc8KNML1mmAWywRFVt/dn1KYJH8Agt5UJNujfM3znU5PxgAzA2w=="
     },
     "ts-node": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
-      "integrity": "sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "requires": {
         "@cspotcode/source-map-support": "0.7.0",
         "@tsconfig/node10": "^1.0.7",
@@ -30066,6 +30073,7 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.0",
         "yn": "3.1.1"
       },
       "dependencies": {
@@ -30502,6 +30510,11 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "swagger-ui-express": "^4.1.4",
     "tmp": "^0.2.1",
     "tmp-promise": "^3.0.3",
-    "ts-node": "^10.4.0",
+    "ts-node": "^10.7.0",
     "tsconfig-paths": "^3.9.0",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1",


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1096

## Description
Fixes a scenario where:

1. A work item update comes in
2. There are steps that should be queued after this one
3. But the work item update doesn't provide a catalog

we were just letting the job sit in the running state with no more work items and would never be worked.

This PR changes things to mark the job as failed with a message:
"Harmony internal failure: could not create the next work items for the request"

Note I also updated `ts-node` in this PR as I was trying to get a test plugin working correctly in VS Code.

## Local Test Steps
With James' fix for HARMONY-1093 this will be difficult to reproduce. If you want to test this before James merges his PR in you can delete the query-cmr deployment in your local k8s, submit a request, wait at least 10 minutes for the scroll session to expire, then start the query-cmr service.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* :x: Documentation updated (if needed)