### PR TITLE
HARMONY-1143: Ensure workload requests do not get auto-paused.

### DIFF
--- a/workload/harmony/common.py
+++ b/workload/harmony/common.py
@@ -76,6 +76,7 @@ class BaseHarmonyUser(HttpUser):
 
     def _sync_request(self, name, collection, variable, params, test_number):
         full_name = f'{test_number:03}: {name}'
+        params['skipPreview'] = True
 
         self.client.get(
             self.coverages_root.format(
@@ -86,6 +87,7 @@ class BaseHarmonyUser(HttpUser):
 
     def _async_request(self, name, collection, variable, params, test_number):
         full_name = f'{test_number:03}: {name}'
+        params['skipPreview'] = True
 
         start_time = time()
         response = self.client.get(


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1143

## Description
Ensure workload requests do not get auto-paused.

## Local Test Steps
Start up harmony locally.
Start up the workload driver:
```
cd workload
<activate your python environment - I use pyenv activate workload>
locust --tags demo
```
Open up the UI using the link from your terminal.
Choose to send 2 concurrent requests to http://localhost:3000

Open http://localhost:3000/jobs
Make sure that all of the requests for jobs started by the workload run include `skipPreview=true`

## PR Acceptance Checklist
* [X] Acceptance criteria met
* ~[ ] Tests added/updated (if needed) and passing~
* ~[ ] Documentation updated (if needed)~