### PR TITLE
DAS-1463 - Add production services.yml entry for the Trajectory Subsetter

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -386,6 +386,29 @@ https://cmr.earthdata.nasa.gov:
       - image: !Env ${VAR_SUBSETTER_IMAGE}
         operations: ['variableSubset', 'spatialSubset']
 
+  - name: sds/trajectory-subsetter
+    data_operation_version: '0.14.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/sds/trajectory-subsetter
+    umm_s:
+      - S2232210365-ORNL_CLOUD
+    collections: []
+    capabilities:  # The Trajectory Subsetter also supports temporal subsetting
+      subsetting:
+        bbox: true
+        shape: true
+        variable: true
+      output_formats:
+        - application/x-hdf
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+      - image: !Env ${TRAJECTORY_SUBSETTER_IMAGE}
+        operations: ['variableSubset', 'spatialSubset']
 
 https://cmr.uat.earthdata.nasa.gov:
 


### PR DESCRIPTION
## Jira Issue ID

[DAS-1463](https://bugs.earthdata.nasa.gov/browse/DAS-1463)

## Description

This PR adds an entry in the production section of `services.yml`, to enable the Trajectory Subsetter in production.  It also adds a reference to an [ORNL UMM-S record](https://cmr.earthdata.nasa.gov/search/services.umm_json?provider=ORNL_CLOUD). This should enable ORNL to activate the Trajectory Subsetter for their collections as soon as this change is deployed to production.

## Local Test Steps

This change can't really be tested locally, as local Harmony uses the UAT content for `services.yml`.

## PR Acceptance Checklist
* [x] Acceptance criteria met
~* [ ] Tests added/updated (if needed) and passing~
~* [ ] Documentation updated (if needed)~