### PR TITLE
agree to installing sqlite3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=node:16-buster
 FROM $BASE_IMAGE
-RUN apt update && apt-get install sqlite3
+RUN apt update && apt-get -y install sqlite3
 RUN mkdir -p /harmony
 COPY package.json package-lock.json lerna.json /harmony/
 RUN chown node -R /harmony


### PR DESCRIPTION
-------

## Jira Issue ID
None

## Description

I'm not sure what changed, but the node:buster-16 image that is downloading now errors when I'm trying to build harmony.

in the docker build step I see output

      => ERROR [ 2/11] RUN apt update && apt-get install sqlite3        4.4s

and

     #5 4.362 Do you want to continue? [Y/n] Abort.



## Local Test Steps

You should be able to run `nvm use && npm i && npm run build` successfully


## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)