### PR TITLE
Harmony 1304 - Hide retry and logs columns when functionality is inaccessible due to permissions

### DIFF
--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -275,10 +275,9 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
         ' title="view logs"><i class="bi bi-body-text"></i></a>';
     },
     workflowItemRetryButton(): string {
-      const sharedWithNonAdmin = (!isAdmin && (job.username != requestUser));
       const isRunning = WorkItemStatus.RUNNING === this.status;
       const noRetriesLeft = this.retryCount >= env.workItemRetryLimit;
-      if (!isRunning || sharedWithNonAdmin || noRetriesLeft) return '';
+      if (!isRunning || !job.belongsToOrIsAdmin(requestUser, isAdmin) || noRetriesLeft) return '';
       const retryUrl = `/workflow-ui/${job.jobID}/${this.id}/retry`;
       return `<button type="button" class="btn btn-light btn-sm retry-button" data-retry-url="${retryUrl}"` +
         `data-work-item-id="${this.id}" title="retry this item"><i class="bi bi-arrow-clockwise"></i></button>`;
@@ -325,6 +324,7 @@ export async function getWorkItemsTable(
     setPagingHeaders(res, pagination);
     res.render('workflow-ui/job/work-items-table', {
       isAdmin,
+      canShowRetryColumn: job.belongsToOrIsAdmin(req.user, isAdmin),
       job,
       statusClass: statusClass[job.status],
       workItems,
@@ -378,6 +378,7 @@ export async function getWorkItemTableRow(
     }
     res.render('workflow-ui/job/work-item-table-row', {
       isAdmin,
+      canShowRetryColumn: job.belongsToOrIsAdmin(req.user, isAdmin),
       ...workItems[0],
       ...workItemRenderingFunctions(job, isAdmin, req.user),
     });

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -208,6 +208,7 @@ export async function getJob(
       job,
       page,
       limit,
+      isAdminOrOwner: job.belongsToOrIsAdmin(req.user, isAdmin),
       disallowStatusChecked: disallowStatus ? 'checked' : '',
       selectedFilters: tableFilter.originalValues,
       tableFilter: requestQuery.tablefilter,

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -324,6 +324,7 @@ export async function getWorkItemsTable(
     const previousPage = pageLinks.find((l) => l.rel === 'prev');
     setPagingHeaders(res, pagination);
     res.render('workflow-ui/job/work-items-table', {
+      isAdmin,
       job,
       statusClass: statusClass[job.status],
       workItems,
@@ -376,6 +377,7 @@ export async function getWorkItemTableRow(
       return;
     }
     res.render('workflow-ui/job/work-item-table-row', {
+      isAdmin,
       ...workItems[0],
       ...workItemRenderingFunctions(job, isAdmin, req.user),
     });

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -865,6 +865,17 @@ export class Job extends DBRecord implements JobRecord {
   }
 
   /**
+   * Returns true if a particular user either owns the job in question
+   * or belongs to the admin group.
+   * @param requestUser - The user name of the user making the request
+   * @param isAdmin - Whether the requesting user is an admin.
+   * @returns boolean
+   */
+  belongsToOrIsAdmin(requestUser: string, isAdmin: boolean): boolean {
+    return isAdmin || (this.username === requestUser);
+  }
+
+  /**
    * Return whether a user can access this job and its results.
    * (Called whenever a request is made to frontend jobs or STAC endpoints)
    * @param requestingUserName - the person we're checking permissions for
@@ -880,9 +891,9 @@ export class Job extends DBRecord implements JobRecord {
     accessToken: string,
     enableShareability = true,
   ): Promise<boolean> {
-    const isJobOwnerOrAdmin = isAdminAccess || (this.username === requestingUserName);
-    if (isJobOwnerOrAdmin || !enableShareability) {
-      return isJobOwnerOrAdmin;
+    const isAdminOrOwner = this.belongsToOrIsAdmin(requestingUserName, isAdminAccess);
+    if (isAdminOrOwner || !enableShareability) {
+      return isAdminOrOwner;
     }
     // if we get to here, the user is not an admin, nor the owner of the job,
     // but we should still check if the job can be viewed since enableShareability=true

--- a/app/views/workflow-ui/job/index.mustache.html
+++ b/app/views/workflow-ui/job/index.mustache.html
@@ -48,7 +48,7 @@
                 {{/isAdminRoute}}
                 <li class="breadcrumb-item active" aria-current="page">{{job.jobID}}</li>
             </ol>
-            <div id="job-state-links-container">
+            <div id="job-state-links-container" data-is-admin-or-owner="{{isAdminOrOwner}}">
                 <!-- job state change links will go here -->
             </div>
         </div>

--- a/app/views/workflow-ui/job/work-item-table-row.mustache.html
+++ b/app/views/workflow-ui/job/work-item-table-row.mustache.html
@@ -3,7 +3,9 @@
     <td>{{workflowItemStep}}</td>
     <td>{{id}}</td>
     <td><span class="badge bg-{{workflowItemBadge}}">{{status}}</span></td>
+    {{#isAdmin}}
     <td>{{{workflowItemLogsButton}}}</td>
+    {{/isAdmin}}
     <td>{{{workflowItemRetryButton}}}</td>
     <td>{{{retryCount}}}</td>
     <td class="date-td" data-time="{{workflowItemCreatedAt}}"></td>

--- a/app/views/workflow-ui/job/work-item-table-row.mustache.html
+++ b/app/views/workflow-ui/job/work-item-table-row.mustache.html
@@ -6,7 +6,9 @@
     {{#isAdmin}}
     <td>{{{workflowItemLogsButton}}}</td>
     {{/isAdmin}}
+    {{#canShowRetryColumn}}
     <td>{{{workflowItemRetryButton}}}</td>
+    {{/canShowRetryColumn}}
     <td>{{{retryCount}}}</td>
     <td class="date-td" data-time="{{workflowItemCreatedAt}}"></td>
     <td class="date-td" data-time="{{workflowItemUpdatedAt}}"></td>

--- a/app/views/workflow-ui/job/work-items-table.mustache.html
+++ b/app/views/workflow-ui/job/work-items-table.mustache.html
@@ -12,7 +12,9 @@
             {{#isAdmin}}
             <th scope="col">logs</th>
             {{/isAdmin}}
+            {{#canShowRetryColumn}}
             <th scope="col">retry</th>
+            {{/canShowRetryColumn}}
             <th scope="col">retryCount</th>
             <th scope="col">createdAt</th>
             <th scope="col">updatedAt</th>

--- a/app/views/workflow-ui/job/work-items-table.mustache.html
+++ b/app/views/workflow-ui/job/work-items-table.mustache.html
@@ -9,7 +9,9 @@
             <th scope="col">stepName</th>
             <th scope="col">id</th>
             <th scope="col">status</th>
+            {{#isAdmin}}
             <th scope="col">logs</th>
+            {{/isAdmin}}
             <th scope="col">retry</th>
             <th scope="col">retryCount</th>
             <th scope="col">createdAt</th>

--- a/public/js/workflow-ui/job/index.js
+++ b/public/js/workflow-ui/job/index.js
@@ -9,6 +9,11 @@ const jobId = workflowContainer.getAttribute('data-job-id');
 const disallowStatus = workflowContainer.getAttribute('data-disallow-status-checked') === 'checked' ? 'on' : '';
 const tableFilter = workflowContainer.getAttribute('data-table-filter');
 
-await navLinks.init("job-state-links-container", jobId);
+// kick off job state change links logic if this user is allowed to change the job state
+const navLinksContainer = document.getElementById('job-state-links-container');
+const isAdminOrOwner = navLinksContainer.getAttribute('data-is-admin-or-owner') === 'true';
+if (isAdminOrOwner) {
+  await navLinks.init('job-state-links-container', jobId);
+}
 
 workItemsTable.init(jobId, page, limit, disallowStatus, tableFilter);

--- a/test/workflow-ui/work-items-table-row.ts
+++ b/test/workflow-ui/work-items-table-row.ts
@@ -171,6 +171,10 @@ describe('Workflow UI work items table row route', function () {
           const listing = this.res.text;
           expect((listing.match(/logs-button/g) || []).length).to.equal(0);
         });
+        it('does not return a column for the work item logs', async function () {
+          const listing = this.res.text;
+          expect(listing).to.not.contain(mustache.render('<th scope="col">logs</th>', {}));
+        });
         it('returns a retry button for their RUNNING work item', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);

--- a/test/workflow-ui/work-items-table-row.ts
+++ b/test/workflow-ui/work-items-table-row.ts
@@ -171,17 +171,9 @@ describe('Workflow UI work items table row route', function () {
           const listing = this.res.text;
           expect((listing.match(/logs-button/g) || []).length).to.equal(0);
         });
-        it('does not return a column for the work item logs', async function () {
-          const listing = this.res.text;
-          expect(listing).to.not.contain(mustache.render('<th scope="col">logs</th>', {}));
-        });
         it('returns a retry button for their RUNNING work item', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);
-        });
-        it('returns a column for the retry buttons', async function () {
-          const listing = this.res.text;
-          expect(listing).to.not.contain(mustache.render('<th scope="col">retry</th>', {}));
         });
       });
 
@@ -191,10 +183,6 @@ describe('Workflow UI work items table row route', function () {
           const listing = this.res.text;
           expect((listing.match(/logs-button/g) || []).length).to.equal(1);
         });
-        it('does return a column for the work item logs', async function () {
-          const listing = this.res.text;
-          expect(listing).to.contain(mustache.render('<th scope="col">logs</th>', {}));
-        });
       });
 
       describe('who requests a RUNNING work item row for someone else\'s non-shareable job (but is an admin)', function () {
@@ -202,10 +190,6 @@ describe('Workflow UI work items table row route', function () {
         it('returns a retry button for the other user\'s RUNNING work item', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);
-        });
-        it('returns a column for the retry buttons', async function () {
-          const listing = this.res.text;
-          expect(listing).to.not.contain(mustache.render('<th scope="col">retry</th>', {}));
         });
       });
 
@@ -227,17 +211,9 @@ describe('Workflow UI work items table row route', function () {
           expect(listing).to.contain(mustache.render('<td>{{id}}</td>', { id: shareableItem1.id }));
           expect((listing.match(/work-item-table-row/g) || []).length).to.equal(1);
         });
-        it('does not return a column for the work item logs', async function () {
-          const listing = this.res.text;
-          expect(listing).to.not.contain(mustache.render('<th scope="col">logs</th>', {}));
-        });
         it('does not return a retry button for the other user\'s RUNNING work item', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(0);
-        });
-        it('does not return a column for the retry buttons', async function () {
-          const listing = this.res.text;
-          expect(listing).to.not.contain(mustache.render('<th scope="col">retry</th>', {}));
         });
       });
 
@@ -255,10 +231,6 @@ describe('Workflow UI work items table row route', function () {
         it('returns a retry button for the other user\'s RUNNING work item', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);
-        });
-        it('returns a column for the retry buttons', async function () {
-          const listing = this.res.text;
-          expect(listing).to.not.contain(mustache.render('<th scope="col">retry</th>', {}));
         });
       });
 

--- a/test/workflow-ui/work-items-table-row.ts
+++ b/test/workflow-ui/work-items-table-row.ts
@@ -179,6 +179,10 @@ describe('Workflow UI work items table row route', function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);
         });
+        it('returns a column for the retry buttons', async function () {
+          const listing = this.res.text;
+          expect(listing).to.not.contain(mustache.render('<th scope="col">retry</th>', {}));
+        });
       });
 
       describe('who requests a SUCCESSFUL work item row for someone else\'s non-shareable job (but is an admin)', function () {
@@ -194,6 +198,10 @@ describe('Workflow UI work items table row route', function () {
         it('returns a retry button for the other user\'s RUNNING work item', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);
+        });
+        it('returns a column for the retry buttons', async function () {
+          const listing = this.res.text;
+          expect(listing).to.not.contain(mustache.render('<th scope="col">retry</th>', {}));
         });
       });
 
@@ -243,6 +251,10 @@ describe('Workflow UI work items table row route', function () {
         it('returns a retry button for the other user\'s RUNNING work item', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);
+        });
+        it('returns a column for the retry buttons', async function () {
+          const listing = this.res.text;
+          expect(listing).to.not.contain(mustache.render('<th scope="col">retry</th>', {}));
         });
       });
 

--- a/test/workflow-ui/work-items-table-row.ts
+++ b/test/workflow-ui/work-items-table-row.ts
@@ -191,6 +191,10 @@ describe('Workflow UI work items table row route', function () {
           const listing = this.res.text;
           expect((listing.match(/logs-button/g) || []).length).to.equal(1);
         });
+        it('does return a column for the work item logs', async function () {
+          const listing = this.res.text;
+          expect(listing).to.contain(mustache.render('<th scope="col">logs</th>', {}));
+        });
       });
 
       describe('who requests a RUNNING work item row for someone else\'s non-shareable job (but is an admin)', function () {

--- a/test/workflow-ui/work-items-table-row.ts
+++ b/test/workflow-ui/work-items-table-row.ts
@@ -215,9 +215,17 @@ describe('Workflow UI work items table row route', function () {
           expect(listing).to.contain(mustache.render('<td>{{id}}</td>', { id: shareableItem1.id }));
           expect((listing.match(/work-item-table-row/g) || []).length).to.equal(1);
         });
+        it('does not return a column for the work item logs', async function () {
+          const listing = this.res.text;
+          expect(listing).to.not.contain(mustache.render('<th scope="col">logs</th>', {}));
+        });
         it('does not return a retry button for the other user\'s RUNNING work item', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(0);
+        });
+        it('does not return a column for the retry buttons', async function () {
+          const listing = this.res.text;
+          expect(listing).to.not.contain(mustache.render('<th scope="col">retry</th>', {}));
         });
       });
 

--- a/test/workflow-ui/work-items-table.ts
+++ b/test/workflow-ui/work-items-table.ts
@@ -211,9 +211,17 @@ describe('Workflow UI work items table route', function () {
         it('returns a 200 HTTP response', async function () {
           expect(this.res.statusCode).to.equal(200);
         });
+        it('does not return a column for the work item logs', async function () {
+          const listing = this.res.text;
+          expect(listing).to.not.contain(mustache.render('<th scope="col">logs</th>', {}));
+        });
         it('does not return retry buttons for the other user\'s RUNNING work items', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(0);
+        });
+        it('does not return a column for the retry buttons', async function () {
+          const listing = this.res.text;
+          expect(listing).to.not.contain(mustache.render('<th scope="col">retry</th>', {}));
         });
       });
 

--- a/test/workflow-ui/work-items-table.ts
+++ b/test/workflow-ui/work-items-table.ts
@@ -197,6 +197,10 @@ describe('Workflow UI work items table route', function () {
           const listing = this.res.text;
           expect((listing.match(/logs-button/g) || []).length).to.equal(2);
         });
+        it('does return a column for the work item logs', async function () {
+          const listing = this.res.text;
+          expect(listing).to.contain(mustache.render('<th scope="col">logs</th>', {}));
+        });
         it('returns retry buttons for the other user\'s RUNNING work items', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);
@@ -319,13 +323,17 @@ describe('Workflow UI work items table route', function () {
           const listing = this.res.text;
           expect((listing.match(/logs-button/g) || []).length).to.equal(2);
         });
+        it('does return a column for the work item logs', async function () {
+          const listing = this.res.text;
+          expect(listing).to.contain(mustache.render('<th scope="col">logs</th>', {}));
+        });
         it('returns retry buttons for the RUNNING work items', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);
         });
         it('returns a column for the retry buttons', async function () {
           const listing = this.res.text;
-          expect(listing).to.not.contain(mustache.render('<th scope="col">retry</th>', {}));
+          expect(listing).to.contain(mustache.render('<th scope="col">retry</th>', {}));
         });
       });
 

--- a/test/workflow-ui/work-items-table.ts
+++ b/test/workflow-ui/work-items-table.ts
@@ -185,6 +185,10 @@ describe('Workflow UI work items table route', function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);
         });
+        it('returns a column for the retry buttons', async function () {
+          const listing = this.res.text;
+          expect(listing).to.contain(mustache.render('<th scope="col">retry</th>', {}));
+        });
       });
 
       describe('who requests the work items table for someone else\'s non-shareable job (but is an admin)', function () {
@@ -196,6 +200,10 @@ describe('Workflow UI work items table route', function () {
         it('returns retry buttons for the other user\'s RUNNING work items', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);
+        });
+        it('returns a column for the retry buttons', async function () {
+          const listing = this.res.text;
+          expect(listing).to.contain(mustache.render('<th scope="col">retry</th>', {}));
         });
       });
 
@@ -233,6 +241,10 @@ describe('Workflow UI work items table route', function () {
         it('returns retry buttons for the other user\'s RUNNING work items', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);
+        });
+        it('returns a column for the retry buttons', async function () {
+          const listing = this.res.text;
+          expect(listing).to.contain(mustache.render('<th scope="col">retry</th>', {}));
         });
       });
 
@@ -310,6 +322,10 @@ describe('Workflow UI work items table route', function () {
         it('returns retry buttons for the RUNNING work items', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);
+        });
+        it('returns a column for the retry buttons', async function () {
+          const listing = this.res.text;
+          expect(listing).to.not.contain(mustache.render('<th scope="col">retry</th>', {}));
         });
       });
 

--- a/test/workflow-ui/work-items-table.ts
+++ b/test/workflow-ui/work-items-table.ts
@@ -177,6 +177,10 @@ describe('Workflow UI work items table route', function () {
           const listing = this.res.text;
           expect((listing.match(/logs-button/g) || []).length).to.equal(0);
         });
+        it('does not return a column for the work item logs', async function () {
+          const listing = this.res.text;
+          expect(listing).to.not.contain(mustache.render('<th scope="col">logs</th>', {}));
+        });
         it('returns retry buttons for their RUNNING work items', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1304

## Description
This ensures that when a user has inadequate permissions to view the logs or retry button(s) on the workflow UI, the corresponding columns will be hidden. Previously we were just hiding the buttons, but not also the columns. This was confusing, e.g. for a user who will never see the logs button but does see a column header named "logs".

## Local Test Steps

Submit a job (as an admin or non-admin, http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=2), then login to harmony with a different non-admin user and take a look at the other user's job. Make sure that there is no "logs" and no "retry" column.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)