### PR TITLE
Harmony 1257 - Append work item logs to logs.json when items are retried

### DIFF
--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -10,7 +10,7 @@ import db from '../util/db';
 import version from '../util/version';
 import env = require('../util/env');
 import { keysToLowerCase } from '../util/object';
-import { COMPLETED_WORK_ITEM_STATUSES, getItemLogsLocation, WorkItemQuery, WorkItemStatus } from '../models/work-item-interface';
+import { getItemLogsLocation, WorkItemQuery, WorkItemStatus } from '../models/work-item-interface';
 import { getRequestRoot } from '../util/url';
 import { belongsToGroup } from '../util/cmr';
 import { getAllStateChangeLinks, getJobStateChangeLinks } from '../util/links';
@@ -269,7 +269,7 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
     workflowItemCreatedAt(): string { return this.createdAt.getTime(); },
     workflowItemUpdatedAt(): string { return this.updatedAt.getTime(); },
     workflowItemLogsButton(): string {
-      const isComplete = COMPLETED_WORK_ITEM_STATUSES.indexOf(this.status) > -1;
+      const isComplete = [WorkItemStatus.FAILED, WorkItemStatus.SUCCESSFUL].indexOf(this.status) > -1;
       if (!isComplete || !isAdmin || this.serviceID.includes('query-cmr')) return '';
       const logsUrl = `/admin/workflow-ui/${job.jobID}/${this.id}/logs`;
       return `<a type="button" target="__blank" class="btn btn-light btn-sm logs-button" href="${logsUrl}"` +

--- a/tasks/service-runner/app/service/service-runner.ts
+++ b/tasks/service-runner/app/service/service-runner.ts
@@ -181,16 +181,14 @@ export async function runQueryCmrFromPull(workItem: WorkItemRecord, maxCmrGranul
  * @param logs - logs array from the k8s exec call
  */
 export async function uploadLogs(workItem: WorkItemRecord, logs: (string | object)[]): Promise<ManagedUpload.SendData> {
-  let fileJson: string;
+  let fileContent: (string | object)[] = logs;
   const s3 = objectStoreForProtocol('s3');
   const logsLocation = getItemLogsLocation(workItem);
   if (await s3.objectExists(logsLocation)) { // append to existing logs
     const logsArray = await s3.getObjectJson(logsLocation);
-    fileJson = JSON.stringify(logsArray.concat(logs));
-  } else {
-    fileJson = JSON.stringify(logs);
+    fileContent = logsArray.concat(fileContent);
   }
-  return s3.upload(fileJson, logsLocation);
+  return s3.upload(JSON.stringify(fileContent), logsLocation);
 }
 
 /**

--- a/tasks/service-runner/test/service-runner.ts
+++ b/tasks/service-runner/test/service-runner.ts
@@ -109,15 +109,15 @@ describe('Service Runner', function () {
     describe('when there is a logs file already associated with the WorkItem', async function () {
       it('appends the new logs to the old ones', async function () {
         const logsLocation0 = getItemLogsLocation(itemRecord0);
-        const logs = s3.getObjectJson(logsLocation0);
-        expect(logs).to.equal(['the old logs', 'the new logs']);
+        const logs = await s3.getObjectJson(logsLocation0);
+        expect(logs).to.deep.equal(['the old logs', 'the new logs']);
       });
     });
     describe('when there is no logs file associated with the WorkItem', async function () {
       it('writes the logs to a new file', async function () {
         const logsLocation1 = getItemLogsLocation(itemRecord1);
-        const logs = s3.getObjectJson(logsLocation1);
-        expect(logs).to.equal(['the new logs']);
+        const logs = await s3.getObjectJson(logsLocation1);
+        expect(logs).to.deep.equal(['the only logs']);
       });
     });
   });


### PR DESCRIPTION
## Jira Issue ID
Harmony 1257

## Description
When we first implemented the ability to see logs from the workflow ui there was no concept of re-tries, so there was an implicit assumption that a log file would only be written once. Now that that's no longer the case, I have updated the code to append new logs if there is already an existing log file.

## Local Test Steps
In service-runner.ts change `if (status.status === 'Success') {` to `if (status.status === '') {`. Rebuild service runner and restart your services, then submit a request http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=2. When the work item fails, check the logs file, which should include logs for each invocation of the service (with the same work item).

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)