### PR TITLE
DAS-1372 - Add UAT EEDTEST mirrors of ASF collections to HGA.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -398,6 +398,9 @@ https://cmr.uat.earthdata.nasa.gov:
           <<: *default-turbo-env
           STAGING_PATH: public/nasa/harmony-gdal-adapter
     collections:
+      - id: C1244141281-EEDTEST # ALOS AVNIR OBS ORI test collection
+      - id: C1244141250-EEDTEST # Sentinel 1 Interferogram test collection
+      - id: C1244141264-EEDTEST # UAVSAR POLSAR Pauli test collection
       - id: C1225776654-ASF
       - id: C1207038647-ASF
       - id: C1233629671-ASF


### PR DESCRIPTION
## Jira Issue ID

[DAS-1372](https://bugs.earthdata.nasa.gov/browse/DAS-1372) (first acceptance criterion).

## Description

This PR adds the UMM-C concept IDs for EEDTEST mirror collections of ASF collections (AVNIR, Sentinel 1 Interferograms, UAVSAR) to the HGA service entry in UAT. There's currently not a UMM-S record to enable HGA for our new collections via a UMM-S to UMM-C association (either in an ASF or EEDTEST provider).

## Local Test Steps

Update your Harmony local instance to use the new `service.yml` file. The run the following requests, which should be successful:

```
# AVNIR:
http://localhost:3000/C1244141281-EEDTEST/ogc-api-coverages/1.0.0/collections/Band1%2CBand2/coverage/rangeset?subset=lat(-.05:0.25)&subset=lon(-51.0:-50.75)&format=image%2Ftiff&granuleID=G1244144597-EEDTEST

# Sentinel 1 Interferograms:
http://localhost:3000/C1244141250-EEDTEST/ogc-api-coverages/1.0.0/collections/science%2Fgrids%2Fdata%2Famplitude/coverage/rangeset?subset=lat(33:33.1)&subset=lon(-115.5:-115.25)&granuleID=G1244144618-EEDTEST

# UAVSAR:
http://localhost:3000/C1244141264-EEDTEST/ogc-api-coverages/1.0.0/collections/Band1/coverage/rangeset?subset=lat(63.7:64.1)&subset=lon(-145.9:-145.7)&format=image%2Ftiff&granuleID=G1244144733-EEDTEST
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~