### PR TITLE
HARMONY-799: Make sure to cancel out paused requests from notebook

### DIFF
--- a/docs/Harmony Feature Examples.ipynb
+++ b/docs/Harmony Feature Examples.ipynb
@@ -454,7 +454,16 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Cancel out the two paused requests\n",
+    "response = post(my_jobs_cancel_root.format(job_id=response1.json()['jobID']))\n",
+    "print_async_status(response.json())\n",
+    "assert response.json()['status'] == 'canceled'\n",
+    "\n",
+    "response = post(my_jobs_cancel_root.format(job_id=response2.json()['jobID']))\n",
+    "print_async_status(response.json())\n",
+    "assert response.json()['status'] == 'canceled'\n"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -467,7 +476,7 @@
  "metadata": {
   "file_extension": ".py",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/env-defaults
+++ b/env-defaults
@@ -316,7 +316,7 @@ GIOVANNI_ADAPTER_INVOCATION_ARGS='node tasks/giovanni-adapter/app/cli'
 LOCALLY_DEPLOYED_SERVICES=harmony-service-example,harmony-netcdf-to-zarr
 
 # page size to use with CMR calls
-CMR_MAX_PAGE_SIZE=100
+CMR_MAX_PAGE_SIZE=2000
 
 # Prefix before "harmonyservices/task-name" for built-in tasks like query-cmr, e.g. an ECR location
 # If not blank, it should end in a slash if there is a slash before "harmony"


### PR DESCRIPTION
## Jira Issue ID
HARMONY-799

## Description
I tested out all the notebooks in this repo and in harmony-py now that we've raised the granule limit. I did not run into any issues with requests attempting to retrieve a large number of granules. The only change I made was to cancel out the two requests that are left in a paused state after previewing with 176 granules each.

Also sets the CMR page size back to 2000 for best performance.

## Local Test Steps
You can run the individual notebooks to verify they do not make large requests (or take a look at my requests using the admin page on the workflow-ui to verify I did not kick off any large requests as a result of my testing today).

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)