### PR TITLE
Harmony 1204 - Handle JSON service logs properly

### DIFF
--- a/tasks/service-runner/app/service/service-runner.ts
+++ b/tasks/service-runner/app/service/service-runner.ts
@@ -63,6 +63,13 @@ export class LogStream extends stream.Writable {
     try {
       const logObj: object = JSON.parse(logStr);
       this.logStrArr.push(logObj);
+      for (const propertyName of ['timestamp', 'level']) {
+        if (propertyName in logObj) {
+          const upperCasedPropName = propertyName[0].toUpperCase() + propertyName.substring(1);
+          logObj[`worker${upperCasedPropName}`] = logObj[propertyName];
+          delete logObj[propertyName];
+        }
+      }
       this.streamLogger.debug({ ...logObj, worker: true });
     } catch (e) {
       if (e instanceof SyntaxError) { // string log

--- a/tasks/service-runner/app/service/service-runner.ts
+++ b/tasks/service-runner/app/service/service-runner.ts
@@ -7,6 +7,7 @@ import { resolve as resolveUrl } from '../../../../app/util/url';
 import { objectStoreForProtocol } from '../../../../app/util/object-store';
 import { WorkItemRecord, getStacLocation, getItemLogsLocation } from '../../../../app/models/work-item-interface';
 import axios from 'axios';
+import { Logger } from 'winston';
 
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
@@ -26,33 +27,49 @@ const { workerTimeout } = env;
 
 /**
  * A writable stream that is passed to the k8s exec call for the worker container.
- * Allows us to capture, log and store the logs of the worker container's execution.
+ * Captures, logs and stores the logs of the worker container's execution.
  */
-class LogStream extends stream.Writable {
+export class LogStream extends stream.Writable {
   
+  // logs each chunk received
+  streamLogger: Logger;
+
   // all of the logs that are written
   // to this stream (gets uploaded to s3)
   logStrArr = [];
   
   aggregateLogStr = (): string => this.logStrArr.join();
 
+  constructor(streamLogger: Logger = logger) {
+    super();
+    this.streamLogger = streamLogger;
+  }
+
   /**
-   * Parse the log chunk (service log), push it to the logs array, and log it.
-   * @param chunk - the chunk to log (could emanate from a string or JSON logger) 
+   * Write a chunk to the log stream.
+   * @param chunk - the chunk recieved by the stream (likely a Buffer)
    */
   _write(chunk, enc: BufferEncoding, next: (error?: Error | null) => void): void {
     const logStr: string = chunk.toString('utf8');
+    this._handleLogString(logStr);
+    next();
+  }
+
+  /**
+   * Parse the log chunk (if JSON), push it to the logs array, and log it.
+   * @param logStr - the string to log (could emanate from a text or JSON logger) 
+   */
+  _handleLogString(logStr: string): void {
     try {
       const logObj: object = JSON.parse(logStr);
       this.logStrArr.push(logObj);
-      logger.debug({ ...logObj, worker: true });
+      this.streamLogger.debug({ ...logObj, worker: true });
     } catch (e) {
       if (e instanceof SyntaxError) { // string log
         this.logStrArr.push(logStr);
-        logger.debug(logStr, { worker: true });
+        this.streamLogger.debug(logStr, { worker: true });
       }
     }
-    next();
   }
 }
 

--- a/tasks/service-runner/app/workers/pull-worker.ts
+++ b/tasks/service-runner/app/workers/pull-worker.ts
@@ -168,8 +168,6 @@ async function _pullAndDoWork(repeat = true): Promise<void> {
       logger.debug(`Performing work for work item with id ${work.item.id} for job id ${work.item.jobID}`);
       const workItem = await _doWork(work.item, work.maxCmrGranules);
       workItem.duration = Date.now() - startTime;
-      logger.debug(JSON.stringify(workItem.outputGranuleSizes));
-      logger.debug(JSON.stringify(workItem));
       // call back to Harmony to mark the work unit as complete or failed
       logger.debug(`Sending response to Harmony for results of work item with id ${workItem.id} for job id ${workItem.jobID}`);
       try {

--- a/tasks/service-runner/test/service-runner.ts
+++ b/tasks/service-runner/test/service-runner.ts
@@ -6,7 +6,6 @@ import { objectStoreForProtocol } from '../../../app/util/object-store';
 import * as serviceRunner from '../app/service/service-runner';
 import { resolve } from '../../../app/util/url';
 import { createLoggerForTest } from '../../../test/helpers/log';
-import { Logger } from 'winston';
 
 const { _getErrorMessage, _getStacCatalogs } = serviceRunner.exportedForTesting;
 
@@ -266,7 +265,7 @@ describe('Service Runner', function () {
     describe('aggregateLogStr with a JSON logger', function () {
   
       before(function () {
-        const { getTestLogs, testLogger } = createLoggerForTest(true);
+        const { testLogger } = createLoggerForTest(true);
         this.testLogger = testLogger;
         this.logStream = new serviceRunner.LogStream(testLogger);
         this.logStream._handleLogString(nonErrorLog);

--- a/tasks/service-runner/test/service-runner.ts
+++ b/tasks/service-runner/test/service-runner.ts
@@ -187,7 +187,7 @@ describe('Service Runner', function () {
         testLogger.close();
       });
   
-      it('saves the logs to an array, as a string or JSON', function () {
+      it('saves each log to an array in the original format, as a string or JSON', function () {
         expect(logStream.logStrArr.length == 2);
         expect(logStream.logStrArr[0] === JSON.parse(jsonLog));
         expect(logStream.logStrArr[1] === textLog);
@@ -195,7 +195,7 @@ describe('Service Runner', function () {
 
       it('outputs the logs to the log\'s stream', function () {
         const testLogs = getTestLogs();
-        const testLogsArr = testLogs.split('\n')
+        const testLogsArr = testLogs.split('\n');
         const textLogOutput = JSON.parse(testLogsArr[0]);
         const jsonLogOutput = JSON.parse(testLogsArr[1]);
         expect(testLogsArr.length == 2);
@@ -239,7 +239,7 @@ describe('Service Runner', function () {
         testLogger.close();
       });
   
-      it('saves the logs to an array, as a string or JSON', function () {
+      it('saves each log to an array in the original format, as a string or JSON', function () {
         expect(logStream.logStrArr.length == 2);
         expect(logStream.logStrArr[0] === JSON.parse(jsonLog));
         expect(logStream.logStrArr[1] === textLog);
@@ -247,7 +247,7 @@ describe('Service Runner', function () {
 
       it('outputs the logs to the log\'s stream', function () {
         const testLogs = getTestLogs();
-        const jsonLogOutput = `[${requestId}]: mv \'/tmp/tmpkwxpifmr/tmp-result.tif\' \'/tmp/tmpkwxpifmr/result.tif\'`;
+        const jsonLogOutput = `[${requestId}]: ${message}`;
         expect(testLogs.split('\n').length == 2);
         expect(testLogs.includes(textLog));
         expect(testLogs.includes(jsonLogOutput));

--- a/tasks/service-runner/test/service-runner.ts
+++ b/tasks/service-runner/test/service-runner.ts
@@ -160,10 +160,10 @@ describe('Service Runner', function () {
 
   describe('LogStream', function () {
     
-    const message = `mv '/tmp/tmpkwxpifmr/tmp-result.tif' '/tmp/tmpkwxpifmr/result.tif'`;
+    const message = 'mv \'/tmp/tmpkwxpifmr/tmp-result.tif\' \'/tmp/tmpkwxpifmr/result.tif\'';
     const user = 'bo';
     const requestId = 'cdea7cb8-4c77-4342-8f00-6285e32c9123';
-    const textLog = `2022-10-06 17:12:28,530 [INFO] [harmony-service.cmd:199] ${message}`;
+    const textLog = '2022-10-06 17:12:28,530 [INFO] [harmony-service.cmd:199] ${message}';
     const jsonLog = `{ "message":"${message}", "user":"${user}", "requestId":"${requestId}" }`;
     
     describe('_handleLogString with a JSON logger', function () {
@@ -193,9 +193,9 @@ describe('Service Runner', function () {
       it('outputs the logs to the log\'s stream', function () {
         const testLogs = getTestLogs();
         expect(testLogs.split('\n').length == 2);
-        [user, requestId, "user", "requestId"]
+        [user, requestId, 'user', 'requestId']
           .forEach((attribute) => expect((testLogs.match(new RegExp(attribute, 'gm')) || []).length).to.equal(1));
-        [message, "message"]
+        [message, 'message']
           .forEach((attribute) => expect((testLogs.match(new RegExp(attribute, 'gm')) || []).length).to.equal(2));
       });
     });
@@ -226,7 +226,7 @@ describe('Service Runner', function () {
 
       it('outputs the logs to the log\'s stream', function () {
         const testLogs = getTestLogs();
-        const jsonLogOutput = `[cdea7cb8-4c77-4342-8f00-6285e32c9123]: mv '/tmp/tmpkwxpifmr/tmp-result.tif' '/tmp/tmpkwxpifmr/result.tif'`;
+        const jsonLogOutput = '[cdea7cb8-4c77-4342-8f00-6285e32c9123]: mv \'/tmp/tmpkwxpifmr/tmp-result.tif\' \'/tmp/tmpkwxpifmr/result.tif\'';
         expect(testLogs.split('\n').length == 2);
         expect(testLogs.includes(textLog));
         expect(testLogs.includes(jsonLogOutput));

--- a/tasks/service-runner/test/service-runner.ts
+++ b/tasks/service-runner/test/service-runner.ts
@@ -217,7 +217,7 @@ describe('Service Runner', function () {
 
         expect(textLogOutput.level.toLowerCase()).to.equal('debug');
         expect(jsonLogOutput.level.toLowerCase()).to.equal('debug');
-        expect(jsonLogOutput.workerLevel.toLowerCase()).to.equal('info');
+        expect(jsonLogOutput.workerLevel.toLowerCase()).to.equal(level.toLocaleLowerCase());
       });
     });
 

--- a/tasks/service-runner/test/service-runner.ts
+++ b/tasks/service-runner/test/service-runner.ts
@@ -163,7 +163,7 @@ describe('Service Runner', function () {
     const message = 'mv \'/tmp/tmpkwxpifmr/tmp-result.tif\' \'/tmp/tmpkwxpifmr/result.tif\'';
     const user = 'bo';
     const requestId = 'cdea7cb8-4c77-4342-8f00-6285e32c9123';
-    const textLog = '2022-10-06 17:12:28,530 [INFO] [harmony-service.cmd:199] ${message}';
+    const textLog = `2022-10-06 17:12:28,530 [INFO] [harmony-service.cmd:199] ${message}`;
     const jsonLog = `{ "message":"${message}", "user":"${user}", "requestId":"${requestId}" }`;
     
     describe('_handleLogString with a JSON logger', function () {
@@ -193,10 +193,18 @@ describe('Service Runner', function () {
       it('outputs the logs to the log\'s stream', function () {
         const testLogs = getTestLogs();
         expect(testLogs.split('\n').length == 2);
-        [user, requestId, 'user', 'requestId']
-          .forEach((attribute) => expect((testLogs.match(new RegExp(attribute, 'gm')) || []).length).to.equal(1));
-        [message, 'message']
-          .forEach((attribute) => expect((testLogs.match(new RegExp(attribute, 'gm')) || []).length).to.equal(2));
+
+        // things we expect in the json log
+        expect((testLogs.match(new RegExp(user, 'gm')) || []).length).to.equal(1);
+        expect((testLogs.match(new RegExp(requestId, 'gm')) || []).length).to.equal(1);
+        expect((testLogs.match(new RegExp('user', 'gm')) || []).length).to.equal(1);
+        expect((testLogs.match(new RegExp('requestId', 'gm')) || []).length).to.equal(1);
+        
+        // things we expect from both logs
+        expect((testLogs.match(new RegExp(message, 'gm')) || []).length).to.equal(2);
+        expect((testLogs.match(new RegExp('message', 'gm')) || []).length).to.equal(2);
+        expect((testLogs.match(new RegExp('worker', 'gm')) || []).length).to.equal(2);
+        expect((testLogs.match(new RegExp('true', 'gm')) || []).length).to.equal(2);
       });
     });
 

--- a/tasks/service-runner/test/service-runner.ts
+++ b/tasks/service-runner/test/service-runner.ts
@@ -162,9 +162,12 @@ describe('Service Runner', function () {
     
     const message = 'mv \'/tmp/tmpkwxpifmr/tmp-result.tif\' \'/tmp/tmpkwxpifmr/result.tif\'';
     const user = 'bo';
+    const timestamp =  '2022-10-06T17:04:21.090726Z';
     const requestId = 'cdea7cb8-4c77-4342-8f00-6285e32c9123';
-    const textLog = `2022-10-06 17:12:28,530 [INFO] [harmony-service.cmd:199] ${message}`;
-    const jsonLog = `{ "message":"${message}", "user":"${user}", "requestId":"${requestId}" }`;
+    const level = 'INFO';
+    
+    const textLog = `${timestamp} [${level}] [harmony-service.cmd:199] ${message}`;
+    const jsonLog = `{ "level":"${level}", "message":"${message}", "user":"${user}", "requestId":"${requestId}", "timestamp":"${timestamp}"}`;
     
     describe('_handleLogString with a JSON logger', function () {
   
@@ -192,19 +195,29 @@ describe('Service Runner', function () {
 
       it('outputs the logs to the log\'s stream', function () {
         const testLogs = getTestLogs();
-        expect(testLogs.split('\n').length == 2);
+        const testLogsArr = testLogs.split('\n')
+        const textLogOutput = JSON.parse(testLogsArr[0]);
+        const jsonLogOutput = JSON.parse(testLogsArr[1]);
+        expect(testLogsArr.length == 2);
 
-        // things we expect in the json log
-        expect((testLogs.match(new RegExp(user, 'gm')) || []).length).to.equal(1);
-        expect((testLogs.match(new RegExp(requestId, 'gm')) || []).length).to.equal(1);
-        expect((testLogs.match(new RegExp('user', 'gm')) || []).length).to.equal(1);
-        expect((testLogs.match(new RegExp('requestId', 'gm')) || []).length).to.equal(1);
+        // things we expect in the jsonLog
+        expect(jsonLogOutput.user).to.equal(user);
+        expect(jsonLogOutput.requestId).to.equal(requestId);
         
         // things we expect from both logs
-        expect((testLogs.match(new RegExp(message, 'gm')) || []).length).to.equal(2);
-        expect((testLogs.match(new RegExp('message', 'gm')) || []).length).to.equal(2);
-        expect((testLogs.match(new RegExp('worker', 'gm')) || []).length).to.equal(2);
-        expect((testLogs.match(new RegExp('true', 'gm')) || []).length).to.equal(2);
+        expect(textLogOutput.message).to.equal(textLog);
+        expect(jsonLogOutput.message).to.equal(message);
+        
+        expect(textLogOutput.timestamp).to.not.equal(timestamp);
+        expect(jsonLogOutput.timestamp).to.not.equal(timestamp);
+        expect(jsonLogOutput.workerTimestamp).to.equal(timestamp);
+        
+        expect(textLogOutput.worker).to.equal(true);
+        expect(jsonLogOutput.worker).to.equal(true);
+
+        expect(textLogOutput.level.toLowerCase()).to.equal('debug');
+        expect(jsonLogOutput.level.toLowerCase()).to.equal('debug');
+        expect(jsonLogOutput.workerLevel.toLowerCase()).to.equal('info');
       });
     });
 
@@ -234,7 +247,7 @@ describe('Service Runner', function () {
 
       it('outputs the logs to the log\'s stream', function () {
         const testLogs = getTestLogs();
-        const jsonLogOutput = '[cdea7cb8-4c77-4342-8f00-6285e32c9123]: mv \'/tmp/tmpkwxpifmr/tmp-result.tif\' \'/tmp/tmpkwxpifmr/result.tif\'';
+        const jsonLogOutput = `[${requestId}]: mv \'/tmp/tmpkwxpifmr/tmp-result.tif\' \'/tmp/tmpkwxpifmr/result.tif\'`;
         expect(testLogs.split('\n').length == 2);
         expect(testLogs.includes(textLog));
         expect(testLogs.includes(jsonLogOutput));

--- a/tasks/service-runner/test/service-runner.ts
+++ b/tasks/service-runner/test/service-runner.ts
@@ -217,7 +217,7 @@ describe('Service Runner', function () {
 
         expect(textLogOutput.level.toLowerCase()).to.equal('debug');
         expect(jsonLogOutput.level.toLowerCase()).to.equal('debug');
-        expect(jsonLogOutput.workerLevel.toLowerCase()).to.equal(level.toLocaleLowerCase());
+        expect(jsonLogOutput.workerLevel.toLowerCase()).to.equal(level.toLowerCase());
       });
     });
 

--- a/test/helpers/log.ts
+++ b/test/helpers/log.ts
@@ -19,7 +19,7 @@ export function createLoggerForTest(logJson = true): {
     outputString += chunk.toString();
     next();
   };
-  const streamTransport = new winston.transports.Stream({ stream });
+  const streamTransport = new winston.transports.Stream({ stream, level: 'debug' });
   const testLogger = logJson ? createJsonLogger([streamTransport]) : createTextLogger([streamTransport]);
   
   return { getTestLogs, testLogger };


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1204

## Description
We were logging JSON service logs improperly in the service runner. This was causing the nesting of a message attribute within a message attribute, 
```json
{
    "stream": "stdout",
    "env_name": "harmony-unknown",
    "level": "debug",
    "message": {
        "application": "/home/harmony_service_example/__main__.py",
        "level": "INFO",
        "message": "timing./home/harmony_service_example/__main__.py.start",
        "requestId": "95640a9c-8fd1-413d-b9c8-b59ea322194b",
        "timestamp": "2022-10-05T15:21:22.243421Z",
        "user": "vinverso"
    },
    "timestamp": "2022-10-05T15:21:22.244Z",
    "worker": true,
}
```
which was tripping up the metrics team's log parser which expects `message` to be of type `string` (not `object`). This PR fixes that by changing the way we pass a _JSON_ log to the winston logger. 

`this.streamLogger.debug({ ...logObj, worker: true });` instead of:
`this.streamLogger.debug(logObj, { worker: true });` (which works well for a passing a `string`, but not `object`)

This PR also ensures that if both the manager and worker container are logging the same property (like `level`), the same property name emanating from the worker container will get prepended with `worker`.

## Local Test Steps
1 - rebuild the service runner from this branch
2 - set TEXT_LOGGER=false in your harmony .env 
3 - restart your services (with at least one service using the latest version of the service library)
4 - make a request and check that the manager container logs only have a single `message` attribute

e.g.
```json
{
  "application": "/home/harmony_service_example/__main__.py",
  "env_name": "harmony-local",
  "level": "debug",
  "message": "gdalinfo '/tmp/tmpqjk4uawy/f1f8f8abf0556048561fff1ab55ff89237ddc5d97612c2b8c5fbbe3bd4fc7dc8.nc'",
  "requestId": "1c13d6be-d21b-467b-9f9f-7b02b96967dc",
  "timestamp": "2022-10-11T15:16:45.212Z",
  "user": "vinverso",
  "worker": true,
  "workerLevel": "INFO",
  "workerTimestamp": "2022-10-11T15:16:45.209778Z"
}
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)