### PR TITLE
HARMONY-1255: Don't stringify data operation for query-cmr

### DIFF
--- a/tasks/service-runner/app/service/service-runner.ts
+++ b/tasks/service-runner/app/service/service-runner.ts
@@ -110,7 +110,7 @@ export async function runQueryCmrFromPull(workItem: WorkItemRecord, maxCmrGranul
       const resp = await axios.post(`http://localhost:${env.workerPort}/work`,
         {
           outputDir: catalogDir,
-          harmonyInput: `${JSON.stringify(operation)}`,
+          harmonyInput: operation,
           scrollId: scrollID,
           maxCmrGranules,
         },


### PR DESCRIPTION
## Jira Issue ID
harmony-1255

## Description
We were unable to parse the access token successfully in the query CMR task due to unnecessary stringification.

## Local Test Steps
Rebuild query cmr and restart services. Issue a request and log the access token in query.ts. (Inspect the query cmr worker logs.)

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)