### PR TITLE
HARMONY-1266: Reduce database locking time for query-cmr work items

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,1 +1,7 @@
-{}
+{
+  "1084448": {
+    "active": true,
+    "notes": "Ignoring issue with lerna dev dependency",
+    "expiry": "2022-10-15"
+  }
+}

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -411,7 +411,7 @@ export class Job extends DBRecord implements JobRecord {
       .select()
       .where(constraints.where)
       .orderBy(
-        constraints?.orderBy?.field ?? 'createdAt', 
+        constraints?.orderBy?.field ?? 'createdAt',
         constraints?.orderBy?.value ?? 'desc')
       .modify((queryBuilder) => {
         if (constraints.whereIn) {
@@ -518,6 +518,23 @@ export class Job extends DBRecord implements JobRecord {
       }
       return job;
     }
+  }
+
+  /**
+  * Returns the number of input granules for the given jobID
+  *
+  * @param tx - the database transaction to use for querying
+  * @param jobID - the jobID for the job that should be retrieved
+  * @param getLinks - if true include the job links when returning the job
+  * @param lock - if true lock the row in the jobs table
+  * @returns the Job with the given JobID or null if not found
+  */
+  static async getNumInputGranules(tx: Transaction, jobID: string): Promise<number> {
+    const results = await tx('jobs')
+      .select('numInputGranules')
+      .where({ jobID });
+
+    return results[0].numInputGranules;
   }
 
   /**

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -525,9 +525,7 @@ export class Job extends DBRecord implements JobRecord {
   *
   * @param tx - the database transaction to use for querying
   * @param jobID - the jobID for the job that should be retrieved
-  * @param getLinks - if true include the job links when returning the job
-  * @param lock - if true lock the row in the jobs table
-  * @returns the Job with the given JobID or null if not found
+  * @returns the number of input granules for the job
   */
   static async getNumInputGranules(tx: Transaction, jobID: string): Promise<number> {
     const results = await tx('jobs')

--- a/fixtures/cmr.uat.earthdata.nasa.gov-443/166326376631952362
+++ b/fixtures/cmr.uat.earthdata.nasa.gov-443/166326376631952362
@@ -1,0 +1,27 @@
+GET /search/collections.json?concept_id=C1233800302-EEDTEST&page_size=3
+accept: application/json
+accept-encoding: gzip,deflate
+
+HTTP/1.1 200 OK
+content-type: application/json;charset=utf-8
+connection: close
+date: Thu, 15 Sep 2022 17:42:46 GMT
+x-frame-options: SAMEORIGIN
+access-control-allow-origin: *
+x-xss-protection: 1; mode=block
+cmr-request-id: b14946e1-0352-4910-90a2-69999dc57308
+strict-transport-security: max-age=31536000
+cmr-search-after: ["harmony example data","EEDTEST","harmony_example","1",1233800302,2]
+cmr-hits: 1
+access-control-expose-headers: CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out, CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+x-content-type-options: nosniff
+cmr-took: 33
+x-request-id: FM0p4-vtP2cwEsnDpSRTqYzPVOikCQoWE0axnN8cbC5gXgAwgU1XKg==
+vary: Accept-Encoding, User-Agent
+server: ServerTokens ProductOnly
+x-cache: Miss from cloudfront
+via: 1.1 d64082f0604a4e84007fec84d28e9f32.cloudfront.net (CloudFront)
+x-amz-cf-pop: IAD79-C3
+x-amz-cf-id: FM0p4-vtP2cwEsnDpSRTqYzPVOikCQoWE0axnN8cbC5gXgAwgU1XKg==
+
+{"feed":{"updated":"2022-09-15T17:42:46.426Z","id":"https://cmr.uat.earthdata.nasa.gov:443/search/collections.json?concept_id=C1233800302-EEDTEST&page_size=3","title":"ECHO dataset metadata","entry":[{"cloud_hosted":false,"time_start":"1970-06-26T00:00:00.000Z","version_id":"1","updated":"2000-01-01T00:00:00.000Z","dataset_id":"Harmony Example Data","has_spatial_subsetting":true,"has_transforms":true,"associations":{"variables":["V1233801695-EEDTEST","V1233801696-EEDTEST","V1233801716-EEDTEST","V1233801717-EEDTEST"],"services":["S1237974227-EEDTEST","S1237980031-EEDTEST","S1237974711-EEDTEST"]},"has_variables":true,"data_center":"EEDTEST","short_name":"harmony_example","title":"Harmony Example Data","summary":"    A collection to use in testing Harmony whose data have the following attributes, useful in testing current    and future Harmony work, ensuring that results come back correctly, and that metadata is preserved.    1. Granule data is very small, under 1MB, often well under 1MB    2. Data follows the outlines of the continents, making visual inspection easy    3. Data follows a consistent gradient, with hue differing slightly by granule in sequential temporal order from       blue/purple (oldest) to red (newest)    4. Files have color interpretation set, allowing for color output, if services preserve it    5. Files have 4 variables / bands    6. Data bands have descriptions set    7. Files have custom metadata, HARMONY_HEX_COLOR, set to the central hex value of the file's gradient, and HARMONY_HUE, set to the numeric hue (0.0-1.0)    8. File names contain useful information about their sequential order, color, and contents    9. Granules with global extents exist, as well as granules which cover each continent, with corresponding metadata    10. Granule temporal aligns to full days (UTC) starting with January 1, 2020, with each file name starting with the numeric        julian date  ","service_features":{"harmony":{"has_formats":true,"has_variables":true,"has_transforms":true,"has_spatial_subsetting":true,"has_temporal_subsetting":false},"opendap":{"has_formats":false,"has_variables":false,"has_transforms":false,"has_spatial_subsetting":false,"has_temporal_subsetting":false},"esi":{"has_formats":false,"has_variables":false,"has_transforms":false,"has_spatial_subsetting":false,"has_temporal_subsetting":false}},"orbit_parameters":{},"id":"C1233800302-EEDTEST","has_formats":true,"original_format":"ECHO10","has_temporal_subsetting":false,"browse_flag":false,"platforms":[],"online_access_flag":false}]}}

--- a/fixtures/cmr.uat.earthdata.nasa.gov-443/166326376654863707
+++ b/fixtures/cmr.uat.earthdata.nasa.gov-443/166326376654863707
@@ -1,0 +1,27 @@
+GET /search/collections.json?include_tags=harmony.has-eula&concept_id=C1233800302-EEDTEST&page_size=3
+accept: application/json
+accept-encoding: gzip,deflate
+
+HTTP/1.1 200 OK
+content-type: application/json;charset=utf-8
+connection: close
+date: Thu, 15 Sep 2022 17:42:46 GMT
+x-frame-options: SAMEORIGIN
+access-control-allow-origin: *
+x-xss-protection: 1; mode=block
+cmr-request-id: ce1d5f68-aba3-4c8b-9a90-b8c6dd087eb6
+strict-transport-security: max-age=31536000
+cmr-search-after: ["harmony example data","EEDTEST","harmony_example","1",1233800302,2]
+cmr-hits: 1
+access-control-expose-headers: CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out, CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+x-content-type-options: nosniff
+cmr-took: 37
+x-request-id: v8M-RgngYW_oKcYwdCHRifiqZN7uCBo5FupuApEC-6xUetDRLrlIHg==
+vary: Accept-Encoding, User-Agent
+server: ServerTokens ProductOnly
+x-cache: Miss from cloudfront
+via: 1.1 fed66e6ba2cb68c8ee66c75c4798daf8.cloudfront.net (CloudFront)
+x-amz-cf-pop: IAD79-C3
+x-amz-cf-id: v8M-RgngYW_oKcYwdCHRifiqZN7uCBo5FupuApEC-6xUetDRLrlIHg==
+
+{"feed":{"updated":"2022-09-15T17:42:46.652Z","id":"https://cmr.uat.earthdata.nasa.gov:443/search/collections.json?include_tags=harmony.has-eula&concept_id=C1233800302-EEDTEST&page_size=3","title":"ECHO dataset metadata","entry":[{"cloud_hosted":false,"tags":{"harmony.has-eula":{"data":false}},"time_start":"1970-06-26T00:00:00.000Z","version_id":"1","updated":"2000-01-01T00:00:00.000Z","dataset_id":"Harmony Example Data","has_spatial_subsetting":true,"has_transforms":true,"associations":{"variables":["V1233801695-EEDTEST","V1233801696-EEDTEST","V1233801716-EEDTEST","V1233801717-EEDTEST"],"services":["S1237974227-EEDTEST","S1237980031-EEDTEST","S1237974711-EEDTEST"]},"has_variables":true,"data_center":"EEDTEST","short_name":"harmony_example","title":"Harmony Example Data","summary":"    A collection to use in testing Harmony whose data have the following attributes, useful in testing current    and future Harmony work, ensuring that results come back correctly, and that metadata is preserved.    1. Granule data is very small, under 1MB, often well under 1MB    2. Data follows the outlines of the continents, making visual inspection easy    3. Data follows a consistent gradient, with hue differing slightly by granule in sequential temporal order from       blue/purple (oldest) to red (newest)    4. Files have color interpretation set, allowing for color output, if services preserve it    5. Files have 4 variables / bands    6. Data bands have descriptions set    7. Files have custom metadata, HARMONY_HEX_COLOR, set to the central hex value of the file's gradient, and HARMONY_HUE, set to the numeric hue (0.0-1.0)    8. File names contain useful information about their sequential order, color, and contents    9. Granules with global extents exist, as well as granules which cover each continent, with corresponding metadata    10. Granule temporal aligns to full days (UTC) starting with January 1, 2020, with each file name starting with the numeric        julian date  ","service_features":{"harmony":{"has_formats":true,"has_variables":true,"has_transforms":true,"has_spatial_subsetting":true,"has_temporal_subsetting":false},"opendap":{"has_formats":false,"has_variables":false,"has_transforms":false,"has_spatial_subsetting":false,"has_temporal_subsetting":false},"esi":{"has_formats":false,"has_variables":false,"has_transforms":false,"has_spatial_subsetting":false,"has_temporal_subsetting":false}},"orbit_parameters":{},"id":"C1233800302-EEDTEST","has_formats":true,"original_format":"ECHO10","has_temporal_subsetting":false,"browse_flag":false,"platforms":[],"online_access_flag":false}]}}

--- a/test/ignore-errors.ts
+++ b/test/ignore-errors.ts
@@ -532,6 +532,15 @@ describe('when setting ignoreErrors=true', function () {
   });
 
   describe('When a request spans multiple CMR pages', function () {
+    let pageStub;
+    before(function () {
+      pageStub = stub(env, 'cmrMaxPageSize').get(() => 3);
+    });
+    after(function () {
+      if (pageStub.restore) {
+        pageStub.restore();
+      }
+    });
     hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery, ...{ maxResults: 5 } } });
     hookRedirect('joe');
 
@@ -540,6 +549,7 @@ describe('when setting ignoreErrors=true', function () {
       let workItemJobID;
 
       before(async function () {
+        stub(env, 'cmrMaxPageSize').get(() => 3);
         const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
         const { workItem } = JSON.parse(res.text);
         workItemJobID = workItem.jobID;


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1266

## Description
Changes the way harmony determines the number of granules to request back from the CMR for each query-cmr task to only database queries without having to potentially read many files from S3 to determine how many granules are left to process.

## Local Test Steps

Set CMR_MAX_PAGE_SIZE to a small number like 3 and submit a request that will cause multiple calls to CMR to execute. Make sure the last page size should be something other than CMR_MAX_PAGE_SIZE to verify the calculation is correct for the last item.

For example with 3 I might request 8 granules back which results in 3, 3, and 2 items for the 3 query-cmr requests. Here's an example request:

http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(20%3A80)&subset=lon(-140%3A0)&outputCrs=EPSG%3A4326&format=image%2Fpng&ignoreErrors=true&maxResults=8

I ran a workload run in sandbox to make sure this didn't have any issues.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)