### PR TITLE
Harmony 1132 - job status link for unpausing

### DIFF
--- a/app/frontends/jobs.ts
+++ b/app/frontends/jobs.ts
@@ -52,6 +52,7 @@ function getLinksForDisplay(job: Job, urlRoot: string, statusLinkRel: string): J
       title: 'Resumes the job.',
       href: `${urlRoot}/jobs/${job.jobID}/resume`,
       type: 'application/json',
+      rel: 'resumer',
     }));
   }
   // add a 'self' or 'item' link if it does not already exist

--- a/app/frontends/jobs.ts
+++ b/app/frontends/jobs.ts
@@ -47,6 +47,13 @@ function getLinksForDisplay(job: Job, urlRoot: string, statusLinkRel: string): J
   if (job.status === JobStatus.SUCCESSFUL && needsStacLink(dataLinks)) {
     links.unshift(new JobLink(getStacCatalogLink(urlRoot, job.jobID)));
   }
+  if (job.status === JobStatus.PAUSED) {
+    links.unshift(new JobLink({
+      title: 'Resumes the job.',
+      href: `${urlRoot}/jobs/${job.jobID}/resume`,
+      type: 'application/json',
+    }));
+  }
   // add a 'self' or 'item' link if it does not already exist
   // 'item' is for use in jobs listings, 'self' for job status
   if (links.filter((link) => link.rel === 'self').length === 0) {
@@ -70,6 +77,9 @@ function getMessageForDisplay(job: Job, urlRoot: string): string {
     }
     message += ' Contains results in AWS S3. Access from AWS '
       + `${env.awsDefaultRegion} with keys from ${urlRoot}/cloud-access.sh`;
+  }
+  if (job.status === JobStatus.PAUSED) {
+    message += '. The job may be resumed using the provided link.';
   }
   return message;
 }

--- a/test/helpers/jobs.ts
+++ b/test/helpers/jobs.ts
@@ -136,16 +136,21 @@ export function areStacJobLinksEqual(jobLinks: JobLink[], stacLinks: JobLink[]):
  * @param jobRecord - a job record
  * @param serializedJob - a job record serialized
  * @param skipLinks - if true links are not used in the comparison
+ * @param skipMessage - if true message is not used in the comparison
  * @returns true if the jobs are the same
  */
-export function jobsEqual(jobRecord: JobRecord, serializedJob: Job, skipLinks = false): boolean {
+export function jobsEqual(
+  jobRecord: JobRecord, 
+  serializedJob: Job, 
+  skipLinks = false,
+  skipMessage = false): boolean {
   const recordLinks = new Job(jobRecord).getRelatedLinks('data');
   const serializedLinks = serializedJob.getRelatedLinks('data');
 
   return (jobRecord.requestId === serializedJob.jobID
     && jobRecord.username === serializedJob.username
-    && jobRecord.message && serializedJob.message
-    && jobRecord.progress && serializedJob.progress
+    && ((jobRecord.message === serializedJob.message) || skipMessage)
+    && jobRecord.progress === serializedJob.progress
     && jobRecord.status === serializedJob.status
     && jobRecord.request === serializedJob.request
     && (skipLinks || areJobLinksEqual(recordLinks, serializedLinks)));

--- a/test/helpers/jobs.ts
+++ b/test/helpers/jobs.ts
@@ -149,7 +149,7 @@ export function jobsEqual(
 
   return (jobRecord.requestId === serializedJob.jobID
     && jobRecord.username === serializedJob.username
-    && ((jobRecord.message === serializedJob.message) || skipMessage)
+    && (skipMessage || (jobRecord.message === serializedJob.message))
     && jobRecord.progress === serializedJob.progress
     && jobRecord.status === serializedJob.status
     && jobRecord.request === serializedJob.request

--- a/test/jobs/pause-jobs.ts
+++ b/test/jobs/pause-jobs.ts
@@ -461,6 +461,11 @@ describe('Pausing and resuming a job - user endpoint', function () {
               expect(actualJob.message).to.eql('The job is paused. The job may be resumed using the provided link.');
             });
 
+            it('provides a link for resuming the job', function () {
+              const actualJob = JSON.parse(this.res.text);
+              expect(actualJob.links.some((link) => link.href.includes('/resume')));
+            });
+
             it('does not modify any of the other job fields', function () {
               const actualJob = new Job(JSON.parse(this.res.text));
               const expectedJob: JobRecord = _.cloneDeep(joeJob1);
@@ -642,6 +647,10 @@ describe('Pausing and resuming a job - admin endpoint', function () {
             it('sets the appropriate message', function () {
               const actualJob = JSON.parse(this.res.text);
               expect(actualJob.message).to.eql('The job is paused. The job may be resumed using the provided link.');
+            });
+            it('provides a link for resuming the job', function () {
+              const actualJob = JSON.parse(this.res.text);
+              expect(actualJob.links.some((link) => link.href.includes('/resume')));
             });
             it('does not modify any of the other job fields', function () {
               const actualJob = new Job(JSON.parse(this.res.text));

--- a/test/jobs/pause-jobs.ts
+++ b/test/jobs/pause-jobs.ts
@@ -456,17 +456,16 @@ describe('Pausing and resuming a job - user endpoint', function () {
               expect(actualJob.status).to.eql('paused');
             });
 
-            it('sets the message to the job is paused', function () {
+            it('sets the appropriate message', function () {
               const actualJob = JSON.parse(this.res.text);
-              expect(actualJob.message).to.eql('The job is paused');
+              expect(actualJob.message).to.eql('The job is paused. The job may be resumed using the provided link.');
             });
 
             it('does not modify any of the other job fields', function () {
               const actualJob = new Job(JSON.parse(this.res.text));
               const expectedJob: JobRecord = _.cloneDeep(joeJob1);
-              expectedJob.message = 'The job is paused';
               expectedJob.status = JobStatus.PAUSED;
-              expect(jobsEqual(expectedJob, actualJob)).to.be.true;
+              expect(jobsEqual(expectedJob, actualJob, false, true)).to.be.true;
             });
           });
         });
@@ -640,16 +639,15 @@ describe('Pausing and resuming a job - admin endpoint', function () {
               const actualJob = JSON.parse(this.res.text);
               expect(actualJob.status).to.eql('paused');
             });
-            it('sets the message to the job is paused', function () {
+            it('sets the appropriate message', function () {
               const actualJob = JSON.parse(this.res.text);
-              expect(actualJob.message).to.eql('The job is paused');
+              expect(actualJob.message).to.eql('The job is paused. The job may be resumed using the provided link.');
             });
             it('does not modify any of the other job fields', function () {
               const actualJob = new Job(JSON.parse(this.res.text));
               const expectedJob: JobRecord = _.cloneDeep(joeJob1);
-              expectedJob.message = 'The job is paused';
               expectedJob.status = JobStatus.PAUSED;
-              expect(jobsEqual(expectedJob, actualJob)).to.be.true;
+              expect(jobsEqual(expectedJob, actualJob, false, true)).to.be.true;
             });
           });
         });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1132

## Description
Updates the job status page with a link for resuming.

## Local Test Steps
Pause a running job. Navigate to the job status page and take note of the message as well as a link for resuming the job.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing