### PR TITLE
add ORNL harmony-gdal-adapter service to UAT

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -882,6 +882,7 @@ https://cmr.uat.earthdata.nasa.gov:
           STAGING_PATH: public/nasa/harmony-gdal-adapter
     umm_s:
       - S1245787332-EEDTEST
+      - S1255775104-ORNL_CLOUD
     collections:
       - id: C1225776654-ASF
       - id: C1207038647-ASF


### PR DESCRIPTION
Adding ORNL version of gdal-adapter service to UAT:

https://cmr.uat.earthdata.nasa.gov/search/services.umm_json?provider=ORNL_CLOUD&native-id=harmony-gdal-adapter