### PR TITLE
DAS-1451 - Implement HOSS-MaskFill chained service.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -409,7 +409,7 @@ https://cmr.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${TRAJECTORY_SUBSETTER_IMAGE}
-        operations: ['variableSubset', 'spatialSubset']
+        operations: ['variableSubset', 'spatialSubset', 'shapefileSubset']
 
 https://cmr.uat.earthdata.nasa.gov:
 
@@ -802,7 +802,7 @@ https://cmr.uat.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${TRAJECTORY_SUBSETTER_IMAGE}
-        operations: ['variableSubset', 'spatialSubset']
+        operations: ['variableSubset', 'spatialSubset', 'shapefileSubset']
 
   # This is an example service and backend from example/http-backend.js mounted by
   # the frontend callback server.
@@ -983,3 +983,34 @@ https://cmr.uat.earthdata.nasa.gov:
         operations: ['reformat', 'concatenate']
         conditional:
           format: ['application/x-zarr']
+
+  - name: sds/HOSS-maskfill
+    # Provides polygon spatial subsetting for collections hosted in OPeNDAP
+    # Also provides variable and temporal subsetting through HOSS.
+    data_operation_version: '0.16.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/sds/HOSS
+    umm_s:
+      - S1245117629-EEDTEST
+    collections:
+      - id: C1222931739-GHRC_CLOUD
+    capabilities:
+      subsetting:
+        bbox: true
+        dimension: true
+        shape: true
+        variable: true
+      output_formats:
+        - application/netcdf # Incorrect mime-type, remove when no longer needed
+        - application/x-netcdf4
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+      - image: !Env ${VAR_SUBSETTER_IMAGE}
+        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset']
+      - image: !Env ${SDS_MASKFILL_IMAGE}
+        operations: ['shapefileSubset', 'spatialSubset']

--- a/test/versions.ts
+++ b/test/versions.ts
@@ -36,6 +36,7 @@ describe('Versions endpoint', function () {
           'harmony/netcdf-to-zarr',
           'harmony/podaac-l2-subsetter-netcdf-to-zarr',
           'harmony/swot-repr-netcdf-to-zarr',
+          'sds/HOSS-maskfill',
         ]);
       });
 


### PR DESCRIPTION
## Jira Issue ID

DAS-1451

## Description

This PR adds a chained services that combines the Harmony OPeNDAP SubSetter (HOSS) with MaskFill. This will be used to allow polygon spatial subsetting of geographically gridded data hosted in OPeNDAP. HOSS extracts a minimally encompassing bounding box, and retrieves those data from OPeNDAP. The output is then passed to MaskFill which masks pixels within the bounding box, but outside the polygon.

Another minor addition in this PR is to specify that the Trajectory Subsetter operations includes the `spatialSubset` option. The omission of this entry from the list was preventing shape file information reaching the Trajectory Subsetter.

## Local Test Steps

### To test the HOSS-MaskFill chain:

_This might not work - I've been seeing issues with OPeNDAP hanging for RSSMIF16D requests. I think this relates to HYRAX-744._

* Configure the new service entry to run with RSSMIF16D:

```yaml
    collections:
      - C1222931739-GHRC_CLOUD
```

* Pull the DAS-1451-RSSMIF16D-configuration branch from the [MaskFill repository](https://git.earthdata.nasa.gov/projects/SITC/repos/maskfill). Run the `bin/build-harmony-image` script.
* Pull the DAS-1451 branch from the [HOSS repository](https://git.earthdata.nasa.gov/projects/SITC/repos/var_subsetter/browse). Run the `bin/build-image` script.
* Reload services.yml: `bin/reload-services-config`.
* Restart the services in your local Harmony instance: `bin/restart-services`.
* Make a shape file request for RSSMIF16D (note - you'll need to restrict your request to the ocean in the eastern hemisphere):

```python
from harmony import Client, Collection, Environment, Request

harmony_client = Client(env=Environment.LOCAL)
rssmif16d = Collection(id='C1222931739-GHRC_CLOUD')
request = Request(collection=rssmif16d,
                  shape='/path/to/local/shape.geo.json',
                  max_results=1)
```

### To test Trajectory Subsetter updates:

* Clone the [Trajectory Subsetter](https://git.earthdata.nasa.gov/projects/SITC/repos/trajectorysubsetter/browse). Build the latest Docker image using `bin/build-image`.
* Reload `services.yml`: `bin/reload-services-config`.
* Restart Harmony services: `bin/restart-services`.
* Make a shape file request for GEDI L4A (there's currently 1 test granule available, so Egypt is a great shape file):

```python
from harmony import Client, Collection, Environment, Request

gedi_l4a = Collection(id='C1242267295-EEDTEST')
egypt_granule_id = 'G1242274852-EEDTEST'
polygon_subset_request = Request(collection=gedi_l4a, granule_id=[egypt_granule_id],
                                 variables=variables, shape='/path/to/egypt.geo.json')
polygon_subset_job_id = harmony_client.submit(polygon_subset_request)
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)