### PR TITLE
HARMONY-1158: Wrap all routes to prevent crashing on asynchronous exceptions

### DIFF
--- a/app/routers/router.ts
+++ b/app/routers/router.ts
@@ -1,5 +1,6 @@
 import process from 'process';
 import express, { RequestHandler } from 'express';
+import asyncHandler from 'express-async-handler';
 import cookieParser from 'cookie-parser';
 import swaggerUi from 'swagger-ui-express';
 import * as yaml from 'js-yaml';
@@ -154,7 +155,7 @@ export default function router({ skipEarthdataLogin = 'false' }: RouterConfig): 
 
   // Handle multipart/form-data (used for shapefiles). Files will be uploaded to
   // a bucket.
-  result.post(collectionPrefix('(ogc-api-coverages)'), shapefileUpload());
+  result.post(collectionPrefix('(ogc-api-coverages)'), asyncHandler(shapefileUpload()));
 
   result.use(logged(earthdataLoginTokenAuthorizer(authorizedRoutes)));
 
@@ -171,7 +172,7 @@ export default function router({ skipEarthdataLogin = 'false' }: RouterConfig): 
   }
 
   // Routes and middleware not dealing with service requests
-  result.get('/service-results/:bucket/:key(*)', getServiceResult);
+  result.get('/service-results/:bucket/:key(*)', asyncHandler(getServiceResult));
 
   // Routes and middleware for handling service requests
   result.use(logged(cmrCollectionReader));
@@ -191,41 +192,41 @@ export default function router({ skipEarthdataLogin = 'false' }: RouterConfig): 
   result.use(logged(cmrGranuleLocator));
   result.use(logged(addRequestContextToOperation));
 
-  result.get('/', landingPage);
-  result.get('/versions', getVersions);
+  result.get('/', asyncHandler(landingPage));
+  result.get('/versions', asyncHandler(getVersions));
   result.use('/docs/api', swaggerUi.serve, swaggerUi.setup(yaml.load(ogcCoverageApi.openApiContent), { customJs: '/js/docs/analytics-tag.js' }));
-  result.get(collectionPrefix('(wms|eoss)'), service(serviceInvoker));
-  result.get(/^.*?\/ogc-api-coverages\/.*?\/collections\/.*?\/coverage\/rangeset/, service(serviceInvoker));
-  result.post(/^.*?\/ogc-api-coverages\/.*?\/collections\/.*?\/coverage\/rangeset/, service(serviceInvoker));
-  result.get('/jobs', getJobsListing);
-  result.get('/jobs/:jobID', getJobStatus);
-  result.post('/jobs/:jobID/cancel', cancelJob);
-  result.post('/jobs/:jobID/resume', resumeJob);
+  result.get(collectionPrefix('(wms|eoss)'), asyncHandler(service(serviceInvoker)));
+  result.get(/^.*?\/ogc-api-coverages\/.*?\/collections\/.*?\/coverage\/rangeset/, asyncHandler(service(serviceInvoker)));
+  result.post(/^.*?\/ogc-api-coverages\/.*?\/collections\/.*?\/coverage\/rangeset/, asyncHandler(service(serviceInvoker)));
+  result.get('/jobs', asyncHandler(getJobsListing));
+  result.get('/jobs/:jobID', asyncHandler(getJobStatus));
+  result.post('/jobs/:jobID/cancel', asyncHandler(cancelJob));
+  result.post('/jobs/:jobID/resume', asyncHandler(resumeJob));
 
-  result.get('/admin/jobs', getJobsListing);
-  result.get('/admin/jobs/:jobID', getJobStatus);
-  result.post('/admin/jobs/:jobID/cancel', cancelJob);
-  result.post('/admin/jobs/:jobID/resume', resumeJob);
+  result.get('/admin/jobs', asyncHandler(getJobsListing));
+  result.get('/admin/jobs/:jobID', asyncHandler(getJobStatus));
+  result.post('/admin/jobs/:jobID/cancel', asyncHandler(cancelJob));
+  result.post('/admin/jobs/:jobID/resume', asyncHandler(resumeJob));
 
-  result.get('/workflow-ui', getJobs);
-  result.get('/workflow-ui/:jobID', getJob);
-  result.get('/workflow-ui/:jobID/work-items', getWorkItemsTable);
-  result.get('/admin/workflow-ui', getJobs);
-  result.get('/admin/workflow-ui/:jobID', getJob);
-  result.get('/admin/workflow-ui/:jobID/work-items', getWorkItemsTable);
+  result.get('/workflow-ui', asyncHandler(getJobs));
+  result.get('/workflow-ui/:jobID', asyncHandler(getJob));
+  result.get('/workflow-ui/:jobID/work-items', asyncHandler(getWorkItemsTable));
+  result.get('/admin/workflow-ui', asyncHandler(getJobs));
+  result.get('/admin/workflow-ui/:jobID', asyncHandler(getJob));
+  result.get('/admin/workflow-ui/:jobID/work-items', asyncHandler(getWorkItemsTable));
 
   // Allow canceling/resuming with a GET in addition to POST to workaround issues with redirects using EDL
-  result.get('/jobs/:jobID/cancel', cancelJob);
-  result.get('/admin/jobs/:jobID/cancel', cancelJob);
-  result.get('/jobs/:jobID/resume', resumeJob);
-  result.get('/admin/jobs/:jobID/resume', resumeJob);
+  result.get('/jobs/:jobID/cancel', asyncHandler(cancelJob));
+  result.get('/admin/jobs/:jobID/cancel', asyncHandler(cancelJob));
+  result.get('/jobs/:jobID/resume', asyncHandler(resumeJob));
+  result.get('/admin/jobs/:jobID/resume', asyncHandler(resumeJob));
 
