### PR TITLE
HARMONY-1181 - Remove GeoTIFF, PNG and GIF output options from the Swath Projector.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -701,9 +701,6 @@ https://cmr.uat.earthdata.nasa.gov:
         bbox: false
         variable: false
       output_formats:
-        - image/tiff
-        - image/png
-        - image/gif
         - application/netcdf # Incorrect mime-type, remove when no longer needed
         - application/x-netcdf4
       reprojection: true
@@ -972,9 +969,6 @@ https://cmr.uat.earthdata.nasa.gov:
         bbox: false
         variable: false
       output_formats:
-        - image/tiff
-        - image/png
-        - image/gif
         - application/netcdf # Incorrect mime-type, remove when no longer needed
         - application/x-netcdf4
         - application/x-zarr


### PR DESCRIPTION
## Jira Issue ID

HARMONY-1181

## Description

The Swath Projector entry in `services.yml` (and the chained service with the Swath Projector and NetCDF-to-Zarr service) incorrectly specified several output formats that are not supported by the service. This PR removes those output formats.

The [associated UMM-S record](https://cmr.uat.earthdata.nasa.gov/search/services.umm_json?concept_id=S1237974711-EEDTEST) correctly states that the services takes a NetCDF-4 input and produces a NetCDF-4 output.

## Local Test Steps

* In a local Harmony environment try to make a request for a collection that is only configured for use with the Swath Projector.
* Specify a GeoTIFF output format (`format='image/tiff'`).
* The request should just return a direct download link, because there are no services configured for that collection that can offer a GeoTIFF output.

## PR Acceptance Checklist
* [x] ~Acceptance criteria met~
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)