### PR TITLE
HARMONY-1248: Handle output files with spaces in the output filename

### DIFF
--- a/app/util/object-store.ts
+++ b/app/util/object-store.ts
@@ -22,7 +22,7 @@ interface BucketParams {
 
 /**
  * Read a stream into a string
- * 
+ *
  * @param readableStream - The stream to read
  * @returns A string containing the contents of the stream
  */
@@ -90,7 +90,7 @@ export class S3ObjectStore {
     }
     const object = {
       Bucket: url.hostname,
-      Key: url.pathname.substr(1), // Nuke leading "/"
+      Key: url.pathname.substr(1).replaceAll('%20', ' '), // Nuke leading "/" and convert %20 to spaces
     };
 
     // Verifies that the object exists, or throws NotFound
@@ -145,7 +145,7 @@ export class S3ObjectStore {
 
   /**
    * List all of the object keys for the given prefix.
-   * 
+   *
    * @param paramsOrUrl - a map of parameters (Bucket, Key) indicating the objects to
    *   be retrieved or the object URL
    * @returns a promise resolving to a list of s3 object keys (strings)

--- a/tasks/giovanni-adapter/tsconfig.json
+++ b/tasks/giovanni-adapter/tsconfig.json
@@ -6,7 +6,7 @@
         "@harmony/*": ["../../app/*"]
       },
       "moduleResolution": "node",
-      "target": "ES2019",
+      "target": "ES2021",
       "esModuleInterop": true,
       "allowJs": true,
       "noImplicitAny": false,

--- a/tasks/query-cmr/tsconfig.json
+++ b/tasks/query-cmr/tsconfig.json
@@ -6,7 +6,7 @@
         "@harmony/*": ["../../app/*"]
       },
       "moduleResolution": "node",
-      "target": "ES2019",
+      "target": "ES2021",
       "esModuleInterop": true,
       "allowJs": true,
       "noImplicitAny": false,

--- a/tasks/service-runner/tsconfig.json
+++ b/tasks/service-runner/tsconfig.json
@@ -4,7 +4,7 @@
       "module": "commonjs",
       "baseUrl": ".",
       "moduleResolution": "node",
-      "target": "ES2019",
+      "target": "ES2021",
       "esModuleInterop": true,
       "allowJs": true,
       "noImplicitAny": false,

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,7 +3,7 @@
       "module": "commonjs",
       "baseUrl": ".",
       "moduleResolution": "node",
-      "target": "ES2019",
+      "target": "ES2021",
       "esModuleInterop": true,
       "allowJs": true,
       "noImplicitAny": false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
       "module": "commonjs",
       "baseUrl": ".",
       "moduleResolution": "node",
-      "target": "ES2019",
+      "target": "ES2021",
       "esModuleInterop": true,
       "allowJs": true,
       "noImplicitAny": false,


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1248

## Description
Handle output files with spaces in the output filename.

## Local Test Steps
Test the request from the ticket:

http://localhost:3000/C1215720341-GES_DISC/ogc-api-coverages/1.0.0/collections/%2FHDFEOS%2FSWATHS%2FOMI%20Total%20Column%20Amount%20SO2%2FData%20Fields%2FCloudFraction/coverage/rangeset?forceAsync=true&subset=lat(-80%3A80)&subset=lon(-180%3A180)&maxResults=1

First test from main and verify you get a 404 when trying to retrieve the output file. Then start harmony from this branch and verify you can retrieve the output file and it opens fine in Panoply.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)