### PR TITLE
HARMONY-1177: Default to binding only localhost network interface.

### DIFF
--- a/env-defaults
+++ b/env-defaults
@@ -32,6 +32,9 @@ OAUTH_PASSWORD=
 # Settings to control how Harmony behaves                                 #
 ###########################################################################
 
+# The host network interface to bind against
+HOST_BINDING='127.0.0.1'
+
 # The port on which to run the Harmony frontend
 PORT=3000
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1177

## Description
Only bind harmony to listen on the localhost network interface.

## Local Test Steps
Start harmony and verify it logs that it is listening on ports 3000 and 3001 on 127.0.0.1.
Verify harmony works.

Note for deployed environments we will use 0.0.0.0. I tested that in sandbox and submitted a harmony-ci-cd PR. Also if for any reason the user's O/S does not support 127.0.0.1 they can override it with the HOST_BINDING environment variable.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~