### PR TITLE
HARMONY-1197: Do not fail work items and jobs that have been in the READY state for more than 4 hours.

### DIFF
--- a/app/workers/work-failer.ts
+++ b/app/workers/work-failer.ts
@@ -37,7 +37,7 @@ export default class WorkFailer implements Worker {
     };
     try {
       const workItems = await getWorkItemsByAgeAndStatus(
-        tx, olderThanMinutes, [WorkItemStatus.RUNNING, WorkItemStatus.READY],
+        tx, olderThanMinutes, [WorkItemStatus.RUNNING],
       );
       if (workItems.length) {
         const workItemIds = workItems.map((item) => item.id);


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1197

## Description
Do not fail work items and jobs that have been in the READY state for more than 4 hours. Only fail for work items that have been in the RUNNING state for more than 4 hours.

## Local Test Steps
1.) Set FAILABLE_WORK_AGE_MINUTES to 1
2.) Submit a request for a service that you do not have deployed locally (so that the work item for that service stays in the READY state).
3.) Wait at least 6 minutes (watch for the job reaper to run in the logs). If in a hurry you can set WORK_FAILER_PERIOD_SEC to 30 to run every 30 seconds instead of 6 minutes.
4.) Verify the job stays in the Running state and is not failed.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~