### PR TITLE
DAS-1608 - Update HOSS entries in services.yml.

### DIFF
--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -20,6 +20,7 @@ export interface ServiceCapabilities {
   concatenate_by_default?: boolean;
   subsetting?: {
     bbox?: boolean;
+    shape?: boolean;
     variable?: boolean;
     multiple_variable?: true;
   };
@@ -99,6 +100,7 @@ const conditionToOperationField = {
   reproject: 'crs',
   reformat: 'outputFormat',
   variableSubset: 'shouldVariableSubset',
+  shapefileSubset: 'shouldShapefileSubset',
   spatialSubset: 'shouldSpatialSubset',
   temporalSubset: 'shouldTemporalSubset',
   concatenate: 'shouldConcatenate',

--- a/bin/update-harmony
+++ b/bin/update-harmony
@@ -78,7 +78,7 @@ while read -r line; do
 done < <(sort <(echo "${referenced_images[*]}") <(echo "${pulled_images[*]}") | uniq -d)
 
 # always reload the harmony image and the query-cmr image
-all_images+=( "harmonyservices/harmony:latest" "harmonyservices/query-cmr:latest" )
+all_images+=( "harmonyservices/harmony:latest" "harmonyservices/query-cmr:latest" "harmonyservices/service-runner:latest" )
 
 for image in ${all_images[@]}; do
   echo "${image}"

--- a/bin/update-harmony
+++ b/bin/update-harmony
@@ -77,7 +77,7 @@ while read -r line; do
   all_images+=( "$line" )
 done < <(sort <(echo "${referenced_images[*]}") <(echo "${pulled_images[*]}") | uniq -d)
 
-# always reload the harmony image and the query-cmr image
+# always reload the harmony image, query-cmr and service-runner images
 all_images+=( "harmonyservices/harmony:latest" "harmonyservices/query-cmr:latest" "harmonyservices/service-runner:latest" )
 
 for image in ${all_images[@]}; do

--- a/config/services.yml
+++ b/config/services.yml
@@ -329,34 +329,6 @@ https://cmr.earthdata.nasa.gov:
         conditional:
           exists: ['concatenate']
 
-  - name: sds/HOSS
-    # HOSS provides variable and bounding box spatial subsetting (geographically gridded collections)
-    data_operation_version: '0.17.0'
-    type:
-      <<: *default-turbo-config
-      params:
-        <<: *default-turbo-params
-        env:
-          <<: *default-turbo-env
-          STAGING_PATH: public/sds/HOSS
-    umm_s:
-      - S2164732315-XYZ_PROV
-      - S2378172160-ORNL_CLOUD
-    #   - Add GES-DISC production UMM-S record here.
-    collections: []
-    capabilities:
-      subsetting:
-        bbox: true
-        variable: true
-        dimension: true
-      output_formats:
-        - application/netcdf # Incorrect mime-type, remove when no longer needed
-        - application/x-netcdf4
-    steps:
-      - image: !Env ${QUERY_CMR_IMAGE}
-      - image: !Env ${VAR_SUBSETTER_IMAGE}
-        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset']
-
   - name: sds/trajectory-subsetter
     data_operation_version: '0.17.0'
     type:
@@ -381,9 +353,42 @@ https://cmr.earthdata.nasa.gov:
       - image: !Env ${TRAJECTORY_SUBSETTER_IMAGE}
         operations: ['variableSubset', 'spatialSubset', 'shapefileSubset']
 
-  - name: sds/HOSS-maskfill
-    # Provides polygon spatial subsetting for collections hosted in OPeNDAP
-    # Also provides variable and temporal subsetting through HOSS.
+  - name: sds/HOSS-geographic
+    # Provides variable, temporal, bounding box spatial and polygon spatial
+    # subsetting for geographically gridded collections hosted in OPeNDAP.
+    data_operation_version: '0.17.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/sds/HOSS
+    umm_s:
+      - S2164732315-XYZ_PROV
+      - S2378172160-ORNL_CLOUD
+    collections: []
+    capabilities:
+      subsetting:
+        bbox: true
+        dimension: true
+        shape: true
+        variable: true
+      output_formats:
+        - application/netcdf # Incorrect mime-type, remove when no longer needed
+        - application/x-netcdf4
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+      - image: !Env ${VAR_SUBSETTER_IMAGE}
+        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset']
+      - image: !Env ${SDS_MASKFILL_IMAGE}
+        operations: ['shapefileSubset']
+        conditional:
+          exists: ['shapefileSubset']
+
+  - name: sds/HOSS-projection-gridded
+    # Provides variable, temporal, bounding box spatial and polygon spatial
+    # subsetting for projection gridded collections hosted in OPeNDAP.
     data_operation_version: '0.17.0'
     type:
       <<: *default-turbo-config
@@ -410,6 +415,8 @@ https://cmr.earthdata.nasa.gov:
         operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset']
       - image: !Env ${SDS_MASKFILL_IMAGE}
         operations: ['shapefileSubset', 'spatialSubset']
+        conditional:
+          exists: ['shapefileSubset', 'spatialSubset']
 
   # OPS GDAL
   - name: nasa/harmony-gdal-adapter
@@ -687,6 +694,7 @@ https://cmr.uat.earthdata.nasa.gov:
     capabilities:
       subsetting:
         bbox: false
+        shape: false
         variable: true
       output_formats:
         - application/netcdf # Incorrect mime-type, remove when no longer needed
@@ -695,34 +703,6 @@ https://cmr.uat.earthdata.nasa.gov:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${VAR_SUBSETTER_IMAGE}
         operations: ['variableSubset']
-
-  - name: sds/HOSS
-    # HOSS provides variable and bounding box spatial subsetting (geographically gridded collections)
-    data_operation_version: '0.17.0'
-    type:
-      <<: *default-turbo-config
-      params:
-        <<: *default-turbo-params
-        env:
-          <<: *default-turbo-env
-          STAGING_PATH: public/sds/HOSS
-    umm_s:
-      - S1240682712-EEDTEST
-      - S1241070355-GES_DISC # GESDISC_HOSS
-      - S1246887053-ORNL_CLOUD
-    collections: []
-    capabilities:
-      subsetting:
-        bbox: true
-        variable: true
-        dimension: true
-      output_formats:
-        - application/netcdf # Incorrect mime-type, remove when no longer needed
-        - application/x-netcdf4
-    steps:
-      - image: !Env ${QUERY_CMR_IMAGE}
-      - image: !Env ${VAR_SUBSETTER_IMAGE}
-        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset']
 
   - name: sds/maskfill
     data_operation_version: '0.17.0'
@@ -1016,9 +996,43 @@ https://cmr.uat.earthdata.nasa.gov:
         conditional:
           format: ['application/x-zarr']
 
-  - name: sds/HOSS-maskfill
-    # Provides polygon spatial subsetting for collections hosted in OPeNDAP
-    # Also provides variable and temporal subsetting through HOSS.
+  - name: sds/HOSS-geographic
+    # Provides variable, temporal, bounding box spatial and polygon spatial
+    # subsetting for geographically gridded collections hosted in OPeNDAP.
+    data_operation_version: '0.17.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/sds/HOSS
+    umm_s:
+      - S1240682712-EEDTEST
+      - S1241070355-GES_DISC # GESDISC_HOSS
+      - S1246887053-ORNL_CLOUD
+    collections: []
+    capabilities:
+      subsetting:
+        bbox: true
+        dimension: true
+        shape: true
+        variable: true
+      output_formats:
+        - application/netcdf # Incorrect mime-type, remove when no longer needed
+        - application/x-netcdf4
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+      - image: !Env ${VAR_SUBSETTER_IMAGE}
+        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset']
+      - image: !Env ${SDS_MASKFILL_IMAGE}
+        operations: ['shapefileSubset']
+        conditional:
+          exists: ['shapefileSubset']
+
+  - name: sds/HOSS-projection-gridded
+    # Provides variable, temporal, bounding box spatial and polygon spatial
+    # subsetting for projection gridded collections hosted in OPeNDAP.
     data_operation_version: '0.17.0'
     type:
       <<: *default-turbo-config
@@ -1029,8 +1043,7 @@ https://cmr.uat.earthdata.nasa.gov:
           STAGING_PATH: public/sds/HOSS
     umm_s:
       - S1245117629-EEDTEST
-    collections:
-      - id: C1222931739-GHRC_CLOUD
+    collections: []
     capabilities:
       subsetting:
         bbox: true
@@ -1046,3 +1059,5 @@ https://cmr.uat.earthdata.nasa.gov:
         operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset']
       - image: !Env ${SDS_MASKFILL_IMAGE}
         operations: ['shapefileSubset', 'spatialSubset']
+        conditional:
+          exists: ['shapefileSubset', 'spatialSubset']

--- a/config/services.yml
+++ b/config/services.yml
@@ -363,7 +363,7 @@ https://cmr.earthdata.nasa.gov:
         <<: *default-turbo-params
         env:
           <<: *default-turbo-env
-          STAGING_PATH: public/sds/HOSS
+          STAGING_PATH: public/sds/HOSS-geographic
     umm_s:
       - S2164732315-XYZ_PROV
       - S2378172160-ORNL_CLOUD
@@ -396,7 +396,7 @@ https://cmr.earthdata.nasa.gov:
         <<: *default-turbo-params
         env:
           <<: *default-turbo-env
-          STAGING_PATH: public/sds/HOSS
+          STAGING_PATH: public/sds/HOSS-projection-gridded
     umm_s:
       - S2300730272-XYZ_PROV
     collections: []
@@ -1006,7 +1006,7 @@ https://cmr.uat.earthdata.nasa.gov:
         <<: *default-turbo-params
         env:
           <<: *default-turbo-env
-          STAGING_PATH: public/sds/HOSS
+          STAGING_PATH: public/sds/HOSS-geographic
     umm_s:
       - S1240682712-EEDTEST
       - S1241070355-GES_DISC # GESDISC_HOSS
@@ -1040,7 +1040,7 @@ https://cmr.uat.earthdata.nasa.gov:
         <<: *default-turbo-params
         env:
           <<: *default-turbo-env
-          STAGING_PATH: public/sds/HOSS
+          STAGING_PATH: public/sds/HOSS-projection-gridded
     umm_s:
       - S1245117629-EEDTEST
     collections: []

--- a/test/versions.ts
+++ b/test/versions.ts
@@ -29,14 +29,14 @@ describe('Versions endpoint', function () {
           'podaac/l2-subsetter-concise',
           'sds/swot-reproject',
           'sds/variable-subsetter',
-          'sds/HOSS',
           'sds/maskfill',
           'sds/trajectory-subsetter',
           'harmony/netcdf-to-zarr',
           'nasa/harmony-gdal-adapter',
           'harmony/podaac-l2-subsetter-netcdf-to-zarr',
           'harmony/swot-repr-netcdf-to-zarr',
-          'sds/HOSS-maskfill',
+          'sds/HOSS-geographic',
+          'sds/HOSS-projection-gridded',
         ]);
       });
 


