### PR TITLE
Harmony 1139 token refresh upon resume

### DIFF
--- a/app/frontends/jobs.ts
+++ b/app/frontends/jobs.ts
@@ -192,7 +192,7 @@ export async function changeJobState(
   req: HarmonyRequest,
   res: Response,
   next: NextFunction,
-  jobFn: (jobID: string, logger: Logger, username: string) => Promise<void>,
+  jobFn: (jobID: string, logger: Logger, username: string, token: string) => Promise<void>,
 ): Promise<void> {
   try {
     const { jobID } = req.params;
@@ -203,7 +203,7 @@ export async function changeJobState(
       username = req.user;
     }
 
-    await jobFn(jobID, req.context.logger, username);
+    await jobFn(jobID, req.context.logger, username, req.accessToken);
 
     if (req.context.isAdminAccess) {
       res.redirect(`/admin/jobs/${jobID}`);

--- a/app/util/job.ts
+++ b/app/util/job.ts
@@ -8,6 +8,9 @@ import { ConflictError, NotFoundError, RequestValidationError } from './errors';
 import isUUID from './uuid';
 import { clearScrollSession } from './cmr';
 import { WorkItemStatus } from '../models/work-item-interface';
+import { getWorkflowStepsByJobId } from '../models/workflow-steps';
+import DataOperation, { CURRENT_SCHEMA_VERSION } from '../models/data-operation';
+import { createDecrypter, createEncrypter } from './crypto';
 
 /**
  * Cleans up the temporary work items for the provided jobID
@@ -44,50 +47,6 @@ async function lookupJob(tx: Transaction, jobID: string, username: string): Prom
     throw new NotFoundError(`Unable to find job ${jobID}`);
   }
   return job;
-}
-
-/**
- * Pause a job and then save it.
- *
- * @param jobID - the id of job (requestId in the db)
- * @param _logger - the logger to use for logging errors/info (unused, here to )
- * @param username - the name of the user requesting the pause - null if the admin
- * @throws {@link ConflictError} if the job is already in a terminal state.
- * @throws {@link NotFoundError} if the job does not exist or the job does not
- * belong to the user.
- */
-export async function pauseAndSaveJob(
-  jobID: string,
-  _logger: Logger,
-  username: string,
-): Promise<void> {
-  await db.transaction(async (tx) => {
-    const job = await lookupJob(tx, jobID, username);
-    job.pause();
-    await job.save(tx);
-  });
-}
-
-/**
- * Resume a paused job then save it.
- *
- * @param jobID - the id of job (requestId in the db)
- * @param _logger - the logger to use for logging errors/info
- * @param username - the name of the user requesting the resume - null if the admin
- * @throws {@link ConflictError} if the job is already in a terminal state.
- * @throws {@link NotFoundError} if the job does not exist or the job does not
- * belong to the user.
- */
-export async function resumeAndSaveJob(
-  jobID: string,
-  _logger: Logger,
-  username: string,
-): Promise<void> {
-  await db.transaction(async (tx) => {
-    const job = await lookupJob(tx, jobID, username);
-    job.resume();
-    await job.save(tx);
-  });
 }
 
 /**
@@ -133,13 +92,16 @@ export async function completeJob(
  * @param jobID - the id of job (requestId in the db)
  * @param logger - the logger to use for logging errors/info
  * @param username - the name of the user requesting the cancel - null if the admin
+ * @param _token - the access token for the user (not used)
+ * @throws {@link ConflictError} if the job is already in a terminal state.
  * @throws {@link NotFoundError} if the job does not exist or the job does not
  * belong to the user.
  */
 export async function cancelAndSaveJob(
   jobID: string,
   logger: Logger,
-  username: string,
+  username?: string,
+  _token?: string,
 ): Promise<void> {
   await db.transaction(async (tx) => {
     const job = await lookupJob(tx, jobID, username);
@@ -160,3 +122,67 @@ export function validateJobId(jobID: string): void {
     throw new RequestValidationError(`Invalid format for Job ID '${jobID}'. Job ID must be a UUID.`);
   }
 }
+
+/**
+ * Pause a job and then save it.
+ *
+ * @param jobID - the id of job (requestId in the db)
+ * @param _logger - the logger to use for logging errors/info (unused, here to )
+ * @param username - the name of the user requesting the pause - null if the admin
+ * @param _token - the access token for the user (not used)
+ * @throws {@link ConflictError} if the job is already in a terminal state.
+ * @throws {@link NotFoundError} if the job does not exist or the job does not
+ * belong to the user.
+ */
+export async function pauseAndSaveJob(
+  jobID: string,
+  _logger: Logger,
+  username?: string,
+  _token?: string,
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    const job = await lookupJob(tx, jobID, username);
+    job.pause();
+    await job.save(tx);
+  });
+}
+
+/**
+ * Resume a paused job then save it.
+ *
+ * @param jobID - the id of job (requestId in the db)
+ * @param _logger - the logger to use for logging errors/info
+ * @param username - the name of the user requesting the resume - null if the admin
+ * @param token - the access token for the user
+ * @throws {@link ConflictError} if the job is already in a terminal state.
+ * @throws {@link NotFoundError} if the job does not exist or the job does not
+ * belong to the user.
+ */
+export async function resumeAndSaveJob(
+  jobID: string,
+  _logger: Logger,
+  username?: string,
+  token?: string,
+
+): Promise<void> {
+  const encrypter = createEncrypter(env.sharedSecretKey);
+  const decrypter = createDecrypter(env.sharedSecretKey);
+  await db.transaction(async (tx) => {
+    const job = await lookupJob(tx, jobID, username);
+    if (username && token) {
+      // update access token
+      const workflowSteps = await getWorkflowStepsByJobId(tx, jobID);
+      for (const workflowStep of workflowSteps) {
+        const { operation } = workflowStep;
+        const op = new DataOperation(JSON.parse(operation), encrypter, decrypter);
+        op.model.accessToken = token;
+        const serialOp = op.serialize(CURRENT_SCHEMA_VERSION);
+        workflowStep.operation = serialOp;
+        workflowStep.save(tx);
+      }
+    }
+    job.resume();
+    await job.save(tx);
+  });
+}
+

--- a/docs/harmony_request_cost_estimator.ipynb
+++ b/docs/harmony_request_cost_estimator.ipynb
@@ -222,6 +222,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "2c0323d7",
+   "metadata": {
+    "vscode": {
+     "languageId": "julia"
+    }
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "1f43382c-c8c1-400a-bc3f-3a4bf0739d4e",
    "metadata": {},
    "outputs": [],

--- a/fixtures/cmr.uat.earthdata.nasa.gov-443/165098979910431734
+++ b/fixtures/cmr.uat.earthdata.nasa.gov-443/165098979910431734
@@ -1,0 +1,25 @@
+POST /search/clear-scroll
+accept: application/json
+content-type: application/json
+accept-encoding: gzip,deflate
+body: {\"scroll_id\":\"598028169\"}
+
+HTTP/1.1 404 Not Found
+content-type: application/json
+content-length: 56
+connection: close
+date: Tue, 26 Apr 2022 16:16:37 GMT
+access-control-allow-origin: *
+cmr-request-id: d5ae6bf2-fae2-4ba6-971d-262791931766
+x-request-id: IInCCjllXTZzuXWLdei_3WHhXL2-nFd4wU7VsoXtD7JuZMZFZqnw6Q==
+strict-transport-security: max-age=31536000
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+server: ServerTokens ProductOnly
+x-cache: Error from cloudfront
+via: 1.1 e0a78b49206aba2a7e76eb45b9688a8e.cloudfront.net (CloudFront)
+x-amz-cf-pop: IAD89-P2
+x-amz-cf-id: IInCCjllXTZzuXWLdei_3WHhXL2-nFd4wU7VsoXtD7JuZMZFZqnw6Q==
+
+{"errors":["Scroll session [598028169] does not exist"]}

--- a/test/util/job.ts
+++ b/test/util/job.ts
@@ -66,13 +66,13 @@ describe('Canceling a job', async function () {
     describe('And the workflow is in the accepted or running state', async function () {
       hookClearScrollSessionExpect();
       it('is able to cancel the job in accepted state', async function () {
-        await cancelAndSaveJob(acceptedTurboJob.requestId, 'Canceled by admin', log, 'doe');
+        await cancelAndSaveJob(acceptedTurboJob.requestId, log, 'doe');
         const { workItems } = await getWorkItemsByJobId(db, readyTurboWorkItem.jobID);
         expect(workItems[0].status).to.equal(WorkItemStatus.CANCELED);
       });
 
       it('is able to cancel the job in running state', async function () {
-        await cancelAndSaveJob(aTurboJob.requestId, 'Canceled by admin', log, 'doe');
+        await cancelAndSaveJob(aTurboJob.requestId, log, 'doe');
         const { workItems } = await getWorkItemsByJobId(db, aTurboJob.jobID);
         expect(workItems[0].status).to.equal(WorkItemStatus.CANCELED);
         expect(workItems[1].status).to.equal(WorkItemStatus.SUCCESSFUL);
@@ -81,15 +81,15 @@ describe('Canceling a job', async function () {
     });
 
     it('fails to cancel an already-canceled workflow', async function () {
-      await cancelAndSaveJob(anotherTurboJob.requestId, 'Canceled by user', log, 'doe');
+      await cancelAndSaveJob(anotherTurboJob.requestId, log, 'doe');
       await expect(
-        cancelAndSaveJob(anotherTurboJob.requestId, 'Canceled by admin', log, 'doe'),
+        cancelAndSaveJob(anotherTurboJob.requestId, log, 'doe'),
       ).to.be.rejectedWith('Job status cannot be updated from canceled to canceled.');
     });
 
     it('fails to cancel an already-finished workflow', async function () {
       await expect(
-        cancelAndSaveJob(finishedTurboJob.requestId, 'Canceled by admin', log, 'doe'),
+        cancelAndSaveJob(finishedTurboJob.requestId, log, 'doe'),
       ).to.be.rejectedWith('Job status cannot be updated from successful to canceled.');
       const { workItems } = await getWorkItemsByJobId(db, finishedTurboWorkItem.jobID);
       expect(workItems[0].status).to.equal(WorkItemStatus.SUCCESSFUL);
@@ -97,7 +97,7 @@ describe('Canceling a job', async function () {
 
     it('fails to cancel a failed workflow', async function () {
       await expect(
-        cancelAndSaveJob(failedTurboJob.requestId, 'Canceled by admin', log, 'doe'),
+        cancelAndSaveJob(failedTurboJob.requestId, log, 'doe'),
       ).to.be.rejectedWith('Job status cannot be updated from failed to canceled.');
       const { workItems } = await getWorkItemsByJobId(db, failedTurboWorkItem.jobID);
       expect(workItems[0].status).to.equal(WorkItemStatus.FAILED);


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1139

## Description
Updates access token when non-admin user resumes a job.

## Local Test Steps
* Start a long running job
* Pause the job
* Check the workflow-steps table for the rows for the job to get the `accessToken` from the `operation` column.
* Log out of EDL
* Log back into EDL (not sure if this will force a new token - if not update the dB directly as described below)
* Resume the job
* Check the workflow-steps table for the rows for the job to get the `accessToken` from the `operation` column.
* See that the new accessToken is different from the previous one

Alternatively it may be easier to edit the `accessToken` value in the `operation` string directly and update the database with that, then compare that value to the value retrieved after resuming.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~