### PR TITLE
HARMONY-1207: Switch to maintained gdal-async library.

### DIFF
--- a/app/util/crs.ts
+++ b/app/util/crs.ts
@@ -1,4 +1,4 @@
-import { SpatialReference } from 'gdal';
+import { SpatialReference } from 'gdal-async';
 import { RequestValidationError } from './errors';
 import { SRS } from '../models/data-operation';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "express-validator": "^6.13.0",
         "express-winston": "^4.1.0",
         "form-data": "^4.0.0",
-        "gdal": "^0.11.1",
+        "gdal-async": "^3.5.0",
         "js-yaml": "^4.1.0",
         "json2csv": "^5.0.7",
         "knex": "^0.95.14",
@@ -2910,6 +2910,50 @@
       "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^11.2.0"
+      }
+    },
+    "node_modules/@oozcitak/dom": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
+      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/url": "1.0.4",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/infra": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
+      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
+      "dependencies": {
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@oozcitak/url": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
+      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/util": {
+      "version": "8.3.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
+      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==",
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/@panva/asn1.js": {
@@ -7803,18 +7847,564 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/gdal": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/gdal/-/gdal-0.11.1.tgz",
-      "integrity": "sha512-nzlAzcU3/s3I58dcYtj27pRLV3UDubExUIdEDRj4NAUlRbFbgD6uE3/jr8aRMUyexHekQ7f99JvjlAkjDFwKsA==",
+    "node_modules/gdal-async": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/gdal-async/-/gdal-async-3.5.0.tgz",
+      "integrity": "sha512-C9mAJ5Qi5b5JvEGsys3ubOUOGn8QZJx6ebcsW2L4cqThRLQ2+LXzia/XlCrIleNtE5LY2MQ7v7DSSmoM7JyOsw==",
+      "bundleDependencies": [
+        "@mapbox/node-pre-gyp"
+      ],
       "hasInstallScript": true,
       "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.6",
-        "nan": "~2.15.0"
+        "@mapbox/node-pre-gyp": "^1.0.8",
+        "nan": "^2.14.0",
+        "xmlbuilder2": "^3.0.2"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/mmomtchev"
       }
