### PR TITLE
HARMONY-1317: Ensure 2 items complete before calculating smart timeout threshold

### DIFF
--- a/app/workers/work-failer.ts
+++ b/app/workers/work-failer.ts
@@ -51,15 +51,15 @@ export default class WorkFailer implements Worker {
     const workItems = await getWorkItemsByUpdateAgeAndStatus(
       db, lastUpdateOlderThanMinutes, [WorkItemStatus.RUNNING],
       [JobStatus.RUNNING, JobStatus.RUNNING_WITH_ERRORS],
-      ['w.id', 'w.jobID', 'serviceID', 'startedAt'],
+      ['w.id', 'w.jobID', 'serviceID', 'startedAt', 'workflowStepIndex'],
     );
     if (workItems?.length > 0) {
       // compute duration thresholds for each job/service
       for (const workItem of workItems) {
-        const { jobID, serviceID } = workItem;
+        const { jobID, serviceID, workflowStepIndex } = workItem;
         const key = `${jobID}${serviceID}`;
         if (!jobServiceThresholds[key]) {
-          const outlierThreshold = await computeWorkItemDurationOutlierThresholdForJobService(jobID, serviceID);
+          const outlierThreshold = await computeWorkItemDurationOutlierThresholdForJobService(jobID, serviceID, workflowStepIndex);
           jobServiceThresholds[key] = outlierThreshold;
         }
       }

--- a/test/models/work-item.ts
+++ b/test/models/work-item.ts
@@ -19,23 +19,19 @@ describe('WorkItem computeWorkItemDurationOutlierThresholdForJobService', functi
   before(async function () {
     await jobWithTwoComplete.save(this.trx);
     await buildWorkItem({ jobID: jobWithTwoComplete.jobID, status: WorkItemStatus.SUCCESSFUL,
-      workflowStepIndex: 0, startedAt: new Date(), duration: 100 }).save(this.trx);
+      workflowStepIndex: 0, startedAt: new Date(), serviceID: 'subsetter', duration: 100 }).save(this.trx);
     await buildWorkItem({ jobID: jobWithTwoComplete.jobID, status: WorkItemStatus.SUCCESSFUL,
-      workflowStepIndex: 0, startedAt: new Date(), duration: 200 }).save(this.trx);
+      workflowStepIndex: 0, startedAt: new Date(), serviceID: 'subsetter', duration: 200 }).save(this.trx);
     await buildWorkflowStep({ jobID: jobWithTwoComplete.jobID, stepIndex: 0, serviceID: 'subsetter' }).save(this.trx);
 
     await jobWithOneComplete.save(this.trx);
     await buildWorkItem({ jobID: jobWithOneComplete.jobID, status: WorkItemStatus.SUCCESSFUL,
-      workflowStepIndex: 0, startedAt: new Date() }).save(this.trx);
+      workflowStepIndex: 0, startedAt: new Date(), serviceID: 'subsetter' }).save(this.trx);
     await buildWorkItem({ jobID: jobWithOneComplete.jobID, status: WorkItemStatus.RUNNING,
-      workflowStepIndex: 0, startedAt: new Date() }).save(this.trx);
+      workflowStepIndex: 0, startedAt: new Date(), serviceID: 'subsetter' }).save(this.trx);
     await buildWorkflowStep({ jobID: jobWithOneComplete.jobID, stepIndex: 0, serviceID: 'subsetter' }).save(this.trx);
 
     await this.trx.commit();
-  });
-
-  after(async function () {
-    await truncateAll();
   });
 
   it('returns the default threshold when less than 2 items are successful', async function () {

--- a/test/models/work-item.ts
+++ b/test/models/work-item.ts
@@ -1,0 +1,56 @@
+import { describe } from 'mocha';
+import { buildJob } from '../helpers/jobs';
+import { JobStatus } from '../../app/models/job';
+import { computeWorkItemDurationOutlierThresholdForJobService } from '../../app/models/work-item';
+import { hookTransaction, truncateAll } from '../helpers/db';
+import { buildWorkItem } from '../helpers/work-items';
+import { expect } from 'chai';
+import { WorkItemStatus } from '../../app/models/work-item-interface';
+import { buildWorkflowStep } from '../helpers/workflow-steps';
+
+
+describe('WorkItem computeWorkItemDurationOutlierThresholdForJobService', function () {
+
+  const jobWithTwoComplete = buildJob({ status: JobStatus.RUNNING });
+  const jobWithOneComplete = buildJob({ status: JobStatus.RUNNING, ignoreErrors: true });
+
+  hookTransaction();
+
+  before(async function () {
+    await jobWithTwoComplete.save(this.trx);
+    await buildWorkItem({ jobID: jobWithTwoComplete.jobID, status: WorkItemStatus.SUCCESSFUL,
+      workflowStepIndex: 0, startedAt: new Date(), duration: 100 }).save(this.trx);
+    await buildWorkItem({ jobID: jobWithTwoComplete.jobID, status: WorkItemStatus.SUCCESSFUL,
+      workflowStepIndex: 0, startedAt: new Date(), duration: 200 }).save(this.trx);
+    await buildWorkflowStep({ jobID: jobWithTwoComplete.jobID, stepIndex: 0, serviceID: 'subsetter' }).save(this.trx);
+
+    await jobWithOneComplete.save(this.trx);
+    await buildWorkItem({ jobID: jobWithOneComplete.jobID, status: WorkItemStatus.SUCCESSFUL,
+      workflowStepIndex: 0, startedAt: new Date() }).save(this.trx);
+    await buildWorkItem({ jobID: jobWithOneComplete.jobID, status: WorkItemStatus.RUNNING,
+      workflowStepIndex: 0, startedAt: new Date() }).save(this.trx);
+    await buildWorkflowStep({ jobID: jobWithOneComplete.jobID, stepIndex: 0, serviceID: 'subsetter' }).save(this.trx);
+
+    await this.trx.commit();
+  });
+
+  after(async function () {
+    await truncateAll();
+  });
+
+  it('returns the default threshold when less than 2 items are successful', async function () {
+    expect(await computeWorkItemDurationOutlierThresholdForJobService(
+      jobWithOneComplete.jobID,
+      'subsetter',
+      0,
+    )).to.equal(7200000);
+  });
+  
+  it('returns 2*maxDuration when at least 2 items are successful', async function () {
+    expect(await computeWorkItemDurationOutlierThresholdForJobService(
+      jobWithTwoComplete.jobID,
+      'subsetter',
+      0,
+    )).to.equal(400);
+  });
+});

--- a/test/models/work-item.ts
+++ b/test/models/work-item.ts
@@ -2,7 +2,7 @@ import { describe } from 'mocha';
 import { buildJob } from '../helpers/jobs';
 import { JobStatus } from '../../app/models/job';
 import { computeWorkItemDurationOutlierThresholdForJobService } from '../../app/models/work-item';
-import { hookTransaction, truncateAll } from '../helpers/db';
+import { hookTransaction } from '../helpers/db';
 import { buildWorkItem } from '../helpers/work-items';
 import { expect } from 'chai';
 import { WorkItemStatus } from '../../app/models/work-item-interface';


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1317

## Description
For work item timeouts, this change ensures that at least 2 items complete before calculating the smart timeout threshold, otherwise it will return the default timeout threshold.

## Local Test Steps
Follow steps from https://github.com/nasa/harmony/pull/266 and also log the `computeWorkItemDurationOutlierThresholdForJobService` logic to see if the computation is working as expected.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)