### PR TITLE
HARMONY-276: Effectively remove the system granule limit.

### DIFF
--- a/app/middleware/cmr-granule-locator.ts
+++ b/app/middleware/cmr-granule-locator.ts
@@ -52,7 +52,7 @@ function getBbox(collection: CmrCollection, granule: CmrGranule): BoundingBox {
  *
  * @param req - The client request, containing an operation
  * @param collection - The id of the collection to which the granules belong
- * @returns a tuple containing the maximum number of granules to return from the CMR and the
+ * @returns an object containing the maximum number of granules to return from the CMR and the
  * reason why it is being limited
  */
 function getMaxGranules(req: HarmonyRequest, collection: string):

--- a/app/middleware/cmr-granule-locator.ts
+++ b/app/middleware/cmr-granule-locator.ts
@@ -16,7 +16,7 @@ import { CmrCollection, CmrGranule, CmrQuery, filterGranuleLinks, queryGranulesF
  */
 enum GranuleLimitReason {
   Collection, // limited by the collection configuration
-  Service,    // liminted by the service chain configuration
+  Service,    // limited by the service chain configuration
   MaxResults, // limited by the maxResults query parameter
   System,     // limited by the system environment
   None,       // not limited

--- a/app/middleware/cmr-granule-locator.ts
+++ b/app/middleware/cmr-granule-locator.ts
@@ -16,6 +16,7 @@ import { CmrCollection, CmrGranule, CmrQuery, filterGranuleLinks, queryGranulesF
  */
 enum GranuleLimitReason {
   Collection, // limited by the collection configuration
+  Service,    // liminted by the service chain configuration
   MaxResults, // limited by the maxResults query parameter
   System,     // limited by the system environment
   None,       // not limited
@@ -48,13 +49,14 @@ function getBbox(collection: CmrCollection, granule: CmrGranule): BoundingBox {
 
 /**
  * Get the maximum number of granules that should be used from the CMR results
- * 
+ *
  * @param req - The client request, containing an operation
  * @param collection - The id of the collection to which the granules belong
  * @returns a tuple containing the maximum number of granules to return from the CMR and the
  * reason why it is being limited
  */
-function getMaxGranules(req: HarmonyRequest, collection: string): { maxGranules: number; reason: GranuleLimitReason; } {
+function getMaxGranules(req: HarmonyRequest, collection: string):
+{ maxGranules: number; reason: GranuleLimitReason; } {
   let reason = GranuleLimitReason.None;
   let maxResults = Number.MAX_SAFE_INTEGER;
 
@@ -70,11 +72,16 @@ function getMaxGranules(req: HarmonyRequest, collection: string): { maxGranules:
     }
 
     const { serviceConfig } = context;
+    if (serviceConfig.granule_limit && serviceConfig.granule_limit < maxResults) {
+      maxResults = serviceConfig.granule_limit;
+      reason = GranuleLimitReason.Service;
+    }
+
     const serviceCollection = serviceConfig.collections?.find((sc) => sc.id === collection);
     if (serviceCollection &&
-      serviceCollection.granuleLimit &&
-      serviceCollection.granuleLimit < maxResults) {
-      maxResults = serviceCollection.granuleLimit;
+      serviceCollection.granule_limit &&
+      serviceCollection.granule_limit < maxResults) {
+      maxResults = serviceCollection.granule_limit;
       reason = GranuleLimitReason.Collection;
     }
   }
@@ -84,11 +91,11 @@ function getMaxGranules(req: HarmonyRequest, collection: string): { maxGranules:
 
 /**
  * Create a message indicating that the results have been limited and why - if necessary
- * 
+ *
  * @param req - The client request, containing an operation
  * @param collection - The id of the collection to which the granules belong
  * @returns a warning message if not all matching granules will be processed, or undefined
- * if not applicable 
+ * if not applicable
  */
 function getResultsLimitedMessage(req: HarmonyRequest, collection: string): string {
   const { operation } = req;
@@ -105,6 +112,10 @@ function getResultsLimitedMessage(req: HarmonyRequest, collection: string): stri
     switch (reason) {
       case GranuleLimitReason.MaxResults:
         message += ` because you requested ${operation.maxResults} maxResults.`;
+        break;
+
+      case GranuleLimitReason.Service:
+        message += ` because the service ${req.context.serviceConfig.name} is limited to ${maxGranules}.`;
         break;
 
       case GranuleLimitReason.Collection:

--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -36,7 +36,7 @@ export interface ServiceStep {
 
 export interface ServiceCollection {
   id: string;
-  granuleLimit?: number;
+  granule_limit?: number;
   variables?: string[]
 }
 
@@ -44,6 +44,7 @@ export interface ServiceConfig<ServiceParamType> {
   batch_size?: number;
   name?: string;
   data_operation_version?: string;
+  granule_limit?: number;
   has_granule_limit?: boolean;
   default_sync?: boolean;
   type?: {

--- a/config/services.yml
+++ b/config/services.yml
@@ -167,7 +167,7 @@ https://cmr.earthdata.nasa.gov:
     maximum_sync_granules: 0
     capabilities:
       concatenation: true
-      concatenate_by_default: true
+      concatenate_by_default: false
       subsetting:
         variable: false
       output_formats:
@@ -259,6 +259,7 @@ https://cmr.earthdata.nasa.gov:
     umm_s:
       - S2153799015-POCLOUD
     collections: []
+    granule_limit: 350 # Cannot support more granules for concatenation services yet
     capabilities:
       concatenation: true
       subsetting:
@@ -309,6 +310,7 @@ https://cmr.earthdata.nasa.gov:
       - id: C1968979561-POCLOUD
       - id: C1968980609-POCLOUD
       - id: C1996881752-POCLOUD
+    granule_limit: 350 # Cannot support more granules for concatenation services yet
     capabilities:
       concatenation: true
       subsetting:
@@ -496,7 +498,7 @@ https://cmr.uat.earthdata.nasa.gov:
       - id: C1233800302-EEDTEST
       - id: C1234088182-EEDTEST
       - id: C1243747507-EEDTEST
-        granuleLimit: 100 # added to test collection granule limits for HARMONY-795
+        granule_limit: 100 # added to test collection granule limits for HARMONY-795
       - id: C1244968414-EEDTEST
     capabilities:
       subsetting:
@@ -588,6 +590,7 @@ https://cmr.uat.earthdata.nasa.gov:
       - id: C1234208437-POCLOUD
       - id: C1234208438-POCLOUD
       - id: C1243729749-EEDTEST
+    granule_limit: 350 # Cannot support more granules for concatenation services yet
     capabilities:
       concatenation: true
       subsetting:
@@ -623,6 +626,7 @@ https://cmr.uat.earthdata.nasa.gov:
       - id: C1238658052-POCLOUD
       - id: C1243729749-EEDTEST
       - id: C1243747507-EEDTEST
+    granule_limit: 350 # Cannot support more granules for concatenation services yet
     capabilities:
       concatenation: true
       subsetting:
@@ -856,7 +860,7 @@ https://cmr.uat.earthdata.nasa.gov:
     maximum_sync_granules: 0
     capabilities:
       concatenation: true
-      concatenate_by_default: true
+      concatenate_by_default: false
       subsetting:
         variable: false
       output_formats:
@@ -959,7 +963,7 @@ https://cmr.uat.earthdata.nasa.gov:
       - id: C1243747507-EEDTEST
     capabilities:
       concatenation: true
-      concatenate_by_default: true
+      concatenate_by_default: false
       subsetting:
         bbox: true
         variable: true
@@ -993,7 +997,7 @@ https://cmr.uat.earthdata.nasa.gov:
     maximum_sync_granules: 0
     capabilities:
       concatenation: true
-      concatenate_by_default: true
+      concatenate_by_default: false
       subsetting:
         bbox: false
         variable: false

--- a/env-defaults
+++ b/env-defaults
@@ -110,7 +110,7 @@ MAX_SYNCHRONOUS_GRANULES=1
 # The maximum allowed granules in any request synchronous or asynchronous. If a service
 # attempts to configure a value greater than this limit for either maximum_async_granules
 # or maximum_async_granules we will override the configuration to limit to this value.
-MAX_GRANULE_LIMIT=2100
+MAX_GRANULE_LIMIT=10000000
 
 # The threshold of the number of granules in a request that will trigger auto-pausing with preview
 PREVIEW_THRESHOLD=100

--- a/test/concatenation.ts
+++ b/test/concatenation.ts
@@ -194,7 +194,12 @@ describe('testing concatenation', function () {
       };
       StubService.hook({ params: { redirect: 'http://example.com' } });
       hookRangesetRequest('1.0.0', zarrCollection, 'all', { query });
-      it('sets the concatenate flag on the operation to be true by default', function () {
+      // We should be setting to true by default, but there's a bug with concatenation with the
+      // service right now, so we are defaulting to false
+      it('sets the concatenate flag on the operation to be false by default', function () {
+        expect(this.service.operation.shouldConcatenate).to.equal(false);
+      });
+      xit('sets the concatenate flag on the operation to be true by default', function () {
         expect(this.service.operation.shouldConcatenate).to.equal(true);
       });
     });

--- a/test/ogc-api-coverages/get-coverage-rangeset.ts
+++ b/test/ogc-api-coverages/get-coverage-rangeset.ts
@@ -443,7 +443,7 @@ describe('OGC API Coverages - getCoverageRangeset', function () {
       });
     });
 
-    describe('and maxResults from the a query is set to a value greater than the granule limit for the collection', function () {
+    describe('and maxResults from the query is set to a value greater than the granule limit for the collection', function () {
       const maxResults = 10;
 
       hookRangesetRequest(version, collection, variableName, { username: 'jdoe1', query: { maxResults } });
@@ -461,7 +461,7 @@ describe('OGC API Coverages - getCoverageRangeset', function () {
       });
     });
 
-    describe('and maxResults from the a query is set to a value less than the granule limit for the collection', function () {
+    describe('and maxResults from the query is set to a value less than the granule limit for the collection', function () {
       const maxResults = 2;
 
       hookRangesetRequest(version, collection, variableName, { username: 'jdoe1', query: { maxResults } });
@@ -544,7 +544,7 @@ describe('OGC API Coverages - getCoverageRangeset', function () {
       });
     });
 
-    describe('and maxResults from the a query is set to a value greater than the granule limit for the collection', function () {
+    describe('and maxResults from the query is set to a value greater than the granule limit for the collection', function () {
       const maxResults = 10;
 
       hookRangesetRequest(version, collection, variableName, { username: 'jdoe1', query: { maxResults } });
@@ -562,7 +562,7 @@ describe('OGC API Coverages - getCoverageRangeset', function () {
       });
     });
 
-    describe('and maxResults from the a query is set to a value less than the granule limit for the collection', function () {
+    describe('and maxResults from the query is set to a value less than the granule limit for the collection', function () {
       const maxResults = 2;
 
       hookRangesetRequest(version, collection, variableName, { username: 'jdoe1', query: { maxResults } });
@@ -641,7 +641,7 @@ describe('OGC API Coverages - getCoverageRangeset', function () {
       });
     });
 
-    describe('and maxResults from the a query is set to a value greater than the granule limit for the collection', function () {
+    describe('and maxResults from the query is set to a value greater than the granule limit for the collection', function () {
       const maxResults = 200;
 
       hookRangesetRequest(version, collection, variableName, { username: 'jdoe1', query: { maxResults } });
@@ -659,7 +659,7 @@ describe('OGC API Coverages - getCoverageRangeset', function () {
       });
     });
 
-    describe('and maxResults from the a query is set to a value less than the granule limit for the collection', function () {
+    describe('and maxResults from the query is set to a value less than the granule limit for the collection', function () {
       const maxResults = 2;
 
       hookRangesetRequest(version, collection, variableName, { username: 'jdoe1', query: { maxResults } });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-276

## Description

Bumps up the system granule limit to 10 million (more than the number of granules in any collection supported by harmony).

Ran into issues testing with concatenation and netcdf-to-zarr (even with as few as 20 granules), so changed all zarr service chains to not concatenate by default (though users can still request concatenation by passing in the parameter).

Based on testing we'll continue to limit Concise to no more than 350 granules. I ran a test successfully with 580 granules, but ran out of ephemeral storage space with 600 granules. We'll work on a fix for that next PI.

## Local Test Steps
Try out:

http://localhost:3000/C1234724470-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?format=application%2Fnetcdf&concatenate=true and verify it limits it to 350 granules with a message indicating it's a limitation on the service.

Then try out:
http://localhost:3000/C1234724470-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-45%3A45)&subset=lon(0%3A180)&format=application%2Fnetcdf

and verify that it does NOT display any warning message about limiting results and you see:

	"numInputGranules": 230161,

on the job status page and workflow-ui

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)