### PR TITLE
HARMONY-1256: Always set the user_ip to a blank string in the request metrics

### DIFF
--- a/app/util/metrics.ts
+++ b/app/util/metrics.ts
@@ -24,7 +24,9 @@ export interface RequestMetric {
   referrer_request_id?: string; // We do not have this information
   request_id: string;
   user_id: string;
-  user_ip?: string; // We do not have this information
+  // We do not have the user_ip information, but the metrics team needs it set to a blank string
+  // rather than omitting it
+  user_ip: string;
   rangeBeginDateTime?: string;
   rangeEndDateTime?: string;
   bbox?: BboxMetric;
@@ -101,6 +103,7 @@ export function getRequestMetric(operation: DataOperation, serviceName: string):
 
   const metric: RequestMetric = {
     request_id: operation.requestId,
+    user_ip: '',
     user_id: operation.user,
     parameters: { service_name: serviceName },
   };

--- a/test/util/metrics.ts
+++ b/test/util/metrics.ts
@@ -16,12 +16,16 @@ describe('Metrics construction', function () {
 
       it('includes all of the fields in the metric', function () {
         expect(Object.keys(metric)).to.eql([
-          'request_id', 'user_id', 'parameters', 'bbox', 'rangeBeginDateTime', 'rangeEndDateTime',
+          'request_id', 'user_ip', 'user_id', 'parameters', 'bbox', 'rangeBeginDateTime', 'rangeEndDateTime',
         ]);
       });
 
       it('sets the request ID correctly', function () {
         expect(metric.request_id).to.equal(operation.requestId);
+      });
+
+      it('sets the user IP to a blank string', function () {
+        expect(metric.user_ip).to.equal('');
       });
 
       it('sets the user ID correctly', function () {
@@ -53,7 +57,7 @@ describe('Metrics construction', function () {
 
       it('does not include a bbox in the metric', function () {
         expect(Object.keys(metric)).to.eql([
-          'request_id', 'user_id', 'parameters', 'rangeBeginDateTime', 'rangeEndDateTime',
+          'request_id', 'user_ip', 'user_id', 'parameters', 'rangeBeginDateTime', 'rangeEndDateTime',
         ]);
       });
     });
@@ -66,7 +70,7 @@ describe('Metrics construction', function () {
 
       it('does not include a rangeBeginDateTime in the metric', function () {
         expect(Object.keys(metric)).to.eql([
-          'request_id', 'user_id', 'parameters', 'bbox', 'rangeEndDateTime',
+          'request_id', 'user_ip', 'user_id', 'parameters', 'bbox', 'rangeEndDateTime',
         ]);
       });
     });
@@ -79,7 +83,7 @@ describe('Metrics construction', function () {
 
       it('does not include a rangeEndDateTime in the metric', function () {
         expect(Object.keys(metric)).to.eql([
-          'request_id', 'user_id', 'parameters', 'bbox', 'rangeBeginDateTime',
+          'request_id', 'user_ip', 'user_id', 'parameters', 'bbox', 'rangeBeginDateTime',
         ]);
       });
     });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1256

## Description
The metrics team has asked us to set the user_ip string to a blank string rather than omit the value in able to make their parsing easier.

## Local Test Steps
Set TEXT_LOGGER=false in your .env and then submit a request. Verify in your logs for the request metric that you see the blank user_ip:
```
{... , "message":"Request metric for request ...", ... "user_ip":""}
```

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)