### PR DESCRIPTION
## Jira Issue ID

DAS-1608

## Description

This PR makes better use of conditions for chained service steps such that DAACs need only associate against one service per collection for HOSS:

* sds/HOSS-geographic - For L3/L4 data with a geographic grid.
* sds/HOSS-projection-gridded - For L3/L4 data with a non-geographic grid.
* sds/variable-subsetter - For non-gridded collections that still want variable subsetting only.

One thing this PR does not do is remove duplicated UMM-S entries for these services. I'll contact the UMM-S record curators involved to allow them to decide what they want to do with their records.

## Local Test Steps

* Pull this branch.
* Build the Harmony image: `npm run build`. (There are a couple of necessary tweaks to Harmony itself, too)
* Run `./bin/bootstrap-harmony` to start a local instance of Harmony.
* Run through the Variable Subsetter and HOSS tests in the [SDS Regression test notebook](https://github.com/nasa/harmony-regression-tests/blob/main/test/sds/SDS_Regression.ipynb).
* In the `/workflow-ui` endpoint, check that each request used the correct service chain (e.g., look in the logs for any of the steps and check for the staging bucket name. Geographic requests will go to `local-staging-bucket/public/sds/HOSS-geographic/{job ID}`, while projection-gridded requests will go to `local-staging-bucket/public/sds/HOSS-projection-gridded/{job ID}`.
* In the `/workflow-ui` endpoint, check that only shape file subsets trigger a MaskFill step for geographic collections.
* In the `/workflow-ui` endpoint, check that bounding box and shape file subsets both trigger a MaskFill step for projection-gridded collections.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing (I didn't see anywhere obvious for the `shapefileSubset` changes)
* ~~Documentation updated (if needed)~~