### PR TITLE
Harmony 1130 unpause

### DIFF
--- a/app/frontends/jobs.ts
+++ b/app/frontends/jobs.ts
@@ -180,7 +180,7 @@ export async function getJobStatus(
 }
 
 /**
- * Express.js handler that cancels a single job `(POST /jobs/{jobID})`. A user can cancel their own
+ * Express.js handler that cancels a single job `(POST /jobs/{jobID}/cancel)`. A user can cancel their own
  * request. An admin can cancel any user's request.
  *
  * @param req - The request sent by the client
@@ -223,7 +223,7 @@ export async function cancelJob(
 }
 
 /**
- * Express.js handler that resumes a single job `(POST /jobs/{jobID})`. A user can resume their own
+ * Express.js handler that resumes a single job `(POST /jobs/{jobID}/resume)`. A user can resume their own
  * request. An admin can resume any user's request.
  *
  * @param req - The request sent by the client

--- a/app/frontends/jobs.ts
+++ b/app/frontends/jobs.ts
@@ -1,7 +1,7 @@
 import { Response, NextFunction } from 'express';
 import { Job, JobStatus, JobQuery } from '../models/job';
 import { keysToLowerCase } from '../util/object';
-import cancelAndSaveJob, { validateJobId } from '../util/job';
+import { cancelAndSaveJob, resumeAndSaveJob, validateJobId } from '../util/job';
 import JobLink from '../models/job-link';
 import { needsStacLink } from '../util/stac';
 import { getRequestRoot } from '../util/url';
@@ -206,6 +206,45 @@ export async function cancelJob(
     }
 
     await cancelAndSaveJob(jobID, message, req.context.logger, true, username);
+
+    if (req.context.isAdminAccess) {
+      res.redirect(`/admin/jobs/${jobID}`);
+    } else {
+      res.redirect(`/jobs/${jobID}`);
+    }
+  } catch (e) {
+    req.context.logger.error(e);
+    if (e instanceof TypeError) {
+      next(new RequestValidationError(e.message));
+    } else {
+      next(e);
+    }
+  }
+}
+
+/**
+ * Express.js handler that resumes a single job `(POST /jobs/{jobID})`. A user can resume their own
+ * request. An admin can resume any user's request.
+ *
+ * @param req - The request sent by the client
+ * @param res - The response to send to the client
+ * @param next - The next function in the call chain
+ * @returns Resolves when the request is complete
+ */
+export async function resumeJob(
+  req: HarmonyRequest, res: Response, next: NextFunction,
+): Promise<void> {
+  const { jobID } = req.params;
+  req.context.logger.info(`Resume requested for job ${jobID} by user ${req.user}`);
+  try {
+    validateJobId(jobID);
+    let username: string;
+
+    if (!req.context.isAdminAccess) {
+      username = req.user;
+    }
+
+    await resumeAndSaveJob(jobID, req.context.logger, username);
 
     if (req.context.isAdminAccess) {
       res.redirect(`/admin/jobs/${jobID}`);

--- a/app/routers/router.ts
+++ b/app/routers/router.ts
@@ -11,7 +11,7 @@ import earthdataLoginTokenAuthorizer from '../middleware/earthdata-login-token-a
 import earthdataLoginOauthAuthorizer from '../middleware/earthdata-login-oauth-authorizer';
 import admin from '../middleware/admin';
 import wmsFrontend from '../frontends/wms';
-import { getJobsListing, getJobStatus, cancelJob } from '../frontends/jobs';
+import { getJobsListing, getJobStatus, cancelJob, resumeJob } from '../frontends/jobs';
 import { getJobs, getJob, getWorkItemsTable } from '../frontends/workflow-ui';
 import { getStacCatalog, getStacItem } from '../frontends/stac';
 import { getServiceResult } from '../frontends/service-results';
@@ -200,10 +200,12 @@ export default function router({ skipEarthdataLogin = 'false' }: RouterConfig): 
   result.get('/jobs', getJobsListing);
   result.get('/jobs/:jobID', getJobStatus);
   result.post('/jobs/:jobID/cancel', cancelJob);
+  result.post('/jobs/:jobID/resume', resumeJob);
 
   result.get('/admin/jobs', getJobsListing);
   result.get('/admin/jobs/:jobID', getJobStatus);
   result.post('/admin/jobs/:jobID/cancel', cancelJob);
+  result.post('/admin/jobs/:jobID/resume', resumeJob);
 
   result.get('/workflow-ui', getJobs);
   result.get('/workflow-ui/:jobID', getJob);
@@ -212,9 +214,11 @@ export default function router({ skipEarthdataLogin = 'false' }: RouterConfig): 
   result.get('/admin/workflow-ui/:jobID', getJob);
   result.get('/admin/workflow-ui/:jobID/work-items', getWorkItemsTable);
 
-  // Allow canceling with a GET in addition to POST to workaround issues with redirects using EDL
+  // Allow canceling/resuming with a GET in addition to POST to workaround issues with redirects using EDL
   result.get('/jobs/:jobID/cancel', cancelJob);
   result.get('/admin/jobs/:jobID/cancel', cancelJob);
+  result.get('/jobs/:jobID/resume', resumeJob);
+  result.get('/admin/jobs/:jobID/resume', resumeJob);
 
   result.get('/admin/configuration/log-level', setLogLevel);
 

--- a/app/util/job.ts
+++ b/app/util/job.ts
@@ -53,7 +53,7 @@ export async function pauseAndSaveJob(
    * 
    * @param jobID - the id of job (requestId in the db)
    * @param logger - the logger to use for logging errors/info
-   * @param username - the name of the user requesting the cancel - null if the admin
+   * @param username - the name of the user requesting the resume - null if the admin
    * @throws {@link ConflictError} if the job is already in a terminal state.
  */
 export async function resumeAndSaveJob(

--- a/test/helpers/jobs.ts
+++ b/test/helpers/jobs.ts
@@ -248,6 +248,46 @@ export function adminCancelJobWithGET(app: Express.Application, { jobID }: Job):
   return request(app).get(`/admin/jobs/${jobID}/cancel`);
 }
 
+/**
+ * Submits a resume job request as the given user
+ * 
+ * @param app - The express application (typically this.frontend)
+ * @param job - The job
+ */
+export function resumeJob(app: Express.Application, { jobID }: Job): Test {
+  return request(app).post(`/jobs/${jobID}/resume`);
+}
+
+/**
+ * Submits a resume job request as the given user
+ *
+ * @param app - The express application (typically this.frontend)
+ * @param job - The job
+ */
+export function adminResumeJob(app: Express.Application, { jobID }: Job): Test {
+  return request(app).post(`/admin/jobs/${jobID}/resume`);
+}
+
+/**
+ * Submits a resume job request as the given user using a GET instead of POST
+ *
+ * @param app - The express application (typically this.frontend)
+ * @param job - The job
+ */
+export function resumeJobWithGET(app: Express.Application, { jobID }: Job): Test {
+  return request(app).get(`/jobs/${jobID}/resume`);
+}
+
+/**
+ * Submits a resume job request as the given user using a GET instead of POST
+ *
+ * @param app - The express application (typically this.frontend)
+ * @param job - The job
+ */
+export function adminResumeJobWithGET(app: Express.Application, { jobID }: Job): Test {
+  return request(app).get(`/admin/jobs/${jobID}/resume`);
+}
+
 export const hookJobListing = hookRequest.bind(this, jobListing);
 export const hookAdminJobListing = hookRequest.bind(this, adminJobListing);
 export const hookJobStatus = hookRequest.bind(this, jobStatus);
@@ -256,6 +296,10 @@ export const hookCancelJob = hookRequest.bind(this, cancelJob);
 export const hookAdminCancelJob = hookRequest.bind(this, adminCancelJob);
 export const hookCancelJobWithGET = hookRequest.bind(this, cancelJobWithGET);
 export const hookAdminCancelJobWithGET = hookRequest.bind(this, adminCancelJobWithGET);
+export const hookResumeJob = hookRequest.bind(this, resumeJob);
+export const hookAdminResumeJob = hookRequest.bind(this, adminResumeJob);
+export const hookResumeJobWithGET = hookRequest.bind(this, resumeJobWithGET);
+export const hookAdminResumeJobWithGET = hookRequest.bind(this, adminResumeJobWithGET);
 
 /**
  * Given a string returns a new string with all characters escaped such that the string

--- a/test/helpers/jobs.ts
+++ b/test/helpers/jobs.ts
@@ -259,7 +259,7 @@ export function resumeJob(app: Express.Application, { jobID }: Job): Test {
 }
 
 /**
- * Submits a resume job request as the given user
+ * Submits a resume job request as the given user on the admin endpoint
  *
  * @param app - The express application (typically this.frontend)
  * @param job - The job
@@ -279,7 +279,7 @@ export function resumeJobWithGET(app: Express.Application, { jobID }: Job): Test
 }
 
 /**
- * Submits a resume job request as the given user using a GET instead of POST
+ * Submits a resume job request as the given user on the admin endpoint using a GET instead of POST
  *
  * @param app - The express application (typically this.frontend)
  * @param job - The job

--- a/test/jobs/pause-jobs.ts
+++ b/test/jobs/pause-jobs.ts
@@ -82,7 +82,8 @@ describe('Pausing jobs', function () {
  * 
  * Define common tests to be run for resuming jobs to allow use with admin/normal endpoints
  * 
- * @param resumeEndpointHook - Hook function to be used to resume job.
+ * @param resumeEndpointHook - hook function to be used to resume job.
+ * @param username - user to use when calling Harmony
  */
 function resumeJobCommonTests(resumeEndpointHook: Function, username: string): void {
   describe('when the job does not exist', function () {

--- a/test/jobs/pause-jobs.ts
+++ b/test/jobs/pause-jobs.ts
@@ -1,6 +1,22 @@
+/* eslint-disable no-loop-func */
 import { expect } from 'chai';
 import { v4 as uuid } from 'uuid';
-import { JobStatus, Job } from './../../app/models/job';
+import _ from 'lodash';
+import hookServersStartStop from '../helpers/servers';
+import { hookTransaction } from '../helpers/db';
+import {
+  jobsEqual,
+  resumeJob,
+  adminResumeJob,
+  hookResumeJob,
+  hookAdminResumeJob,
+  adminUsername,
+  hookResumeJobWithGET,
+  hookAdminResumeJobWithGET,
+  buildJob,
+} from '../helpers/jobs';
+import { hookRedirect } from '../helpers/hooks';
+import { JobRecord, JobStatus, Job } from '../../app/models/job';
 
 // unit tests for pausing/resuming jobs
 
@@ -56,4 +72,430 @@ describe('Pausing jobs', function () {
       });
     });
   });
+});
+
+// integration tests for resuming jobs
+
+describe('Resuming a job - user endpoint', function () {
+  const resumeEndpointHooks = {
+    POST: hookResumeJob,
+    GET: hookResumeJobWithGET,
+  };
+  for (const [httpMethod, resumeEndpointHook] of Object.entries(resumeEndpointHooks)) {
+    describe(`Resuming using ${httpMethod}`, function () {
+      hookServersStartStop({ skipEarthdataLogin: false });
+      hookTransaction();
+      const joeJob1 = buildJob({ username: 'joe' });
+      before(async function () {
+        joeJob1.pause();
+        await joeJob1.save(this.trx);
+        this.trx.commit();
+        this.trx = null;
+      });
+      const { jobID } = joeJob1;
+      describe('For a user who is not logged in', function () {
+        before(async function () {
+          this.res = await resumeJob(this.frontend, { jobID } as Job).redirects(0);
+        });
+        it('redirects to Earthdata Login', function () {
+          expect(this.res.statusCode).to.equal(303);
+          expect(this.res.headers.location).to.include(process.env.OAUTH_HOST);
+        });
+
+        it('sets the "redirect" cookie to the originally-requested resource', function () {
+          expect(this.res.headers['set-cookie'][0]).to.include(encodeURIComponent(`/jobs/${jobID}/resume`));
+        });
+      });
+
+      describe('For a logged-in user who owns the job', function () {
+        resumeEndpointHook({ jobID, username: 'joe' });
+
+        it('returns a redirect to the running job', function () {
+          expect(this.res.statusCode).to.equal(302);
+          expect(this.res.headers.location).to.include(`/jobs/${jobID}`);
+        });
+
+        describe('When following the redirect to the resumed job', function () {
+          hookRedirect('joe');
+          it('returns an HTTP success response', function () {
+            expect(this.res.statusCode).to.equal(200);
+          });
+
+          it('changes the status to running', function () {
+            const actualJob = JSON.parse(this.res.text);
+            expect(actualJob.status).to.eql('running');
+          });
+
+          it('sets the message to the job is being processed', function () {
+            const actualJob = JSON.parse(this.res.text);
+            expect(actualJob.message).to.eql('The job is being processed');
+          });
+
+          it('does not modify any of the other job fields', function () {
+            const actualJob = new Job(JSON.parse(this.res.text));
+            const expectedJob: JobRecord = _.cloneDeep(joeJob1);
+            expectedJob.message = 'The job is being processed';
+            expectedJob.status = JobStatus.RUNNING;
+            expect(jobsEqual(expectedJob, actualJob)).to.be.true;
+          });
+        });
+      });
+
+      describe('For a logged-in admin who does not own the job', function () {
+        const joeJob2 = buildJob({ username: 'joe' });
+        hookTransaction();
+        before(async function () {
+          await new Job(joeJob2).save(this.trx);
+          this.trx.commit();
+          this.trx = null;
+        });
+        resumeEndpointHook({ jobID: joeJob2.requestId, username: adminUsername });
+        it('returns a 404 not found', function () {
+          expect(this.res.statusCode).to.equal(404);
+        });
+
+        it('returns a JSON error response', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.NotFoundError',
+            description: `Error: Unable to find job ${joeJob2.requestId}`,
+          });
+        });
+      });
+
+      describe('when the job does not exist', function () {
+        const idDoesNotExist = 'aaaaaaaa-1111-bbbb-2222-cccccccccccc';
+        resumeEndpointHook({ jobID: idDoesNotExist, username: 'joe' });
+        it('returns a 404 HTTP Not found response', function () {
+          expect(this.res.statusCode).to.equal(404);
+        });
+
+        it('returns a JSON error response', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.NotFoundError',
+            description: `Error: Unable to find job ${idDoesNotExist}`,
+          });
+        });
+      });
+
+      describe('when the jobID is in an invalid format', function () {
+        const invalidJobID = 'foo';
+        resumeEndpointHook({ jobID: invalidJobID, username: 'joe' });
+        it('returns a 400 HTTP bad request', function () {
+          expect(this.res.statusCode).to.equal(400);
+        });
+
+        it('returns a JSON error response', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.RequestValidationError',
+            description: `Error: Invalid format for Job ID '${invalidJobID}'. Job ID must be a UUID.`,
+          });
+        });
+      });
+
+      describe('when resuming a running job', function () {
+        const successfulJob = buildJob({ username: 'joe' });
+        successfulJob.status = JobStatus.RUNNING;
+        hookTransaction();
+        before(async function () {
+          await new Job(successfulJob).save(this.trx);
+          this.trx.commit();
+          this.trx = null;
+        });
+
+        resumeEndpointHook({ jobID: successfulJob.requestId, username: 'joe' });
+        it('returns a 409 HTTP conflict', function () {
+          expect(this.res.statusCode).to.equal(409);
+        });
+
+        it('returns a JSON error response indicating the job cannot be resumed', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.ConflictError',
+            description: 'Error: Job status is running - only paused jobs can be resumed.',
+          });
+        });
+      });
+
+      describe('when resuming a successful job', function () {
+        const successfulJob = buildJob({ username: 'joe' });
+        successfulJob.status = JobStatus.SUCCESSFUL;
+        hookTransaction();
+        before(async function () {
+          await new Job(successfulJob).save(this.trx);
+          this.trx.commit();
+          this.trx = null;
+        });
+
+        resumeEndpointHook({ jobID: successfulJob.requestId, username: 'joe' });
+        it('returns a 409 HTTP conflict', function () {
+          expect(this.res.statusCode).to.equal(409);
+        });
+
+        it('returns a JSON error response indicating the job cannot be resumed', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.ConflictError',
+            description: 'Error: Job status is successful - only paused jobs can be resumed.',
+          });
+        });
+      });
+
+      describe('when resuming a failed job', function () {
+        const failedJob = buildJob({ username: 'joe' });
+        failedJob.status = JobStatus.FAILED;
+        hookTransaction();
+        before(async function () {
+          await new Job(failedJob).save(this.trx);
+          this.trx.commit();
+          this.trx = null;
+        });
+        resumeEndpointHook({ jobID: failedJob.requestId, username: 'joe' });
+        it('returns a 409 HTTP conflict', function () {
+          expect(this.res.statusCode).to.equal(409);
+        });
+
+        it('returns a JSON error response indicating the job cannot be resumed', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.ConflictError',
+            description: 'Error: Job status is failed - only paused jobs can be resumed.',
+          });
+        });
+      });
+
+      describe('when resuming a canceled job', function () {
+        const canceledJob = buildJob({ username: 'joe' });
+        canceledJob.status = JobStatus.CANCELED;
+        hookTransaction();
+        before(async function () {
+          await new Job(canceledJob).save(this.trx);
+          this.trx.commit();
+          this.trx = null;
+        });
+
+        resumeEndpointHook({ jobID: canceledJob.requestId, username: 'joe' });
+        it('returns a 409 HTTP conflict', function () {
+          expect(this.res.statusCode).to.equal(409);
+        });
+
+        it('returns a JSON error response indicating the job cannot be resumed', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.ConflictError',
+            description: 'Error: Job status is canceled - only paused jobs can be resumed.',
+          });
+        });
+      });
+    });
+  }
+});
+
+describe('Resuming a job - admin endpoint', function () {
+  const resumeEndpointHooks = {
+    POST: hookAdminResumeJob,
+    GET: hookAdminResumeJobWithGET,
+  };
+  for (const [httpMethod, resumeEndpointHook] of Object.entries(resumeEndpointHooks)) {
+    describe(`Resuming using ${httpMethod}`, function () {
+      hookServersStartStop({ skipEarthdataLogin: false });
+      hookTransaction();
+      const joeJob1 = buildJob({ username: 'joe' });
+      before(async function () {
+        joeJob1.pause();
+        await joeJob1.save(this.trx);
+        this.trx.commit();
+        this.trx = null;
+      });
+      const jobID = joeJob1.requestId;
+      describe('For a user who is not logged in', function () {
+        before(async function () {
+          this.res = await adminResumeJob(this.frontend, { jobID } as Job).redirects(0);
+        });
+        it('redirects to Earthdata Login', function () {
+          expect(this.res.statusCode).to.equal(303);
+          expect(this.res.headers.location).to.include(process.env.OAUTH_HOST);
+        });
+
+        it('sets the "redirect" cookie to the originally-requested resource', function () {
+          expect(this.res.headers['set-cookie'][0]).to.include(encodeURIComponent(`/jobs/${jobID}/resume`));
+        });
+      });
+
+      describe('For a logged-in user (but not admin) who owns the job', function () {
+        resumeEndpointHook({ jobID, username: 'joe' });
+        it('returns a 403 forbidden because they are not an admin', function () {
+          expect(this.res.statusCode).to.equal(403);
+        });
+
+        it('returns a JSON error response', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.ForbiddenError',
+            description: 'Error: You are not permitted to access this resource',
+          });
+        });
+      });
+
+      describe('For a logged-in admin', function () {
+        resumeEndpointHook({ jobID, username: adminUsername });
+        it('returns a redirect to the resumed job', function () {
+          expect(this.res.statusCode).to.equal(302);
+          expect(this.res.headers.location).to.include(`/admin/jobs/${jobID}`);
+        });
+
+        describe('When following the redirect to the resumed job', function () {
+          hookRedirect(adminUsername);
+          it('returns an HTTP success response', function () {
+            expect(this.res.statusCode).to.equal(200);
+          });
+
+          it('changes the status to running', function () {
+            const actualJob = JSON.parse(this.res.text);
+            expect(actualJob.status).to.eql('running');
+          });
+          it('sets the message to the job is being processed', function () {
+            const actualJob = JSON.parse(this.res.text);
+            expect(actualJob.message).to.eql('The job is being processed');
+          });
+          it('does not modify any of the other job fields', function () {
+            const actualJob = new Job(JSON.parse(this.res.text));
+            const expectedJob: JobRecord = _.cloneDeep(joeJob1);
+            expectedJob.message = 'The job is being processed';
+            expectedJob.status = JobStatus.RUNNING;
+            expect(jobsEqual(expectedJob, actualJob)).to.be.true;
+          });
+        });
+      });
+
+      describe('when the job does not exist', function () {
+        const idDoesNotExist = 'aaaaaaaa-1111-bbbb-2222-cccccccccccc';
+        resumeEndpointHook({ jobID: idDoesNotExist, username: adminUsername });
+        it('returns a 404 HTTP Not found response', function () {
+          expect(this.res.statusCode).to.equal(404);
+        });
+
+        it('returns a JSON error response', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.NotFoundError',
+            description: `Error: Unable to find job ${idDoesNotExist}`,
+          });
+        });
+      });
+
+      describe('when the jobID is in an invalid format', function () {
+        const notjoeJob1ID = 'foo';
+        resumeEndpointHook({ jobID: notjoeJob1ID, username: adminUsername });
+        it('returns a 409 HTTP conflict', function () {
+          expect(this.res.statusCode).to.equal(400);
+        });
+
+        it('returns a JSON error response', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.RequestValidationError',
+            description: `Error: Invalid format for Job ID '${notjoeJob1ID}'. Job ID must be a UUID.`,
+          });
+        });
+      });
+
+      describe('when resuming a running job', function () {
+        const successfulJob = buildJob({ username: 'joe' });
+        successfulJob.status = JobStatus.RUNNING;
+        hookTransaction();
+        before(async function () {
+          await new Job(successfulJob).save(this.trx);
+          this.trx.commit();
+          this.trx = null;
+        });
+
+        resumeEndpointHook({ jobID: successfulJob.requestId, username: adminUsername });
+        it('returns a 409 HTTP conflict', function () {
+          expect(this.res.statusCode).to.equal(409);
+        });
+
+        it('returns a JSON error response indicating the job cannot be resumed', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.ConflictError',
+            description: 'Error: Job status is running - only paused jobs can be resumed.',
+          });
+        });
+      });
+
+      describe('when resuming a successful job', function () {
+        const successfulJob = buildJob({ username: 'joe' });
+        successfulJob.status = JobStatus.SUCCESSFUL;
+        hookTransaction();
+        before(async function () {
+          await new Job(successfulJob).save(this.trx);
+          this.trx.commit();
+          this.trx = null;
+        });
+        resumeEndpointHook({ jobID: successfulJob.requestId, username: adminUsername });
+        it('returns a 409 HTTP conflict', function () {
+          expect(this.res.statusCode).to.equal(409);
+        });
+
+        it('returns a JSON error response indicating the job cannot be resumed', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.ConflictError',
+            description: 'Error: Job status is successful - only paused jobs can be resumed.',
+          });
+        });
+      });
+
+      describe('when resuming a failed job', function () {
+        const failedJob = buildJob({ username: 'joe' });
+        failedJob.status = JobStatus.FAILED;
+        hookTransaction();
+        before(async function () {
+          await new Job(failedJob).save(this.trx);
+          this.trx.commit();
+          this.trx = null;
+        });
+
+        resumeEndpointHook({ jobID: failedJob.requestId, username: adminUsername });
+        it('returns a 409 HTTP conflict', function () {
+          expect(this.res.statusCode).to.equal(409);
+        });
+
+        it('returns a JSON error response indicating the job cannot be resumed', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.ConflictError',
+            description: 'Error: Job status is failed - only paused jobs can be resumed.',
+          });
+        });
+      });
+
+      describe('when resuming a canceled job', function () {
+        const canceledJob = buildJob({ username: 'joe' });
+        canceledJob.status = JobStatus.CANCELED;
+        hookTransaction();
+        before(async function () {
+          await new Job(canceledJob).save(this.trx);
+          this.trx.commit();
+          this.trx = null;
+        });
+
+        resumeEndpointHook({ jobID: canceledJob.requestId, username: adminUsername });
+        it('returns a 409 HTTP conflict', function () {
+          expect(this.res.statusCode).to.equal(409);
+        });
+
+        it('returns a JSON error response indicating the job cannot be resumed', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.ConflictError',
+            description: 'Error: Job status is canceled - only paused jobs can be resumed.',
+          });
+        });
+      });
+    });
+  }
 });

--- a/test/util/job.ts
+++ b/test/util/job.ts
@@ -3,7 +3,7 @@ import _ from 'lodash';
 import { buildJob } from '../helpers/jobs';
 import { buildWorkItem } from '../helpers/work-items';
 import { hookTransaction } from '../helpers/db';
-import cancelAndSaveJob from '../../app/util/job';
+import { cancelAndSaveJob } from '../../app/util/job';
 import { JobStatus } from '../../app/models/job';
 import { getWorkItemsByJobId, WorkItemStatus } from '../../app/models/work-item';
 import db from '../../app/util/db';


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1130

## Description
Adds a resume endpoint for normal users and admin users. 

## Local Test Steps
* Start a long-running (async) job
* Change the state of the job to 'paused' in the database
* Connect to the job status page and verify that the job is paused
* Resume the job using the `/jobs/:jobID/resume` endpoint
* Connect to the job status page and verify that the job is running

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~ - will need to wait until auto-pause is added as there is currently no way for a user to pause their own job, therefore no way for a user to make use of the resume endpoint right now