+    },
+    "node_modules/gdal-async/node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.9",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/gdal-async/node_modules/abbrev": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/gdal-async/node_modules/agent-base": {
+      "version": "6.0.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/gdal-async/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gdal-async/node_modules/aproba": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/gdal-async/node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gdal-async/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/gdal-async/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/gdal-async/node_modules/chownr": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gdal-async/node_modules/color-support": {
+      "version": "1.1.3",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/gdal-async/node_modules/concat-map": {
+      "version": "0.0.1",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/gdal-async/node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/gdal-async/node_modules/debug": {
+      "version": "4.3.4",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gdal-async/node_modules/delegates": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/gdal-async/node_modules/detect-libc": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gdal-async/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/gdal-async/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/gdal-async/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/gdal-async/node_modules/gauge": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gdal-async/node_modules/glob": {
+      "version": "7.2.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gdal-async/node_modules/has-unicode": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/gdal-async/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gdal-async/node_modules/inflight": {
+      "version": "1.0.6",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/gdal-async/node_modules/inherits": {
+      "version": "2.0.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/gdal-async/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gdal-async/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gdal-async/node_modules/make-dir": {
+      "version": "3.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gdal-async/node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/gdal-async/node_modules/minimatch": {
+      "version": "3.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/gdal-async/node_modules/minipass": {
+      "version": "3.1.6",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gdal-async/node_modules/minizlib": {
+      "version": "2.1.2",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/gdal-async/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gdal-async/node_modules/ms": {
+      "version": "2.1.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/gdal-async/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/gdal-async/node_modules/nopt": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/gdal-async/node_modules/npmlog": {
+      "version": "5.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/gdal-async/node_modules/object-assign": {
+      "version": "4.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gdal-async/node_modules/once": {
+      "version": "1.4.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/gdal-async/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gdal-async/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/gdal-async/node_modules/rimraf": {
+      "version": "3.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gdal-async/node_modules/semver": {
+      "version": "7.3.7",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/gdal-async/node_modules/set-blocking": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/gdal-async/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/gdal-async/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/gdal-async/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/gdal-async/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gdal-async/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gdal-async/node_modules/tar": {
+      "version": "6.1.11",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/gdal-async/node_modules/tr46": {
+      "version": "0.0.3",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/gdal-async/node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/gdal-async/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/gdal-async/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/gdal-async/node_modules/wide-align": {
+      "version": "1.1.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/gdal-async/node_modules/wrappy": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/gdal-async/node_modules/yallist": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "ISC"
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -16806,6 +17396,41 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/xmlbuilder2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.0.2.tgz",
+      "integrity": "sha512-h4MUawGY21CTdhV4xm3DG9dgsqyhDkZvVJBx88beqX8wJs3VgyGQgAn5VreHuae6unTQxh115aMK5InCVmOIKw==",
+      "dependencies": {
+        "@oozcitak/dom": "1.15.10",
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8",
+        "@types/node": "*",
+        "js-yaml": "3.14.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/xmlbuilder2/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/xmlbuilder2/node_modules/js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/xmldom": {
       "version": "0.7.0",
       "resolved": "git+ssh://git@github.com/xmldom/xmldom.git#c568938641cc1f121cef5b4df80fcfda1e489b6e",
@@ -19252,6 +19877,38 @@
       "requires": {
         "@octokit/openapi-types": "^11.2.0"
       }
+    },
+    "@oozcitak/dom": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
+      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
+      "requires": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/url": "1.0.4",
+        "@oozcitak/util": "8.3.8"
+      }
+    },
+    "@oozcitak/infra": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
+      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
+      "requires": {
+        "@oozcitak/util": "8.3.8"
+      }
+    },
+    "@oozcitak/url": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
+      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
+      "requires": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8"
+      }
+    },
+    "@oozcitak/util": {
+      "version": "8.3.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
+      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ=="
     },
     "@panva/asn1.js": {
       "version": "1.0.0",
@@ -23144,13 +23801,367 @@
         }
       }
     },
-    "gdal": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/gdal/-/gdal-0.11.1.tgz",
-      "integrity": "sha512-nzlAzcU3/s3I58dcYtj27pRLV3UDubExUIdEDRj4NAUlRbFbgD6uE3/jr8aRMUyexHekQ7f99JvjlAkjDFwKsA==",
+    "gdal-async": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/gdal-async/-/gdal-async-3.5.0.tgz",
+      "integrity": "sha512-C9mAJ5Qi5b5JvEGsys3ubOUOGn8QZJx6ebcsW2L4cqThRLQ2+LXzia/XlCrIleNtE5LY2MQ7v7DSSmoM7JyOsw==",
       "requires": {
-        "@mapbox/node-pre-gyp": "^1.0.6",
-        "nan": "~2.15.0"
+        "@mapbox/node-pre-gyp": "^1.0.8",
+        "nan": "^2.14.0",
+        "xmlbuilder2": "^3.0.2"
+      },
+      "dependencies": {
+        "@mapbox/node-pre-gyp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "detect-libc": "^2.0.0",
+            "https-proxy-agent": "^5.0.0",
+            "make-dir": "^3.1.0",
+            "node-fetch": "^2.6.7",
+            "nopt": "^5.0.0",
+            "npmlog": "^5.0.1",
+            "rimraf": "^3.0.2",
+            "semver": "^7.3.5",
+            "tar": "^6.1.11"
+          }
+        },
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "agent-base": {
+          "version": "6.0.2",
+          "bundled": true,
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "are-we-there-yet": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^3.6.0"
+          }
+        },
+        "balanced-match": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "chownr": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "color-support": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "debug": {
+          "version": "4.3.4",
+          "bundled": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "detect-libc": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "bundled": true
+        },
+        "fs-minipass": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "minipass": "^3.0.0"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "gauge": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "aproba": "^1.0.3 || ^2.0.0",
+            "color-support": "^1.1.2",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.1",
+            "object-assign": "^4.1.1",
+            "signal-exit": "^3.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
+            "wide-align": "^1.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.2.0",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "https-proxy-agent": {
+          "version": "5.0.1",
+          "bundled": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "bundled": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "minipass": {
+          "version": "3.1.6",
+          "bundled": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "2.1.2",
+          "bundled": true,
+          "requires": {
+            "minipass": "^3.0.0",
+            "yallist": "^4.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "bundled": true
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "bundled": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "nopt": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1"
+          }
+        },
+        "npmlog": {
+          "version": "5.0.1",
+          "bundled": true,
+          "requires": {
+            "are-we-there-yet": "^2.0.0",
+            "console-control-strings": "^1.1.0",
+            "gauge": "^3.0.0",
+            "set-blocking": "^2.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "bundled": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "bundled": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "signal-exit": {
+          "version": "3.0.7",
+          "bundled": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.2.1",
+              "bundled": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "bundled": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "tar": {
+          "version": "6.1.11",
+          "bundled": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.0.0",
+            "minipass": "^3.0.0",
+            "minizlib": "^2.1.1",
+            "mkdirp": "^1.0.3",
+            "yallist": "^4.0.0"
+          }
+        },
+        "tr46": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.5",
+          "bundled": true,
+          "requires": {
+            "string-width": "^1.0.2 || 2 || 3 || 4"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "bundled": true
+        }
       }
     },
     "gensync": {
@@ -30169,6 +31180,37 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    },
+    "xmlbuilder2": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.0.2.tgz",
+      "integrity": "sha512-h4MUawGY21CTdhV4xm3DG9dgsqyhDkZvVJBx88beqX8wJs3VgyGQgAn5VreHuae6unTQxh115aMK5InCVmOIKw==",
+      "requires": {
+        "@oozcitak/dom": "1.15.10",
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8",
+        "@types/node": "*",
+        "js-yaml": "3.14.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
     },
     "xmldom": {
       "version": "git+ssh://git@github.com/xmldom/xmldom.git#c568938641cc1f121cef5b4df80fcfda1e489b6e",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "express-validator": "^6.13.0",
     "express-winston": "^4.1.0",
     "form-data": "^4.0.0",
-    "gdal": "^0.11.1",
+    "gdal-async": "^3.5.0",
     "js-yaml": "^4.1.0",
     "json2csv": "^5.0.7",
     "knex": "^0.95.14",

--- a/test/ogc-api-coverages/get-coverage-rangeset-shapefile.ts
+++ b/test/ogc-api-coverages/get-coverage-rangeset-shapefile.ts
@@ -87,7 +87,7 @@ describe('OGC API Coverages - getCoverageRangeset with shapefile', function () {
 
       it('passes the outputCrs parameter to the backend via srs object', function () {
         expect(this.service.operation.srs.proj4).to.equal('+proj=longlat +datum=WGS84 +no_defs');
-        expect(this.service.operation.srs.wkt).to.equal('GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]');
+        expect(this.service.operation.srs.wkt).to.equal('GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]');
         expect(this.service.operation.srs.epsg).to.equal('EPSG:4326');
       });
 

--- a/test/wms/get-map.ts
+++ b/test/wms/get-map.ts
@@ -38,7 +38,7 @@ describe('WMS GetMap', function () {
 
       it('passes the crs parameter to the backend via srs object', function () {
         expect(this.service.operation.srs.proj4).to.equal('+proj=longlat +datum=WGS84 +no_defs');
-        expect(this.service.operation.srs.wkt).to.equal('GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]]');
+        expect(this.service.operation.srs.wkt).to.equal('GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]');
         expect(this.service.operation.srs.epsg).to.equal('EPSG:4326');
       });
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1207

## Description
We've had issues with the gdal library not being updated in the past (causing problems with security vulnerabilities and not being able to update our version of nodeJS). Also we have to custom install gdal from source on our Amazon Linux 2 EC2 instances. With the switch to `gdal-async`, which is actively maintained we should be in better shape in the future.

There is additional AXIS information passed in WKT but seems to match the spec:
https://docs.geotools.org/stable/javadocs/org/opengis/referencing/doc-files/WKT.html

```
AXIS["Latitude",NORTH],AXIS["Longitude",EAST]
```


## Local Test Steps
Make sure you have SWOT reprojection built and deployed locally.

`npm install` to update your gdal library (you may have to first remove your node_modules directory)
Submit this request:

http://localhost:3000/C1233860183-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?granuleId=G1233860486-EEDTEST&outputCrs=%2Bproj%3Dlcc%20%2Blat_1%3D43%20%2Blat_2%3D62%20%2Blat_0%3D30%20%2Blon_0%3D10%20%2Bx_0%3D0%20%2By_0%3D0%20%2Bellps%3Dintl%20%2Bunits%3Dm%20no_defs&interpolation=near&scaleExtent=-7000000,1000000,8000000,8000000

Verify that it is reprojected with `lambert_conformal_conic` listed as one of the dataset names in the netcdf4 file that is generated. You can also compare the file to what is generated in the UAT environment.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~