### PR TITLE
HARMONY-1027: Add next/prev links to aggregated step input catalogs

### DIFF
--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -1,4 +1,4 @@
-import _, { sum } from 'lodash';
+import _, { ceil, range, sum } from 'lodash';
 import { NextFunction, Response } from 'express';
 import { v4 as uuid } from 'uuid';
 import { Logger } from 'winston';
@@ -207,24 +207,62 @@ async function createAggregatingWorkItem(
     throw new ServiceError(500, `Failed to retrieve all work items for step ${nextStep.stepIndex - 1}`);
   }
 
-  // create a STAC catalog using `catalogLinks`
-  const catalog = {
-    stac_version: '1.0.0-beta.2',
-    stac_extensions: [],
-    id: uuid(),
-    description: 'Aggregation input catalogs',
-    links: itemLinks,
-  };
-
-  const catalogJson = JSON.stringify(catalog, null, 4);
-  // write the new catalog out to the file system
+  // create the directory to hold the catalog(s)
   const outputDir = path.join(env.hostVolumePath, nextStep.jobID, `aggregate-${currentWorkItem.id}`, 'outputs');
   await fs.mkdir(outputDir, { recursive: true });
-  const catalogPath = path.join(outputDir, 'catalog0.json');
-  await fs.writeFile(catalogPath, catalogJson);
+
+  // path to use in the catalogs when generating links (correct for worker container not Harmony)
+  // we don't use fs.join here because the pods use linux paths
+  const containerOutputPath = `${PATH_TO_CONTAINER_ARTIFACTS}/${nextStep.jobID}/aggregate-${currentWorkItem.id}/outputs`;
+
+  const pageSize = env.aggregateStacCatalogMaxPageSize;
+  const catalogCount = ceil(itemLinks.length / env.aggregateStacCatalogMaxPageSize);
+  for (const index of range(0, catalogCount)) {
+    const start = index * pageSize;
+    const end = start + pageSize;
+    const links = itemLinks.slice(start, end);
+
+    // and prev/next links as needed
+    if (index > 0) {
+      const prevCatUrl = `${containerOutputPath}/catalog${index - 1}.json`;
+      const prevLink: StacItemLink = {
+        href: prevCatUrl,
+        rel: 'prev',
+        title: 'Previous page',
+        type: 'application/json',
+      };
+      links.push(prevLink);
+    }
+
+    if (index < catalogCount - 1) {
+      const nextCatUrl = `${containerOutputPath}/catalog${index + 1}.json`;
+      const nextLink: StacItemLink = {
+        href: nextCatUrl,
+        rel: 'next',
+        title: 'Next page',
+        type: 'application/json',
+      };
+      links.push(nextLink);
+    }
+
+    // create a STAC catalog with links
+    const catalog = {
+      stac_version: '1.0.0-beta.2',
+      stac_extensions: [],
+      id: uuid(),
+      description: 'Aggregation input catalogs',
+      links: links,
+    };
+
+    const catalogJson = JSON.stringify(catalog, null, 4);
+
+    // write the new catalog out to the file system
+    const catalogPath = path.join(outputDir, `catalog${index}.json`);
+    await fs.writeFile(catalogPath, catalogJson);
+  }
 
   // we don't use fs.join here because the pods use linux paths
-  const podCatalogPath = `${PATH_TO_CONTAINER_ARTIFACTS}/${nextStep.jobID}/aggregate-${currentWorkItem.id}/outputs/catalog0.json`;
+  const podCatalogPath = `${containerOutputPath}/catalog0.json`;
 
   const newWorkItem = new WorkItem({
     jobID: currentWorkItem.jobID,

--- a/app/util/env.ts
+++ b/app/util/env.ts
@@ -66,6 +66,7 @@ if (missingVars.length > 0) {
 
 interface HarmonyEnv {
   adminGroupId: string;
+  aggregateStacCatalogMaxPageSize: number;
   artifactBucket: string;
   awsDefaultRegion: string;
   builtInTaskPrefix: string;

--- a/env-defaults
+++ b/env-defaults
@@ -95,6 +95,9 @@ DEFAULT_RESULT_PAGE_SIZE=2000
 # Default number of jobs listed in a page
 DEFAULT_JOB_LIST_PAGE_SIZE=10
 
+# TODO change this to a smaller number when aggregating services are updated to handle paged catalogs
+AGGREGATE_STAC_CATALOG_MAX_PAGE_SIZE=1000000
+
 # Maximum number of results in a page
 MAX_PAGE_SIZE=2000
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1027

## Description
Adds 'next' and 'prev' links to STAC catalogs generated as input to aggregation steps to let us page large granule sets.
The aggregating services will need to be updated to take advantage of the linked catalogs, but that is outside the scope of this ticket. For now the threshold for doing the paging (generating more than one catalog and adding links) is set to one million granules, effectively disabling the paging. We will change this when the services are updated.

## Local Test Steps
1. Add `AGGREGATE_STAC_CATALOG_MAX_PAGE_SIZE=2` to your local .env file and restart Harmony
2. Execute the following query:
http://localhost:3000/C1234208438-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=10&concatenate=true
This will try to use the concise service, which will fail, because the service needs to be updated to handle the paged catalogs. This doesn't matter for this test.
3. Look at the catalogs (should be five) in your metadata directory under `<job_id>/aggregate-<work item number>/outputs`. They should have paging links. The first catalog only has 'next' and last only has 'prev'. All the rest should have both.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~