### PR TITLE
HARMONY-1200: Remove jobs table locking when getting work and updating work items

### DIFF
--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -349,7 +349,7 @@ export async function updateWorkItem(req: HarmonyRequest, res: Response): Promis
   logger.info(`Updating work item for ${id} to ${status}`);
   await db.transaction(async (tx) => {
     const workItem = await getWorkItemById(tx, parseInt(id, 10));
-    const job: Job = await Job.byJobID(tx, workItem.jobID, false, true);
+    const job: Job = await Job.byJobID(tx, workItem.jobID, false, false);
     const thisStep = await getWorkflowStepByJobIdStepIndex(tx, workItem.jobID, workItem.workflowStepIndex);
     const isQueryCmr = workItem.serviceID.match(/query-cmr/);
 

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -102,25 +102,13 @@ export async function getNextWorkItem(
   }
 
   try {
+    // query to get users that have active jobs that have available work items for the service
     const subQueryForUsersRequestingService =
       tx(Job.table)
         .select('username')
         .join(`${WorkItem.table} as w`, `${Job.table}.jobID`, 'w.jobID')
         .whereIn(`${Job.table}.status`, acceptableJobStatuses)
         .where({ 'w.status': 'ready', serviceID });
-    // lock rows in the jobs table for users requesting this service - needed as a workaround
-    // for postgres limitation (https://stackoverflow.com/questions/5272412/group-by-in-update-from-clause)
-    let jobQuery = tx(Job.table)
-      .forUpdate()
-      .join(WorkItem.table, `${Job.table}.jobID`, '=', `${WorkItem.table}.jobID`)
-      .select(['username', 'serviceID', `${WorkItem.table}.serviceID`])
-      .whereIn('username', subQueryForUsersRequestingService);
-
-    if (db.client.config.client === 'pg') {
-      jobQuery = jobQuery.skipLocked();
-    }
-
-    await jobQuery;
 
     const userData = await tx(Job.table)
       .join(WorkItem.table, `${Job.table}.jobID`, '=', `${WorkItem.table}.jobID`)


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1200

## Description
Changes to fix work requests from returning no data even when work items are available. Should still preserve fair queuing for the most part (best effort, not guaranteed).

## Local Test Steps
* Deploy to sandbox and issue a long-running request
* Verify that the workers are getting work items (no long periods of 'polling for work' in the logs)
* Issue on or more additional short requests
* Verify that the new requests are worked in parallel with the long-running one 

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~