### PR TITLE
Harmony 1172 - Retain original results limited message after resuming job

### DIFF
--- a/app/frontends/jobs.ts
+++ b/app/frontends/jobs.ts
@@ -1,6 +1,6 @@
 import { Response, NextFunction } from 'express';
 import { Logger } from 'winston';
-import { Job, JobStatus, JobQuery } from '../models/job';
+import { Job, JobStatus, JobQuery, SerializedJob } from '../models/job';
 import { keysToLowerCase } from '../util/object';
 import { cancelAndSaveJob, pauseAndSaveJob, resumeAndSaveJob, skipPreviewAndSaveJob, validateJobId } from '../util/job';
 import JobLink from '../models/job-link';
@@ -21,7 +21,7 @@ import _ from 'lodash';
  * @param job - the serialized job
  * @returns true if job contains S3 direct access links and false otherwise
  */
-function containsS3DirectAccessLink(job: Job): boolean {
+function containsS3DirectAccessLink(job: SerializedJob): boolean {
   const dataLinks = job.getRelatedLinks('data');
   return dataLinks.some((l) => l.href.match(/^s3:\/\/.*$/));
 }
@@ -36,7 +36,7 @@ function containsS3DirectAccessLink(job: Job): boolean {
  * @param statusLinkRel - the type of relation (self|item) for the status link
  * @returns a list of job links
  */
-function getLinksForDisplay(job: Job, urlRoot: string, statusLinkRel: string): JobLink[] {
+function getLinksForDisplay(job: SerializedJob, urlRoot: string, statusLinkRel: string): JobLink[] {
   let { links } = job;
   const dataLinks = job.getRelatedLinks('data');
   if (containsS3DirectAccessLink(job)) {
@@ -66,7 +66,7 @@ function getLinksForDisplay(job: Job, urlRoot: string, statusLinkRel: string): J
  * @param job - the serialized job
  * @param urlRoot - the root URL to be used when constructing links
  */
-function getMessageForDisplay(job: Job, urlRoot: string): string {
+function getMessageForDisplay(job: SerializedJob, urlRoot: string): string {
   let { message } = job;
   if (containsS3DirectAccessLink(job)) {
     if (!message.endsWith('.')) {
@@ -87,14 +87,13 @@ function getMessageForDisplay(job: Job, urlRoot: string): string {
  * @param errors - a list of errors for the job
  * @returns the job for display
  */
-function getJobForDisplay(job: Job, urlRoot: string, linkType?: string, errors?: JobError[]): Job {
+function getJobForDisplay(job: Job, urlRoot: string, linkType?: string, errors?: JobError[]): SerializedJob {
   const serializedJob = job.serialize(urlRoot, linkType);
   const statusLinkRel = linkType === 'none' ? 'item' : 'self';
   serializedJob.links = getLinksForDisplay(serializedJob, urlRoot, statusLinkRel);
   serializedJob.message = getMessageForDisplay(serializedJob, urlRoot);
-
   if (errors.length > 0) {
-    serializedJob.errors =  errors.map((e) => _.pick(e, ['url', 'message'])) as unknown as JobError[];
+    serializedJob.errors =  errors.map((e) => _.pick(e, ['url', 'message'])) as JobError[];
   }
 
   return serializedJob;
@@ -102,7 +101,7 @@ function getJobForDisplay(job: Job, urlRoot: string, linkType?: string, errors?:
 
 export interface JobListing {
   count: number;
-  jobs: Job[];
+  jobs: SerializedJob[];
   links: Link[];
 }
 /**

--- a/app/frontends/jobs.ts
+++ b/app/frontends/jobs.ts
@@ -1,6 +1,6 @@
 import { Response, NextFunction } from 'express';
 import { Logger } from 'winston';
-import { Job, JobStatus, JobQuery, SerializedJob } from '../models/job';
+import { Job, JobStatus, JobQuery, SerializedJob, getRelatedLinks } from '../models/job';
 import { keysToLowerCase } from '../util/object';
 import { cancelAndSaveJob, pauseAndSaveJob, resumeAndSaveJob, skipPreviewAndSaveJob, validateJobId } from '../util/job';
 import JobLink from '../models/job-link';
@@ -22,7 +22,7 @@ import _ from 'lodash';
  * @returns true if job contains S3 direct access links and false otherwise
  */
 function containsS3DirectAccessLink(job: SerializedJob): boolean {
-  const dataLinks = job.getRelatedLinks('data');
+  const dataLinks = getRelatedLinks('data', job.links);
   return dataLinks.some((l) => l.href.match(/^s3:\/\/.*$/));
 }
 
@@ -38,7 +38,7 @@ function containsS3DirectAccessLink(job: SerializedJob): boolean {
  */
 function getLinksForDisplay(job: SerializedJob, urlRoot: string, statusLinkRel: string): JobLink[] {
   let { links } = job;
-  const dataLinks = job.getRelatedLinks('data');
+  const dataLinks = getRelatedLinks('data', job.links);
   if (containsS3DirectAccessLink(job)) {
     links.unshift(new JobLink(getCloudAccessJsonLink(urlRoot)));
     links.unshift(new JobLink(getCloudAccessShLink(urlRoot)));

--- a/app/frontends/jobs.ts
+++ b/app/frontends/jobs.ts
@@ -92,6 +92,7 @@ function getJobForDisplay(job: Job, urlRoot: string, linkType?: string, errors?:
   const statusLinkRel = linkType === 'none' ? 'item' : 'self';
   serializedJob.links = getLinksForDisplay(serializedJob, urlRoot, statusLinkRel);
   serializedJob.message = getMessageForDisplay(serializedJob, urlRoot);
+
   if (errors.length > 0) {
     serializedJob.errors =  errors.map((e) => _.pick(e, ['url', 'message'])) as JobError[];
   }

--- a/app/frontends/jobs.ts
+++ b/app/frontends/jobs.ts
@@ -76,7 +76,7 @@ function getMessageForDisplay(job: Job, urlRoot: string): string {
       + `${env.awsDefaultRegion} with keys from ${urlRoot}/cloud-access.sh`;
   }
   if (job.status === JobStatus.PAUSED) {
-    message += '. The job may be resumed using the provided link.';
+    message += ' The job may be resumed using the provided link.';
   }
   return message;
 }

--- a/app/frontends/jobs.ts
+++ b/app/frontends/jobs.ts
@@ -75,9 +75,6 @@ function getMessageForDisplay(job: Job, urlRoot: string): string {
     message += ' Contains results in AWS S3. Access from AWS '
       + `${env.awsDefaultRegion} with keys from ${urlRoot}/cloud-access.sh`;
   }
-  if (job.status === JobStatus.PAUSED) {
-    message += ' The job may be resumed using the provided link.';
-  }
   return message;
 }
 

--- a/app/frontends/stac.ts
+++ b/app/frontends/stac.ts
@@ -1,5 +1,5 @@
 import { ILengthAwarePagination } from 'knex-paginate';
-import { Job } from '../models/job';
+import { Job, SerializedJob } from '../models/job';
 import { keysToLowerCase } from '../util/object';
 import isUUID from '../util/uuid';
 import { getRequestRoot } from '../util/url';
@@ -21,7 +21,7 @@ import env from '../util/env';
  * @returns Resolves when the request is complete
  */
 async function handleStacRequest(
-  req, res, callback: (job: Job, pagination: ILengthAwarePagination) => void, pagingParams: PagingParams, linkType?: string,
+  req, res, callback: (job: SerializedJob, pagination: ILengthAwarePagination) => void, pagingParams: PagingParams, linkType?: string,
 ): Promise<void> {
   const { jobId } = req.params;
   if (!isUUID(jobId)) {
@@ -86,7 +86,7 @@ export async function getStacCatalog(req, res, next): Promise<void> {
     const pagingParams = getPagingParams(req, env.defaultResultPageSize);
     await handleStacRequest(
       req, res,
-      (job: Job, pagination: ILengthAwarePagination) => {
+      (job: SerializedJob, pagination: ILengthAwarePagination) => {
         const pagingLinks = getPagingLinks(req, pagination).map((link) => new JobLink(link));
         return stacCatalogCreate(
           job.jobID, job.request, job.links, pagingLinks, linkType,
@@ -120,10 +120,10 @@ export async function getStacItem(req, res, next): Promise<void> {
     await handleStacRequest(
       req,
       res,
-      (job: Job) => stacItemCreate.apply(
+      (job: SerializedJob) => stacItemCreate.apply(
         null,
         [job.jobID, job.request, job.links[0], itemIndexInt,
-          linkType, job.createdAt, job.getDataExpiration()],
+          linkType, job.createdAt, job.dataExpiration],
       ),
       pagingParams,
       linkType,

--- a/app/frontends/stac.ts
+++ b/app/frontends/stac.ts
@@ -1,5 +1,5 @@
 import { ILengthAwarePagination } from 'knex-paginate';
-import { Job, SerializedJob } from '../models/job';
+import { Job, JobForDisplay } from '../models/job';
 import { keysToLowerCase } from '../util/object';
 import isUUID from '../util/uuid';
 import { getRequestRoot } from '../util/url';
@@ -21,7 +21,7 @@ import env from '../util/env';
  * @returns Resolves when the request is complete
  */
 async function handleStacRequest(
-  req, res, callback: (job: SerializedJob, pagination: ILengthAwarePagination) => void, pagingParams: PagingParams, linkType?: string,
+  req, res, callback: (job: JobForDisplay, pagination: ILengthAwarePagination) => void, pagingParams: PagingParams, linkType?: string,
 ): Promise<void> {
   const { jobId } = req.params;
   if (!isUUID(jobId)) {
@@ -86,7 +86,7 @@ export async function getStacCatalog(req, res, next): Promise<void> {
     const pagingParams = getPagingParams(req, env.defaultResultPageSize);
     await handleStacRequest(
       req, res,
-      (job: SerializedJob, pagination: ILengthAwarePagination) => {
+      (job: JobForDisplay, pagination: ILengthAwarePagination) => {
         const pagingLinks = getPagingLinks(req, pagination).map((link) => new JobLink(link));
         return stacCatalogCreate(
           job.jobID, job.request, job.links, pagingLinks, linkType,
@@ -120,7 +120,7 @@ export async function getStacItem(req, res, next): Promise<void> {
     await handleStacRequest(
       req,
       res,
-      (job: SerializedJob) => stacItemCreate.apply(
+      (job: JobForDisplay) => stacItemCreate.apply(
         null,
         [job.jobID, job.request, job.links[0], itemIndexInt,
           linkType, job.createdAt, job.dataExpiration],

--- a/app/middleware/cmr-granule-locator.ts
+++ b/app/middleware/cmr-granule-locator.ts
@@ -89,8 +89,16 @@ function getMaxGranules(req: HarmonyRequest, collection: string):
   return { maxGranules: maxResults, reason };
 }
 
-export const baseResultsLimitedMessage = (hits: number, maxGranules: number): string => `CMR query identified ${hits} granules, but the request has been limited `
-+ `to process only the first ${maxGranules} granules`;
+/**
+ * Constructs the base of the results limited message.
+ * @param hits - number of CMR hits
+ * @param maxGranules - limit for granule processing
+ * @returns the base of the results limited message
+ */
+export function baseResultsLimitedMessage(hits: number, maxGranules: number): string {
+  return `CMR query identified ${hits} granules, but the request has been limited `
+    + `to process only the first ${maxGranules} granules`;
+}
 
 /**
  * Create a message indicating that the results have been limited and why - if necessary

--- a/app/middleware/cmr-granule-locator.ts
+++ b/app/middleware/cmr-granule-locator.ts
@@ -82,6 +82,9 @@ function getMaxGranules(req: HarmonyRequest, collection: string): { maxGranules:
   return { maxGranules: maxResults, reason };
 }
 
+export const baseResultsLimitedMessage = (hits: number, maxGranules: number): string => `CMR query identified ${hits} granules, but the request has been limited `
++ `to process only the first ${maxGranules} granules`;
+
 /**
  * Create a message indicating that the results have been limited and why - if necessary
  * 
@@ -99,8 +102,7 @@ function getResultsLimitedMessage(req: HarmonyRequest, collection: string): stri
   const { maxGranules, reason } = getMaxGranules(req, collection);
 
   if (operation.cmrHits > maxGranules) {
-    message = `CMR query identified ${operation.cmrHits} granules, but the request has been limited `
-      + `to process only the first ${maxGranules} granules`;
+    message = baseResultsLimitedMessage(operation.cmrHits, maxGranules);
 
     switch (reason) {
       case GranuleLimitReason.MaxResults:

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -99,26 +99,6 @@ export class SerializedJob {
 
   errors?: JobError[];
 
-  /**
-   * Returns only the links with a rel that matches the passed in value.
-   *
-   * @param rel - the relation to return links for
-   * @returns the job output links with the given rel
-   */
-  getRelatedLinks(rel: string): JobLink[] {
-    const links = this.links.filter((link) => link.rel === rel);
-    return links.map(removeEmptyProperties) as JobLink[];
-  }
-
-  /**
-   * Constructs a serialized job from an object.
-   * @param fields - the fields to initialize the SerializedJob with.
-   */
-  constructor(fields: SerializedJob) {
-    if (fields) {
-      Object.assign(this, fields);
-    }
-  }
 }
 
 export interface JobQuery {
@@ -305,6 +285,17 @@ export function validateTransition(
   if (!canTransition(currentStatus, desiredStatus, event)) {
     throw new ConflictError(errorMessage);
   }
+}
+
+/**
+ * Returns only the links with a rel that matches the passed in value.
+ *
+ * @param rel - the relation to return links for
+ * @returns the job output links with the given rel
+ */
+export function getRelatedLinks(rel: string, links: JobLink[]): JobLink[] {
+  const relatedLinks = links.filter((link) => link.rel === rel);
+  return relatedLinks.map(removeEmptyProperties) as JobLink[];
 }
 
 /**
@@ -952,7 +943,6 @@ export class Job extends DBRecord implements JobRecord {
       request: this.request,
       numInputGranules: this.numInputGranules,
       jobID: this.jobID,
-      getRelatedLinks: this.getRelatedLinks,
     };
     if (urlRoot && linkType !== 'none') {
       serializedJob.links = serializedJob.links.map((link) => {
@@ -975,10 +965,7 @@ export class Job extends DBRecord implements JobRecord {
    * @param rel - the relation to return links for
    * @returns the job output links with the given rel
    */
-  getRelatedLinks(rel: string): JobLink[] {
-    const links = this.links.filter((link) => link.rel === rel);
-    return links.map(removeEmptyProperties) as JobLink[];
-  }
+  getRelatedLinks = (rel: string): JobLink[] => getRelatedLinks(rel, this.links);
 
   /**
    *  Computes and returns the date the data produced by the job will expire based on `createdAt`

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -316,7 +316,7 @@ export class Job extends DBRecord implements JobRecord {
 
   errors: JobError[];
 
-  statesToMessages: Record<JobStatus, string>;
+  statesToMessages: { [key in JobStatus]?: string };
 
   username: string;
 
@@ -361,7 +361,7 @@ export class Job extends DBRecord implements JobRecord {
     if (!message) {
       return;
     }
-    this.statesToMessages ??= cloneDeep(statesToDefaultMessages);
+    this.statesToMessages ??= {};
     try {
       this.statesToMessages = JSON.parse(message);
     } catch (e) {
@@ -880,6 +880,7 @@ export class Job extends DBRecord implements JobRecord {
     const dbRecord: Record<string, unknown> = pick(this, jobRecordFields);
     dbRecord.collectionIds = JSON.stringify(this.collectionIds || []);
     dbRecord.message = JSON.stringify(this.statesToMessages || {});
+    console.log(dbRecord);
     await super.save(transaction, dbRecord);
     const promises = [];
     for (const link of this.links) {

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -1,4 +1,4 @@
-import { pick, cloneDeep } from 'lodash';
+import { pick } from 'lodash';
 import { ILengthAwarePagination } from 'knex-paginate'; // For types only
 import subMinutes from 'date-fns/subMinutes';
 import { createMachine } from 'xstate';

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -645,7 +645,7 @@ export class Job extends Record implements JobRecord {
     let newMessage = `${statesToDefaultMessages[JobStatus.PAUSED]}.`;
     const messagePartsToRemove = activeJobStatuses.map((status) => statesToDefaultMessages[status]);
     const retainedMessage = removeMessageParts(
-      this.message, 
+      this.message,
       messagePartsToRemove,
       (part) => part.includes('CMR query identified'));
     if (retainedMessage) {

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -355,7 +355,7 @@ export class Job extends DBRecord implements JobRecord {
   ignoreErrors: boolean;
 
   /**
-   * Get the job message for a this.status.
+   * Get the job message for the current status.
    * @returns the message string describing the job
    */
   get message(): string {
@@ -363,7 +363,7 @@ export class Job extends DBRecord implements JobRecord {
   }
 
   /**
-   * Set the job message (for this.status) in this.statesToMessages.
+   * Set the job message for the current status.
    * @param message - a message string describing the job
    */
   set message(message: string) {
@@ -380,8 +380,8 @@ export class Job extends DBRecord implements JobRecord {
   }
 
   /**
-   * Set the job message in this.statesToMessages using "message".
-   * @param message - a message string describing the job for the status
+   * Set the job message for a particular status.
+   * @param message - a message string describing the job
    * @param status - which status to set the message for (defaults to this.status)
    */
   setMessage(message: string, status: JobStatus = this.status): void {

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -643,9 +643,10 @@ export class Job extends Record implements JobRecord {
   pause(): void {
     validateTransition(this.status, JobStatus.PAUSED, JobEvent.PAUSE);
     let newMessage = `${statesToDefaultMessages[JobStatus.PAUSED]}.`;
+    const messagePartsToRemove = activeJobStatuses.map((status) => statesToDefaultMessages[status]);
     const retainedMessage = removeMessageParts(
       this.message, 
-      activeJobStatuses,
+      messagePartsToRemove,
       (part) => part.includes('CMR query identified'));
     if (retainedMessage) {
       newMessage = `${newMessage} ${retainedMessage}`;

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -364,9 +364,25 @@ export class Job extends DBRecord implements JobRecord {
   ignoreErrors: boolean;
 
   /**
+   * Get the job message for a this.status.
+   * @returns the message string describing the job
+   */
+  get message(): string {
+    return this.getMessage(this.status);
+  }
+
+  /**
+   * Set the job message (for this.status) in this.statesToMessages.
+   * @param message - a message string describing the job
+   */
+  set message(message: string) {
+    this.setMessage(message, this.status);
+  }
+
+  /**
    * Get the job message for a particular status.
    * @param status - the JobStatus that the message is for (defaults to this.status)
-   * @returns the message string
+   * @returns the message string describing the job
    */
   getMessage(status: JobStatus = this.status): string {
     return this?.statesToMessages?.[status] || statesToDefaultMessages[status];
@@ -374,7 +390,7 @@ export class Job extends DBRecord implements JobRecord {
 
   /**
    * Set the job message in this.statesToMessages using "message".
-   * @param message - a message string or stringified message map string
+   * @param message - a message string describing the job for the status
    * @param status - which status to set the message for (defaults to this.status)
    */
   setMessage(message: string, status: JobStatus = this.status): void {
@@ -584,7 +600,7 @@ export class Job extends DBRecord implements JobRecord {
     try {
       // newer jobs will have stringified JSON stored in the DB
       this.statesToMessages = JSON.parse(fields.message);
-      initialMessage = this.getMessage();
+      initialMessage = this.message;
     } catch (e) {
       // this implies that the message is a plain string, i.e.
       // (a) we're initializing an older job from a databse record or
@@ -773,7 +789,7 @@ export class Job extends DBRecord implements JobRecord {
     this.status = status;
     if (message) {
       // Update the message if a new one was provided
-      this.setMessage(message);
+      this.message = message;
     }
     if (this.status === JobStatus.SUCCESSFUL || this.status === JobStatus.COMPLETE_WITH_ERRORS) {
       this.progress = 100;
@@ -927,7 +943,7 @@ export class Job extends DBRecord implements JobRecord {
     const serializedJob: SerializedJob = {
       username: this.username,
       status: this.status,
-      message: this.getMessage(),
+      message: this.message,
       progress: this.progress,
       createdAt: new Date(this.createdAt),
       updatedAt: new Date(this.updatedAt),

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -745,6 +745,7 @@ export class Job extends Record implements JobRecord {
   updateStatus(status: JobStatus, message?: string): void {
     this.status = status;
     // prior default messages related to the previous state may need to be removed
+    // (e.g. cases where the status is updated but no new message is provided)
     const messagePartsToRemove = Object.values(JobStatus)
       .filter((state) => status !== state)
       .map((state) => statesToDefaultMessages[state]);

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -591,6 +591,9 @@ export class Job extends DBRecord implements JobRecord {
       this.statesToMessages = JSON.parse(fields.message);
       initialMessage = this.message;
     } catch (e) {
+      if (!(e instanceof SyntaxError)) {
+        throw e;
+      }
       // this implies that the message is a plain string, i.e.
       // (a) we're initializing an older job from a databse record or
       // (b) a JobRecord that is not emanating from the database

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -661,8 +661,8 @@ export class Job extends Record implements JobRecord {
   resume(): void {
     validateTransition(this.status, JobStatus.RUNNING, JobEvent.RESUME,
       `Job status is ${this.status} - only paused jobs can be resumed.`);
-    const defaultMessage = statesToDefaultMessages[JobStatus.PAUSED];
-    let message = removeMessageParts(this.message, [defaultMessage]);
+    const defaultPausedMessage = statesToDefaultMessages[JobStatus.PAUSED];
+    let message = removeMessageParts(this.message, [defaultPausedMessage]);
     message ||= statesToDefaultMessages[JobStatus.RUNNING];
     this.updateStatus(JobStatus.RUNNING, message);
   }

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -877,10 +877,9 @@ export class Job extends DBRecord implements JobRecord {
     this.validateStatus();
     this.message = truncateString(this.message, 4096);
     this.request = truncateString(this.request, 4096);
-    // Cannot say Record<string, unknown> because of conflict with imported database Record class
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const dbRecord = pick(this, jobRecordFields) as any;
+    const dbRecord: Record<string, unknown> = pick(this, jobRecordFields);
     dbRecord.collectionIds = JSON.stringify(this.collectionIds || []);
+    dbRecord.message = JSON.stringify(this.statesToMessages || {});
     await super.save(transaction, dbRecord);
     const promises = [];
     for (const link of this.links) {

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -195,7 +195,7 @@ const stateMachine = createMachine(
       paused: {
         id: JobStatus.PAUSED,
         meta: {
-          defaultMessage: 'The job is paused',
+          defaultMessage: 'The job is paused and may be resumed using the provided link',
         },
         on: Object.fromEntries([
           [JobEvent.SKIP_PREVIEW, { target: JobStatus.RUNNING }],
@@ -720,7 +720,6 @@ export class Job extends Record implements JobRecord {
     if (this.status === JobStatus.SUCCESSFUL || this.status === JobStatus.COMPLETE_WITH_ERRORS) {
       this.progress = 100;
     }
-    console.log('updated message ' + this.message);
   }
 
   /**

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -109,6 +109,7 @@ export interface JobQuery {
     username?: string;
     requestId?: string;
     status?: string;
+    message?: string;
     progress?: number;
     batchesCompleted?: number;
     request?: string;
@@ -347,10 +348,7 @@ export class Job extends DBRecord implements JobRecord {
    * Get the current job message.
    */
   get message(): string {
-    if (!this.messageMap || !this.messageMap[this.status]) {
-      return statesToDefaultMessages[this.status];
-    }
-    return this.messageMap[this.status];
+    return this?.messageMap[this.status] || statesToDefaultMessages[this.status];
   }
 
   /**

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -615,7 +615,7 @@ export class Job extends Record implements JobRecord {
       .split('.').map((sentence) => sentence.trim())
       .filter((sentence) => sentence && sentence.includes('CMR query identified'));
     if (retainedSentences.length > 0) {
-      newMessage = `${newMessage}${[retainedSentences].join('. ')}.`;
+      newMessage = `${newMessage} ${[retainedSentences].join('. ')}.`;
     }
     this.updateStatus(JobStatus.PAUSED, newMessage);
   }

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -316,7 +316,7 @@ export class Job extends DBRecord implements JobRecord {
 
   errors: JobError[];
 
-  messageMap: Record<JobStatus, string>;
+  statesToMessages: Record<JobStatus, string>;
 
   username: string;
 
@@ -348,24 +348,24 @@ export class Job extends DBRecord implements JobRecord {
    * Get the current job message.
    */
   get message(): string {
-    return this?.messageMap[this.status] || statesToDefaultMessages[this.status];
+    return this?.statesToMessages[this.status] || statesToDefaultMessages[this.status];
   }
 
   /**
-   * Set the current job message in this.messageMap using "message",
+   * Set the current job message in this.statesToMessages using "message",
    * which may be a plain string (older persisted jobs, or new/not-yet-persisted jobs)
-   * or stringified JSON, in which case we'll initialize the entire messageMap.
+   * or stringified JSON, in which case we'll initialize the entire statesToMessages.
    * @param message - a message string or stringified message map string
    */
   set message(message: string) {
     if (!message) {
       return;
     }
-    this.messageMap ??= cloneDeep(statesToDefaultMessages);
+    this.statesToMessages ??= cloneDeep(statesToDefaultMessages);
     try {
-      this.messageMap = JSON.parse(message);
+      this.statesToMessages = JSON.parse(message);
     } catch (e) {
-      this.messageMap[this.status] = message;
+      this.statesToMessages[this.status] = message;
     }
   }
 
@@ -658,7 +658,7 @@ export class Job extends DBRecord implements JobRecord {
    */
   pause(): void {
     validateTransition(this.status, JobStatus.PAUSED, JobEvent.PAUSE);
-    this.updateStatus(JobStatus.PAUSED, this.messageMap[JobStatus.PAUSED]);
+    this.updateStatus(JobStatus.PAUSED, this.statesToMessages[JobStatus.PAUSED]);
   }
 
   /**
@@ -669,7 +669,7 @@ export class Job extends DBRecord implements JobRecord {
   resume(): void {
     validateTransition(this.status, JobStatus.RUNNING, JobEvent.RESUME,
       `Job status is ${this.status} - only paused jobs can be resumed.`);
-    this.updateStatus(JobStatus.RUNNING, this.messageMap[JobStatus.RUNNING]);
+    this.updateStatus(JobStatus.RUNNING, this.statesToMessages[JobStatus.RUNNING]);
   }
 
   /**
@@ -680,7 +680,7 @@ export class Job extends DBRecord implements JobRecord {
   skipPreview(): void {
     validateTransition(this.status, JobStatus.RUNNING, JobEvent.SKIP_PREVIEW,
       `Job status is ${this.status} - only previewing jobs can skip preview.`);
-    this.updateStatus(JobStatus.RUNNING, this.messageMap[JobStatus.RUNNING]);
+    this.updateStatus(JobStatus.RUNNING, this.statesToMessages[JobStatus.RUNNING]);
   }
 
   /**

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -70,11 +70,9 @@ export interface JobRecord {
 }
 
 /**
- * The format of a Job when returned to an end user. Serialized in
- * the sense of displaying to an end user, not in the sense of serializing
- * to the database.
+ * The format of a Job when returned to an end user.
  */
-export class SerializedJob {
+export class JobForDisplay {
   jobID: string;
 
   username: string;
@@ -930,8 +928,8 @@ export class Job extends DBRecord implements JobRecord {
    * @param linkType - the type to use for data links (http|https =\> https | s3 =\> s3 | none)
    * @returns an object with the serialized job fields.
    */
-  serialize(urlRoot?: string, linkType?: string): SerializedJob {
-    const serializedJob: SerializedJob = {
+  serialize(urlRoot?: string, linkType?: string): JobForDisplay {
+    const serializedJob: JobForDisplay = {
       username: this.username,
       status: this.status,
       message: this.message,

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -589,7 +589,7 @@ export class Job extends DBRecord implements JobRecord {
     super(fields);
     let initialMessage: string;
     try {
-      // newer jobs will have stringified JSON stored in the DB
+      // newer jobs will have stringified JSON stored in the database
       this.statesToMessages = JSON.parse(fields.message);
       initialMessage = this.message;
     } catch (e) {

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -675,7 +675,7 @@ export class Job extends Record implements JobRecord {
    */
   skipPreview(): void {
     validateTransition(this.status, JobStatus.RUNNING, JobEvent.SKIP_PREVIEW,
-      `Job status is ${this.status} - only previewing or paused jobs can skip preview.`);
+      `Job status is ${this.status} - only previewing jobs can skip preview.`);
     const messagePartsToRemove = [statesToDefaultMessages[JobStatus.PREVIEWING], 
       statesToDefaultMessages[JobStatus.PAUSED]];
     let message = removeMessageParts(this.message, messagePartsToRemove);

--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -317,10 +317,10 @@ export default abstract class BaseService<ServiceParamType> {
       ignoreErrors: this.operation.ignoreErrors,
     });
     if (this.operation.message) {
-      job.setMessageForStatus(JobStatus.SUCCESSFUL,  this.operation.message);
+      job.setMessage(this.operation.message, JobStatus.SUCCESSFUL);
     }
     if (this.operation.message && !skipPreview) {
-      job.setMessageForStatus(JobStatus.RUNNING, this.operation.message);
+      job.setMessage(this.operation.message, JobStatus.RUNNING);
     }
     job.addStagingBucketLink(this.operation.stagingLocation);
     return job;

--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -316,11 +316,11 @@ export default abstract class BaseService<ServiceParamType> {
       collectionIds: this.operation.collectionIds,
       ignoreErrors: this.operation.ignoreErrors,
     });
-    if (!skipPreview && this.operation.message) {
-      // previewing message will get set via Job constructor
-      // but we should also save the running/successful message for later
-      job.statesToMessages[JobStatus.RUNNING] = this.operation.message;
+    if (this.operation.message && skipPreview) {
       job.statesToMessages[JobStatus.SUCCESSFUL] = this.operation.message;
+    }
+    if (this.operation.message && !skipPreview) {
+      job.statesToMessages[JobStatus.RUNNING] = this.operation.message;
     }
     job.addStagingBucketLink(this.operation.stagingLocation);
     return job;

--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -286,11 +286,10 @@ export default abstract class BaseService<ServiceParamType> {
    * Creates a new job object for this service's operation
    *
    * @param requestUrl - The URL the end user invoked
-   * @param stagingLocation - The staging location for this job
    * @returns The created job
    * @throws ServerError - if the job cannot be created
    */
-  _createJob(
+  protected _createJob(
     requestUrl: string,
   ): Job {
     const url = new URL(requestUrl);

--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -318,8 +318,9 @@ export default abstract class BaseService<ServiceParamType> {
     });
     if (!skipPreview && this.operation.message) {
       // previewing message will get set via Job constructor
-      // but we should also save the running message for later
+      // but we should also save the running/successful message for later
       job.statesToMessages[JobStatus.RUNNING] = this.operation.message;
+      job.statesToMessages[JobStatus.SUCCESSFUL] = this.operation.message;
     }
     job.addStagingBucketLink(this.operation.stagingLocation);
     return job;

--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -290,7 +290,7 @@ export default abstract class BaseService<ServiceParamType> {
    * @returns The created job
    * @throws ServerError - if the job cannot be created
    */
-  protected _createJob(
+  _createJob(
     requestUrl: string,
   ): Job {
     const url = new URL(requestUrl);
@@ -316,11 +316,11 @@ export default abstract class BaseService<ServiceParamType> {
       collectionIds: this.operation.collectionIds,
       ignoreErrors: this.operation.ignoreErrors,
     });
-    if (this.operation.message && skipPreview) {
-      job.statesToMessages[JobStatus.SUCCESSFUL] = this.operation.message;
+    if (this.operation.message) {
+      job.setMessageForStatus(JobStatus.SUCCESSFUL,  this.operation.message);
     }
     if (this.operation.message && !skipPreview) {
-      job.statesToMessages[JobStatus.RUNNING] = this.operation.message;
+      job.setMessageForStatus(JobStatus.RUNNING, this.operation.message);
     }
     job.addStagingBucketLink(this.operation.stagingLocation);
     return job;

--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -316,6 +316,11 @@ export default abstract class BaseService<ServiceParamType> {
       collectionIds: this.operation.collectionIds,
       ignoreErrors: this.operation.ignoreErrors,
     });
+    if (!skipPreview && this.operation.message) {
+      // previewing message will get set via Job constructor
+      // but we should also save the running message for later
+      job.statesToMessages[JobStatus.RUNNING] = this.operation.message;
+    }
     job.addStagingBucketLink(this.operation.stagingLocation);
     return job;
   }

--- a/app/models/services/no-op-service.ts
+++ b/app/models/services/no-op-service.ts
@@ -62,10 +62,10 @@ export default class NoOpService extends BaseService<void> {
       request: requestUrl,
       numInputGranules: this.operation.cmrHits,
     });
-    job = job.serialize(harmonyRoot);
+    const serializedJob = job.serialize(harmonyRoot);
     // No-op service response should look like a job, but doesn't actually create one
     // so do not include a jobID in the response.
-    delete job.jobID;
+    delete serializedJob.jobID;
     const response = {
       error: null,
       redirect: null,
@@ -73,7 +73,7 @@ export default class NoOpService extends BaseService<void> {
       onComplete: null,
       headers: { contentType: 'application/json' },
       statusCode: 200,
-      content: JSON.stringify(job),
+      content: JSON.stringify(serializedJob),
     };
 
     return response;

--- a/app/models/services/no-op-service.ts
+++ b/app/models/services/no-op-service.ts
@@ -48,7 +48,7 @@ export default class NoOpService extends BaseService<void> {
     const granuleLists = this.operation.sources.map((source) => source.granules);
     const granules = granuleLists.reduce((acc, val) => acc.concat(val), []);
     const links = granules.map((granule) => ({ title: granule.id, href: granule.url, rel: 'data' }));
-    let job = new Job({
+    const job = new Job({
       username: this.operation.user,
       requestId: this.operation.requestId,
       jobID: this.operation.requestId,

--- a/app/models/services/turbo-service.ts
+++ b/app/models/services/turbo-service.ts
@@ -30,7 +30,7 @@ export default class TurboService extends BaseService<TurboServiceParams> {
  */
 export class TestTurboService extends TurboService {
   /**
-   * Calls this._createJob which creates a job from a service and its operation.
+   * Calls _createJob which creates a job from a service and its operation.
    * @param requestUrl - The URL the end user invoked
    * @returns The created job
    */

--- a/app/models/services/turbo-service.ts
+++ b/app/models/services/turbo-service.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import { Logger } from 'winston';
+import { Job } from '../job';
 import BaseService from './base-service';
 import InvocationResult from './invocation-result';
 
@@ -21,5 +22,21 @@ export default class TurboService extends BaseService<TurboServiceParams> {
    */
   async _run(_logger: Logger): Promise<InvocationResult> {
     return null;
+  }
+}
+
+/**
+ * Extends TurboService for testing purposes.
+ */
+export class TestTurboService extends TurboService {
+  /**
+   * Calls this._createJob which creates a job from a service and its operation.
+   * @param requestUrl - The URL the end user invoked
+   * @returns The created job
+   */
+  createJob(
+    requestUrl: string,
+  ): Job {
+    return this._createJob(requestUrl);
   }
 }

--- a/app/models/services/turbo-service.ts
+++ b/app/models/services/turbo-service.ts
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import { Logger } from 'winston';
-import { Job } from '../job';
 import BaseService from './base-service';
 import InvocationResult from './invocation-result';
 
@@ -22,21 +21,5 @@ export default class TurboService extends BaseService<TurboServiceParams> {
    */
   async _run(_logger: Logger): Promise<InvocationResult> {
     return null;
-  }
-}
-
-/**
- * Extends TurboService for testing purposes.
- */
-export class TestTurboService extends TurboService {
-  /**
-   * Calls _createJob which creates a job from a service and its operation.
-   * @param requestUrl - The URL the end user invoked
-   * @returns The created job
-   */
-  createJob(
-    requestUrl: string,
-  ): Job {
-    return this._createJob(requestUrl);
   }
 }

--- a/app/util/links.ts
+++ b/app/util/links.ts
@@ -1,4 +1,4 @@
-import { canTransition, Job, JobEvent, JobStatus } from '../models/job';
+import { canTransition, Job, JobEvent, JobStatus, SerializedJob } from '../models/job';
 import JobLink from '../models/job-link';
 import env = require('./env');
 
@@ -126,10 +126,10 @@ function getLinkForJobEvent(
  * to a user for a particular job.
  * Note that this only returns actions that users can precipitate via state change links
  * (e.g. JobEvent.FAIL will not be returned).
- * @param job - the job to return valid actions (JobEvents) for
+ * @param job - the serialized job to return valid actions (JobEvents) for
  * @returns a set of JobEvent
  */
-export function getLinkRelevantJobEvents(job: Job): Set<JobEvent> {
+export function getLinkRelevantJobEvents(job: SerializedJob): Set<JobEvent> {
   const transitions: [JobEvent, JobStatus][] = [
     // [event, resultant status]
     [JobEvent.CANCEL, JobStatus.CANCELED],
@@ -154,14 +154,14 @@ export function getLinkRelevantJobEvents(job: Job): Set<JobEvent> {
 /**
  * Generate links that represent the actions that are available to a user with
  * respect to job status state transitions (cancel, pause, etc.).
- * @param job - the job to generate links for
+ * @param job - the serialized job to generate links for
  * @param urlRoot - the root url for the links being generated 
  * @param isAdmin - boolean representing whether we are generating links for 
  * an admin request
  * @returns JobLink[]
  */
 export function getJobStateChangeLinks(
-  job: Job,
+  job: SerializedJob,
   urlRoot: string,
   isAdmin = false,
 ): JobLink[] {
@@ -179,7 +179,7 @@ export function getJobStateChangeLinks(
  * @returns JobLink[]
  */
 export function getAllStateChangeLinks(
-  job: Job,
+  job: SerializedJob,
   urlRoot: string,
   isAdmin = false,
 ): JobLink[] {

--- a/app/util/links.ts
+++ b/app/util/links.ts
@@ -1,4 +1,4 @@
-import { canTransition, JobEvent, JobStatus, SerializedJob } from '../models/job';
+import { canTransition, JobEvent, JobStatus, JobForDisplay } from '../models/job';
 import JobLink from '../models/job-link';
 import env = require('./env');
 
@@ -129,7 +129,7 @@ function getLinkForJobEvent(
  * @param job - the serialized job to return valid actions (JobEvents) for
  * @returns a set of JobEvent
  */
-export function getLinkRelevantJobEvents(job: SerializedJob): Set<JobEvent> {
+export function getLinkRelevantJobEvents(job: JobForDisplay): Set<JobEvent> {
   const transitions: [JobEvent, JobStatus][] = [
     // [event, resultant status]
     [JobEvent.CANCEL, JobStatus.CANCELED],
@@ -161,7 +161,7 @@ export function getLinkRelevantJobEvents(job: SerializedJob): Set<JobEvent> {
  * @returns JobLink[]
  */
 export function getJobStateChangeLinks(
-  job: SerializedJob,
+  job: JobForDisplay,
   urlRoot: string,
   isAdmin = false,
 ): JobLink[] {
@@ -179,7 +179,7 @@ export function getJobStateChangeLinks(
  * @returns JobLink[]
  */
 export function getAllStateChangeLinks(
-  job: SerializedJob,
+  job: JobForDisplay,
   urlRoot: string,
   isAdmin = false,
 ): JobLink[] {

--- a/app/util/links.ts
+++ b/app/util/links.ts
@@ -1,4 +1,4 @@
-import { canTransition, Job, JobEvent, JobStatus, SerializedJob } from '../models/job';
+import { canTransition, JobEvent, JobStatus, SerializedJob } from '../models/job';
 import JobLink from '../models/job-link';
 import env = require('./env');
 

--- a/test/helpers/data-operation.ts
+++ b/test/helpers/data-operation.ts
@@ -1,5 +1,7 @@
+import DataOperation from '../../app/models/data-operation';
 import * as fs from 'fs';
 import * as path from 'path';
+import { v4 as uuid } from 'uuid';
 
 export const samplesDir = './test/resources/data-operation-samples';
 
@@ -30,4 +32,24 @@ export function parseSchemaFile(
   filename: string = null,
 ): any { // eslint-disable-line @typescript-eslint/no-explicit-any
   return JSON.parse(fs.readFileSync(path.join(samplesDir, filename)).toString());
+}
+
+/**
+ * Build an operation for testing.
+ * @returns DataOperation
+ */
+export function buildOperation(message: string): DataOperation {
+  const operation = new DataOperation();
+  operation.requestId = uuid().toString();
+  operation.user = 'Bo';
+  operation.granuleIds = ['g1'];
+  operation.requireSynchronous = false;
+  operation.maxResults = 10;
+  operation.cmrHits = 100;
+  operation.scrollIDs = [];
+  operation.cmrQueryLocations = [];
+  operation.message = message;
+  operation.requestStartTime = new Date();
+  operation.ignoreErrors = true;
+  return operation;
 }

--- a/test/helpers/jobs.ts
+++ b/test/helpers/jobs.ts
@@ -5,7 +5,7 @@ import { v4 as uuid } from 'uuid';
 import { Application } from 'express';
 import _ from 'lodash';
 import JobLink from '../../app/models/job-link';
-import { Job, JobStatus, JobRecord, jobRecordFields, SerializedJob, getRelatedLinks } from '../../app/models/job';
+import { Job, JobStatus, JobRecord, jobRecordFields, JobForDisplay, getRelatedLinks } from '../../app/models/job';
 import { JobListing } from '../../app/frontends/jobs';
 import db, { Transaction } from '../../app/util/db';
 import { hookRequest } from './hooks';
@@ -143,7 +143,7 @@ export function areStacJobLinksEqual(jobLinks: JobLink[], stacLinks: JobLink[]):
  */
 export function jobsEqual(
   jobRecord: JobRecord,
-  serializedJob: SerializedJob,
+  serializedJob: JobForDisplay,
   skipLinks = false,
   skipMessage = false): boolean {
   const recordLinks = new Job(jobRecord).getRelatedLinks('data');

--- a/test/helpers/jobs.ts
+++ b/test/helpers/jobs.ts
@@ -5,7 +5,7 @@ import { v4 as uuid } from 'uuid';
 import { Application } from 'express';
 import _ from 'lodash';
 import JobLink from '../../app/models/job-link';
-import { Job, JobStatus, JobRecord, jobRecordFields, SerializedJob } from '../../app/models/job';
+import { Job, JobStatus, JobRecord, jobRecordFields, SerializedJob, getRelatedLinks } from '../../app/models/job';
 import { JobListing } from '../../app/frontends/jobs';
 import db, { Transaction } from '../../app/util/db';
 import { hookRequest } from './hooks';
@@ -147,7 +147,7 @@ export function jobsEqual(
   skipLinks = false,
   skipMessage = false): boolean {
   const recordLinks = new Job(jobRecord).getRelatedLinks('data');
-  const serializedLinks = serializedJob.getRelatedLinks('data');
+  const serializedLinks = getRelatedLinks('data', serializedJob.links);
 
   return (jobRecord.requestId === serializedJob.jobID
     && jobRecord.username === serializedJob.username
@@ -167,7 +167,7 @@ export function jobsEqual(
  * @returns true if the object is found
  */
 export function containsJob(job: JobRecord, jobList: JobListing): boolean {
-  return !!jobList.jobs.find((j) => jobsEqual(job, new SerializedJob(j), true));
+  return !!jobList.jobs.find((j) => jobsEqual(job, j, true));
 }
 
 /**

--- a/test/helpers/jobs.ts
+++ b/test/helpers/jobs.ts
@@ -5,7 +5,7 @@ import { v4 as uuid } from 'uuid';
 import { Application } from 'express';
 import _ from 'lodash';
 import JobLink from '../../app/models/job-link';
-import { Job, JobStatus, JobRecord, jobRecordFields } from '../../app/models/job';
+import { Job, JobStatus, JobRecord, jobRecordFields, SerializedJob } from '../../app/models/job';
 import { JobListing } from '../../app/frontends/jobs';
 import db, { Transaction } from '../../app/util/db';
 import { hookRequest } from './hooks';
@@ -143,7 +143,7 @@ export function areStacJobLinksEqual(jobLinks: JobLink[], stacLinks: JobLink[]):
  */
 export function jobsEqual(
   jobRecord: JobRecord,
-  serializedJob: Job,
+  serializedJob: SerializedJob,
   skipLinks = false,
   skipMessage = false): boolean {
   const recordLinks = new Job(jobRecord).getRelatedLinks('data');
@@ -167,7 +167,7 @@ export function jobsEqual(
  * @returns true if the object is found
  */
 export function containsJob(job: JobRecord, jobList: JobListing): boolean {
-  return !!jobList.jobs.find((j) => jobsEqual(job, new Job(j), true));
+  return !!jobList.jobs.find((j) => jobsEqual(job, j, true));
 }
 
 /**

--- a/test/helpers/jobs.ts
+++ b/test/helpers/jobs.ts
@@ -167,7 +167,7 @@ export function jobsEqual(
  * @returns true if the object is found
  */
 export function containsJob(job: JobRecord, jobList: JobListing): boolean {
-  return !!jobList.jobs.find((j) => jobsEqual(job, j, true));
+  return !!jobList.jobs.find((j) => jobsEqual(job, new SerializedJob(j), true));
 }
 
 /**

--- a/test/helpers/turbo-service.ts
+++ b/test/helpers/turbo-service.ts
@@ -1,0 +1,19 @@
+import { Job } from '../../app/models/job';
+import TurboService from '../../app/models/services/turbo-service';
+
+
+/**
+ * Extends TurboService for testing purposes.
+ */
+export class TestTurboService extends TurboService {
+  /**
+   * Calls _createJob which creates a job from a service and its operation.
+   * @param requestUrl - The URL the end user invoked
+   * @returns The created job
+   */
+  createJob(
+    requestUrl: string,
+  ): Job {
+    return this._createJob(requestUrl);
+  }
+}

--- a/test/jobs/auto-pause-jobs.ts
+++ b/test/jobs/auto-pause-jobs.ts
@@ -90,7 +90,7 @@ function previewingToPauseTest(username: string): void {
       await truncateAll();
     });
 
-    autoPauseCommonTests(username, 'paused', 'The job is paused');
+    autoPauseCommonTests(username, 'paused', 'The job is paused and may be resumed using the provided link');
   });
 }
 

--- a/test/jobs/cancel-jobs.ts
+++ b/test/jobs/cancel-jobs.ts
@@ -16,7 +16,7 @@ import {
   buildJob,
 } from '../helpers/jobs';
 import { hookRedirect } from '../helpers/hooks';
-import { JobRecord, JobStatus, Job } from '../../app/models/job';
+import { JobStatus, Job, SerializedJob } from '../../app/models/job';
 
 describe('Canceling a job - user endpoint', function () {
   const cancelEndpointHooks = {
@@ -78,9 +78,9 @@ describe('Canceling a job - user endpoint', function () {
           });
 
           it('does not modify any of the other job fields', function () {
-            const actualJob = new Job(JSON.parse(this.res.text));
-            const expectedJob: JobRecord = _.cloneDeep(joeJob1);
-            expectedJob.message = 'foo';
+            const actualJob = new SerializedJob(JSON.parse(this.res.text));
+            const expectedJob = _.cloneDeep(joeJob1);
+            expectedJob.setMessage('foo', JobStatus.CANCELED);
             actualJob.message = 'foo';
             actualJob.status = JobStatus.CANCELED;
             expectedJob.status = JobStatus.CANCELED;
@@ -289,9 +289,9 @@ describe('Canceling a job - admin endpoint', function () {
             expect(actualJob.message).to.eql('Canceled by admin.');
           });
           it('does not modify any of the other job fields', function () {
-            const actualJob = new Job(JSON.parse(this.res.text));
-            const expectedJob: JobRecord = _.cloneDeep(joeJob1);
-            expectedJob.message = 'foo';
+            const actualJob = new SerializedJob(JSON.parse(this.res.text));
+            const expectedJob: Job = _.cloneDeep(joeJob1);
+            expectedJob.setMessage('foo', JobStatus.CANCELED);
             actualJob.message = 'foo';
             actualJob.status = JobStatus.CANCELED;
             expectedJob.status = JobStatus.CANCELED;

--- a/test/jobs/cancel-jobs.ts
+++ b/test/jobs/cancel-jobs.ts
@@ -78,7 +78,7 @@ describe('Canceling a job - user endpoint', function () {
           });
 
           it('does not modify any of the other job fields', function () {
-            const actualJob = new SerializedJob(JSON.parse(this.res.text));
+            const actualJob = JSON.parse(this.res.text);
             const expectedJob = _.cloneDeep(joeJob1);
             expectedJob.setMessage('foo', JobStatus.CANCELED);
             actualJob.message = 'foo';
@@ -289,7 +289,7 @@ describe('Canceling a job - admin endpoint', function () {
             expect(actualJob.message).to.eql('Canceled by admin.');
           });
           it('does not modify any of the other job fields', function () {
-            const actualJob = new SerializedJob(JSON.parse(this.res.text));
+            const actualJob = JSON.parse(this.res.text);
             const expectedJob: Job = _.cloneDeep(joeJob1);
             expectedJob.setMessage('foo', JobStatus.CANCELED);
             actualJob.message = 'foo';

--- a/test/jobs/cancel-jobs.ts
+++ b/test/jobs/cancel-jobs.ts
@@ -16,7 +16,7 @@ import {
   buildJob,
 } from '../helpers/jobs';
 import { hookRedirect } from '../helpers/hooks';
-import { JobStatus, Job, SerializedJob } from '../../app/models/job';
+import { JobStatus, Job } from '../../app/models/job';
 
 describe('Canceling a job - user endpoint', function () {
   const cancelEndpointHooks = {

--- a/test/jobs/jobs-status.ts
+++ b/test/jobs/jobs-status.ts
@@ -68,7 +68,7 @@ describe('Individual job status route', function () {
     });
 
     it('returns a single job record in JSON format', function () {
-      const actualJob = new SerializedJob(JSON.parse(this.res.text));
+      const actualJob = JSON.parse(this.res.text);
       expect(jobsEqual(aJob, actualJob)).to.be.true;
     });
 

--- a/test/jobs/jobs-status.ts
+++ b/test/jobs/jobs-status.ts
@@ -130,7 +130,7 @@ describe('Individual job status route', function () {
 
     it('returns a human-readable message field corresponding to its state', function () {
       const job = JSON.parse(this.res.text);
-      expect(job.message).to.include('The job is paused');
+      expect(job.message).to.include('The job is paused and may be resumed using the provided link');
     });
 
     it('includes links for canceling and resuming the job', function () {

--- a/test/jobs/jobs-status.ts
+++ b/test/jobs/jobs-status.ts
@@ -1,4 +1,4 @@
-import { EXPIRATION_DAYS, Job, JobStatus } from './../../app/models/job';
+import { EXPIRATION_DAYS, Job, JobStatus, SerializedJob } from './../../app/models/job';
 import { expect } from 'chai';
 import { stub } from 'sinon';
 import { describe, it, before, after } from 'mocha';
@@ -68,7 +68,7 @@ describe('Individual job status route', function () {
     });
 
     it('returns a single job record in JSON format', function () {
-      const actualJob = new Job(JSON.parse(this.res.text));
+      const actualJob = new SerializedJob(JSON.parse(this.res.text));
       expect(jobsEqual(aJob, actualJob)).to.be.true;
     });
 

--- a/test/jobs/jobs-status.ts
+++ b/test/jobs/jobs-status.ts
@@ -1,4 +1,4 @@
-import { EXPIRATION_DAYS, Job, JobStatus, SerializedJob } from './../../app/models/job';
+import { EXPIRATION_DAYS, Job, JobStatus } from './../../app/models/job';
 import { expect } from 'chai';
 import { stub } from 'sinon';
 import { describe, it, before, after } from 'mocha';

--- a/test/jobs/message.ts
+++ b/test/jobs/message.ts
@@ -33,7 +33,7 @@ describe('skipPreview, pause and resume job message handling', async function ()
       let limitedMessage;
       hookTransaction();
       before(async function () {
-        limitedMessage = baseResultsLimitedMessage(100, 10);
+        limitedMessage = `${baseResultsLimitedMessage(100, 10)}.`;
         job = buildJob({ status: JobStatus.RUNNING, message: limitedMessage });
         await job.save(this.trx);
       });
@@ -103,7 +103,7 @@ describe('skipPreview, pause and resume job message handling', async function ()
       let limitedMessage;
       hookTransaction();
       before(async function () {
-        limitedMessage = baseResultsLimitedMessage(100, 10);
+        limitedMessage = `${baseResultsLimitedMessage(100, 10)}.`;
         job = buildJob({ status: JobStatus.PREVIEWING, message: `The job is generating a preview before auto-pausing. ${limitedMessage}` });
         await job.save(this.trx);
         skipJob = buildJob({ status: JobStatus.PREVIEWING, message: `The job is generating a preview before auto-pausing. ${limitedMessage}` });

--- a/test/jobs/message.ts
+++ b/test/jobs/message.ts
@@ -245,7 +245,7 @@ describe('job constructor message handling', function () {
           collectionIds: [] });
       });
       it('uses the default message for that status', function () {
-        expect(job.message).to.eq(statesToDefaultMessages.running);
+        expect(job.getMessage(JobStatus.FAILED)).to.eq(statesToDefaultMessages.running);
         expect(job.message).to.eq(statesToDefaultMessages.running);
       });
     });

--- a/test/jobs/message.ts
+++ b/test/jobs/message.ts
@@ -3,11 +3,10 @@ import { Job, JobStatus } from '../../app/models/job';
 import { hookTransaction } from '../helpers/db';
 import { assert, expect } from 'chai';
 import { baseResultsLimitedMessage } from '../../app/middleware/cmr-granule-locator';
-import { TestTurboService } from '../../app/models/services/turbo-service';
-import DataOperation from '../../app/models/data-operation';
+import { TestTurboService } from '../helpers/turbo-service';
 import env from '../../app/util/env';
-import { v4 as uuid } from 'uuid';
 import { stub } from 'sinon';
+import { buildOperation } from '../helpers/data-operation';
 
 /**
  * A service config to use when building the TestTurboServices.
@@ -22,26 +21,6 @@ const config = {
     },
   },
 };
-
-/**
- * Build an operation for the tests.
- * @returns DataOperation
- */
-function buildOperation(message: string): DataOperation {
-  const operation = new DataOperation();
-  operation.requestId = uuid().toString();
-  operation.user = 'Bo';
-  operation.granuleIds = ['g1'];
-  operation.requireSynchronous = false;
-  operation.maxResults = 10;
-  operation.cmrHits = 100;
-  operation.scrollIDs = [];
-  operation.cmrQueryLocations = [];
-  operation.message = message;
-  operation.requestStartTime = new Date();
-  operation.ignoreErrors = true;
-  return operation;
-}
 
 
 describe('skipPreview, pause, resume, and updateStatus job message handling', async function () {

--- a/test/jobs/message.ts
+++ b/test/jobs/message.ts
@@ -1,9 +1,45 @@
 import { describe, it } from 'mocha';
-import { buildJob } from '../helpers/jobs';
 import { Job, JobStatus } from '../../app/models/job';
 import { hookTransaction } from '../helpers/db';
-import { expect } from 'chai';
+import { assert, expect } from 'chai';
 import { baseResultsLimitedMessage } from '../../app/middleware/cmr-granule-locator';
+import TurboService from '../../app/models/services/turbo-service';
+import DataOperation from '../../app/models/data-operation';
+import env from '../../app/util/env';
+import { v4 as uuid } from 'uuid';
+
+
+const config = {
+  name: 'first-service',
+  type: { name: 'turbo' },
+  collections: [{ id: 'collection' }],
+  capabilities: {
+    output_formats: ['image/tiff', 'application/x-netcdf4'],
+    subsetting: {
+    },
+  },
+};
+const originalPreviewThreshold = env.previewThreshold;
+
+/**
+ * Build an operation for the tests.
+ * @returns DataOperation
+ */
+function buildOperation(message: string): DataOperation {
+  const operation = new DataOperation();
+  operation.requestId = uuid().toString();
+  operation.user = 'Bo';
+  operation.granuleIds = ['g1'];
+  operation.requireSynchronous = false;
+  operation.maxResults = 10;
+  operation.cmrHits = 100;
+  operation.scrollIDs = [];
+  operation.cmrQueryLocations = [];
+  operation.message = message;
+  operation.requestStartTime = new Date();
+  operation.ignoreErrors = true;
+  return operation;
+}
 
 
 describe('skipPreview, pause, resume, and updateStatus job message handling', async function () {
@@ -12,14 +48,20 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
       let job: Job;
       hookTransaction();
       before(async function () {
-        job = buildJob({ status: JobStatus.RUNNING, message: 'The job is being processed.' });
+        env.previewThreshold = 100; // ensure initial job state is RUNNING
+        const requestString = 'http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=10';
+        job = (new TurboService(config, buildOperation(undefined)))._createJob(requestString);
+        assert(job.status === JobStatus.RUNNING);
         await job.save(this.trx);
+      });
+      after(async function () {
+        env.previewThreshold = originalPreviewThreshold;
       });
       it('sets the appropriate message when paused', async function () {
         job.pause();
         await job.save(this.trx);
         const updatedJob = await Job.byJobID(this.trx, job.jobID);
-        expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link.');
+        expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link');
       });
       it('sets the appropriate message when resumed', async function () {
         job.resume();
@@ -33,15 +75,18 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
       let limitedMessage: string;
       hookTransaction();
       before(async function () {
+        env.previewThreshold = 100; // ensure initial job state is RUNNING
         limitedMessage = `${baseResultsLimitedMessage(100, 10)}.`;
-        job = buildJob({ status: JobStatus.RUNNING, message: limitedMessage });
+        const requestString = 'http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=10';
+        job = (new TurboService(config, buildOperation(limitedMessage)))._createJob(requestString);
+        assert(job.status === JobStatus.RUNNING);
         await job.save(this.trx);
       });
       it('sets the appropriate message when paused', async function () {
         job.pause();
         await job.save(this.trx);
         const updatedJob = await Job.byJobID(this.trx, job.jobID);
-        expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link.');
+        expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link');
       });
       it('sets the appropriate message when resumed', async function () {
         job.resume();
@@ -57,17 +102,21 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
       let skipJob: Job;
       hookTransaction();
       before(async function () {
-        job = buildJob({ status: JobStatus.PREVIEWING, message: 'The job is generating a preview before auto-pausing.' });
+        env.previewThreshold = 5; // ensure initial job state is PREVIEWING
+        const requestString = 'http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=10';
+        job = (new TurboService(config, buildOperation(undefined)))._createJob(requestString);
         await job.save(this.trx);
-        skipJob = buildJob({ status: JobStatus.PREVIEWING, message: 'The job is generating a preview before auto-pausing.' });
+        assert(job.status === JobStatus.PREVIEWING);
+        skipJob = (new TurboService(config, buildOperation(undefined)))._createJob(requestString);
         await skipJob.save(this.trx);
+        assert(skipJob.status === JobStatus.PREVIEWING);
       });
       describe('which is paused, then resumed', function () {
         it('sets the appropriate message when paused', async function () {
           job.pause();
           await job.save(this.trx);
           const updatedJob = await Job.byJobID(this.trx, job.jobID);
-          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link.');
+          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link');
         });
         it('sets the appropriate message when resumed', async function () {
           job.resume();
@@ -87,7 +136,7 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
           skipJob.pause();
           await skipJob.save(this.trx);
           const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
-          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link.');
+          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link');
         });
         it('sets the appropriate message when resumed', async function () {
           skipJob.resume();
@@ -104,20 +153,28 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
       let limitedMessage: string;
       hookTransaction();
       before(async function () {
-        limitedMessage = `${baseResultsLimitedMessage(100, 10)}.`;
-        job = buildJob({ status: JobStatus.PREVIEWING, message: `The job is generating a preview before auto-pausing. ${limitedMessage}` });
+        env.previewThreshold = 5; // ensure initial job state is PREVIEWING
+        const requestString = 'http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=10';
+        limitedMessage = `${baseResultsLimitedMessage(100, 10)}.`;        
+        job = (new TurboService(config, buildOperation(limitedMessage)))._createJob(requestString);
         await job.save(this.trx);
-        skipJob = buildJob({ status: JobStatus.PREVIEWING, message: `The job is generating a preview before auto-pausing. ${limitedMessage}` });
+        assert(job.status === JobStatus.PREVIEWING);
+        skipJob = (new TurboService(config, buildOperation(limitedMessage)))._createJob(requestString);
         await skipJob.save(this.trx);
-        completeJob = buildJob({ status: JobStatus.PREVIEWING, message: `The job is generating a preview before auto-pausing. ${limitedMessage}` });
+        assert(skipJob.status === JobStatus.PREVIEWING);
+        completeJob = (new TurboService(config, buildOperation(limitedMessage)))._createJob(requestString);
         await completeJob.save(this.trx);
+        assert(completeJob.status === JobStatus.PREVIEWING);
+      });
+      after(async function () {
+        env.previewThreshold = originalPreviewThreshold;
       });
       describe('which is paused, then resumed', function () {
         it('sets the appropriate message when paused', async function () {
           job.pause();
           await job.save(this.trx);
           const updatedJob = await Job.byJobID(this.trx, job.jobID);
-          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link.');
+          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link');
         });
         it('sets the appropriate message when resumed', async function () {
           job.resume();
@@ -137,7 +194,7 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
           skipJob.pause();
           await skipJob.save(this.trx);
           const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
-          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link.');
+          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link');
         });
         it('sets the appropriate message when resumed', async function () {
           skipJob.resume();
@@ -151,7 +208,7 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
           completeJob.pause();
           await completeJob.save(this.trx);
           const updatedJob = await Job.byJobID(this.trx, completeJob.jobID);
-          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link.');
+          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link');
         });
         it('sets the appropriate message when completed', async function () {
           completeJob.updateStatus(JobStatus.SUCCESSFUL);

--- a/test/jobs/message.ts
+++ b/test/jobs/message.ts
@@ -3,6 +3,7 @@ import { buildJob } from '../helpers/jobs';
 import { Job, JobStatus } from '../../app/models/job';
 import { hookTransaction } from '../helpers/db';
 import { expect } from 'chai';
+import { baseResultsLimitedMessage } from 'app/middleware/cmr-granule-locator';
 
 
 describe('skipPreview, pause and resume job message handling', async function () {
@@ -32,7 +33,7 @@ describe('skipPreview, pause and resume job message handling', async function ()
       let limitedMessage;
       hookTransaction();
       before(async function () {
-        limitedMessage = 'CMR query identified 10 granules, but the request has been limited.';
+        limitedMessage = baseResultsLimitedMessage(100, 10);
         job = buildJob({ status: JobStatus.RUNNING, message: limitedMessage });
         await job.save(this.trx);
       });
@@ -102,7 +103,7 @@ describe('skipPreview, pause and resume job message handling', async function ()
       let limitedMessage;
       hookTransaction();
       before(async function () {
-        limitedMessage = 'CMR query identified 10 granules, but the request has been limited.';
+        limitedMessage = baseResultsLimitedMessage(100, 10);
         job = buildJob({ status: JobStatus.PREVIEWING, message: `The job is generating a preview before auto-pausing. ${limitedMessage}` });
         await job.save(this.trx);
         skipJob = buildJob({ status: JobStatus.PREVIEWING, message: `The job is generating a preview before auto-pausing. ${limitedMessage}` });

--- a/test/jobs/message.ts
+++ b/test/jobs/message.ts
@@ -3,7 +3,7 @@ import { buildJob } from '../helpers/jobs';
 import { Job, JobStatus } from '../../app/models/job';
 import { hookTransaction } from '../helpers/db';
 import { expect } from 'chai';
-import { baseResultsLimitedMessage } from 'app/middleware/cmr-granule-locator';
+import { baseResultsLimitedMessage } from '../../app/middleware/cmr-granule-locator';
 
 
 describe('skipPreview, pause and resume job message handling', async function () {

--- a/test/jobs/message.ts
+++ b/test/jobs/message.ts
@@ -3,7 +3,7 @@ import { Job, JobStatus } from '../../app/models/job';
 import { hookTransaction } from '../helpers/db';
 import { assert, expect } from 'chai';
 import { baseResultsLimitedMessage } from '../../app/middleware/cmr-granule-locator';
-import TurboService from '../../app/models/services/turbo-service';
+import { TestTurboService } from '../../app/models/services/turbo-service';
 import DataOperation from '../../app/models/data-operation';
 import env from '../../app/util/env';
 import { v4 as uuid } from 'uuid';
@@ -50,7 +50,7 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
       before(async function () {
         env.previewThreshold = 100; // ensure initial job state is RUNNING
         const requestString = 'http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=10';
-        job = (new TurboService(config, buildOperation(undefined)))._createJob(requestString);
+        job = (new TestTurboService(config, buildOperation(undefined))).createJob(requestString);
         assert(job.status === JobStatus.RUNNING);
         await job.save(this.trx);
       });
@@ -78,7 +78,7 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
         env.previewThreshold = 100; // ensure initial job state is RUNNING
         limitedMessage = `${baseResultsLimitedMessage(100, 10)}.`;
         const requestString = 'http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=10';
-        job = (new TurboService(config, buildOperation(limitedMessage)))._createJob(requestString);
+        job = (new TestTurboService(config, buildOperation(limitedMessage))).createJob(requestString);
         assert(job.status === JobStatus.RUNNING);
         await job.save(this.trx);
       });
@@ -104,10 +104,10 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
       before(async function () {
         env.previewThreshold = 5; // ensure initial job state is PREVIEWING
         const requestString = 'http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=10';
-        job = (new TurboService(config, buildOperation(undefined)))._createJob(requestString);
+        job = (new TestTurboService(config, buildOperation(undefined))).createJob(requestString);
         await job.save(this.trx);
         assert(job.status === JobStatus.PREVIEWING);
-        skipJob = (new TurboService(config, buildOperation(undefined)))._createJob(requestString);
+        skipJob = (new TestTurboService(config, buildOperation(undefined))).createJob(requestString);
         await skipJob.save(this.trx);
         assert(skipJob.status === JobStatus.PREVIEWING);
       });
@@ -156,13 +156,13 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
         env.previewThreshold = 5; // ensure initial job state is PREVIEWING
         const requestString = 'http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=10';
         limitedMessage = `${baseResultsLimitedMessage(100, 10)}.`;        
-        job = (new TurboService(config, buildOperation(limitedMessage)))._createJob(requestString);
+        job = (new TestTurboService(config, buildOperation(limitedMessage))).createJob(requestString);
         await job.save(this.trx);
         assert(job.status === JobStatus.PREVIEWING);
-        skipJob = (new TurboService(config, buildOperation(limitedMessage)))._createJob(requestString);
+        skipJob = (new TestTurboService(config, buildOperation(limitedMessage))).createJob(requestString);
         await skipJob.save(this.trx);
         assert(skipJob.status === JobStatus.PREVIEWING);
-        completeJob = (new TurboService(config, buildOperation(limitedMessage)))._createJob(requestString);
+        completeJob = (new TestTurboService(config, buildOperation(limitedMessage))).createJob(requestString);
         await completeJob.save(this.trx);
         assert(completeJob.status === JobStatus.PREVIEWING);
       });

--- a/test/jobs/message.ts
+++ b/test/jobs/message.ts
@@ -4,12 +4,12 @@ import { Job, JobStatus } from '../../app/models/job';
 import { hookTransaction } from '../helpers/db';
 import { expect } from 'chai';
 
-hookTransaction();
 
 describe('skipPreview, pause and resume job message handling', async function () {
   describe('for a RUNNING job', function () {
     describe('with a default running message', function () {
       let job;
+      hookTransaction();
       before(async function () {
         job = buildJob({ status: JobStatus.RUNNING, message: 'The job is being processed.' });
         await job.save(this.trx);
@@ -30,6 +30,7 @@ describe('skipPreview, pause and resume job message handling', async function ()
     describe('with a results limited running message', function () {
       let job;
       let limitedMessage;
+      hookTransaction();
       before(async function () {
         limitedMessage = 'CMR query identified 10 granules, but the request has been limited.';
         job = buildJob({ status: JobStatus.RUNNING, message: limitedMessage });
@@ -53,6 +54,7 @@ describe('skipPreview, pause and resume job message handling', async function ()
     describe('with a default previewing message', function () {
       let job;
       let skipJob;
+      hookTransaction();
       before(async function () {
         job = buildJob({ status: JobStatus.PREVIEWING, message: 'The job is generating a preview before auto-pausing.' });
         await job.save(this.trx);
@@ -98,6 +100,7 @@ describe('skipPreview, pause and resume job message handling', async function ()
       let job;
       let skipJob;
       let limitedMessage;
+      hookTransaction();
       before(async function () {
         limitedMessage = 'CMR query identified 10 granules, but the request has been limited.';
         job = buildJob({ status: JobStatus.PREVIEWING, message: `The job is generating a preview before auto-pausing. ${limitedMessage}` });

--- a/test/jobs/message.ts
+++ b/test/jobs/message.ts
@@ -1,0 +1,144 @@
+import { describe, it } from 'mocha';
+import { buildJob } from '../helpers/jobs';
+import { Job, JobStatus } from '../../app/models/job';
+import { hookTransaction } from '../helpers/db';
+import { expect } from 'chai';
+
+hookTransaction();
+
+describe('skipPreview, pause and resume job message handling', async function () {
+  describe('for a RUNNING job', function () {
+    describe('with a default running message', function () {
+      let job;
+      before(async function () {
+        job = buildJob({ status: JobStatus.RUNNING, message: 'The job is being processed.' });
+        await job.save(this.trx);
+      });
+      it('sets the appropriate message when paused', async function () {
+        job.pause();
+        await job.save(this.trx);
+        const updatedJob = await Job.byJobID(this.trx, job.jobID);
+        expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link.');
+      });
+      it('sets the appropriate message when resumed', async function () {
+        job.resume();
+        await job.save(this.trx);
+        const updatedJob = await Job.byJobID(this.trx, job.jobID);
+        expect(updatedJob.message).to.eq('The job is being processed');
+      });
+    });
+    describe('with a results limited running message', function () {
+      let job;
+      let limitedMessage;
+      before(async function () {
+        limitedMessage = 'CMR query identified 10 granules, but the request has been limited.';
+        job = buildJob({ status: JobStatus.RUNNING, message: limitedMessage });
+        await job.save(this.trx);
+      });
+      it('sets the appropriate message when paused', async function () {
+        job.pause();
+        await job.save(this.trx);
+        const updatedJob = await Job.byJobID(this.trx, job.jobID);
+        expect(updatedJob.message).to.eq(`The job is paused and may be resumed using the provided link. ${limitedMessage}`);
+      });
+      it('sets the appropriate message when resumed', async function () {
+        job.resume();
+        await job.save(this.trx);
+        const updatedJob = await Job.byJobID(this.trx, job.jobID);
+        expect(updatedJob.message).to.eq(limitedMessage);
+      });
+    });
+  });
+  describe('for a PREVIEWING job', function () {
+    describe('with a default previewing message', function () {
+      let job;
+      let skipJob;
+      before(async function () {
+        job = buildJob({ status: JobStatus.PREVIEWING, message: 'The job is generating a preview before auto-pausing.' });
+        await job.save(this.trx);
+        skipJob = buildJob({ status: JobStatus.PREVIEWING, message: 'The job is generating a preview before auto-pausing.' });
+        await skipJob.save(this.trx);
+      });
+      describe('which is paused, then resumed', function () {
+        it('sets the appropriate message when paused', async function () {
+          job.pause();
+          await job.save(this.trx);
+          const updatedJob = await Job.byJobID(this.trx, job.jobID);
+          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link.');
+        });
+        it('sets the appropriate message when resumed', async function () {
+          job.resume();
+          await job.save(this.trx);
+          const updatedJob = await Job.byJobID(this.trx, job.jobID);
+          expect(updatedJob.message).to.eq('The job is being processed');
+        });
+      });
+      describe('which skips preview, pauses, and then resumes', function () {
+        it('sets the appropriate message when skipping preview', async function () {
+          skipJob.skipPreview();
+          await skipJob.save(this.trx);
+          const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
+          expect(updatedJob.message).to.eq('The job is being processed');
+        });
+        it('sets the appropriate message when paused', async function () {
+          skipJob.pause();
+          await skipJob.save(this.trx);
+          const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
+          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link.');
+        });
+        it('sets the appropriate message when resumed', async function () {
+          skipJob.resume();
+          await skipJob.save(this.trx);
+          const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
+          expect(updatedJob.message).to.eq('The job is being processed');
+        });
+      });
+    });
+    describe('with a results limited previewing message', function () {
+      let job;
+      let skipJob;
+      let limitedMessage;
+      before(async function () {
+        limitedMessage = 'CMR query identified 10 granules, but the request has been limited.';
+        job = buildJob({ status: JobStatus.PREVIEWING, message: `The job is generating a preview before auto-pausing. ${limitedMessage}` });
+        await job.save(this.trx);
+        skipJob = buildJob({ status: JobStatus.PREVIEWING, message: `The job is generating a preview before auto-pausing. ${limitedMessage}` });
+        await skipJob.save(this.trx);
+      });
+      describe('which is paused, then resumed', function () {
+        it('sets the appropriate message when paused', async function () {
+          job.pause();
+          await job.save(this.trx);
+          const updatedJob = await Job.byJobID(this.trx, job.jobID);
+          expect(updatedJob.message).to.eq(`The job is paused and may be resumed using the provided link. ${limitedMessage}`);
+        });
+        it('sets the appropriate message when resumed', async function () {
+          job.resume();
+          await job.save(this.trx);
+          const updatedJob = await Job.byJobID(this.trx, job.jobID);
+          expect(updatedJob.message).to.eq(limitedMessage);
+        });
+      });
+      describe('which skips preview, pauses, and then resumes', function () {
+        it('sets the appropriate message when skipping preview', async function () {
+          skipJob.skipPreview();
+          await skipJob.save(this.trx);
+          const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
+          expect(updatedJob.message).to.eq(limitedMessage);
+        });
+        it('sets the appropriate message when paused', async function () {
+          skipJob.pause();
+          await skipJob.save(this.trx);
+          const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
+          expect(updatedJob.message).to.eq(`The job is paused and may be resumed using the provided link. ${limitedMessage}`);
+        });
+        it('sets the appropriate message when resumed', async function () {
+          skipJob.resume();
+          await skipJob.save(this.trx);
+          const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
+          expect(updatedJob.message).to.eq(limitedMessage);
+        });
+      });
+    });
+  });
+});

--- a/test/jobs/message.ts
+++ b/test/jobs/message.ts
@@ -245,7 +245,7 @@ describe('job constructor message handling', function () {
           collectionIds: [] });
       });
       it('uses the default message for that status', function () {
-        expect(job.getMessage(JobStatus.FAILED)).to.eq(statesToDefaultMessages.running);
+        expect(job.getMessage(JobStatus.RUNNING)).to.eq(statesToDefaultMessages.running);
         expect(job.message).to.eq(statesToDefaultMessages.running);
       });
     });

--- a/test/jobs/message.ts
+++ b/test/jobs/message.ts
@@ -41,7 +41,7 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
         job.pause();
         await job.save(this.trx);
         const updatedJob = await Job.byJobID(this.trx, job.jobID);
-        expect(updatedJob.message).to.eq(`The job is paused and may be resumed using the provided link. ${limitedMessage}`);
+        expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link.');
       });
       it('sets the appropriate message when resumed', async function () {
         job.resume();
@@ -117,7 +117,7 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
           job.pause();
           await job.save(this.trx);
           const updatedJob = await Job.byJobID(this.trx, job.jobID);
-          expect(updatedJob.message).to.eq(`The job is paused and may be resumed using the provided link. ${limitedMessage}`);
+          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link.');
         });
         it('sets the appropriate message when resumed', async function () {
           job.resume();
@@ -137,7 +137,7 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
           skipJob.pause();
           await skipJob.save(this.trx);
           const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
-          expect(updatedJob.message).to.eq(`The job is paused and may be resumed using the provided link. ${limitedMessage}`);
+          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link.');
         });
         it('sets the appropriate message when resumed', async function () {
           skipJob.resume();
@@ -151,7 +151,7 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
           completeJob.pause();
           await completeJob.save(this.trx);
           const updatedJob = await Job.byJobID(this.trx, completeJob.jobID);
-          expect(updatedJob.message).to.eq(`The job is paused and may be resumed using the provided link. ${limitedMessage}`);
+          expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link.');
         });
         it('sets the appropriate message when completed', async function () {
           completeJob.updateStatus(JobStatus.SUCCESSFUL);

--- a/test/jobs/pause-jobs.ts
+++ b/test/jobs/pause-jobs.ts
@@ -545,13 +545,7 @@ describe('Pausing and resuming a job - admin endpoint', function () {
       hookServersStartStop({ skipEarthdataLogin: false });
       describe('Resuming a job', function () {
         hookTransaction();
-        const resultsLimitedMessage = 'CMR query identified 177 granules, but the request has been limited to ' +
-          'process only the first 3 granules because you requested 3 maxResults.';
-        const joeJob1 = buildJob({ 
-          username: normalUsername,
-          status: JobStatus.RUNNING,
-          message: resultsLimitedMessage,
-        });
+        const joeJob1 = buildJob({ username: normalUsername });
         before(async function () {
           joeJob1.pause();
           await joeJob1.save(this.trx);
@@ -605,14 +599,14 @@ describe('Pausing and resuming a job - admin endpoint', function () {
               const actualJob = JSON.parse(this.res.text);
               expect(actualJob.status).to.eql('running');
             });
-            it('sets the message to the previous "running" state message', function () {
+            it('sets the message to the job is being processed', function () {
               const actualJob = JSON.parse(this.res.text);
-              expect(actualJob.message).to.eql(resultsLimitedMessage);
+              expect(actualJob.message).to.eql('The job is being processed');
             });
             it('does not modify any of the other job fields', function () {
               const actualJob = new Job(JSON.parse(this.res.text));
               const expectedJob: JobRecord = _.cloneDeep(joeJob1);
-              expectedJob.message = resultsLimitedMessage;
+              expectedJob.message = 'The job is being processed';
               expectedJob.status = JobStatus.RUNNING;
               expect(jobsEqual(expectedJob, actualJob)).to.be.true;
             });

--- a/test/jobs/pause-jobs.ts
+++ b/test/jobs/pause-jobs.ts
@@ -22,7 +22,7 @@ import {
   hookAdminPauseJob,
 } from '../helpers/jobs';
 import { hookRedirect } from '../helpers/hooks';
-import { JobRecord, JobStatus, Job } from '../../app/models/job';
+import { JobRecord, JobStatus, Job, SerializedJob } from '../../app/models/job';
 import { getWorkflowStepsByJobId } from '../../app/models/workflow-steps';
 import db from '../../app/util/db';
 import { createDecrypter, createEncrypter } from '../../app/util/crypto';
@@ -406,7 +406,7 @@ describe('Pausing and resuming a job - user endpoint', function () {
             });
 
             it('does not modify any of the other job fields', function () {
-              const actualJob = new Job(JSON.parse(this.res.text));
+              const actualJob = new SerializedJob(JSON.parse(this.res.text));
               const expectedJob: JobRecord = _.cloneDeep(joeJob1);
               expectedJob.message = 'it is running';
               expectedJob.status = JobStatus.RUNNING;
@@ -492,7 +492,7 @@ describe('Pausing and resuming a job - user endpoint', function () {
             });
 
             it('does not modify any of the other job fields', function () {
-              const actualJob = new Job(JSON.parse(this.res.text));
+              const actualJob = new SerializedJob(JSON.parse(this.res.text));
               const expectedJob: JobRecord = _.cloneDeep(joeJob1);
               expectedJob.status = JobStatus.PAUSED;
               expect(jobsEqual(expectedJob, actualJob, false, true)).to.be.true;
@@ -604,7 +604,7 @@ describe('Pausing and resuming a job - admin endpoint', function () {
               expect(actualJob.message).to.eql('it is running');
             });
             it('does not modify any of the other job fields', function () {
-              const actualJob = new Job(JSON.parse(this.res.text));
+              const actualJob = new SerializedJob(JSON.parse(this.res.text));
               const expectedJob: JobRecord = _.cloneDeep(joeJob1);
               expectedJob.message = 'it is running';
               expectedJob.status = JobStatus.RUNNING;
@@ -678,7 +678,7 @@ describe('Pausing and resuming a job - admin endpoint', function () {
               expect(actualJob.links.some((link) => link.href.includes('/resume')));
             });
             it('does not modify any of the other job fields', function () {
-              const actualJob = new Job(JSON.parse(this.res.text));
+              const actualJob = new SerializedJob(JSON.parse(this.res.text));
               const expectedJob: JobRecord = _.cloneDeep(joeJob1);
               expectedJob.status = JobStatus.PAUSED;
               expect(jobsEqual(expectedJob, actualJob, false, true)).to.be.true;

--- a/test/jobs/pause-jobs.ts
+++ b/test/jobs/pause-jobs.ts
@@ -406,7 +406,7 @@ describe('Pausing and resuming a job - user endpoint', function () {
             });
 
             it('does not modify any of the other job fields', function () {
-              const actualJob = new SerializedJob(JSON.parse(this.res.text));
+              const actualJob = JSON.parse(this.res.text);
               const expectedJob: JobRecord = _.cloneDeep(joeJob1);
               expectedJob.message = 'it is running';
               expectedJob.status = JobStatus.RUNNING;
@@ -492,7 +492,7 @@ describe('Pausing and resuming a job - user endpoint', function () {
             });
 
             it('does not modify any of the other job fields', function () {
-              const actualJob = new SerializedJob(JSON.parse(this.res.text));
+              const actualJob = JSON.parse(this.res.text);
               const expectedJob: JobRecord = _.cloneDeep(joeJob1);
               expectedJob.status = JobStatus.PAUSED;
               expect(jobsEqual(expectedJob, actualJob, false, true)).to.be.true;
@@ -604,7 +604,7 @@ describe('Pausing and resuming a job - admin endpoint', function () {
               expect(actualJob.message).to.eql('it is running');
             });
             it('does not modify any of the other job fields', function () {
-              const actualJob = new SerializedJob(JSON.parse(this.res.text));
+              const actualJob = JSON.parse(this.res.text);
               const expectedJob: JobRecord = _.cloneDeep(joeJob1);
               expectedJob.message = 'it is running';
               expectedJob.status = JobStatus.RUNNING;
@@ -678,7 +678,7 @@ describe('Pausing and resuming a job - admin endpoint', function () {
               expect(actualJob.links.some((link) => link.href.includes('/resume')));
             });
             it('does not modify any of the other job fields', function () {
-              const actualJob = new SerializedJob(JSON.parse(this.res.text));
+              const actualJob = JSON.parse(this.res.text);
               const expectedJob: JobRecord = _.cloneDeep(joeJob1);
               expectedJob.status = JobStatus.PAUSED;
               expect(jobsEqual(expectedJob, actualJob, false, true)).to.be.true;

--- a/test/jobs/pause-jobs.ts
+++ b/test/jobs/pause-jobs.ts
@@ -400,15 +400,15 @@ describe('Pausing and resuming a job - user endpoint', function () {
               expect(actualJob.status).to.eql('running');
             });
 
-            it('sets the message to the job is being processed', function () {
+            it('sets the message to the initial RUNNING message', function () {
               const actualJob = JSON.parse(this.res.text);
-              expect(actualJob.message).to.eql('The job is being processed');
+              expect(actualJob.message).to.eql('it is running');
             });
 
             it('does not modify any of the other job fields', function () {
               const actualJob = new Job(JSON.parse(this.res.text));
               const expectedJob: JobRecord = _.cloneDeep(joeJob1);
-              expectedJob.message = 'The job is being processed';
+              expectedJob.message = 'it is running';
               expectedJob.status = JobStatus.RUNNING;
               expect(jobsEqual(expectedJob, actualJob)).to.be.true;
             });
@@ -483,7 +483,7 @@ describe('Pausing and resuming a job - user endpoint', function () {
 
             it('sets the appropriate message', function () {
               const actualJob = JSON.parse(this.res.text);
-              expect(actualJob.message).to.eql('The job is paused and may be resumed using the provided link.');
+              expect(actualJob.message).to.eql('The job is paused and may be resumed using the provided link');
             });
 
             it('provides a link for resuming the job', function () {
@@ -599,14 +599,14 @@ describe('Pausing and resuming a job - admin endpoint', function () {
               const actualJob = JSON.parse(this.res.text);
               expect(actualJob.status).to.eql('running');
             });
-            it('sets the message to the job is being processed', function () {
+            it('sets the message to the initial RUNNING message', function () {
               const actualJob = JSON.parse(this.res.text);
-              expect(actualJob.message).to.eql('The job is being processed');
+              expect(actualJob.message).to.eql('it is running');
             });
             it('does not modify any of the other job fields', function () {
               const actualJob = new Job(JSON.parse(this.res.text));
               const expectedJob: JobRecord = _.cloneDeep(joeJob1);
-              expectedJob.message = 'The job is being processed';
+              expectedJob.message = 'it is running';
               expectedJob.status = JobStatus.RUNNING;
               expect(jobsEqual(expectedJob, actualJob)).to.be.true;
             });
@@ -671,7 +671,7 @@ describe('Pausing and resuming a job - admin endpoint', function () {
             });
             it('sets the appropriate message', function () {
               const actualJob = JSON.parse(this.res.text);
-              expect(actualJob.message).to.eql('The job is paused and may be resumed using the provided link.');
+              expect(actualJob.message).to.eql('The job is paused and may be resumed using the provided link');
             });
             it('provides a link for resuming the job', function () {
               const actualJob = JSON.parse(this.res.text);

--- a/test/jobs/pause-jobs.ts
+++ b/test/jobs/pause-jobs.ts
@@ -483,7 +483,7 @@ describe('Pausing and resuming a job - user endpoint', function () {
 
             it('sets the appropriate message', function () {
               const actualJob = JSON.parse(this.res.text);
-              expect(actualJob.message).to.eql('The job is paused. The job may be resumed using the provided link.');
+              expect(actualJob.message).to.eql('The job is paused and may be resumed using the provided link.');
             });
 
             it('provides a link for resuming the job', function () {
@@ -677,7 +677,7 @@ describe('Pausing and resuming a job - admin endpoint', function () {
             });
             it('sets the appropriate message', function () {
               const actualJob = JSON.parse(this.res.text);
-              expect(actualJob.message).to.eql('The job is paused. The job may be resumed using the provided link.');
+              expect(actualJob.message).to.eql('The job is paused and may be resumed using the provided link.');
             });
             it('provides a link for resuming the job', function () {
               const actualJob = JSON.parse(this.res.text);

--- a/test/jobs/pause-jobs.ts
+++ b/test/jobs/pause-jobs.ts
@@ -22,7 +22,7 @@ import {
   hookAdminPauseJob,
 } from '../helpers/jobs';
 import { hookRedirect } from '../helpers/hooks';
-import { JobRecord, JobStatus, Job, SerializedJob } from '../../app/models/job';
+import { JobRecord, JobStatus, Job } from '../../app/models/job';
 import { getWorkflowStepsByJobId } from '../../app/models/workflow-steps';
 import db from '../../app/util/db';
 import { createDecrypter, createEncrypter } from '../../app/util/crypto';

--- a/test/jobs/skip-job-preview.ts
+++ b/test/jobs/skip-job-preview.ts
@@ -322,7 +322,7 @@ describe('Skipping job preview', function () {
         describe('When a job is paused', function () {
           let token;
           hookTransaction();
-          const message = 'The job is paused';
+          const message = 'The job is paused and may be resumed using the provided link';
           const pausedJob = buildJob({ username: normalUsername, message });
           pausedJob.status = JobStatus.PAUSED;
           before(async function () {

--- a/test/jobs/skip-job-preview.ts
+++ b/test/jobs/skip-job-preview.ts
@@ -123,7 +123,7 @@ function skipJobPreviewCommonTests(
           const response = JSON.parse(this.res.text);
           expect(response).to.eql({
             code: 'harmony.ConflictError',
-            description: 'Error: Job status is running - only previewing or paused jobs can skip preview.',
+            description: 'Error: Job status is running - only previewing jobs can skip preview.',
           });
         });
       });
@@ -148,7 +148,7 @@ function skipJobPreviewCommonTests(
         const response = JSON.parse(this.res.text);
         expect(response).to.eql({
           code: 'harmony.ConflictError',
-          description: 'Error: Job status is successful - only previewing or paused jobs can skip preview.',
+          description: 'Error: Job status is successful - only previewing jobs can skip preview.',
         });
       });
     });
@@ -171,7 +171,7 @@ function skipJobPreviewCommonTests(
         const response = JSON.parse(this.res.text);
         expect(response).to.eql({
           code: 'harmony.ConflictError',
-          description: 'Error: Job status is failed - only previewing or paused jobs can skip preview.',
+          description: 'Error: Job status is failed - only previewing jobs can skip preview.',
         });
       });
     });
@@ -195,7 +195,7 @@ function skipJobPreviewCommonTests(
         const response = JSON.parse(this.res.text);
         expect(response).to.eql({
           code: 'harmony.ConflictError',
-          description: 'Error: Job status is canceled - only previewing or paused jobs can skip preview.',
+          description: 'Error: Job status is canceled - only previewing jobs can skip preview.',
         });
       });
     });

--- a/test/jobs/skip-job-preview.ts
+++ b/test/jobs/skip-job-preview.ts
@@ -123,7 +123,7 @@ function skipJobPreviewCommonTests(
           const response = JSON.parse(this.res.text);
           expect(response).to.eql({
             code: 'harmony.ConflictError',
-            description: 'Error: Job status is running - only previewing jobs can skip preview.',
+            description: 'Error: Job status is running - only previewing or paused jobs can skip preview.',
           });
         });
       });
@@ -148,7 +148,7 @@ function skipJobPreviewCommonTests(
         const response = JSON.parse(this.res.text);
         expect(response).to.eql({
           code: 'harmony.ConflictError',
-          description: 'Error: Job status is successful - only previewing jobs can skip preview.',
+          description: 'Error: Job status is successful - only previewing or paused jobs can skip preview.',
         });
       });
     });
@@ -171,7 +171,7 @@ function skipJobPreviewCommonTests(
         const response = JSON.parse(this.res.text);
         expect(response).to.eql({
           code: 'harmony.ConflictError',
-          description: 'Error: Job status is failed - only previewing jobs can skip preview.',
+          description: 'Error: Job status is failed - only previewing or paused jobs can skip preview.',
         });
       });
     });
@@ -195,7 +195,7 @@ function skipJobPreviewCommonTests(
         const response = JSON.parse(this.res.text);
         expect(response).to.eql({
           code: 'harmony.ConflictError',
-          description: 'Error: Job status is canceled - only previewing jobs can skip preview.',
+          description: 'Error: Job status is canceled - only previewing or paused jobs can skip preview.',
         });
       });
     });

--- a/test/jobs/skip-job-preview.ts
+++ b/test/jobs/skip-job-preview.ts
@@ -284,7 +284,7 @@ describe('Skipping job preview', function () {
                 });
 
                 it('does not modify any of the other job fields', function () {
-                  const actualJob = new SerializedJob(JSON.parse(this.res.text));
+                  const actualJob = JSON.parse(this.res.text);
                   const expectedJob: JobRecord = _.cloneDeep(previewingJob);
                   expectedJob.message = resultsLimitedMessage;
                   expectedJob.status = JobStatus.RUNNING;
@@ -385,7 +385,7 @@ describe('Skipping job preview', function () {
                 });
 
                 it('does not modify any of the other job fields', function () {
-                  const actualJob = new SerializedJob(JSON.parse(this.res.text));
+                  const actualJob = JSON.parse(this.res.text);
                   const expectedJob: JobRecord = _.cloneDeep(pausedJob);
                   expectedJob.message = 'The job is being processed';
                   expectedJob.status = JobStatus.RUNNING;
@@ -492,7 +492,7 @@ describe('Skipping job preview', function () {
                 expect(actualJob.message).to.eql('The job is being processed');
               });
               it('does not modify any of the other job fields', function () {
-                const actualJob = new SerializedJob(JSON.parse(this.res.text));
+                const actualJob = JSON.parse(this.res.text);
                 const expectedJob: JobRecord = _.cloneDeep(previewingJob);
                 expectedJob.message = 'The job is being processed';
                 expectedJob.status = JobStatus.RUNNING;
@@ -567,7 +567,7 @@ describe('Skipping job preview', function () {
                 expect(actualJob.message).to.eql('The job is being processed');
               });
               it('does not modify any of the other job fields', function () {
-                const actualJob = new SerializedJob(JSON.parse(this.res.text));
+                const actualJob = JSON.parse(this.res.text);
                 const expectedJob: JobRecord = _.cloneDeep(pausedJob);
                 expectedJob.message = 'The job is being processed';
                 expectedJob.status = JobStatus.RUNNING;

--- a/test/jobs/skip-job-preview.ts
+++ b/test/jobs/skip-job-preview.ts
@@ -221,8 +221,8 @@ describe('Skipping job preview', function () {
           let token;
           hookTransaction();
           const message = 'The job is generating a preview before auto-pausing. CMR query identified 176 granules, but the request has been limited to process only the first 101 granules because you requested 101 maxResults.';
-          const previewingJob = buildJob({ username: normalUsername, message });
-          previewingJob.status = JobStatus.PREVIEWING;
+          job
+          const previewingJob = buildJob({ username: normalUsername, message, status: JobStatus.PREVIEWING });
           before(async function () {
             await previewingJob.save(this.trx);
             const workflowStep = buildWorkflowStep({ jobID: previewingJob.requestId });
@@ -323,8 +323,7 @@ describe('Skipping job preview', function () {
           let token;
           hookTransaction();
           const message = 'The job is paused and may be resumed using the provided link';
-          const pausedJob = buildJob({ username: normalUsername, message });
-          pausedJob.status = JobStatus.PAUSED;
+          const pausedJob = buildJob({ username: normalUsername, message, status: JobStatus.PAUSED });
           before(async function () {
             await pausedJob.save(this.trx);
             const workflowStep = buildWorkflowStep({ jobID: pausedJob.requestId });
@@ -433,8 +432,7 @@ describe('Skipping job preview', function () {
         describe('When a job is previewing', function () {
           hookTransaction();
           const message = 'The job is generating a preview before auto-pausing';
-          const previewingJob = buildJob({ username: normalUsername, message });
-          previewingJob.status = JobStatus.PREVIEWING;
+          const previewingJob = buildJob({ username: normalUsername, message, status: JobStatus.PREVIEWING });
           before(async function () {
             await previewingJob.save(this.trx);
             this.trx.commit();
@@ -509,8 +507,7 @@ describe('Skipping job preview', function () {
         describe('When a job is paused', function () {
           hookTransaction();
           const message = 'The job is generating a preview before auto-pausing';
-          const pausedJob = buildJob({ username: normalUsername, message });
-          pausedJob.status = JobStatus.PAUSED;
+          const pausedJob = buildJob({ username: normalUsername, message, status: JobStatus.PAUSED });
           before(async function () {
             await pausedJob.save(this.trx);
             this.trx.commit();

--- a/test/jobs/skip-job-preview.ts
+++ b/test/jobs/skip-job-preview.ts
@@ -1,4 +1,4 @@
-import { JobRecord, JobStatus, Job, SerializedJob } from './../../app/models/job';
+import { JobRecord, JobStatus, Job } from './../../app/models/job';
 import {
   hookSkipPreview,
   buildJob,

--- a/test/models/job.ts
+++ b/test/models/job.ts
@@ -188,11 +188,6 @@ describe('Job', function () {
       expect(new Job({ status: JobStatus.FAILED } as JobRecord).message).to.eql('The job failed with an unknown error');
     });
 
-    it('updates the message if a default was used and the status changed', function () {
-      expect(new Job({ status: JobStatus.SUCCESSFUL, message: 'The job is being processed' } as JobRecord).message)
-        .to.equal('The job has completed successfully');
-    });
-
     it('defaults links to an empty array', function () {
       expect(new Job({} as JobRecord).links).to.eql([]);
     });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1172

## Description
When a job is paused and then resumed it should now always retain the original results limited message. 

~I am not totally in love with the ultimate solution but I wanted to avoid making a major change given that our job messages and associated logic seems like it is reaching a pretty stable point.~

Refactored the job message logic to pull from a map of messages. Made some changes to job serialization as well that hopefully simplify things.

## Local Test Steps
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=2

Pause and resume the job. Does the message look OK (are relevant parts, e.g. results limited messaging, retained after resumption)?

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)