### PR TITLE
HARMONY-1161: Fix harmony running from Docker to work with Node 16 changes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,9 @@ node_modules
 services
 .env
 db/*.sqlite3
+logs
+tasks
+test
+docs
+workload
+fixtures

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,16 @@ ARG BASE_IMAGE=node:16-buster
 FROM $BASE_IMAGE
 RUN apt update && apt-get install sqlite3
 RUN mkdir -p /harmony
-COPY ./package.json package-lock.json lerna.json /harmony/
+COPY package.json package-lock.json lerna.json /harmony/
+RUN chown node -R /harmony
+USER node
 WORKDIR /harmony
-RUN npm install
+RUN npm ci
+RUN npm install sqlite3 --save
 COPY . /harmony/
-RUN rm -f config/services.yml
 # build the sqlite dabase
+USER root
 RUN ./bin/create-database development
-RUN chown -R node /harmony
+RUN chown -R node db
 USER node
 ENTRYPOINT [ "npm", "run", "start" ]


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1161

## Description
Harmony in a box with harmony running in k8s was broken by the Node 16 changes. This fixes that. Also I changed the way the Dockerfile was structured to build much faster.

It took 690 seconds the first time I built and every build after that was still taking hundreds of seconds. Now as long as the libraries in package.json do not change it takes 8 seconds to build. If package.json changes and an install needs to run it still completes in 2-3 minutes.

## Local Test Steps
In your .env make sure to not override the defaults for LOCALSTACK_HOST, BACKEND_HOST, and CALLBACK_URL_ROOT so that you can use harmony in a box.

```
npm run build
bin/start-harmony
bin/restart-services
```

After harmony starts up submit a request and verify it is successful.

## PR Acceptance Checklist
* [X] Acceptance criteria met
~* [ ] Tests added/updated (if needed) and passing~
~* [ ] Documentation updated (if needed)~