### PR TITLE
HARMONY-1164: Fix inconsistent job status

### DIFF
--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -241,6 +241,8 @@ export class Job extends Record implements JobRecord {
   *
   * @param transaction - the transaction to use for querying
   * @param jobID - the jobID for the job that should be retrieved
+  * @param getLinks - if true include the job links when returning the job
+  * @param lock - if true lock the row in the jobs table
   * @returns the Job with the given JobID or null if not found
   */
   static async byJobID(

--- a/app/workers/work-failer.ts
+++ b/app/workers/work-failer.ts
@@ -44,7 +44,7 @@ export default class WorkFailer implements Worker {
         await updateWorkItemStatuses(tx, workItemIds, WorkItemStatus.FAILED);
         const jobIds = new Set(workItems.map((item) => item.jobID));
         for (const jobId of jobIds) {
-          const job = await Job.byJobID(tx, jobId);
+          const job = await Job.byJobID(tx, jobId, false, true);
           await completeJob(
             tx, job, JobStatus.FAILED, this.logger,
             `Job failed because one or more work items took too long (more than ${olderThanMinutes} minutes) to complete.`,

--- a/fixtures/cmr.uat.earthdata.nasa.gov-443/165099102895369026
+++ b/fixtures/cmr.uat.earthdata.nasa.gov-443/165099102895369026
@@ -1,0 +1,25 @@
+POST /search/clear-scroll
+accept: application/json
+content-type: application/json
+accept-encoding: gzip,deflate
+body: {\"scroll_id\":\"598028169\"}
+
+HTTP/1.1 404 Not Found
+content-type: application/json
+content-length: 56
+connection: close
+date: Tue, 26 Apr 2022 16:37:09 GMT
+access-control-allow-origin: *
+cmr-request-id: cd48174f-6c4d-4eaf-879c-0a5a28af0283
+x-request-id: GXKNfUpcsJsj4HYFhoA2lPn8OHX-cWAWF45HCXluWU1LWs6Sc1sOdA==
+strict-transport-security: max-age=31536000
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+server: ServerTokens ProductOnly
+x-cache: Error from cloudfront
+via: 1.1 0dc81f450c72d91e34b5a0b41d441f28.cloudfront.net (CloudFront)
+x-amz-cf-pop: IAD89-P2
+x-amz-cf-id: GXKNfUpcsJsj4HYFhoA2lPn8OHX-cWAWF45HCXluWU1LWs6Sc1sOdA==
+
+{"errors":["Scroll session [598028169] does not exist"]}


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1164

## Description
We've been seeing some inconsistent job status when several work items complete work for a job around the same time. Sometimes the progress percent would go down and in some instances the status would go back to running when the request should have been successful. When performing a workload run with just a single request going at a time with a random number of granules between 1 and 97 for a harmony-service-example request I would consistently see this error condition where all work items were successful, but the job was still in the running state. I'd usually see it within just a couple of requests from the start of running and never made it past 10 requests.

After this change to make sure the job is locked when updating the status after a work item completes I've been able to run a workload run in my own sandbox for hours without issue (more than 250 requests).

Note that on a couple of occasions I've seen a case where a work item stays in the running state and the job stays running. While that needs to be figured out and fixed there is a separate ticket for handling it. This ticket is just to make sure the job status is consistent with the work items.

## Local Test Steps
Testing locally is difficult because you'd need to have many granules processed in parallel. I would recommend deploying to a sandbox environment where we run 50 in parallel.

Run a workload run with just the harmony-service-example with a random number of granules:
`HTTP_PROXY=socks5h://localhost:8080 locust --tags random`

In the locust UI choose to run just 1 worker at a time (for maximum contention on work items updating for the same job and also so the run will stop as soon as one job is hung in the running state). Make sure that the requests continue to go through successfully, or if things do get stuck make sure that not all of the work items are in the successful state for that job.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* ~[ ] Tests added/updated (if needed) and passing~
* ~[ ] Documentation updated (if needed) ~