### PR TITLE
Shapefile subsetting l2ss-py in UAT

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -570,6 +570,7 @@ https://cmr.uat.earthdata.nasa.gov:
       subsetting:
         bbox: true
         variable: true
+        shape: true
       output_formats:
         - application/netcdf # Incorrect mime-type, remove when no longer needed
         - application/x-netcdf4


### PR DESCRIPTION
## Jira Issue ID

N/A


## Description

Added `shape: true` option to l2ss-py in UAT so we can test our 1.4.0 UAT release that adds shapefile subsetting. We will open another PR soon with this same change into prod once we have validated this behavior in uat.

## Local Test Steps


## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)