### PR TITLE
HARMONY-1260 and HARMONY-1268: Docs fix and increased timeout for backend service metrics

### DIFF
--- a/env-defaults
+++ b/env-defaults
@@ -306,13 +306,11 @@ GIOVANNI_ADAPTER_INVOCATION_ARGS='node tasks/giovanni-adapter/app/cli'
 
 # The services to deploy locally. A comma-separated list of services that the bin/deploy-services
 # script should attempt to deploy. By default only a couple of harmony example services are deployed.
-# When specifying another service to be deployed make sure the name matches the prefix for the
-# sidecar file in tasks/service-runner-config and the name of the service in that file. For example
-# to deploy the SWOT reprojection service which has a sidecar file swot-reproject-sidecar.yaml
-# and service-name of swot-reproject, specify swot-reproject. query-cmr is required for all services,
-# so it will always be deployed, and does not need to be specified. Make sure if the image for the
-# service is not publicly available that you have built the docker image locally, otherwise the
-# service will fail to start.
+# When specifying another service to be deployed make sure the name matches the lower and dash case
+# prefix for the image variable name. For example to deploy the Giovanni adapter image which has
+# a variable name of GIOVANNI_ADAPTER_IMAGE you would specify giovanni-adapter (converting to lowercase
+# and dash case and dropping _IMAGE. Make sure if the image for the service is not publicly available
+# that you have built the docker image locally, otherwise the service will fail to start.
 LOCALLY_DEPLOYED_SERVICES=harmony-service-example,harmony-netcdf-to-zarr
 
 # page size to use with CMR calls

--- a/tasks/service-runner/app/routers/router.ts
+++ b/tasks/service-runner/app/routers/router.ts
@@ -2,7 +2,6 @@ import express, { NextFunction } from 'express';
 import { generateMetricsForPrometheus } from '../service/service-metrics';
 import env from '../util/env';
 import axios from 'axios';
-import logger from '../../../../app/util/log';
 
 /**
  *

--- a/tasks/service-runner/app/routers/router.ts
+++ b/tasks/service-runner/app/routers/router.ts
@@ -2,6 +2,7 @@ import express, { NextFunction } from 'express';
 import { generateMetricsForPrometheus } from '../service/service-metrics';
 import env from '../util/env';
 import axios from 'axios';
+import logger from '../../../../app/util/log';
 
 /**
  *

--- a/tasks/service-runner/app/service/service-metrics.ts
+++ b/tasks/service-runner/app/service/service-metrics.ts
@@ -2,6 +2,7 @@ import { Response, Request, NextFunction } from 'express';
 import axios from 'axios';
 import env from '../util/env';
 import { keepAliveAgent } from '../util/axios-clients';
+import logger from '../../../../app/util/log';
 
 /**
  * Get prometheus-compatible metric message from harmony backend
@@ -10,8 +11,7 @@ import { keepAliveAgent } from '../util/axios-clients';
  */
 async function _getHarmonyMetric(serviceID: string): Promise<string> {
 
-  const timeout = 3_000; // Wait up to 3 seconds for the server to start sending
-
+  const timeout = 60_000; // Wait up to one minute for the harmony backend server to respond
   const workUrl = `http://${env.backendHost}:${env.backendPort}/service/metrics`;
   const response = await axios
     .get(workUrl, {
@@ -55,6 +55,7 @@ export async function generateMetricsForPrometheus(
     // Send response
     res.send(metric_message);
   } catch (e) {
+    logger.error('Failed to query harmony backend for service metrics.');
     next(e);
   }
 }


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1260 and HARMONY-1268

## Description
Fixes the documentation for the LOCALLY_DEPLOYED_SERVICES variable. Changes the backend metrics service timeout.

## Local Test Steps
Build the service runner image - `cd tasks/service-runner && npm run build`
Restart services - `bin/restart-services`
Add `await sleep(90000);` to `getEligibleWorkItemCountForServiceID` and restart harmony locally
Tail the logs for one of the services and verify you see:

```
2022-10-05T20:25:54.205Z [error]: Failed to query harmony backend for service metrics.
Error: timeout of 60000ms exceeded
    at createError (/service-runner/node_modules/axios/lib/core/createError.js:16:15)
    at RedirectableRequest.handleRequestTimeout (/service-runner/node_modules/axios/lib/adapters/http.js:328:16)
    at RedirectableRequest.emit (node:events:513:28)
    at RedirectableRequest.emit (node:domain:489:12)
    at Timeout.<anonymous> (/service-runner/node_modules/follow-redirects/index.js:164:12)
    at listOnTimeout (node:internal/timers:559:17)
    at processTimers (node:internal/timers:502:7)
```

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)