### PR TITLE
Use correct projection string in l2 example

### DIFF
--- a/docs/Harmony API introduction.ipynb
+++ b/docs/Harmony API introduction.ipynb
@@ -78,8 +78,7 @@
    "outputs": [],
    "source": [
     "# ---- Change this to save to a directory where you have write permissions\n",
-    "local_dir = 'tmp/test_output/'\n",
-    "!mkdir -p {local_dir}"
+    "local_dir = '/tmp/test_output/'"
    ]
   },
   {
@@ -231,8 +230,8 @@
    },
    "outputs": [],
    "source": [
-    "# Modify if you are not currently in this notebook directory within the Harmony repo. \n",
-    "yml_path = os.path.join(os.getcwd(), os.pardir, 'config', 'services.yml')\n",
+    "os.chdir('..') # Move up a directory in harmony repo. Modify if you are not currently in this notebook directory within the Harmony repo. \n",
+    "yml_path = str(os.getcwd() + '/config/services.yml')\n",
     "\n",
     "with open(yml_path, 'r') as yml:\n",
     "    data = yml.read()\n",
@@ -791,7 +790,7 @@
     "}\n",
     "shapefile_url = harmony_root+'/{collection_id}/ogc-api-coverages/{ogc-api-coverages_version}/collections/{variable}/coverage/rangeset'.format(**shapefileSubsetConfig)\n",
     "\n",
-    "shapefile_path = os.path.join(os.getcwd(), 'shapefiles', 'south_america.geojson')\n",
+    "shapefile_path = str(os.getcwd() + '/docs/shapefiles/south_america.geojson')\n",
     "with open(shapefile_path, 'rb') as fd1:\n",
     "    # the form must have a 'shapefile' key which must include the mime-type as shown. Additional parameters\n",
     "    # such as temporal subsetting can be included in the form.\n",

--- a/docs/Harmony API introduction.ipynb
+++ b/docs/Harmony API introduction.ipynb
@@ -78,7 +78,8 @@
    "outputs": [],
    "source": [
     "# ---- Change this to save to a directory where you have write permissions\n",
-    "local_dir = '/tmp/test_output/'"
+    "local_dir = 'tmp/test_output/'\n",
+    "!mkdir -p {local_dir}"
    ]
   },
   {
@@ -230,8 +231,8 @@
    },
    "outputs": [],
    "source": [
-    "os.chdir('..') # Move up a directory in harmony repo. Modify if you are not currently in this notebook directory within the Harmony repo. \n",
-    "yml_path = str(os.getcwd() + '/config/services.yml')\n",
+    "# Modify if you are not currently in this notebook directory within the Harmony repo. \n",
+    "yml_path = os.path.join(os.getcwd(), os.pardir, 'config', 'services.yml')\n",
     "\n",
     "with open(yml_path, 'r') as yml:\n",
     "    data = yml.read()\n",
@@ -790,7 +791,7 @@
     "}\n",
     "shapefile_url = harmony_root+'/{collection_id}/ogc-api-coverages/{ogc-api-coverages_version}/collections/{variable}/coverage/rangeset'.format(**shapefileSubsetConfig)\n",
     "\n",
-    "shapefile_path = str(os.getcwd() + '/docs/shapefiles/south_america.geojson')\n",
+    "shapefile_path = os.path.join(os.getcwd(), 'shapefiles', 'south_america.geojson')\n",
     "with open(shapefile_path, 'rb') as fd1:\n",
     "    # the form must have a 'shapefile' key which must include the mime-type as shown. Additional parameters\n",
     "    # such as temporal subsetting can be included in the form.\n",
@@ -1428,7 +1429,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/docs/Harmony API introduction.ipynb
+++ b/docs/Harmony API introduction.ipynb
@@ -1050,7 +1050,7 @@
    "source": [
     "# URL encode string using urllib parse package\n",
     "l2proj_string = '+proj=lcc +lat_1=43 +lat_2=62 +lat_0=30 +lon_0=10 +x_0=0 +y_0=0 +ellps=intl +units=m +no_defs'\n",
-    "l2proj_encode = parse.quote(proj_string)\n",
+    "l2proj_encode = parse.quote(l2proj_string)\n",
     "\n",
     "\n",
     "regridConfig = {\n",

--- a/docs/Harmony API introduction.ipynb
+++ b/docs/Harmony API introduction.ipynb
@@ -800,7 +800,7 @@
     "        'subset': (None, 'time(\"2020-01-01T20:00:00.000Z\":\"2020-01-01T22:00:00.000Z\")')\n",
     "    }\n",
     "    # submit the form using a POST request and prepare to stream the result\n",
-    "    shapefile_repsonse = requests.post(shapefile_url, files=multipart_form_data, stream=True)"
+    "    shapefile_response = requests.post(shapefile_url, files=multipart_form_data, stream=True)"
    ]
   },
   {
@@ -818,7 +818,7 @@
    "source": [
     "shapefile_output_filepath = str(local_dir + 'shapefile_output.tif')\n",
     "with open(shapefile_output_filepath, 'wb') as fd:\n",
-    "    for chunk in shapefile_repsonse.iter_content(chunk_size=128):\n",
+    "    for chunk in shapefile_response.iter_content(chunk_size=128):\n",
     "        fd.write(chunk)"
    ]
   },


### PR DESCRIPTION
- Replaces `proj_string` with `l2proj_string` to correctly encode the query string in the l2w *Access Level 2 swath regridded data* section of the notebook. 
- fixes typo `repsonse` with `response`
- Does not reproduce the `example-notebook.html` file since the notebook can't be run to completion currently.