### PR TITLE
HARMONY-1154: If a request requires dimension subsetting (other than time/lat/lon) only send the request to a service that supports dimension subsetting.

### DIFF
--- a/app/frontends/ogc-coverages/get-coverage-rangeset.ts
+++ b/app/frontends/ogc-coverages/get-coverage-rangeset.ts
@@ -66,6 +66,9 @@ export default function getCoverageRangeset(
   }
   try {
     const subset = parseSubsetParams(wrap(query.subset));
+    // Update in HARMONY-1120
+    operation.dimensionSubset = !Object.keys(subset).every((k) => ['time', 'lat', 'lon'].includes(k));
+
     const bbox = subsetParamsToBbox(subset);
     if (bbox) {
       operation.boundingRectangle = bbox;

--- a/app/models/data-operation.ts
+++ b/app/models/data-operation.ts
@@ -263,6 +263,9 @@ export default class DataOperation {
 
   requestStartTime: Date; // The time that the initial request to harmony was received
 
+  // Temporary - remove when implementing HARMONY-1120
+  dimensionSubset?: boolean;
+
   /**
    * Creates an instance of DataOperation.
    *
@@ -315,6 +318,16 @@ export default class DataOperation {
   get shouldVariableSubset(): boolean {
     const varSources = this.sources.filter((s) => s.variables && s.variables.length > 0);
     return varSources.length > 0;
+  }
+
+  /**
+   * Returns true if the operation is requesting dimension subsetting
+   *
+   * @returns true if the operation requests dimension subsetting
+   */
+  get shouldDimensionSubset(): boolean {
+    // Update this with HARMONY-1120 to check the operation field
+    return this.dimensionSubset;
   }
 
   /**
@@ -851,6 +864,9 @@ export default class DataOperation {
       }
       if (!fieldsToInclude.includes('shapefileSubset')) {
         delete toWrite.subset.shape;
+      }
+      if (!fieldsToInclude.includes('dimensionSubset')) {
+        delete toWrite.subset.dimensions;
       }
 
       if (Object.keys(toWrite.subset).length === 0) {

--- a/config/services.yml
+++ b/config/services.yml
@@ -378,13 +378,14 @@ https://cmr.earthdata.nasa.gov:
       subsetting:
         bbox: true
         variable: true
+        dimension: true
       output_formats:
         - application/netcdf # Incorrect mime-type, remove when no longer needed
         - application/x-netcdf4
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${VAR_SUBSETTER_IMAGE}
-        operations: ['variableSubset', 'spatialSubset']
+        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset']
 
   - name: sds/trajectory-subsetter
     data_operation_version: '0.15.0'
@@ -753,13 +754,14 @@ https://cmr.uat.earthdata.nasa.gov:
       subsetting:
         bbox: true
         variable: true
+        dimension: true
       output_formats:
         - application/netcdf # Incorrect mime-type, remove when no longer needed
         - application/x-netcdf4
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${VAR_SUBSETTER_IMAGE}
-        operations: ['variableSubset', 'spatialSubset']
+        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset']
 
   - name: sds/maskfill
     data_operation_version: '0.15.0'

--- a/test/models/services.ts
+++ b/test/models/services.ts
@@ -11,7 +11,7 @@ import env from '../../app/util/env';
 import TurboService from '../../app/models/services/turbo-service';
 
 describe('services.chooseServiceConfig and services.buildService', function () {
-  describe("when the operation's collection is configured for two services", function () {
+  describe("when the operation's collection is configured for several services", function () {
     beforeEach(function () {
       const collectionId = 'C123-TEST';
       const operation = new DataOperation();
@@ -47,6 +47,16 @@ describe('services.chooseServiceConfig and services.buildService', function () {
           capabilities: {
             output_formats: ['image/tiff', 'image/png'],
             reprojection: true,
+          },
+        },
+        {
+          name: 'fourth-service',
+          type: { name: 'turbo' },
+          collections: [{ id: collectionId }],
+          capabilities: {
+            subsetting: {
+              dimension: true,
+            },
           },
         },
       ];
@@ -138,6 +148,17 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       it('chooses the service that supports shapefile subsetting', function () {
         const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
         expect(serviceConfig.name).to.equal('first-service');
+      });
+    });
+
+    describe('and the request needs dimension subsetting', function () {
+      beforeEach(function () {
+        this.operation.dimensionSubset = true;
+      });
+
+      it('chooses the service that supports dimension subsetting', function () {
+        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        expect(serviceConfig.name).to.equal('fourth-service');
       });
     });
 
@@ -589,7 +610,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
         expect(service.constructor.name).to.equal('TurboService');
       });
     });
-  
+
     describe('requesting service with two variable subsetting and only one matches', function () {
       const operation = new DataOperation();
       operation.addSource(collectionId, [{ meta: { 'concept-id': variableId1 }, umm: { Name: 'the-var-1' } },


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1154

## Description
If a request requires dimension subsetting (other than time/lat/lon) only send the request to a service that supports dimension subsetting.

Some placeholders were added, which will be replaced once we implement HARMONY-1120 to pass the dimension subsetting parameters to the backend services.

## Local Test Steps
Verify that:
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?granuleId=G1233800343-EEDTEST&format=image%2Fpng&subset=bar(15.0%3A30)

returns download links instead of performing a service request because harmony-service-example does not support dimension subsetting.

Verify that:
http://localhost:3000/C1222931739-GHRC_CLOUD/ogc-api-coverages/1.0.0/collections/atmosphere_cloud_liquid_water_content/coverage/rangeset?format=application%2Fnetcdf&forceAsync=false&subset=lat(-60%3A-30)&subset=lon(-120%3A-90)&maxResults=1&subset=foo(15.0%3A30)

is directed to the variable subsetter service (via the sds/HOSS service in services.yml) and the request works successfully. Note this will require deploying the var-subsetter service locally.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~