### PR TITLE
HARMONY-1264: Fix performance bottlenecks with polling for work.

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,12 +1,1 @@
-{
-  "1080830": {
-    "active": true,
-    "notes": "No available fix. We should fix as soon as a fix becomes available.",
-    "expiry": "2022-09-21"
-  },
-  "1080829": {
-    "active": true,
-    "notes": "No available fix. We should fix as soon as a fix becomes available.",
-    "expiry": "2022-09-21"
-  }
-}
+{}

--- a/.nsprc
+++ b/.nsprc
@@ -2,11 +2,11 @@
   "1080830": {
     "active": true,
     "notes": "No available fix. We should fix as soon as a fix becomes available.",
-    "expiry": "2022-08-21"
+    "expiry": "2022-09-21"
   },
   "1080829": {
     "active": true,
     "notes": "No available fix. We should fix as soon as a fix becomes available.",
-    "expiry": "2022-08-21"
+    "expiry": "2022-09-21"
   }
 }

--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -18,7 +18,7 @@ import { COMPLETED_WORK_ITEM_STATUSES, WorkItemStatus } from '../models/work-ite
 import JobError, { getErrorCountForJob } from '../models/job-error';
 
 const MAX_TRY_COUNT = 1;
-const RETRY_DELAY = 1000;
+const RETRY_DELAY = 1000 * 120;
 const QUERY_CMR_SERVICE_REGEX = /harmonyservices\/query-cmr:.*/;
 
 /**
@@ -423,7 +423,7 @@ async function handleFailedWorkItems(
     continueProcessing = job.ignoreErrors;
     if (!job.isComplete()) {
       let jobMessage;
-      
+
       if (errorMessage) {
         jobMessage = `WorkItem [${workItem.id}] failed with error: ${errorMessage}`;
       }
@@ -466,8 +466,8 @@ async function handleFailedWorkItems(
 }
 
 /**
- * Updated the workflow steps `workItemCount` field for the given job to match the new 
- * 
+ * Updated the workflow steps `workItemCount` field for the given job to match the new
+ *
  * @param transaction - the transaction to use for the update
  * @param job - A Job that has a new input granule count
  */

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -112,7 +112,7 @@ export async function getNextWorkItem(
 ): Promise<WorkItem> {
   let workItemData;
   const acceptableJobStatuses = _.cloneDeep(activeJobStatuses);
-  // Now that we use search-after instead of scrolling we could allow pausing of query-cmr
+  // TODO: Now that we use search-after instead of scrolling we could allow pausing of query-cmr
   // work items and start them back up when the job is resumed because there is no session
   if (serviceID.includes('query-cmr')) {
     acceptableJobStatuses.push(JobStatus.PAUSED);

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -87,7 +87,7 @@ export default class WorkItem extends Record implements WorkItemRecord {
    * resolved relative to the STAC outputs directory.
    * e.g. s3://artifacts/abc/123/outputs/ with a targetUrl of ./catalog0.json or catalog0.json would resolve to
    * s3://artifacts/abc/123/outputs/catalog0.json
-   * @param targetUrl - URL to resolve against the base outptuts directory 
+   * @param targetUrl - URL to resolve against the base outptuts directory
    * @param isAggregate - include the word aggregate in the URL
    * @returns - the path to the STAC outputs directory (e.g. s3://artifacts/abc/123/outputs/) or the full path to the target URL
    */
@@ -112,14 +112,14 @@ export async function getNextWorkItem(
 ): Promise<WorkItem> {
   let workItemData;
   const acceptableJobStatuses = _.cloneDeep(activeJobStatuses);
-  // The query-cmr service should keep going for paused jobs to avoid the ten minute CMR
-  // scroll session timeout
+  // Now that we use search-after instead of scrolling we could allow pausing of query-cmr
+  // work items and start them back up when the job is resumed because there is no session
   if (serviceID.includes('query-cmr')) {
     acceptableJobStatuses.push(JobStatus.PAUSED);
   }
 
   try {
-    // query to get users that have active jobs that have available work items for the service
+    // Find users with work items queued for the service
     const subQueryForUsersRequestingService =
       tx(Job.table)
         .select('username')
@@ -137,40 +137,48 @@ export async function getNextWorkItem(
       .first();
 
     if (userData?.username) {
-      let workItemDataQuery = tx(`${WorkItem.table} as w`)
-        .forUpdate()
-        .join(`${Job.table} as j`, 'w.jobID', 'j.jobID')
-        .join(`${WorkflowStep.table} as wf`, function () {
-          this.on('w.jobID', '=', 'wf.jobID')
-            .on('w.workflowStepIndex', '=', 'wf.stepIndex');
-        })
-        .select(...tableFields, 'wf.operation')
-        .whereIn('j.status', acceptableJobStatuses)
-        .where('w.status', '=', 'ready')
-        .where('w.serviceID', '=', serviceID)
-        .where('j.username', '=', userData.username)
-        .orderBy('j.isAsync', 'asc')
-        .orderBy('j.updatedAt', 'asc')
+      // query to choose the job that should be worked on next based on fair queueing policy
+      const jobData = await tx(Job.table)
+        .select([`${Job.table}.jobID`])
+        .join(`${WorkItem.table} as w`, `${Job.table}.jobID`, 'w.jobID')
+        .where('username', '=', userData.username)
+        .whereIn(`${Job.table}.status`, acceptableJobStatuses)
+        .where({ 'w.status': 'ready', serviceID })
+        .orderBy('isAsync', 'asc')
+        .orderBy(`${Job.table}.updatedAt`, 'asc')
         .first();
 
-      if (db.client.config.client === 'pg') {
-        workItemDataQuery = workItemDataQuery.skipLocked();
+      if (jobData?.jobID) {
+        let workItemDataQuery = tx(`${WorkItem.table} as w`)
+          .forUpdate()
+          .join(`${WorkflowStep.table} as wf`, function () {
+            this.on('w.jobID', '=', 'wf.jobID')
+              .on('w.workflowStepIndex', '=', 'wf.stepIndex');
+          })
+          .select(...tableFields, 'wf.operation')
+          .where('w.jobID', '=', jobData.jobID)
+          .where('w.status', '=', 'ready')
+          .where('w.serviceID', '=', serviceID)
+          .first();
+
+        if (db.client.config.client === 'pg') {
+          workItemDataQuery = workItemDataQuery.skipLocked();
+        }
+
+        workItemData = await workItemDataQuery;
+
+        if (workItemData) {
+          workItemData.operation = JSON.parse(workItemData.operation);
+          await tx(WorkItem.table)
+            .update({ status: WorkItemStatus.RUNNING, updatedAt: new Date() })
+            .where({ id: workItemData.id });
+          // need to update the job otherwise long running jobs won't count against
+          // the user's priority
+          await tx(Job.table)
+            .update({ updatedAt: new Date() })
+            .where({ jobID: workItemData.jobID });
+        }
       }
-
-      workItemData = await workItemDataQuery;
-
-      if (workItemData) {
-        workItemData.operation = JSON.parse(workItemData.operation);
-        await tx(WorkItem.table)
-          .update({ status: WorkItemStatus.RUNNING, updatedAt: new Date() })
-          .where({ id: workItemData.id });
-        // need to update the job otherwise long running jobs won't count against
-        // the user's priority
-        await tx(Job.table)
-          .update({ updatedAt: new Date() })
-          .where({ jobID: workItemData.jobID });
-      }
-
     }
   } catch (e) {
     logger.error(`Error getting next work item for service [${serviceID}]`);

--- a/db/knexfile.js
+++ b/db/knexfile.js
@@ -27,7 +27,7 @@ module.exports = {
     connection: process.env.DATABASE_URL,
     pool: {
       min: 0,
-      max: 7,
+      max: 100,
     },
     searchPath: ['knex', 'public'],
     migrations,

--- a/db/migrations/20220819112559_fix_work_item_polling_indices.js
+++ b/db/migrations/20220819112559_fix_work_item_polling_indices.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.table('work_items', (t) => {
+    t.index(['serviceID', 'status']);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.table('work_items', (t) => {
+    t.dropIndex(['serviceID', 'status']);
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11027,9 +11027,9 @@
       }
     },
     "node_modules/libpq": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/libpq/-/libpq-1.8.9.tgz",
-      "integrity": "sha512-herU0STiW3+/XBoYRycKKf49O9hBKK0JbdC2QmvdC5pyCSu8prb9idpn5bUSbxj8XwcEsWPWWWwTDZE9ZTwJ7g==",
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/libpq/-/libpq-1.8.10.tgz",
+      "integrity": "sha512-bvC/G4+hH6iTFlw9XVhLBTjbfo8kqyel0CLna51Eh6otB9NE2+csiUuhF+3dpnJRIgdn+M5KkWMoVAc1xRdqUQ==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "1.5.0",
@@ -14122,11 +14122,11 @@
       }
     },
     "node_modules/pg-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pg-native/-/pg-native-3.0.0.tgz",
-      "integrity": "sha512-qZZyywXJ8O4lbiIN7mn6vXIow1fd3QZFqzRe+uET/SZIXvCa3HBooXQA4ZU8EQX8Ae6SmaYtDGLp5DwU+8vrfg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pg-native/-/pg-native-3.0.1.tgz",
+      "integrity": "sha512-LBVNWkNh0fVx/cienARRP2y22J5OpUsKBe0TpxzAx3arEUUdIs77aLSAHS3scS7SMaqc+OkG40CEu5fN0/cjIw==",
       "dependencies": {
-        "libpq": "^1.7.0",
+        "libpq": "^1.8.10",
         "pg-types": "^1.12.1",
         "readable-stream": "1.0.31"
       }
@@ -26202,9 +26202,9 @@
       }
     },
     "libpq": {
-      "version": "1.8.9",
-      "resolved": "https://registry.npmjs.org/libpq/-/libpq-1.8.9.tgz",
-      "integrity": "sha512-herU0STiW3+/XBoYRycKKf49O9hBKK0JbdC2QmvdC5pyCSu8prb9idpn5bUSbxj8XwcEsWPWWWwTDZE9ZTwJ7g==",
+      "version": "1.8.10",
+      "resolved": "https://registry.npmjs.org/libpq/-/libpq-1.8.10.tgz",
+      "integrity": "sha512-bvC/G4+hH6iTFlw9XVhLBTjbfo8kqyel0CLna51Eh6otB9NE2+csiUuhF+3dpnJRIgdn+M5KkWMoVAc1xRdqUQ==",
       "requires": {
         "bindings": "1.5.0",
         "nan": "^2.14.0"
@@ -28665,11 +28665,11 @@
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-native": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pg-native/-/pg-native-3.0.0.tgz",
-      "integrity": "sha512-qZZyywXJ8O4lbiIN7mn6vXIow1fd3QZFqzRe+uET/SZIXvCa3HBooXQA4ZU8EQX8Ae6SmaYtDGLp5DwU+8vrfg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/pg-native/-/pg-native-3.0.1.tgz",
+      "integrity": "sha512-LBVNWkNh0fVx/cienARRP2y22J5OpUsKBe0TpxzAx3arEUUdIs77aLSAHS3scS7SMaqc+OkG40CEu5fN0/cjIw==",
       "requires": {
-        "libpq": "^1.7.0",
+        "libpq": "^1.8.10",
         "pg-types": "^1.12.1",
         "readable-stream": "1.0.31"
       },

--- a/test/work-items/fair-queueing.ts
+++ b/test/work-items/fair-queueing.ts
@@ -104,7 +104,7 @@ describe('Fair Queueing', function () {
         expect(results[1].body.workItem.jobID).to.equal('job3');
       });
       it('returns the rest of the work items in fair queueing order', function () {
-        const jobIds = results.slice(2, 5).map((result) => result.body.workItem.jobID);
+        const jobIds = results.slice(2, 5).map((result) => result.body.workItem?.jobID);
         expect(jobIds).to.eql(['job6', 'job1', 'job7']);
       });
       it('returns a 404 status when no work is available', function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1264

## Description
While testing in my sandbox environment I found several database performance issues when issuing a single request for 230K granules.

1.) We were timing out polling for work from the database at 1 second, but the query kept running in the background.
2.) We only allowed 7 concurrent connections causing blocking for requests trying to get info from the database (polling, workflow-ui, job status, etc)
3.) The fair queueing policy queries needed to be tweaked to improve performance (I was seeing them average over 70 seconds to complete).
4.) I added an index for a query on service ID and work item status because I saw the query plans doing table scans when querying on those two fields. I do not actually have evidence that this index improved the performance, but now I'm rarely seeing queries over two seconds. The change for 3 seems to have fixed the main performance issue, but it seems like we should keep this index based on the query plan. 

## Local Test Steps
Locally you can regression test to make sure that nothing is broken. To really test you need to deploy to a sandbox environment and increase the granule limit greater than 230K and then issue a large request:
{root}/C1234724470-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-45%3A45)&subset=lon(0%3A180)&skipPreview=true&ignoreErrors=true

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)