### PR TITLE
HARMONY-1243: Clean up worker artifacts to prevent pod disk space issues

### DIFF
--- a/app/backends/service-metrics.ts
+++ b/app/backends/service-metrics.ts
@@ -5,14 +5,14 @@ import db from '../util/db';
 import { RequestValidationError } from '../util/errors';
 
 /**
- * Express.js handler that returns the number of work items in the 'READY' state for the given serviceID
+ * Express.js handler that returns the number of work items in the 'READY' or 'RUNNING' state for the given serviceID
  *
  * @param req - The request sent by the client
  * @param res - The response to send to the client
  * @param next - The next function in the call chain
  * @returns Resolves when the request is complete
  */
-export async function getReadyWorkItemCountForServiceID(
+export async function getReadyOrRunningWorkItemCountForServiceID(
   req: Request, res: Response, next: NextFunction,
 ): Promise<void> {
 
@@ -28,7 +28,7 @@ export async function getReadyWorkItemCountForServiceID(
   try {
     let workItemCount;
     await db.transaction(async (tx) => {
-      workItemCount = await workItemCountByServiceIDAndStatus(tx, serviceID, [WorkItemStatus.READY]);
+      workItemCount = await workItemCountByServiceIDAndStatus(tx, serviceID, [WorkItemStatus.READY, WorkItemStatus.RUNNING]);
     });
     if (!workItemCount) workItemCount = 0;
     const response = {

--- a/app/routers/service-response-router.ts
+++ b/app/routers/service-response-router.ts
@@ -2,7 +2,7 @@ import { Router, json } from 'express';
 import asyncHandler from 'express-async-handler';
 import { getWork, updateWorkItem } from '../backends/workflow-orchestration';
 import { responseHandler } from '../backends/service-response';
-import { getReadyWorkItemCountForServiceID } from '../backends/service-metrics';
+import { getReadyOrRunningWorkItemCountForServiceID } from '../backends/service-metrics';
 import log from '../util/log';
 
 /**
@@ -21,7 +21,7 @@ export default function router(): Router {
   result.get('/work', asyncHandler(getWork));
   result.put('/work/:id', asyncHandler(updateWorkItem));
 
-  result.get('/metrics', asyncHandler(getReadyWorkItemCountForServiceID));
+  result.get('/metrics', asyncHandler(getReadyOrRunningWorkItemCountForServiceID));
 
   result.use((err, _req, _res, _next) => {
     if (err) {

--- a/tasks/service-runner/app/workers/pull-worker.ts
+++ b/tasks/service-runner/app/workers/pull-worker.ts
@@ -7,7 +7,7 @@ import { runServiceFromPull, runQueryCmrFromPull } from '../service/service-runn
 import sleep from '../../../../app/util/sleep';
 import createAxiosClientWithRetry from '../util/axios-clients';
 import path from 'path';
-import { promises as fs } from 'fs';
+import { existsSync, rmSync, promises as fs } from 'fs';
 import { exit } from 'process';
 
 // Poll every 500 ms for now. Potentially make this a configuration item.
@@ -30,7 +30,8 @@ let pullCounter = 0;
 // how many pulls to execute before logging - used to keep log message count reasonable
 const pullLogPeriod = 10;
 
-const LOCKFILE_DIR = '/tmp';
+const WORK_DIR = '/tmp';
+const LOCKFILE_DIR = WORK_DIR;
 
 // retry twice for tests and 1200 (2 minutes) for real
 const maxPrimeRetries = process.env.NODE_ENV === 'test' ? 2 : 1_200;
@@ -67,6 +68,27 @@ async function _pullWork(): Promise<{ item?: WorkItemRecord; status?: number; er
     return { status: 500, error: err.message };
   }
 }
+
+/**
+ * Remove files and subdirectories from a directory, optionally skipping certain files
+ * 
+ * @param directory - the path to the directory to be emptied
+ * @param matchingFilter - RegExp matching files/directories that should be deleted
+ * 
+ */
+async function emptyDirectory(directory: string, matchingFilter?: RegExp): Promise<void> {
+  const regex = matchingFilter || /^.*$/;
+
+  if (existsSync(directory)) {
+    const files = await fs.readdir(directory);
+    files.filter(f => regex.test(f))
+      .map(f => rmSync(path.join(directory, f), { recursive: true, force: true }));
+
+  } else {
+    logger.error(`Directory ${directory} not found`);
+  }
+}
+
 
 /**
  * Call a service to perform some work
@@ -108,6 +130,9 @@ async function _doWork(
 async function _pullAndDoWork(repeat = true): Promise<void> {
   const workingFilePath = path.join(LOCKFILE_DIR, 'WORKING');
   try {
+    // remove any previous work items to prevent the pod from running out of disk space
+    const regex = /^(?!WORKING|TERMINATING)([a-z0-9]+)$/;
+    await emptyDirectory(WORK_DIR, regex);
     // write out the WORKING file to prevent pod termination while working
     await fs.writeFile(workingFilePath, '1');
 

--- a/tasks/service-runner/app/workers/pull-worker.ts
+++ b/tasks/service-runner/app/workers/pull-worker.ts
@@ -131,7 +131,7 @@ async function _pullAndDoWork(repeat = true): Promise<void> {
   const workingFilePath = path.join(LOCKFILE_DIR, 'WORKING');
   try {
     // remove any previous work items to prevent the pod from running out of disk space
-    const regex = /^(?!WORKING|TERMINATING)([a-z0-9]+)$/;
+    const regex = /^(?!WORKING|TERMINATING)(.+)$/;
     await emptyDirectory(WORK_DIR, regex);
     // write out the WORKING file to prevent pod termination while working
     await fs.writeFile(workingFilePath, '1');

--- a/tasks/service-runner/test/pull-worker.ts
+++ b/tasks/service-runner/test/pull-worker.ts
@@ -205,7 +205,7 @@ describe('Pull Worker', async function () {
       beforeEach(function () {
         mkdirSync('/tmp/abc123');
         writeFileSync('/tmp/abc123/work', '1');
-        pullStub = sinon.stub(pullWorker.exportedForTesting, '_pullWork').callsFake(async function () { return {} });
+        pullStub = sinon.stub(pullWorker.exportedForTesting, '_pullWork').callsFake(async function () { return {}; });
         doWorkStub = sinon.stub(pullWorker.exportedForTesting, '_doWork').callsFake(async function (): Promise<WorkItem> {
           return new WorkItem({});
         });

--- a/test/service-metrics-backends.ts
+++ b/test/service-metrics-backends.ts
@@ -64,6 +64,20 @@ describe('Backend service metrics endpoint', function () {
         status: WorkItemStatus.RUNNING,
         workflowStepIndex: 1,
       }).save(db);
+
+      await buildWorkItem({
+        jobID: 'abc123',
+        serviceID,
+        status: WorkItemStatus.SUCCESSFUL,
+        workflowStepIndex: 1,
+      }).save(db);
+
+      await buildWorkItem({
+        jobID: 'abc123',
+        serviceID,
+        status: WorkItemStatus.FAILED,
+        workflowStepIndex: 1,
+      }).save(db);
     });
 
     hookServiceMetrics(serviceID);


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1243

## Description
Cleans up /tmp (skipping WORKNG or TERMINATING files) before pulling new work to keep long-running pods from
running out of disk space. Also changes HPA metric to include running work items in counts.

## Local Test Steps
1. build the service-runner (`npm run build` in `tasks/service-runner`) image and restart services. 
2. open a terminal on a worker or manager for a service using `kubectl` or `k9s`
3. make a query that invokes that service
4. run `ls /tmp` to see files/directories being created in `/tmp`.
5. after the job completes, run `ls /tmp` again to verify that files/directories have been deleted.
6. optionally use `df -h` to see the disk space at various times. It may take a while after the service completes to see the freed disk space show up

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~