### PR TITLE
HARMONY-1237: Metrics for returning number of available work items to pick up take the job status into account.

### DIFF
--- a/app/backends/service-metrics.ts
+++ b/app/backends/service-metrics.ts
@@ -1,6 +1,5 @@
 import { Response, Request, NextFunction } from 'express';
-import { workItemCountByServiceIDAndStatus } from '../models/work-item';
-import { WorkItemStatus } from '../models/work-item-interface';
+import { getAvailableWorkItemCountByServiceID } from '../models/work-item';
 import db from '../util/db';
 import { RequestValidationError } from '../util/errors';
 
@@ -12,7 +11,7 @@ import { RequestValidationError } from '../util/errors';
  * @param next - The next function in the call chain
  * @returns Resolves when the request is complete
  */
-export async function getReadyOrRunningWorkItemCountForServiceID(
+export async function getEligibleWorkItemCountForServiceID(
   req: Request, res: Response, next: NextFunction,
 ): Promise<void> {
 
@@ -28,7 +27,7 @@ export async function getReadyOrRunningWorkItemCountForServiceID(
   try {
     let workItemCount;
     await db.transaction(async (tx) => {
-      workItemCount = await workItemCountByServiceIDAndStatus(tx, serviceID, [WorkItemStatus.READY, WorkItemStatus.RUNNING]);
+      workItemCount = await getAvailableWorkItemCountByServiceID(tx, serviceID);
     });
     if (!workItemCount) workItemCount = 0;
     const response = {

--- a/app/routers/service-response-router.ts
+++ b/app/routers/service-response-router.ts
@@ -2,7 +2,7 @@ import { Router, json } from 'express';
 import asyncHandler from 'express-async-handler';
 import { getWork, updateWorkItem } from '../backends/workflow-orchestration';
 import { responseHandler } from '../backends/service-response';
-import { getReadyOrRunningWorkItemCountForServiceID } from '../backends/service-metrics';
+import { getEligibleWorkItemCountForServiceID } from '../backends/service-metrics';
 import log from '../util/log';
 
 /**
@@ -21,7 +21,7 @@ export default function router(): Router {
   result.get('/work', asyncHandler(getWork));
   result.put('/work/:id', asyncHandler(updateWorkItem));
 
-  result.get('/metrics', asyncHandler(getReadyOrRunningWorkItemCountForServiceID));
+  result.get('/metrics', asyncHandler(getEligibleWorkItemCountForServiceID));
 
   result.use((err, _req, _res, _next) => {
     if (err) {

--- a/test/service-metrics-backends.ts
+++ b/test/service-metrics-backends.ts
@@ -1,16 +1,61 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
+import { JobStatus } from '../app/models/job';
 import { WorkItemStatus } from '../app/models/work-item-interface';
 import db from '../app/util/db';
 import { truncateAll } from './helpers/db';
+import { buildJob } from './helpers/jobs';
 import hookServersStartStop from './helpers/servers';
 import { hookServiceMetrics } from './helpers/service-metrics';
 import { buildWorkItem } from './helpers/work-items';
 
+/**
+ * Creates a job with the given status and work items for that job
+ *
+ * @param serviceID - the ID of the service for the work items
+ * @param jobStatus - the status of the job
+ */
+async function createJobAndWorkItems(serviceID: string, jobStatus: JobStatus): Promise<void> {
+  await truncateAll();
+  const job = buildJob({ status: jobStatus });
+
+  await job.save(db);
+
+  for (let i = 0; i < 2; i++) {
+    await buildWorkItem({
+      jobID: job.jobID,
+      serviceID,
+      status: WorkItemStatus.READY,
+      workflowStepIndex: 1,
+    }).save(db);
+  }
+
+  await buildWorkItem({
+    jobID: job.jobID,
+    serviceID,
+    status: WorkItemStatus.RUNNING,
+    workflowStepIndex: 1,
+  }).save(db);
+
+  await buildWorkItem({
+    jobID: job.jobID,
+    serviceID,
+    status: WorkItemStatus.SUCCESSFUL,
+    workflowStepIndex: 1,
+  }).save(db);
+
+  await buildWorkItem({
+    jobID: job.jobID,
+    serviceID,
+    status: WorkItemStatus.FAILED,
+    workflowStepIndex: 1,
+  }).save(db);
+}
+
 describe('Backend service metrics endpoint', function () {
 
   hookServersStartStop({ skipEarthdataLogin: true });
-  
+
   describe('when hitting the service/metrics endpoint without serviceID parameter', function () {
     hookServiceMetrics();
 
@@ -46,53 +91,41 @@ describe('Backend service metrics endpoint', function () {
 
   describe('when hitting the service/metrics endpoint with an existing serviceID', async function () {
     const serviceID = 'harmony/query-cmr:latest';
-    before(async function () {
-      // Add two READY work items and one RUNNING work item
-      await truncateAll();
-      for (let i = 0; i < 2; i++) {
-        await buildWorkItem({
-          jobID: 'abc123',
-          serviceID,
-          status: WorkItemStatus.READY,
-          workflowStepIndex: 1,
-        }).save(db);
-      }
 
-      await buildWorkItem({
-        jobID: 'abc123',
-        serviceID,
-        status: WorkItemStatus.RUNNING,
-        workflowStepIndex: 1,
-      }).save(db);
+    // The number of work items that should be returned for each of the job statuses
+    const testParametersList = [
+      { jobStatus: JobStatus.ACCEPTED, itemCount: 3 },
+      { jobStatus: JobStatus.RUNNING, itemCount: 3 },
+      { jobStatus: JobStatus.RUNNING_WITH_ERRORS, itemCount: 3 },
+      { jobStatus: JobStatus.PAUSED, itemCount: 0 },
+      { jobStatus: JobStatus.PREVIEWING, itemCount: 0 },
+      { jobStatus: JobStatus.CANCELED, itemCount: 0 },
+      { jobStatus: JobStatus.FAILED, itemCount: 0 },
+      { jobStatus: JobStatus.COMPLETE_WITH_ERRORS, itemCount: 0 },
+    ];
 
-      await buildWorkItem({
-        jobID: 'abc123',
-        serviceID,
-        status: WorkItemStatus.SUCCESSFUL,
-        workflowStepIndex: 1,
-      }).save(db);
+    for (const testParameters of testParametersList) {
+      const { jobStatus, itemCount } = testParameters;
 
-      await buildWorkItem({
-        jobID: 'abc123',
-        serviceID,
-        status: WorkItemStatus.FAILED,
-        workflowStepIndex: 1,
-      }).save(db);
-    });
+      describe(`with a job status of ${jobStatus}`, async function () {
+        before(async function () {
+          await createJobAndWorkItems(serviceID, jobStatus);
+        });
 
-    hookServiceMetrics(serviceID);
+        hookServiceMetrics(serviceID);
 
-    it('returns 200 status code', function () {
-      expect(this.res.statusCode).to.equal(200);
-    });
+        it('returns 200 status code', function () {
+          expect(this.res.statusCode).to.equal(200);
+        });
 
-    it('returns json content', function () {
-      expect(this.res.get('Content-Type')).to.equal('application/json; charset=utf-8');
-    });
+        it('returns json content', function () {
+          expect(this.res.get('Content-Type')).to.equal('application/json; charset=utf-8');
+        });
 
-    it('returns expected message', function () {
-      expect(JSON.stringify(this.res.body)).to.equal(JSON.stringify({ availableWorkItems: 3 }));
-    });
+        it('returns expected number of work items', function () {
+          expect(JSON.stringify(this.res.body)).to.equal(JSON.stringify({ availableWorkItems: itemCount }));
+        });
+      });
+    }
   });
-
 });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1237

## Description
Our metrics for our pod autoscalers to decide how many work items were ready for work include paused and previewing jobs meaning we were spinning up pods for work items that were not ready to be picked up (or in the case of previewing we only want one item to be worked). Remember that we always have one pod up for each service so the previewing jobs will still have a work item worked even with the metrics reporting that there are no work items available.

With indefinitely paused jobs (which we see a lot in UAT and production) this meant we always had pods running which had no work to pick up.

## Local Test Steps

1. Run `bin/deploy-hpa` to deploy the HPAs to your local k8s cluster.
2. Submit a large request for > 100 granules.
3. Observe the HPA metrics show that it recognizes there are more than 100 granules ready to work and watch a pod spin up.
4. Pause the job.
5. Observe the HPA metrics showing there are now 0 work items ready for that service (within 2 minutes).
6. Observe that the pods are spun back down to 1 (k8s will take a little over 5 minutes from the time the metric goes to 0).
7. Resume the job.
8. Watch the HPA metrics update and pods spin up.


## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)