### PR TITLE
HARMONY-1259: Change service runner to run as root so /tmp cleanup works

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "harmony",
       "version": "0.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/tasks/service-runner/Dockerfile
+++ b/tasks/service-runner/Dockerfile
@@ -8,7 +8,5 @@ RUN mkdir -p /tmp/metadata
 COPY built env-defaults package.json package-lock.json /service-runner/
 WORKDIR /service-runner
 RUN npm ci
-RUN chown -R node /service-runner
-USER node
 
 ENTRYPOINT [ "node", "tasks/service-runner/app/server.js"]

--- a/tasks/service-runner/package-lock.json
+++ b/tasks/service-runner/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "service-runner",
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1259

## Description
Changes service runner Docker file to not create the `node` user. This forces things to run as `root`, which is not great,
but seems like the best solution to allow us to clean up the shared mount point at /tmp. This was failing because
the worker images often use `root` as the user, so files written out are owned by root and can't be cleaned up on the
manager by the `node` user.

## Local Test Steps
1. Rebuild the service-manager (npm run build in tasks/service_manager)
2. use kubectl or k9s to connect to the manager container
3. verify that the manager is running as root
4. Execute some harmony queries to make sure they still work

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~