### PR TITLE
HARMONY-1274: Add tests that batching obeys services.yml configuration

### DIFF
--- a/test/aggregation-batching.ts
+++ b/test/aggregation-batching.ts
@@ -15,6 +15,7 @@ import { Job } from '../app/models/job';
 import WorkItem from '../app/models/work-item';
 import { objectStoreForProtocol } from '../app/util/object-store';
 import { truncateAll } from './helpers/db';
+import { hookServices } from './helpers/stub-service';
 
 /**
  * Create a work item update for a query-cmr get work response
@@ -54,6 +55,15 @@ describe('when testing a batched aggregation service', function () {
   hookServersStartStop({ skipEarthdataLogin: false });
   const collection = 'C1243729749-EEDTEST';
   describe('with only one batch that should be created', function () {
+    let batchInputsStub;
+    before(function () {
+      batchInputsStub = stub(env, 'maxBatchInputs').get(() => 3);
+    });
+    after(function () {
+      if (batchInputsStub.restore) {
+        batchInputsStub.restore();
+      }
+    });
     describe('when submitting a request for concise', function () {
       const conciseQuery = {
         maxResults: 2,
@@ -143,17 +153,22 @@ describe('when testing a batched aggregation service', function () {
     });
   });
 
-  describe('with multiple batches due to item counts and service configuration', function () {
+  describe('with multiple batches due to item counts and global configuration', function () {
     let sizeOfObjectStub;
+    let batchInputsStub;
     let pageStub;
     before(function () {
       pageStub = stub(env, 'cmrMaxPageSize').get(() => 2);
+      batchInputsStub = stub(env, 'maxBatchInputs').get(() => 3);
       sizeOfObjectStub = stub(aggregationBatch, 'sizeOfObject')
         .callsFake(async (_) => 1);
     });
     after(function () {
       if (pageStub.restore) {
         pageStub.restore();
+      }
+      if (batchInputsStub.restore) {
+        batchInputsStub.restore();
       }
       if (sizeOfObjectStub.restore) {
         sizeOfObjectStub.restore();
@@ -165,6 +180,268 @@ describe('when testing a batched aggregation service', function () {
         maxResults: 7,
         concatenate: true,
       };
+
+      hookRangesetRequest('1.0.0', collection, 'all', { query: conciseQuery, username: 'joe' });
+      hookRedirect('joe');
+
+      it('generates a workflow with 2 steps', async function () {
+        const job = JSON.parse(this.res.text);
+        const workflowSteps = await getWorkflowStepsByJobId(db, job.jobID);
+        expect(workflowSteps.length).to.equal(2);
+      });
+
+      it('starts with the query-cmr task', async function () {
+        const job = JSON.parse(this.res.text);
+        const workflowSteps = await getWorkflowStepsByJobId(db, job.jobID);
+        expect(workflowSteps[0].serviceID).to.equal('harmonyservices/query-cmr:latest');
+      });
+
+      it('then requests aggregation using concise', async function () {
+        const job = JSON.parse(this.res.text);
+        const workflowSteps = await getWorkflowStepsByJobId(db, job.jobID);
+        expect(workflowSteps[1].serviceID).to.equal('ghcr.io/podaac/concise:sit');
+      });
+
+      it('has the number of input granules set to 7', function () {
+        const job = JSON.parse(this.res.text);
+        expect(job.numInputGranules).to.equal(7);
+      });
+
+      describe('when first checking for a query-cmr work item', function () {
+        it('finds the first item and can complete it', async function () {
+          const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
+          expect(res.status).to.equal(200);
+          const { workItem, maxCmrGranules } = JSON.parse(res.text);
+          expect(maxCmrGranules).to.equal(2);
+          expect(workItem.serviceID).to.equal('harmonyservices/query-cmr:latest');
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [
+            getStacLocation(workItem, 'catalog0.json'),
+            getStacLocation(workItem, 'catalog1.json'),
+          ];
+          workItem.outputItemSizes = [1, 2];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id, 2, 1);
+          await updateWorkItem(this.backend, workItem);
+        });
+      });
+
+      // Verify that since only 2 items were created from query-cmr it does not yet batch a concise request (need 3)
+      describe('when checking for a concise work item', function () {
+        hookGetWorkForService('ghcr.io/podaac/concise:sit');
+        it('does not find a work item', async function () {
+          expect(this.res.status).to.equal(404);
+        });
+      });
+
+      describe('when checking for a query-cmr work item for the second time', function () {
+        it('finds the second item and can complete it', async function () {
+          const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
+          expect(res.status).to.equal(200);
+          const { workItem, maxCmrGranules } = JSON.parse(res.text);
+          expect(maxCmrGranules).to.equal(2);
+          expect(workItem.serviceID).to.equal('harmonyservices/query-cmr:latest');
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [
+            getStacLocation(workItem, 'catalog0.json'),
+            getStacLocation(workItem, 'catalog1.json'),
+          ];
+          workItem.outputItemSizes = [1, 2];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id, 2, 1);
+          await updateWorkItem(this.backend, workItem);
+        });
+      });
+
+      describe('when checking to see if a concise work item is queued now that four inputs have been generated from query-cmr', function () {
+        it('finds the first concise work item and can complete it', async function () {
+          const res = await getWorkForService(this.backend, 'ghcr.io/podaac/concise:sit');
+          expect(res.status).to.equal(200);
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          workItem.outputItemSizes = [1];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id, 1, 1);
+          await updateWorkItem(this.backend, workItem);
+          expect(workItem.serviceID).to.equal('ghcr.io/podaac/concise:sit');
+        });
+
+        describe('when checking for a second concise work item', function () {
+          hookGetWorkForService('ghcr.io/podaac/concise:sit');
+          it('does not find a work item (currently have 4, but need 6 inputs from query-cmr before the second concise batch)', async function () {
+            expect(this.res.status).to.equal(404);
+          });
+        });
+
+        describe('when checking the jobs listing', function () {
+          it('lists the job as running and progress of 43 with 1 link to the first aggregated output', async function () {
+            const jobs = await Job.forUser(db, 'joe');
+            const job = jobs.data[0];
+            expect(job.status).to.equal('running');
+            expect(job.progress).to.equal(50);
+            const dataLinks = job.links.filter(link => link.rel === 'data');
+            expect(dataLinks.length).to.equal(1);
+          });
+        });
+      });
+
+      describe('when checking for a query-cmr work item for the third time', function () {
+        it('finds the third item and can complete it', async function () {
+          const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
+          expect(res.status).to.equal(200);
+          const { workItem, maxCmrGranules } = JSON.parse(res.text);
+          expect(maxCmrGranules).to.equal(2);
+          expect(workItem.serviceID).to.equal('harmonyservices/query-cmr:latest');
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [
+            getStacLocation(workItem, 'catalog0.json'),
+            getStacLocation(workItem, 'catalog1.json'),
+          ];
+          workItem.outputItemSizes = [1, 2];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id, 2, 1);
+          await updateWorkItem(this.backend, workItem);
+        });
+
+        describe('when checking to see if a second concise work item is queued now that 6 inputs from query-cmr items have completed', function () {
+          it('finds the second concise work item and can complete it', async function () {
+            const res = await getWorkForService(this.backend, 'ghcr.io/podaac/concise:sit');
+            expect(res.status).to.equal(200);
+            const { workItem } = JSON.parse(res.text);
+            workItem.status = WorkItemStatus.SUCCESSFUL;
+            workItem.results = [getStacLocation(workItem, 'catalog.json')];
+            workItem.outputItemSizes = [1];
+            await fakeServiceStacOutput(workItem.jobID, workItem.id, 1, 1);
+            await updateWorkItem(this.backend, workItem);
+            expect(workItem.serviceID).to.equal('ghcr.io/podaac/concise:sit');
+          });
+
+          describe('when checking for a third concise work item', function () {
+            hookGetWorkForService('ghcr.io/podaac/concise:sit');
+            it('does not find a work item (currently have 6, but need 7 inputs from query-cmr before the third concise batch)', async function () {
+              expect(this.res.status).to.equal(404);
+            });
+          });
+
+          describe('when checking the jobs listing', function () {
+            it('marks the job as running and progress of 86 with 2 links to the first two aggregated outputs', async function () {
+              const jobs = await Job.forUser(db, 'joe');
+              const job = jobs.data[0];
+              expect(job.status).to.equal('running');
+              expect(job.progress).to.equal(66);
+              const dataLinks = job.links.filter(link => link.rel === 'data');
+              expect(dataLinks.length).to.equal(2);
+            });
+          });
+        });
+      });
+
+      describe('when checking for a query-cmr work item for the fourth time', function () {
+        it('finds the fourth item and can complete it', async function () {
+          const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
+          expect(res.status).to.equal(200);
+          const { workItem, maxCmrGranules } = JSON.parse(res.text);
+          expect(maxCmrGranules).to.equal(1);
+          expect(workItem.serviceID).to.equal('harmonyservices/query-cmr:latest');
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [
+            getStacLocation(workItem, 'catalog.json'),
+          ];
+          workItem.outputItemSizes = [1];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id, 1, 1);
+          await updateWorkItem(this.backend, workItem);
+        });
+
+        describe('when checking for another query-cmr work item', function () {
+          hookGetWorkForService('harmonyservices/query-cmr:latest');
+          it('does not find a work item since all inputs have been received', async function () {
+            expect(this.res.status).to.equal(404);
+          });
+        });
+
+        describe('when checking to see if a third concise work item is queued now that all 7 inputs from query-cmr items have completed', function () {
+          it('finds the third concise work item and can complete it', async function () {
+            const res = await getWorkForService(this.backend, 'ghcr.io/podaac/concise:sit');
+            expect(res.status).to.equal(200);
+            const { workItem } = JSON.parse(res.text);
+            workItem.status = WorkItemStatus.SUCCESSFUL;
+            workItem.results = [getStacLocation(workItem, 'catalog.json')];
+            workItem.outputItemSizes = [1];
+            await fakeServiceStacOutput(workItem.jobID, workItem.id, 1, 1);
+            await updateWorkItem(this.backend, workItem);
+            expect(workItem.serviceID).to.equal('ghcr.io/podaac/concise:sit');
+          });
+
+          describe('when checking for another concise work item', function () {
+            hookGetWorkForService('ghcr.io/podaac/concise:sit');
+            it('does not find a work item because all items have been processed', async function () {
+              expect(this.res.status).to.equal(404);
+            });
+          });
+
+          describe('when checking the jobs listing', function () {
+            it('marks the job as successful and progress of 100 with 3 links to the three aggregated outputs', async function () {
+              const jobs = await Job.forUser(db, 'joe');
+              const job = jobs.data[0];
+              expect(job.status).to.equal('successful');
+              expect(job.progress).to.equal(100);
+              const dataLinks = job.links.filter(link => link.rel === 'data');
+              expect(dataLinks.length).to.equal(3);
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('with multiple batches due to item counts and service configuration', function () {
+    let sizeOfObjectStub;
+    let batchInputsStub;
+    let pageStub;
+    before(function () {
+      pageStub = stub(env, 'cmrMaxPageSize').get(() => 2);
+      batchInputsStub = stub(env, 'maxBatchInputs').get(() => 1_000_000_000);
+      sizeOfObjectStub = stub(aggregationBatch, 'sizeOfObject')
+        .callsFake(async (_) => 1);
+    });
+    after(function () {
+      if (pageStub.restore) {
+        pageStub.restore();
+      }
+      if (batchInputsStub.restore) {
+        batchInputsStub.restore();
+      }
+      if (sizeOfObjectStub.restore) {
+        sizeOfObjectStub.restore();
+      }
+    });
+
+    describe('when submitting a request for concise', function () {
+      const conciseQuery = {
+        maxResults: 7,
+        concatenate: true,
+      };
+
+      const serviceConfigs = [
+        {
+          name: 'podaac/concise',
+          data_operation_version: '0.17.0',
+          type: {
+            name: 'turbo',
+          },
+          collections: [{ id: collection }],
+          capabilities: {
+            concatenation: true,
+          },
+          steps: [{
+            image: 'harmonyservices/query-cmr:latest',
+          }, {
+            image: 'ghcr.io/podaac/concise:sit',
+            is_batched: true,
+            max_batch_inputs: 3,
+            operations: ['concatenate'],
+          }],
+        },
+      ];
+
+      hookServices(serviceConfigs);
 
       hookRangesetRequest('1.0.0', collection, 'all', { query: conciseQuery, username: 'joe' });
       hookRedirect('joe');
@@ -569,6 +846,260 @@ describe('when testing a batched aggregation service', function () {
             getStacLocation(workItem, 'catalog.json'),
           ];
           workItem.outputItemSizes = [10000];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id, 1, 1);
+          await updateWorkItem(this.backend, workItem);
+        });
+
+        describe('when checking for another query-cmr work item', function () {
+          hookGetWorkForService('harmonyservices/query-cmr:latest');
+          it('does not find a work item since all inputs have been received', async function () {
+            expect(this.res.status).to.equal(404);
+          });
+        });
+
+        describe('when checking to see if a third concise work item is queued now that all 7 inputs from query-cmr items have completed', function () {
+          it('finds the third concise work item and can complete it', async function () {
+            const res = await getWorkForService(this.backend, 'ghcr.io/podaac/concise:sit');
+            expect(res.status).to.equal(200);
+            const { workItem } = JSON.parse(res.text);
+            workItem.status = WorkItemStatus.SUCCESSFUL;
+            workItem.results = [getStacLocation(workItem, 'catalog.json')];
+            workItem.outputItemSizes = [1];
+            await fakeServiceStacOutput(workItem.jobID, workItem.id, 1, 1);
+            await updateWorkItem(this.backend, workItem);
+            expect(workItem.serviceID).to.equal('ghcr.io/podaac/concise:sit');
+          });
+
+          describe('when checking for another concise work item', function () {
+            it('finds the final concise work item and can complete it', async function () {
+              const res = await getWorkForService(this.backend, 'ghcr.io/podaac/concise:sit');
+              expect(res.status).to.equal(200);
+              const { workItem } = JSON.parse(res.text);
+              workItem.status = WorkItemStatus.SUCCESSFUL;
+              workItem.results = [getStacLocation(workItem, 'catalog.json')];
+              workItem.outputItemSizes = [1];
+              await fakeServiceStacOutput(workItem.jobID, workItem.id, 1, 1);
+              await updateWorkItem(this.backend, workItem);
+              expect(workItem.serviceID).to.equal('ghcr.io/podaac/concise:sit');
+            });
+          });
+
+          describe('when checking for another concise work item', function () {
+            hookGetWorkForService('ghcr.io/podaac/concise:sit');
+            it('does not find a work item because all items have been processed', async function () {
+              expect(this.res.status).to.equal(404);
+            });
+          });
+
+          describe('when checking the jobs listing', function () {
+            it('marks the job as successful and progress of 100 with 4 links to the three aggregated outputs', async function () {
+              const jobs = await Job.forUser(db, 'joe');
+              const job = jobs.data[0];
+              expect(job.status).to.equal('successful');
+              expect(job.progress).to.equal(100);
+              const dataLinks = job.links.filter(link => link.rel === 'data');
+              expect(dataLinks.length).to.equal(4);
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('with multiple batches due to service size constraints', function () {
+    let sizeOfObjectStub;
+    let pageStub;
+    let batchSizeStub;
+
+    before(function () {
+      pageStub = stub(env, 'cmrMaxPageSize').get(() => 2);
+      batchSizeStub = stub(env, 'maxBatchSizeInBytes').get(() => 5_000_000);
+      sizeOfObjectStub = stub(aggregationBatch, 'sizeOfObject')
+        .callsFake(async (_) => 3000);
+    });
+    after(function () {
+      if (pageStub.restore) {
+        pageStub.restore();
+      }
+      if (batchSizeStub.restore) {
+        batchSizeStub.restore();
+      }
+      if (sizeOfObjectStub.restore) {
+        sizeOfObjectStub.restore();
+      }
+    });
+    describe('when submitting a request for concise', function () {
+      const conciseQuery = {
+        maxResults: 7,
+        concatenate: true,
+      };
+
+      const serviceConfigs = [
+        {
+          name: 'podaac/concise',
+          data_operation_version: '0.17.0',
+          type: {
+            name: 'turbo',
+          },
+          collections: [{ id: collection }],
+          capabilities: {
+            concatenation: true,
+          },
+          steps: [{
+            image: 'harmonyservices/query-cmr:latest',
+          }, {
+            image: 'ghcr.io/podaac/concise:sit',
+            is_batched: true,
+            max_batch_size_in_bytes: 5,
+            operations: ['concatenate'],
+          }],
+        },
+      ];
+
+      hookServices(serviceConfigs);
+
+      hookRangesetRequest('1.0.0', collection, 'all', { query: conciseQuery, username: 'joe' });
+      hookRedirect('joe');
+
+      describe('when first checking for a query-cmr work item', function () {
+        it('finds the first item and can complete it', async function () {
+          const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
+          expect(res.status).to.equal(200);
+          const { workItem, maxCmrGranules } = JSON.parse(res.text);
+          expect(maxCmrGranules).to.equal(2);
+          expect(workItem.serviceID).to.equal('harmonyservices/query-cmr:latest');
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [
+            getStacLocation(workItem, 'catalog0.json'),
+            getStacLocation(workItem, 'catalog1.json'),
+          ];
+          workItem.outputItemSizes = [2, 1];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id, 2, 1);
+          await updateWorkItem(this.backend, workItem);
+        });
+      });
+
+      // Verify that since only 3 bytes for items were created from query-cmr it does not yet
+      // batch a concise request (limit for this test is 5)
+      describe('when checking for a concise work item', function () {
+        hookGetWorkForService('ghcr.io/podaac/concise:sit');
+        it('does not find a work item', async function () {
+          expect(this.res.status).to.equal(404);
+        });
+      });
+
+      describe('when checking for a query-cmr work item for the second time', function () {
+        it('finds the second item and can complete it', async function () {
+          const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
+          expect(res.status).to.equal(200);
+          const { workItem, maxCmrGranules } = JSON.parse(res.text);
+          expect(maxCmrGranules).to.equal(2);
+          expect(workItem.serviceID).to.equal('harmonyservices/query-cmr:latest');
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [
+            getStacLocation(workItem, 'catalog0.json'),
+            getStacLocation(workItem, 'catalog1.json'),
+          ];
+          workItem.outputItemSizes = [2, 2];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id, 2, 1);
+          await updateWorkItem(this.backend, workItem);
+        });
+      });
+
+      describe('when checking to see if a concise work item is queued now that enough bytes have been generated from query-cmr', function () {
+        it('finds the first concise work item and can complete it', async function () {
+          const res = await getWorkForService(this.backend, 'ghcr.io/podaac/concise:sit');
+          expect(res.status).to.equal(200);
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          workItem.outputItemSizes = [1];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id, 1, 1);
+          await updateWorkItem(this.backend, workItem);
+          expect(workItem.serviceID).to.equal('ghcr.io/podaac/concise:sit');
+        });
+
+        describe('when checking for a second concise work item', function () {
+          hookGetWorkForService('ghcr.io/podaac/concise:sit');
+          it('does not find a work item (current batch has 4 bytes, but can hold up to 5)', async function () {
+            expect(this.res.status).to.equal(404);
+          });
+        });
+
+        describe('when checking the jobs listing', function () {
+          it('lists the job as running and progress of 43 with 1 link to the first aggregated output', async function () {
+            const jobs = await Job.forUser(db, 'joe');
+            const job = jobs.data[0];
+            expect(job.status).to.equal('running');
+            expect(job.progress).to.equal(50);
+            const dataLinks = job.links.filter(link => link.rel === 'data');
+            expect(dataLinks.length).to.equal(1);
+          });
+        });
+      });
+
+      describe('when checking for a query-cmr work item for the third time', function () {
+        it('finds the third item and can complete it', async function () {
+          const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
+          expect(res.status).to.equal(200);
+          const { workItem, maxCmrGranules } = JSON.parse(res.text);
+          expect(maxCmrGranules).to.equal(2);
+          expect(workItem.serviceID).to.equal('harmonyservices/query-cmr:latest');
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [
+            getStacLocation(workItem, 'catalog0.json'),
+            getStacLocation(workItem, 'catalog1.json'),
+          ];
+          workItem.outputItemSizes = [3, 2];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id, 2, 1);
+          await updateWorkItem(this.backend, workItem);
+        });
+
+        describe('when checking to see if a second concise work item is queued now that another 5 bytes of inputs from query-cmr items have completed', function () {
+          it('finds the second concise work item and can complete it', async function () {
+            const res = await getWorkForService(this.backend, 'ghcr.io/podaac/concise:sit');
+            expect(res.status).to.equal(200);
+            const { workItem } = JSON.parse(res.text);
+            workItem.status = WorkItemStatus.SUCCESSFUL;
+            workItem.results = [getStacLocation(workItem, 'catalog.json')];
+            workItem.outputItemSizes = [1];
+            await fakeServiceStacOutput(workItem.jobID, workItem.id, 1, 1);
+            await updateWorkItem(this.backend, workItem);
+            expect(workItem.serviceID).to.equal('ghcr.io/podaac/concise:sit');
+          });
+
+          describe('when checking for a third concise work item', function () {
+            hookGetWorkForService('ghcr.io/podaac/concise:sit');
+            it('does not find a work item (currently have 2 bytes in the batch, but it can hold up to 5)', async function () {
+              expect(this.res.status).to.equal(404);
+            });
+          });
+
+          describe('when checking the jobs listing', function () {
+            it('marks the job as running and progress of 86 with 2 links to the first two aggregated outputs', async function () {
+              const jobs = await Job.forUser(db, 'joe');
+              const job = jobs.data[0];
+              expect(job.status).to.equal('running');
+              expect(job.progress).to.equal(66);
+              const dataLinks = job.links.filter(link => link.rel === 'data');
+              expect(dataLinks.length).to.equal(2);
+            });
+          });
+        });
+      });
+
+      describe('when checking for a query-cmr work item for the fourth time', function () {
+        it('finds the fourth item and can complete it', async function () {
+          const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
+          expect(res.status).to.equal(200);
+          const { workItem, maxCmrGranules } = JSON.parse(res.text);
+          expect(maxCmrGranules).to.equal(1);
+          expect(workItem.serviceID).to.equal('harmonyservices/query-cmr:latest');
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [
+            getStacLocation(workItem, 'catalog.json'),
+          ];
+          workItem.outputItemSizes = [5];
           await fakeServiceStacOutput(workItem.jobID, workItem.id, 1, 1);
           await updateWorkItem(this.backend, workItem);
         });

--- a/test/helpers/env.ts
+++ b/test/helpers/env.ts
@@ -18,6 +18,10 @@ process.env.PREVIEW_THRESHOLD = '500';
 // prevent tests from using a different page size and creating many fixtures
 process.env.CMR_MAX_PAGE_SIZE = '100';
 
+// use reasonable aggregation batch sizes for tests
+process.env.MAX_BATCH_INPUTS = '3';
+process.env.MAX_BATCH_SIZE_IN_BYTES = '10000';
+
 // eslint-disable-next-line import/first
 import env from '../../app/util/env'; // Must set required env before loading the env file
 

--- a/test/helpers/env.ts
+++ b/test/helpers/env.ts
@@ -18,10 +18,6 @@ process.env.PREVIEW_THRESHOLD = '500';
 // prevent tests from using a different page size and creating many fixtures
 process.env.CMR_MAX_PAGE_SIZE = '100';
 
-// use reasonable aggregation batch sizes for tests
-process.env.MAX_BATCH_INPUTS = '3';
-process.env.MAX_BATCH_SIZE_IN_BYTES = '10000';
-
 // eslint-disable-next-line import/first
 import env from '../../app/util/env'; // Must set required env before loading the env file
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1274

## Description
Adds tests to verify that batching for aggregation services obeys configuration set in services.yml

## Local Test Steps
* add `max_batch_inputs: 3` after line 613 in services.yml
* restart harmony
* Issue the following request
```
http://localhost:3000/C1234208438-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?skipPreview=true&maxResults=7&concatenate=true
```
* Verify using the workflow-ui that the job has three concise work items
* Use the following SQL query to verify that there were seven batch_items created in three batches
```sql
select * from batch_items;
```
## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~