### PR TITLE
Harmony 1140 - Add buttons for sorting jobs by number of input granules

### DIFF
--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -89,6 +89,12 @@ export async function getJobs(
   try {
     const requestQuery = keysToLowerCase(req.query);
     const jobQuery: JobQuery = { where: {}, whereIn: {} };
+    if (requestQuery.sortgranules) {
+      jobQuery.orderBy = {
+        field: 'numInputGranules',
+        value: requestQuery.sortgranules,
+      };
+    }
     if (!req.context.isAdminAccess) {
       jobQuery.where.username = req.user;
     }
@@ -140,7 +146,7 @@ export async function getJobs(
       },
       // job table sorting
       sortGranules() {
-        // return a link that either lets the user apply or unapply an asc or desc sort
+        // return links that lets the user apply or unapply an asc or desc sort
         const [ asc, desc ] = [ 'asc', 'desc' ].map((sortValue) => {
           const isSorted = requestQuery.sortgranules === sortValue;
           const url = getRequestUrl(req, true, { sortGranules: isSorted ? '' : sortValue });

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -145,19 +145,22 @@ export async function getJobs(
         }
       },
       // job table sorting
-      sortGranules() {
+      sortGranules: requestQuery.sortgranules,
+      sortGranulesLinks() {
         // return links that lets the user apply or unapply an asc or desc sort
         const [ asc, desc ] = [ 'asc', 'desc' ].map((sortValue) => {
           const isSorted = requestQuery.sortgranules === sortValue;
-          const url = getRequestUrl(req, true, { sortGranules: isSorted ? '' : sortValue });
           const colorClass = isSorted ? 'link-dark' : '';
           const title = `${isSorted ? 'un' : ''}apply ${sortValue === 'asc' ? 'ascending' : 'descending'} sort`;
-          return { url, colorClass, title };
+          const sortGranulesValue = !isSorted ? sortValue : '';
+          return { sortGranulesValue, colorClass, title };
         });
-        return `<a href="${asc.url}" class="${asc.colorClass}">
+        const setValueStr = "document.getElementById('sort-granules').value=";
+        const submitFormStr = "document.getElementById('jobs-query-form').submit()";
+        return `<a href="#" onclick="${setValueStr}'${asc.sortGranulesValue}';${submitFormStr};" class="${asc.colorClass}">
           <i class="bi bi-sort-numeric-up" title="${asc.title}"></i>
         </a>
-        <a href="${desc.url}" class="${desc.colorClass}">
+        <a href="#" onclick="${setValueStr}'${desc.sortGranulesValue}';${submitFormStr};" class="${desc.colorClass}">
           <i class="bi bi-sort-numeric-down-alt" title="${desc.title}"></i>
         </a>`;
       },

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -158,11 +158,11 @@ export async function getJobs(
         // onclick, set a hidden form value that represents the current sort value, then submit the form
         const setValueStr = "document.getElementById('sort-granules').value";
         const submitFormStr = "document.getElementById('jobs-query-form').submit()";
-        return `<a href="#" onclick="${setValueStr}='${asc.sortGranulesValue}';${submitFormStr};" class="${asc.colorClass}">
-          <i class="bi bi-sort-numeric-up" title="${asc.title}"></i>
+        return `<a href="#" onclick="${setValueStr}='${asc.sortGranulesValue}';${submitFormStr};" class="${asc.colorClass}" style="height:12px;">
+          <i class="bi bi-caret-up-fill" title="${asc.title}"></i>
         </a>
         <a href="#" onclick="${setValueStr}='${desc.sortGranulesValue}';${submitFormStr};" class="${desc.colorClass}">
-          <i class="bi bi-sort-numeric-down-alt" title="${desc.title}"></i>
+          <i class="bi bi-caret-down-fill" title="${desc.title}"></i>
         </a>`;
       },
       // job table filters HTML

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -155,6 +155,7 @@ export async function getJobs(
           const sortGranulesValue = !isSorted ? sortValue : '';
           return { sortGranulesValue, colorClass, title };
         });
+        // onclick, set a hidden form value that represents the current sort value, then submit the form
         const setValueStr = "document.getElementById('sort-granules').value";
         const submitFormStr = "document.getElementById('jobs-query-form').submit()";
         return `<a href="#" onclick="${setValueStr}='${asc.sortGranulesValue}';${submitFormStr};" class="${asc.colorClass}">

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -155,12 +155,12 @@ export async function getJobs(
           const sortGranulesValue = !isSorted ? sortValue : '';
           return { sortGranulesValue, colorClass, title };
         });
-        const setValueStr = "document.getElementById('sort-granules').value=";
+        const setValueStr = "document.getElementById('sort-granules').value";
         const submitFormStr = "document.getElementById('jobs-query-form').submit()";
-        return `<a href="#" onclick="${setValueStr}'${asc.sortGranulesValue}';${submitFormStr};" class="${asc.colorClass}">
+        return `<a href="#" onclick="${setValueStr}'=${asc.sortGranulesValue}';${submitFormStr};" class="${asc.colorClass}">
           <i class="bi bi-sort-numeric-up" title="${asc.title}"></i>
         </a>
-        <a href="#" onclick="${setValueStr}'${desc.sortGranulesValue}';${submitFormStr};" class="${desc.colorClass}">
+        <a href="#" onclick="${setValueStr}'=${desc.sortGranulesValue}';${submitFormStr};" class="${desc.colorClass}">
           <i class="bi bi-sort-numeric-down-alt" title="${desc.title}"></i>
         </a>`;
       },

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -11,7 +11,7 @@ import version from '../util/version';
 import env = require('../util/env');
 import { keysToLowerCase } from '../util/object';
 import { COMPLETED_WORK_ITEM_STATUSES, getItemLogsLocation, WorkItemStatus } from '../models/work-item-interface';
-import { getRequestRoot } from '../util/url';
+import { getRequestRoot, getRequestUrl } from '../util/url';
 import { belongsToGroup } from '../util/cmr';
 import { getAllStateChangeLinks, getJobStateChangeLinks } from '../util/links';
 import { objectStoreForProtocol } from '../util/object-store';
@@ -137,6 +137,23 @@ export async function getJobs(
           req.context.logger.error(e);
           return this.request;
         }
+      },
+      // job table sorting
+      sortGranules() {
+        // return a link that either lets the user apply or unapply an asc or desc sort
+        const [ asc, desc ] = [ 'asc', 'desc' ].map((sortValue) => {
+          const isSorted = requestQuery.sortgranules === sortValue;
+          const url = getRequestUrl(req, true, { sortGranules: isSorted ? '' : sortValue });
+          const colorClass = isSorted ? 'link-dark' : '';
+          const title = `${isSorted ? 'un' : ''}apply ${sortValue === 'asc' ? 'ascending' : 'descending'} sort`;
+          return { url, colorClass, title };
+        });
+        return `<a href="${asc.url}" class="${asc.colorClass}">
+          <i class="bi bi-sort-numeric-up" title="${asc.title}"></i>
+        </a>
+        <a href="${desc.url}" class="${desc.colorClass}">
+          <i class="bi bi-sort-numeric-down-alt" title="${desc.title}"></i>
+        </a>`;
       },
       // job table filters HTML
       disallowStatusChecked: disallowStatus ? 'checked' : '',

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -157,10 +157,10 @@ export async function getJobs(
         });
         const setValueStr = "document.getElementById('sort-granules').value";
         const submitFormStr = "document.getElementById('jobs-query-form').submit()";
-        return `<a href="#" onclick="${setValueStr}'=${asc.sortGranulesValue}';${submitFormStr};" class="${asc.colorClass}">
+        return `<a href="#" onclick="${setValueStr}='${asc.sortGranulesValue}';${submitFormStr};" class="${asc.colorClass}">
           <i class="bi bi-sort-numeric-up" title="${asc.title}"></i>
         </a>
-        <a href="#" onclick="${setValueStr}'=${desc.sortGranulesValue}';${submitFormStr};" class="${desc.colorClass}">
+        <a href="#" onclick="${setValueStr}='${desc.sortGranulesValue}';${submitFormStr};" class="${desc.colorClass}">
           <i class="bi bi-sort-numeric-down-alt" title="${desc.title}"></i>
         </a>`;
       },

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -11,7 +11,7 @@ import version from '../util/version';
 import env = require('../util/env');
 import { keysToLowerCase } from '../util/object';
 import { COMPLETED_WORK_ITEM_STATUSES, getItemLogsLocation, WorkItemStatus } from '../models/work-item-interface';
-import { getRequestRoot, getRequestUrl } from '../util/url';
+import { getRequestRoot } from '../util/url';
 import { belongsToGroup } from '../util/cmr';
 import { getAllStateChangeLinks, getJobStateChangeLinks } from '../util/links';
 import { objectStoreForProtocol } from '../util/object-store';

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -94,6 +94,10 @@ export interface JobQuery {
     status?: { in: boolean, values: string[] };
     username?: { in: boolean, values: string[] };
   }
+  orderBy?: {
+    field: string;
+    value: string;
+  }
 }
 
 // State machine definition for jobs. This is not used to maintain state, just to enforce
@@ -335,7 +339,9 @@ export class Job extends Record implements JobRecord {
     const items = await transaction('jobs')
       .select()
       .where(constraints.where)
-      .orderBy('createdAt', 'desc')
+      .orderBy(
+        constraints?.orderBy?.field ?? 'createdAt', 
+        constraints?.orderBy?.value ?? 'desc')
       .modify((queryBuilder) => {
         if (constraints.whereIn) {
           for (const jobField in constraints.whereIn) {

--- a/app/views/workflow-ui/jobs/index.mustache.html
+++ b/app/views/workflow-ui/jobs/index.mustache.html
@@ -44,9 +44,10 @@
     <div class="container-fluid">
         <div class="row pb-4">
             <div class="col-2">
-                <form action="{{currentPage}}" method="get">
+                <form id="jobs-query-form" action="{{currentPage}}" method="get">
                     <input type="hidden" name="page" value="{{page}}" />
                     <input type="hidden" name="limit" value="{{limit}}" />
+                    <input id="sort-granules" type="hidden" name="sortGranules" value="{{sortGranules}}" />
                     <input name="jobsFilter" class="jobs-filter mb-2" placeholder="add a filter"
                         value="{{selectedFilters}}" data-current-user="{{currentUser}}"
                         data-is-admin-route="{{isAdminRoute}}">

--- a/app/views/workflow-ui/jobs/index.mustache.html
+++ b/app/views/workflow-ui/jobs/index.mustache.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="../../../css/eui.min.css">
     <link rel="stylesheet" href="../../../css/default.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css">
     <link href="https://unpkg.com/@yaireo/tagify/dist/tagify.css" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="../../../css/workflow-ui/jobs/index.css">
     <script src="https://unpkg.com/@yaireo/tagify"></script>
@@ -63,7 +64,7 @@
                         </label>
                     </div>
                     {{/isAdminRoute}}
-                    <button type="submit" class="btn btn-primary btn-sm mt-3">∇ apply</button>
+                    <button type="submit" class="btn btn-primary btn-sm mt-3"><i class="bi bi-filter-circle"></i> apply</button>
                 </form>
             </div>
             <div class="col-10">

--- a/app/views/workflow-ui/jobs/jobs-table.mustache.html
+++ b/app/views/workflow-ui/jobs/jobs-table.mustache.html
@@ -1,6 +1,6 @@
 <table class="table table-sm">
     <thead>
-        <tr>
+        <tr class="align-middle">
             <th scope="col">jobID</th>
             {{#isAdminRoute}}
             <th scope="col">user</th>
@@ -8,7 +8,16 @@
             <th scope="col">request</th>
             <th scope="col">status</th>
             <th scope="col">message</th>
-            <th scope="col">granules</th>
+            <th scope="col" class="d-flex flex-row align-items-center"><div>granules</div>&nbsp;
+                <div class="d-flex flex-column">
+                <a href="">
+                    <i class="bi bi-sort-numeric-up" title="apply ascending sort"></i>
+                </a>
+                <a href="" class="link-dark">
+                    <i class="bi bi-sort-numeric-down-alt" title="apply descending sort"></i>
+                </a>
+                </div>
+            </th>
             <th scope="col">progress</th>
             <th scope="col">createdAt</th>
         </tr>

--- a/app/views/workflow-ui/jobs/jobs-table.mustache.html
+++ b/app/views/workflow-ui/jobs/jobs-table.mustache.html
@@ -10,7 +10,7 @@
             <th scope="col">message</th>
             <th scope="col" class="d-flex flex-row align-items-center"><div>granules</div>&nbsp;
                 <div class="d-flex flex-column">
-                {{{sortGranules}}}
+                {{{sortGranulesLinks}}}
                 </div>
             </th>
             <th scope="col">progress</th>

--- a/app/views/workflow-ui/jobs/jobs-table.mustache.html
+++ b/app/views/workflow-ui/jobs/jobs-table.mustache.html
@@ -10,12 +10,7 @@
             <th scope="col">message</th>
             <th scope="col" class="d-flex flex-row align-items-center"><div>granules</div>&nbsp;
                 <div class="d-flex flex-column">
-                <a href="">
-                    <i class="bi bi-sort-numeric-up" title="apply ascending sort"></i>
-                </a>
-                <a href="" class="link-dark">
-                    <i class="bi bi-sort-numeric-down-alt" title="apply descending sort"></i>
-                </a>
+                {{{sortGranules}}}
                 </div>
             </th>
             <th scope="col">progress</th>

--- a/test/workflow-ui/jobs.ts
+++ b/test/workflow-ui/jobs.ts
@@ -17,7 +17,7 @@ const woodyJob1 = buildJob({
   links: [{ href: 'http://example.com/woody1', rel: 'link', type: 'text/plain' }],
   request: 'http://example.com/harmony?request=woody1&turbo=false',
   isAsync: true,
-  numInputGranules: 3,
+  numInputGranules: 89723,
 });
 
 const woodyJob2 = buildJob({
@@ -28,7 +28,7 @@ const woodyJob2 = buildJob({
   links: [{ href: 's3://somebucket/mydata', rel: 'data', type: 'image/tiff' }],
   request: 'http://example.com/harmony?request=woody2&turbo=true',
   isAsync: true,
-  numInputGranules: 5,
+  numInputGranules: 35051,
 });
 
 const woodySyncJob = buildJob({
@@ -39,7 +39,7 @@ const woodySyncJob = buildJob({
   links: [],
   request: 'http://example.com/harmony?request=woody2',
   isAsync: false,
-  numInputGranules: 1,
+  numInputGranules: 12615,
 });
 
 const buzzJob1 = buildJob({
@@ -152,6 +152,24 @@ describe('Workflow UI jobs route', function () {
       });
       it('returns only one job', function () {
         const listing = this.res.text;
+        expect((listing.match(/job-table-row/g) || []).length).to.equal(1);
+      });
+    });
+
+    describe('who asks for page 1, with a limit of 1, descending', function () {
+      hookWorkflowUIJobs({ username: 'woody', limit: 1, sortGranules: 'desc' });
+      it('returns the largest job', function () {
+        const listing = this.res.text;
+        expect(listing).to.contain('89723');
+        expect((listing.match(/job-table-row/g) || []).length).to.equal(1);
+      });
+    });
+
+    describe('who asks for page 1, with a limit of 1, ascending', function () {
+      hookWorkflowUIJobs({ username: 'woody', limit: 1, sortGranules: 'asc' });
+      it('returns the smallest job', function () {
+        const listing = this.res.text;
+        expect(listing).to.contain('12615');
         expect((listing.match(/job-table-row/g) || []).length).to.equal(1);
       });
     });


### PR DESCRIPTION
## Jira Issue ID
harmony-1140

## Description
Both the user and admin workflow-ui endpoints now allow sorting based on the number of input granules.

## Local Test Steps
Try it out by clicking one of the arrow buttons. You can sort ascending or descending. Click the same button again to unapply the sort.

<img width="120" alt="Screen Shot 2022-08-05 at 8 47 45 AM" src="https://user-images.githubusercontent.com/34752045/183080373-31f07b48-4ee9-4400-a6db-4e3ce9b2ec2a.png">


## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)