### PR TITLE
HARMONY-1286: Log the total output size as part of the response metric

### DIFF
--- a/app/frontends/request-metrics.ts
+++ b/app/frontends/request-metrics.ts
@@ -7,7 +7,7 @@ import db from '../util/db';
 import env = require('../util/env');
 import { getPagingParams } from '../util/pagination';
 import { Parser } from 'json2csv';
-import { getTotalWorkItemSizeForJobID } from '../models/work-item';
+import { getTotalWorkItemSizesForJobID } from '../models/work-item';
 import _ from 'lodash';
 import { validateParameterNames } from '../middleware/parameter-validation';
 
@@ -176,7 +176,8 @@ export default async function getRequestMetrics(
         const row = getServiceMetricsFromSteps(steps, req.context.logger);
         row.numInputGranules = job.numInputGranules;
         row.timeTakenSeconds = (job.updatedAt.getTime() - job.createdAt.getTime()) / 1000;
-        row.totalGranuleSizeMb = await getTotalWorkItemSizeForJobID(tx, job.jobID);
+        const workItemSizes = await getTotalWorkItemSizesForJobID(tx, job.jobID);
+        row.totalGranuleSizeMb = workItemSizes.originalSize;
         row.synchronous = 1;
         if (job.isAsync) {
           row.synchronous = 0;

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -324,7 +324,7 @@ export async function queryAll(
     .select()
     .where(constraints.where)
     .orderBy(
-      constraints?.orderBy?.field ?? 'createdAt', 
+      constraints?.orderBy?.field ?? 'createdAt',
       constraints?.orderBy?.value ?? 'desc')
     .modify((queryBuilder) => {
       if (constraints.whereIn) {
@@ -380,8 +380,8 @@ export async function getWorkItemsByJobId(
   perPage = 10,
   sortOrder: 'asc' | 'desc' = 'asc',
 ): Promise<{ workItems: WorkItem[]; pagination: ILengthAwarePagination }> {
-  const query: WorkItemQuery = { 
-    where: { jobID }, 
+  const query: WorkItemQuery = {
+    where: { jobID },
     orderBy : { field: 'id', value: sortOrder },
   };
   return queryAll(tx, query, currentPage, perPage);
@@ -607,29 +607,60 @@ export async function getScrollIdForJob(
  * Returns the sum of the work item sizes for all work items for the provided jobID.
  * @param tx - the transaction to use for querying
  * @param jobID - the ID of the job
+ *
+ * @returns a promise resolving to an object with two keys containing the originalSize
+ * in MB and the outputSize in MB for all items in the request.
  */
-export async function getTotalWorkItemSizeForJobID(
+export async function getTotalWorkItemSizesForJobID(
   tx: Transaction,
   jobID: string,
-): Promise<number> {
-  const results = await tx(WorkItem.table)
+): Promise<{ originalSize: number, outputSize: number }> {
+  const workflowStepIndexResults = await tx(WorkflowStep.table)
     .select()
-    .sum('totalGranulesSize')
+    .min('stepIndex')
+    .max('stepIndex')
     .where({ jobID });
 
-  let totalSize;
+  let firstIndex, lastIndex;
   if (db.client.config.client === 'pg') {
-    totalSize = Number(results[0].sum);
+    firstIndex = workflowStepIndexResults[0].min;
+    lastIndex = workflowStepIndexResults[0].max;
   } else {
-    totalSize = Number(results[0]['sum(`totalGranulesSize`)']);
+    firstIndex = workflowStepIndexResults[0]['min(`stepIndex`)'];
+    lastIndex = workflowStepIndexResults[0]['max(`stepIndex`)'];
   }
 
-  return totalSize;
+  const originalSizeResults = await tx(WorkItem.table)
+    .select()
+    .sum('totalGranulesSize')
+    .where({ jobID, workflowStepIndex: firstIndex });
+
+  let originalSize;
+  if (db.client.config.client === 'pg') {
+    originalSize = Number(originalSizeResults[0].sum);
+  } else {
+    originalSize = Number(originalSizeResults[0]['sum(`totalGranulesSize`)']);
+  }
+
+  const outputSizeResults = await tx(WorkItem.table)
+    .select()
+    .sum('totalGranulesSize')
+    .where({ jobID, workflowStepIndex: lastIndex });
+
+  let outputSize;
+  if (db.client.config.client === 'pg') {
+    outputSize = Number(outputSizeResults[0].sum);
+  } else {
+    outputSize = Number(outputSizeResults[0]['sum(`totalGranulesSize`)']);
+  }
+
+
+  return { originalSize, outputSize };
 }
 
 /**
  * Compute the threshold (in milliseconds) to be used to expire work items for a given job/service
- * 
+ *
  * @param jobID - the ID of the Job for the step
  * @param serviceID - the serviceID of the step within the workflow
  */

--- a/app/util/metrics.ts
+++ b/app/util/metrics.ts
@@ -37,7 +37,6 @@ export interface ProductDataMetric {
   shortName: string;
   versionId: string;
   organization?: string; // We do not have this information
-  product_size?: number; // This represents the total size of outputs which we do not track yet
   variables?: string[]; // An array of variable names
 }
 
@@ -68,8 +67,8 @@ export interface ResponseMetric {
   http_response_code: number;
   time_completed: string;
   total_time: number; // Agreed to use seconds with decimals
-  original_size: number; // Bytes that would have needed to be downloaded
-  output_size?: number; // Bytes returned after transformation - not tracking yet
+  original_size: number; // (Agreed to use MB) MB that would have needed to be downloaded
+  output_size?: number; // (Agreed to use MB) MB returned after transformation
 }
 
 /**
@@ -197,11 +196,12 @@ export function getProductMetric(operation: DataOperation, job: Job)
  *  @param operation - The data operation
  *  @param job - The job associated with the request
  *  @param originalSize - The sum of the sizes of all input granules for the request
+ *  @param outputSize - The sum of the sizes of all outputs for the request
  *
  * @returns Promise that resolves to the response metric for a request
  */
 export async function getResponseMetric(
-  operation: DataOperation, job: Job, originalSize: number,
+  operation: DataOperation, job: Job, originalSize: number, outputSize: number,
 ): Promise<ResponseMetric> {
   let httpResponseCode = 200;
 
@@ -216,6 +216,7 @@ export async function getResponseMetric(
     time_completed: job.updatedAt.toISOString(),
     total_time: ((job.updatedAt.getTime() - job.createdAt.getTime()) / 1000),
     original_size: originalSize,
+    output_size: outputSize,
   };
 
   return metric;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5621,9 +5621,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001422",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz",
+      "integrity": "sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==",
       "dev": true,
       "funding": [
         {
@@ -22892,9 +22892,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001422",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz",
+      "integrity": "sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==",
       "dev": true
     },
     "caseless": {

--- a/test/util/metrics.ts
+++ b/test/util/metrics.ts
@@ -225,12 +225,12 @@ describe('Metrics construction', function () {
         job.status = JobStatus.SUCCESSFUL;
         await job.save(db);
         this.job = job;
-        this.metric = await getResponseMetric(operation, job, 123.45);
+        this.metric = await getResponseMetric(operation, job, 123.45, 0.13);
       });
 
       it('includes all of the fields', function () {
         expect(Object.keys(this.metric)).to.eql([
-          'request_id', 'job_ids', 'http_response_code', 'time_completed', 'total_time', 'original_size',
+          'request_id', 'job_ids', 'http_response_code', 'time_completed', 'total_time', 'original_size', 'output_size',
         ]);
       });
 
@@ -257,6 +257,10 @@ describe('Metrics construction', function () {
       it('sets the original size correctly', function () {
         expect(this.metric.original_size).to.equal(123.45);
       });
+
+      it('sets the output size correctly', function () {
+        expect(this.metric.output_size).to.equal(0.13);
+      });
     });
 
     describe('when the job failed', function () {
@@ -265,7 +269,7 @@ describe('Metrics construction', function () {
         job.status = JobStatus.FAILED;
         await job.save(db);
         this.job = job;
-        this.metric = await getResponseMetric(operation, job, 123.45);
+        this.metric = await getResponseMetric(operation, job, 123.45, 0.13);
       });
 
       it('sets the http response code to 500', function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1286

## Description
Log the total output size as part of the response metric so that the metrics dashboards capture the size reduction for a request.

## Local Test Steps
I tested with both Postgres and Sqlite. I set the CMR_MAX_PAGE_SIZE to 3 so that multiple query-cmr steps would be generated for my request.

Make sure TEXT_LOGGER=false.

Submit a request for more than CMR_MAX_PAGE_SIZE granules. When the request completes look for a log message for the response metric:

It should look similar to:
```
{"application":"backend","env_name":"harmony-local","http_response_code":200,"job_ids":["3dc34c5a-b52d-43a3-979a-f3529a1d872b"],"level":"info","message":"Job 3dc34c5a-b52d-43a3-979a-f3529a1d872b complete - response metric","original_size":4.20245361328125,"output_size":0.16964244842529297,"requestId":"work","requestUrl":"/service/work/14","request_id":"3dc34c5a-b52d-43a3-979a-f3529a1d872b","responseMetric":true,"time_completed":"2022-10-19T12:19:55.364Z","timestamp":"2022-10-19T12:19:55.378Z","total_time":166.755}
```
Make sure that the value for the output_size field adds up to the total size of all the outputs from the request.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)