-  result.get('/admin/configuration/log-level', setLogLevel);
+  result.get('/admin/configuration/log-level', asyncHandler(setLogLevel));
 
-  result.get('/cloud-access', cloudAccessJson);
-  result.get('/cloud-access.sh', cloudAccessSh);
-  result.get('/stac/:jobId', getStacCatalog);
-  result.get('/stac/:jobId/:itemIndex', getStacItem);
+  result.get('/cloud-access', asyncHandler(cloudAccessJson));
+  result.get('/cloud-access.sh', asyncHandler(cloudAccessSh));
+  result.get('/stac/:jobId', asyncHandler(getStacCatalog));
+  result.get('/stac/:jobId/:itemIndex', asyncHandler(getStacItem));
 
   result.get('/*', () => { throw new NotFoundError('The requested page was not found.'); });
   result.post('/*', () => { throw new NotFoundError('The requested POST page was not found.'); });

--- a/app/routers/service-response-router.ts
+++ b/app/routers/service-response-router.ts
@@ -1,4 +1,5 @@
 import { Router, json } from 'express';
+import asyncHandler from 'express-async-handler';
 import { getWork, updateWorkItem } from '../backends/workflow-orchestration';
 import { responseHandler } from '../backends/service-response';
 import { getReadyWorkItemCountForServiceID } from '../backends/service-metrics';
@@ -15,11 +16,11 @@ export default function router(): Router {
   result.use(json({
     type: 'application/json',
   }));
-  result.post('/:requestId/response', responseHandler);
-  result.get('/work', getWork);
-  result.put('/work/:id', updateWorkItem);
+  result.post('/:requestId/response', asyncHandler(responseHandler));
+  result.get('/work', asyncHandler(getWork));
+  result.put('/work/:id', asyncHandler(updateWorkItem));
 
-  result.get('/metrics', getReadyWorkItemCountForServiceID);
+  result.get('/metrics', asyncHandler(getReadyWorkItemCountForServiceID));
 
   result.use((err, _req, _res, _next) => {
     if (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "date-fns": "^2.21.3",
         "dotenv": "^10.0.0",
         "express": "^4.17.3",
+        "express-async-handler": "^1.2.0",
         "express-openapi": "^4.6.5",
         "express-validator": "^6.13.0",
         "express-winston": "^4.1.0",
@@ -7052,6 +7053,11 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/express-async-handler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
+      "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
     },
     "node_modules/express-normalize-query-params-middleware": {
       "version": "0.5.1",
@@ -22618,6 +22624,11 @@
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
+    },
+    "express-async-handler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.2.0.tgz",
+      "integrity": "sha512-rCSVtPXRmQSW8rmik/AIb2P0op6l7r1fMW538yyvTMltCO4xQEWMmobfrIxN2V1/mVrgxB8Az3reYF6yUZw37w=="
     },
     "express-normalize-query-params-middleware": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "date-fns": "^2.21.3",
     "dotenv": "^10.0.0",
     "express": "^4.17.3",
+    "express-async-handler": "^1.2.0",
     "express-openapi": "^4.6.5",
     "express-validator": "^6.13.0",
     "express-winston": "^4.1.0",


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1158

## Description
I'm not entirely sure why unhandled promise rejections are now causing our node application to crash, but we've always been handling them incorrectly.

I looked at the express documentation and for asynchronous errors we need to make sure we catch them and then call the next function. Express automatically does that for synchronous code, but not for asynchronous code. We need to wrap all of routes with code that does a try catch and then call next for the error handling in order to make async code work correctly.

When reading this blog post I found there's a simple library (express-async-handler) that does that wrapping - we just need to call it for all of our routes: 
https://javascript.plainenglish.io/node-express-async-error-handling-e12aa693d84d

## Local Test Steps

1. Submit a request for 50 granules: http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A80)&subset=lon(-140%3A0)&outputCrs=EPSG%3A4326&format=image%2Fpng&maxResults=50
2. Let the request begin processing and picking up work (you'll want to make sure that the polling interval is 500 ms which is a recent change, so be sure you've built service-runner recently and restarted your services).
3. Cancel the request (/jobs/:jobID/cancel)
4. Verify node does not crash and your application is still working

If you've timed things correctly you'll have triggered the error and should see something similar to the following in the harmony log:
```
2022-04-20T16:14:08.170Z [info] [backend] [work]: Updating work item for 208 to successful
2022-04-20T16:14:08.220Z [info] [backend]: HTTP PUT /service/work/208
2022-04-20T16:14:08.227Z [error]: Cannot remove headers after they are sent to the client
Error [ERR_HTTP_HEADERS_SENT]: Cannot remove headers after they are sent to the client
    at new NodeError (node:internal/errors:371:5)
    at ServerResponse.removeHeader (node:_http_outgoing:654:11)
    at ServerResponse.send (/Users/cddurbin/workspace/harmony/harmony/node_modules/express/lib/response.js:210:10)
    at updateWorkItem (/Users/cddurbin/workspace/harmony/harmony/app/backends/workflow-orchestration.ts:331:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
Error [ERR_HTTP_HEADERS_SENT]: Cannot remove headers after they are sent to the client
    at new NodeError (node:internal/errors:371:5)
    at ServerResponse.removeHeader (node:_http_outgoing:654:11)
    at ServerResponse.send (/Users/cddurbin/workspace/harmony/harmony/node_modules/express/lib/response.js:210:10)
    at updateWorkItem (/Users/cddurbin/workspace/harmony/harmony/app/backends/workflow-orchestration.ts:331:19)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```


## PR Acceptance Checklist
* [X] Acceptance criteria met
~* [ ] Tests added/updated (if needed) and passing~
~* [ ] Documentation updated (if needed)~