### PR TITLE
HARMONY-1285: Track the user IP address in request metrics

### DIFF
--- a/app/backends/service-invoker.ts
+++ b/app/backends/service-invoker.ts
@@ -1,5 +1,4 @@
 import { RequestHandler, Response } from 'express';
-import { getRequestRoot, getRequestUrl } from '../util/url';
 import * as services from '../models/services/index';
 import { objectStoreForProtocol } from '../util/object-store';
 import { ServiceError } from '../util/errors';
@@ -79,7 +78,7 @@ export default async function serviceInvoker(
     component: `${service.constructor.name}`,
   });
   try {
-    serviceResult = await service.invoke(serviceLogger, getRequestRoot(req), getRequestUrl(req));
+    serviceResult = await service.invoke(req, serviceLogger);
     await translateServiceResult(serviceResult, req.operation.user, res);
   } finally {
     if (serviceResult && serviceResult.onComplete) {

--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -216,7 +216,7 @@ export default abstract class BaseService<ServiceParamType> {
     await this._createAndSaveWorkflow(job);
 
     const { isAsync, requestId } = job;
-    const requestMetric = getRequestMetric(this.operation, this.config.name);
+    const requestMetric = getRequestMetric(req, this.operation, this.config.name);
     logger.info(`Request metric for request ${requestId}`, { requestMetric: true, ...requestMetric } );
     this.operation.callback = `${env.callbackUrlRoot}/service/${requestId}`;
     return new Promise((resolve, reject) => {

--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -12,6 +12,8 @@ import db from '../../util/db';
 import env from '../../util/env';
 import { WorkItemStatus } from '../work-item-interface';
 import { getRequestMetric } from '../../util/metrics';
+import { getRequestUrl } from '../../util/url';
+import HarmonyRequest from '../harmony-request';
 
 export interface ServiceCapabilities {
   concatenation?: boolean;
@@ -206,13 +208,11 @@ export default abstract class BaseService<ServiceParamType> {
    *
    * @returns A promise resolving to the result of the callback.
    */
-  async invoke(
-    logger?: Logger, harmonyRoot?: string, requestUrl?: string,
-  ): Promise<InvocationResult> {
+  async invoke(req: HarmonyRequest, logger?: Logger): Promise<InvocationResult> {
     this.logger = logger;
     logger.info('Invoking service for operation', { operation: this.operation });
     // TODO handle the skipPreview parameter here when implementing HARMONY-1129
-    const job = this._createJob(requestUrl);
+    const job = this._createJob(getRequestUrl(req));
     await this._createAndSaveWorkflow(job);
 
     const { isAsync, requestId } = job;

--- a/app/models/services/no-op-service.ts
+++ b/app/models/services/no-op-service.ts
@@ -1,4 +1,6 @@
 import { Logger } from 'winston';
+import { getRequestRoot, getRequestUrl } from '../../util/url';
+import HarmonyRequest from '../harmony-request';
 import { Job, JobStatus } from '../job';
 import BaseService from './base-service';
 import InvocationResult from './invocation-result';
@@ -38,12 +40,12 @@ export default class NoOpService extends BaseService<void> {
   /**
    * Generates a response with a list of download links as provided by the CMR.
    *
-   * @param logger - The logger associated with this request
-   * @param harmonyRoot - The harmony root URL
+   * @param req - The harmony request
+   * @param _logger - The logger associated with this request (unused)
    * @param requestUrl - The URL the end user invoked
    * @returns a promise with the Job status response
    */
-  async invoke(_logger, harmonyRoot, requestUrl): Promise<InvocationResult> {
+  async invoke(req: HarmonyRequest, _logger): Promise<InvocationResult> {
     const now = new Date();
     const granuleLists = this.operation.sources.map((source) => source.granules);
     const granules = granuleLists.reduce((acc, val) => acc.concat(val), []);
@@ -59,10 +61,10 @@ export default class NoOpService extends BaseService<void> {
       message: this.message,
       collectionIds: this.operation.collectionIds,
       links,
-      request: requestUrl,
+      request: getRequestUrl(req),
       numInputGranules: this.operation.cmrHits,
     });
-    const serializedJob = job.serialize(harmonyRoot);
+    const serializedJob = job.serialize(getRequestRoot(req));
     // No-op service response should look like a job, but doesn't actually create one
     // so do not include a jobID in the response.
     delete serializedJob.jobID;

--- a/app/util/metrics.ts
+++ b/app/util/metrics.ts
@@ -102,7 +102,7 @@ export function getRequestMetric(
   const rangeBeginDateTime = operation.temporal?.start;
   const rangeEndDateTime = operation.temporal?.end;
   const headers = req?.headers;
-  const forwardedHeader = headers ? headers['x-forwarded-for'] as unknown as string : '';
+  const forwardedHeader = headers ? headers['x-forwarded-for'] as string : '';
   const user_ip = forwardedHeader?.split(',')[0];
 
   const metric: RequestMetric = {

--- a/app/util/metrics.ts
+++ b/app/util/metrics.ts
@@ -24,8 +24,6 @@ export interface RequestMetric {
   referrer_request_id?: string; // We do not have this information
   request_id: string;
   user_id: string;
-  // We do not have the user_ip information, but the metrics team needs it set to a blank string
-  // rather than omitting it
   user_ip: string;
   rangeBeginDateTime?: string;
   rangeEndDateTime?: string;

--- a/app/util/metrics.ts
+++ b/app/util/metrics.ts
@@ -3,6 +3,7 @@
 // See https://wiki.earthdata.nasa.gov/display/METS/Data+Schema+Collaboration+Space
 
 import DataOperation from '../models/data-operation';
+import HarmonyRequest from '../models/harmony-request';
 import { Job } from '../models/job';
 import { isFailureStatus } from './job';
 
@@ -95,13 +96,18 @@ function constructBboxFromOperation(operation: DataOperation): BboxMetric {
  *
  * @returns the request metric
  */
-export function getRequestMetric(operation: DataOperation, serviceName: string): RequestMetric {
+export function getRequestMetric(
+  req: HarmonyRequest, operation: DataOperation, serviceName: string,
+): RequestMetric {
   const rangeBeginDateTime = operation.temporal?.start;
   const rangeEndDateTime = operation.temporal?.end;
+  const headers = req?.headers;
+  const forwardedHeader = headers ? headers['x-forwarded-for'] as unknown as string : '';
+  const user_ip = forwardedHeader?.split(',')[0];
 
   const metric: RequestMetric = {
     request_id: operation.requestId,
-    user_ip: '',
+    user_ip: user_ip || '',
     user_id: operation.user,
     parameters: { service_name: serviceName },
   };


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1285

## Description
Track the user IP address in request metrics

## Local Test Steps
I looked at Kibana logs in SIT, UAT, and Production after hitting some harmony endpoints. I found my IP address logged in the req['headers']['x-forwarded-for'] field. That field was a string with 3 comma separated IP addresses with the first being my own in each example I looked at. Unfortunately we do not use CloudFront in sandbox or locally and so I have no real way to test this PR until it gets to SIT. 

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)