### PR TITLE
HARMONY-1185: Remove code that cleans up artifacts from work items.

### DIFF
--- a/app/util/job.ts
+++ b/app/util/job.ts
@@ -1,5 +1,4 @@
 import { Logger } from 'winston';
-import { promises as fs } from 'fs';
 import db, { Transaction } from './db';
 import { Job, JobStatus, terminalStates } from '../models/job';
 import env from './env';
@@ -11,20 +10,6 @@ import { WorkItemStatus } from '../models/work-item-interface';
 import { getWorkflowStepsByJobId } from '../models/workflow-steps';
 import DataOperation, { CURRENT_SCHEMA_VERSION } from '../models/data-operation';
 import { createDecrypter, createEncrypter } from './crypto';
-
-/**
- * Cleans up the temporary work items for the provided jobID
- * @param jobID - the jobID for which to remove temporary work items
- * @param logger - the logger associated with the request
- */
-async function cleanupWorkItemsForJobID(jobID: string, logger: Logger): Promise<void> {
-  try {
-    await fs.rm(`${env.hostVolumePath}/${jobID}/`, { recursive: true });
-  } catch (e) {
-    logger.warn(`Unable to clean up temporary files for ${jobID}`);
-    logger.warn(e);
-  }
-}
 
 /**
  * Helper function to pull back the provided job ID (optionally by username).
@@ -82,8 +67,6 @@ export async function completeJob(
     logger.error(`Error encountered for job ${job.jobID} while attempting to set final status`);
     logger.error(e);
     throw e;
-  } finally {
-    await cleanupWorkItemsForJobID(job.jobID, logger);
   }
 }
 


### PR DESCRIPTION
Needed to avoid EFS slowness

## Jira Issue ID
HARMONY-1185

## Description
Removes the code that that deletes work item STAC catalogs from EFS to avoid huge slowdowns when canceling jobs. This code is no longer needed once we move off EFS.

This change does not alter any of the existing use of transactions - that turned out to not be the problem. We probably want to revisit our use of transactions at some point.

## Local Test Steps
* Check out this branch
* Set MAX_GRANULE_LIMIT=200000 in your harmony-ci-cd .env file
* Deploy the branch to the sandbox.
* Issue the following query
```
http://<your deployment redirect url>/1234724470-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-45%3A45)&subset=lon(0%3A180)
```
* Open the workflow-ui page and click on the job
* Wait about 15 minutes then cancel the job
You should see the job canceled quickly and all the work items should be canceled within about 60 seconds.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~