### PR TITLE
HARMONY-1167: Prevent node process from exiting when there is an unhandled promise rejection

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -35,7 +35,7 @@ rules:
   no-restricted-syntax: ["error", "LabeledStatement", "WithStatement"]
   class-methods-use-this: "off"
   no-underscore-dangle: "off"
-  "@typescript-eslint/no-floating-promises": ["off"]
+  "@typescript-eslint/no-floating-promises": ["error"]
   require-jsdoc: ["warn"]
   tsdoc/syntax: ["error"]
   no-await-in-loop: ["off"]

--- a/app/middleware/admin.ts
+++ b/app/middleware/admin.ts
@@ -17,11 +17,15 @@ import env from '../util/env';
 export default async function admin(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
-  const isAdmin = await belongsToGroup(req.user, env.adminGroupId, req.accessToken);
-  if (isAdmin) {
-    req.context.isAdminAccess = true;
-    next();
-  } else {
-    next(new ForbiddenError('You are not permitted to access this resource'));
+  try {
+    const isAdmin = await belongsToGroup(req.user, env.adminGroupId, req.accessToken);
+    if (isAdmin) {
+      req.context.isAdminAccess = true;
+      next();
+    } else {
+      next(new ForbiddenError('You are not permitted to access this resource'));
+    }
+  } catch (e) {
+    next(e);
   }
 }

--- a/app/models/job-link.ts
+++ b/app/models/job-link.ts
@@ -189,11 +189,10 @@ export async function getLinksForJob(
     .orderBy(['id'])
     .modify((queryBuilder) => {
       if (rel) {
-        queryBuilder
-          .where({ rel });
+        void queryBuilder.where({ rel });
       }
       if (requireSpatioTemporal) {
-        queryBuilder
+        void queryBuilder
           .whereNotNull('bbox')
           .whereNotNull('temporalStart')
           .whereNotNull('temporalEnd');

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -162,9 +162,9 @@ export class Job extends Record implements JobRecord {
           for (const jobField in constraints.whereIn) {
             const constraint = constraints.whereIn[jobField];
             if (constraint.in) {
-              queryBuilder.whereIn(jobField, constraint.values);
+              void queryBuilder.whereIn(jobField, constraint.values);
             } else {
-              queryBuilder.whereNotIn(jobField, constraint.values);
+              void queryBuilder.whereNotIn(jobField, constraint.values);
             }
           }
         }

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -234,14 +234,9 @@ export async function updateWorkItemStatusesByJobId(
   newStatus: WorkItemStatus,
 ): Promise<void> {
   const updatedAt = new Date();
-  return tx(WorkItem.table)
+  await tx(WorkItem.table)
     .where({ jobID })
-    .modify((queryBuilder) => {
-      if (oldStatuses.length) {
-        queryBuilder
-          .whereIn('status', oldStatuses);
-      }
-    })
+    .whereIn('status', oldStatuses)
     .update({ status: newStatus, updatedAt });
 }
 

--- a/app/server.ts
+++ b/app/server.ts
@@ -152,6 +152,12 @@ export function start(config: Record<string, string>): {
   workReaper: WorkReaper;
   workFailer: WorkFailer;
 } {
+
+  // Log unhandled promise rejections and do not crash the node process
+  process.on('unhandledRejection', (reason, promise) => {
+    logger.error('Unhandled Rejection at:', promise, 'reason:', reason);
+  });
+
   const appPort = +config.PORT;
   const backendPort = +config.BACKEND_PORT;
 

--- a/app/util/job.ts
+++ b/app/util/job.ts
@@ -178,7 +178,7 @@ export async function resumeAndSaveJob(
         op.accessToken = token;
         const serialOp = op.serialize(CURRENT_SCHEMA_VERSION);
         workflowStep.operation = serialOp;
-        workflowStep.save(tx);
+        await workflowStep.save(tx);
       }
     }
     job.resume();

--- a/tasks/giovanni-adapter/app/cli.ts
+++ b/tasks/giovanni-adapter/app/cli.ts
@@ -124,14 +124,14 @@ export default async function main(args: string[]): Promise<void> {
     bbox,
     assets,
   });
-  item.write(stacItemFilename, true);
+  await item.write(stacItemFilename, true);
 
   // save stac catalog
   const relativeFilename = 'catalog.json';
   const catalogFilenames = [];
   const filename = path.join(options.harmonyMetadataDir, relativeFilename);
   catalogFilenames.push(relativeFilename);
-  result.write(filename, true);
+  await result.write(filename, true);
 
   const catalogListFilename = path.join(options.harmonyMetadataDir, 'batch-catalogs.json');
   const catalogCountFilename = path.join(options.harmonyMetadataDir, 'batch-count.txt');

--- a/tasks/giovanni-adapter/test/helpers/cli.ts
+++ b/tasks/giovanni-adapter/test/helpers/cli.ts
@@ -38,7 +38,7 @@ export interface ParseResult {
 export async function parse(...args): Promise<ParseResult> {
   return new Promise((resolve) => {
     const argString = argsToString(...args);
-    parser().exitProcess(false).parse(argString, (error, argv, output) => {
+    void parser().exitProcess(false).parse(argString, (error, argv, output) => {
       resolve({ error, argv, output });
     });
   });

--- a/tasks/service-runner/app/workers/pull-worker.ts
+++ b/tasks/service-runner/app/workers/pull-worker.ts
@@ -228,7 +228,7 @@ export default class PullWorker implements Worker {
           exit(1);
         } else {
           // wait 100 ms before trying again
-          sleep(100);
+          await sleep(100);
         }
       }
     }

--- a/test/helpers/ogc-api-coverages.ts
+++ b/test/helpers/ogc-api-coverages.ts
@@ -86,15 +86,14 @@ export function rangesetRequest(
     cookies = null }: QueryOptions = {},
 ): Test {
   const encodedCoverageId = encodeURIComponent(coverageId);
-  const req = request(app)
+  let req = request(app)
     .get(`/${collection}/ogc-api-coverages/${version}/collections/${encodedCoverageId}/coverage/rangeset`)
     .query(query)
     .set(headers);
 
   if (cookies) {
-    req.set('Cookie', [cookies as unknown as string]);
+    req = req.set('Cookie', [cookies as unknown as string]);
   }
-
   return req;
 }
 
@@ -112,17 +111,17 @@ export function rangesetRequest(
  */
 export function postRangesetRequest(
   app: Express.Application, version: string, collection: string, coverageId: string, form: object, queryString = '',
-): request.Test {
+): Test {
   let urlPathAndParam = `/${collection}/ogc-api-coverages/${version}/collections/${coverageId}/coverage/rangeset`;
   if (queryString) urlPathAndParam += `?${queryString}`;
-  const req = request(app)
+  let req = request(app)
     .post(urlPathAndParam);
 
   Object.keys(form).forEach((key) => {
     if (key === 'shapefile') {
-      req.attach(key, form[key].path, { contentType: form[key].mimetype });
+      req = req.attach(key, form[key].path, { contentType: form[key].mimetype });
     } else {
-      req.field(key, form[key]);
+      req = req.field(key, form[key]);
     }
   });
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1167

## Description
We found another instance of an unhandled promise rejection in UAT. I attempted to fix the exact issue that was encountered, but also did a couple of other things to try and prevent other cases.

1.) I turned on the linter rule for no-floating-promises which identifies places in the code where we were not correctly handling promises. It also uncovered bugs where we were not awaiting.

2.) I added code on server start up to add a listener for unhandled rejections and log an error instead of exiting the node process. I tried for awhile to add an automated test for this functionality, but I just could not get anything to work right.

I did manually test that the behavior works as expected.

## Local Test Steps

I don't have a good way to reproduce the exact error encountered, but to verify that node no longer exits you can do the following:

Modify the bottom of app/server.ts to cause an unhandled promise rejection:

```
/**
 * Cause unhandled promise rejection
 */
async function blowup(): Promise<void> {
  const prom = new Promise((_1, _2) => {
    throw new Error('foo');
  });
  await prom;
}

if (require.main === module) {
  start(process.env);
  blowup();
}
```

Comment out the code that prevents node from exiting on an unhandled promise rejection on lines 157-159:

```
  process.on('unhandledRejection', (reason, promise) => {
    logger.error('Unhandled Rejection at:', promise, 'reason:', reason);
  });
```

Start up harmony:
`npm run start`

Watch the node process exits.

Put lines 157-159 back in place and then restart harmony:
`npm run start`

Verify that it doesn't crash and then execute a harmony request to verify the application is working still.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)