### PR TITLE
HARMONY-1192: Change regexes to support non-alpha characters in dims

### DIFF
--- a/app/frontends/ogc-coverages/util/subset-parameter-parsing.ts
+++ b/app/frontends/ogc-coverages/util/subset-parameter-parsing.ts
@@ -4,20 +4,20 @@ import { ParameterParseError } from '../../../util/parameter-parsing';
 const rangeSeparator = ':';
 const unbounded = '*';
 // Regex to match lat(-10:10) or lon(*:20)
-const numberRangeRegex = new RegExp(`^(\\w+)\\((.+)${rangeSeparator}(.+)\\)$`);
+const numberRangeRegex = new RegExp(`^(.+)\\((.+)${rangeSeparator}(.+)\\)$`);
 
 // time("2001-05-01T12:35:00Z":"2002-07-01T13:18:55Z")
-const twoStringsRegex = new RegExp(`^(\\w+)\\("(.+)"${rangeSeparator}"(.+)"\\)$`);
+const twoStringsRegex = new RegExp(`^(.+)\\("(.+)"${rangeSeparator}"(.+)"\\)$`);
 // time(*:"2001-05-01T12:35:00Z")
-const unboundedMinStringRegex = new RegExp(`^(\\w+)\\((\\*)${rangeSeparator}"(.+)"\\)$`);
+const unboundedMinStringRegex = new RegExp(`^(.+)\\((\\*)${rangeSeparator}"(.+)"\\)$`);
 // time("2001-05-01T12:35:00Z":*)
-const unboundedMaxStringRegex = new RegExp(`^(\\w+)\\("(.+)"${rangeSeparator}(\\*)\\)$`);
+const unboundedMaxStringRegex = new RegExp(`^(.+)\\("(.+)"${rangeSeparator}(\\*)\\)$`);
 // time(*:*)
-const unboundedStringRegex = new RegExp(`^(\\w+)\\((\\*)${rangeSeparator}(\\*)\\)`);
+const unboundedStringRegex = new RegExp(`^(.+)\\((\\*)${rangeSeparator}(\\*)\\)`);
 // time(*)
-const singleUnboundedStringRegex = new RegExp('^(\\w+)\\((\\*)\\)$');
+const singleUnboundedStringRegex = new RegExp('^(.+)\\((\\*)\\)$');
 // time("2001-05-01T12:35:00Z")
-const singleStringRegex = new RegExp('^(\\w+)\\("(.+)"\\)$');
+const singleStringRegex = new RegExp('^(.+)\\("(.+)"\\)$');
 // Date ranges can have several different representations
 const dateTimeRegex = new RegExp(`${twoStringsRegex.source}|${unboundedMinStringRegex.source}|${unboundedMaxStringRegex.source}|${unboundedStringRegex.source}|${singleStringRegex.source}|${singleUnboundedStringRegex.source}`);
 
@@ -128,7 +128,7 @@ function parseDate(dim: Dimension, valueStr: string): Date {
   return value;
 }
 
-const dimensionNameRegex = /^(\w+)\(.+\)$/;
+const dimensionNameRegex = /^(.+)\(.+\)$/;
 
 /**
  * Returns the dimension name (e.g. time, lat, lon) from the value provided.

--- a/test/ogc-api-coverages/subset-parameter-parsing.ts
+++ b/test/ogc-api-coverages/subset-parameter-parsing.ts
@@ -239,6 +239,18 @@ describe('OGC API Coverages - Utilities', function () {
           });
         });
 
+        describe('with non-alphanumeric dimension', function () {
+          it('returns a parsed object', function () {
+            expect(parseSubsetParams(['/lev(0:1000)'])).to.eql({ '/lev': { min: 0, max: 1000.0 } });
+          });
+        });
+
+        describe('with spaces in the dimension', function () {
+          it('returns a parsed object', function () {
+            expect(parseSubsetParams(['my lev(0:1000)'])).to.eql({ 'my lev': { min: 0, max: 1000.0 } });
+          });
+        });
+
         describe('with a min greater than max', function () {
           it('throws a parse error', function () {
             expect(parseSubsetParamsFn(['wrap(500:-100)'])).to.throw(ParameterParseError, 'subset dimension "wrap" values must be ordered from low to high');


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1192

## Description
Adds support for non-alphanumeric characters in dimension names, e.g., '/lev' or 'my lev'.

## Local Test Steps
Issue the following query and verify the result. (Not sure why this query is treated as async when it only has one granule):
```
http://localhost:3000/C1215726323-GES_DISC/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&subset=lat%28-10%3A10%29&subset=lon%28-160%3A-75%29&subset=%2Flev%28800%3A900%29&maxResults=1
```
The job should run and the workflow step in the database should have an operation that includes

```json
"subset":{"dimensions":[{"name":"/lev","min":800,"max":900}
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~