### PR TITLE
DAS-1528 - Add UMM-S record for HGA in UAT.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -423,10 +423,9 @@ https://cmr.uat.earthdata.nasa.gov:
         env:
           <<: *default-turbo-env
           STAGING_PATH: public/nasa/harmony-gdal-adapter
+    umm_s:
+      - S1245787332-EEDTEST
     collections:
-      - id: C1244141281-EEDTEST # ALOS AVNIR OBS ORI test collection
-      - id: C1244141250-EEDTEST # Sentinel 1 Interferogram test collection
-      - id: C1244141264-EEDTEST # UAVSAR POLSAR Pauli test collection
       - id: C1225776654-ASF
       - id: C1207038647-ASF
       - id: C1233629671-ASF


### PR DESCRIPTION
## Jira Issue ID

DAS-1528

## Description

This PR adds a reference to a UMM-S record for HGA in the EEDTEST provider in UAT ([S1245787332-EEDTEST](https://cmr.uat.earthdata.nasa.gov/search/services.umm_json?concept_id=S1245787332-EEDTEST)). It also removes the explicit collection associations listed for EEDTEST collections in `services.yml` as these are now present as collection-to-service associations directly in CMR.

## Local Test Steps

* Pull this branch and rebuild your local Harmony instance using it. (`./bin/bootstrap-harmony`).
* Run the [HGA regression test notebook](https://github.com/nasa/harmony-regression-tests/tree/main/test/hga) using a local Jupyter notebook server. You should modify the notebook to run against your local instance by updating the 3rd code cell ("Set up environment dependent variables") with the following lines at the bottom of the cell:

```
...

# For testing locally:
harmony_client = Client(env=Environment.LOCAL)
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] ~Tests added/updated (if needed) and passing~
* [x] ~Documentation updated (if needed)~