### PR TITLE
HARMONY-1206: Restrict variables returned for described collections when defined in services.yml

### DIFF
--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -20,7 +20,7 @@ export interface ServiceCapabilities {
     variable?: boolean;
     multiple_variable?: true;
   };
-  output_formats?: [string];
+  output_formats?: string[];
   reprojection?: boolean;
 }
 

--- a/config/services.yml
+++ b/config/services.yml
@@ -38,16 +38,16 @@ https://cmr.earthdata.nasa.gov:
     collections:
       - id: C1598621093-GES_DISC
         variables:
-        - V2144690146-GES_DISC
-        - V2144682160-GES_DISC
-        - V2144444407-GES_DISC
-        - V2144674651-GES_DISC
-        - V2144680005-GES_DISC
-        - V2144683811-GES_DISC
-        - V2144672700-GES_DISC
-        - V2144443981-GES_DISC
-        - V2144677987-GES_DISC
-        - V2144685939-GES_DISC
+        - V2296949098-GES_DISC
+        - V2296949172-GES_DISC
+        - V2296949242-GES_DISC
+        - V2296949978-GES_DISC
+        - V2296949195-GES_DISC
+        - V2296949905-GES_DISC
+        - V2296949990-GES_DISC
+        - V2296949860-GES_DISC
+        - V2296949142-GES_DISC
+        - V2296949998-GES_DISC
     capabilities:
       concatenation: true
       concatenate_by_default: true
@@ -459,16 +459,16 @@ https://cmr.uat.earthdata.nasa.gov:
     collections:
       - id: C1225808238-GES_DISC
         variables:
-        - V1240788781-GES_DISC
-        - V1242222137-GES_DISC
-        - V1240788730-GES_DISC
-        - V1242222299-GES_DISC
-        - V1242222009-GES_DISC
-        - V1242222265-GES_DISC
-        - V1242222196-GES_DISC
-        - V1242222340-GES_DISC
-        - V1242222234-GES_DISC
-        - V1242222036-GES_DISC
+        - V1245551685-GES_DISC
+        - V1245551715-GES_DISC
+        - V1245551687-GES_DISC
+        - V1245551691-GES_DISC
+        - V1245551713-GES_DISC
+        - V1245551711-GES_DISC
+        - V1245551709-GES_DISC
+        - V1245551689-GES_DISC
+        - V1245551693-GES_DISC
+        - V1245551717-GES_DISC
     capabilities:
       concatenation: true
       concatenate_by_default: true


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1206

## Description
When a service.yml service entry has a collection and that collection lists the variables it can use, restrict the list of OGC collections (variables) to the variables in the collection entry when describing the collection. 

## Local Test Steps
* Run Harmony locally then execute the following query
```
curl -Ln -bj "http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections"
```
You should see several variables listed.
* Edit `services.yml` and add the following to the  `C1233800302-EEDTEST` collection under the UAT harmony-service-example
```
variables:
        - V1233801717-EEDTEST
```
* Restart Harmony to pick up the changes to services.yml
* Rerun the query above - you should see only the V1233801717-EEDTEST variable returned.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~