### PR TITLE
HARMONY-1280: As a harmony user, I want my aggregation request to be able to complete even if some items fail

### DIFF
--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -262,78 +262,81 @@ async function createAggregatingWorkItem(
  * Creates the next work items for the workflow based on the results of the current step and handle
  * any needed batching
  * @param tx - The database transaction
+ * @param nextWorkflowStep - the next workflow step in the chain after the current workItem
  * @param logger - a Logger instance
  * @param workItem - The current work item
+ * @param status - The status returned for the work item update
  * @param allWorkItemsForStepComplete - true if all the work items for the current step are complete
  * @param results - an array of paths to STAC catalogs
  * @param outputItemSizes - an array of sizes (in bytes) of the output items for the current step
  */
 async function createNextWorkItems(
   tx: Transaction,
+  nextWorkflowStep: WorkflowStep,
   logger: Logger,
   workItem: WorkItem,
+  status: WorkItemStatus,
   allWorkItemsForStepComplete: boolean,
   results: string[],
   outputItemSizes: number[],
-): Promise<WorkflowStep> {
-  const nextStep = await getWorkflowStepByJobIdStepIndex(
-    tx, workItem.jobID, workItem.workflowStepIndex + 1,
-  );
-
-  if (nextStep) {
-    if (results && results.length > 0) {
-      // if we have completed all the work items for this step or if the next step does not
-      // aggregate then create a work item for the next step
-      if (nextStep.hasAggregatedOutput) {
-        if (nextStep.isBatched) {
-          const outputItemUrls = await outputStacItemUrls(results);
-          // TODO add other services that can produce more than one output and so should have their batching sortIndex propagated to child work items to provide consistent batching
-          let sortIndex;
-          if (!QUERY_CMR_SERVICE_REGEX.test(workItem.serviceID)) {
-            // eslint-disable-next-line prefer-destructuring
-            sortIndex = workItem.sortIndex;
-          }
-          await handleBatching(
-            tx,
-            logger,
-            nextStep,
-            outputItemUrls,
-            outputItemSizes,
-            sortIndex,
-            allWorkItemsForStepComplete);
-        } else if (allWorkItemsForStepComplete) {
-          await createAggregatingWorkItem(tx, workItem, nextStep);
+): Promise<void> {
+  if (results && results.length > 0) {
+    // if we have completed all the work items for this step or if the next step does not
+    // aggregate then create a work item for the next step
+    if (nextWorkflowStep.hasAggregatedOutput) {
+      if (nextWorkflowStep.isBatched) {
+        let sortIndex;
+        if (!QUERY_CMR_SERVICE_REGEX.test(workItem.serviceID)) {
+          // eslint-disable-next-line prefer-destructuring
+          sortIndex = workItem.sortIndex;
         }
-      } else {
-        // Create a new work item for each result using the next step
-
-        // use the sort index from the previous step's work item unless we have more than one
-        // result, in which case we start from the previous highest sort index for this step
-        // NOTE: This is only valid if the work-items for this multi-output step are worked
-        // sequentially, as with query-cmr. If they are worked in parallel then we need a
-        // different approach.
-        let { sortIndex } = workItem;
-        if (results.length > 1) {
-          sortIndex = await maxSortIndexForJobService(tx, nextStep.jobID, nextStep.serviceID);
+        let outputItemUrls = [];
+        if (workItem.status !== WorkItemStatus.FAILED) {
+          outputItemUrls = await outputStacItemUrls(results);
         }
-        const newItems = results.map(result => {
-          sortIndex += 1;
-          return new WorkItem({
-            jobID: workItem.jobID,
-            serviceID: nextStep.serviceID,
-            status: WorkItemStatus.READY,
-            stacCatalogLocation: result,
-            workflowStepIndex: nextStep.stepIndex,
-            sortIndex,
-          });
+        logger.error(`CDD: workItem is ${JSON.stringify(workItem)} and workItemStatus is ${workItem.status}`);
+        // TODO add other services that can produce more than one output and so should have their
+        // batching sortIndex propagated to child work items to provide consistent batching
+        await handleBatching(
+          tx,
+          logger,
+          nextWorkflowStep,
+          outputItemUrls,
+          outputItemSizes,
+          sortIndex,
+          status,
+          allWorkItemsForStepComplete);
+      } else if (allWorkItemsForStepComplete) {
+        await createAggregatingWorkItem(tx, workItem, nextWorkflowStep);
+      }
+    } else {
+      // Create a new work item for each result using the next step
+
+      // use the sort index from the previous step's work item unless we have more than one
+      // result, in which case we start from the previous highest sort index for this step
+      // NOTE: This is only valid if the work-items for this multi-output step are worked
+      // sequentially, as with query-cmr. If they are worked in parallel then we need a
+      // different approach.
+      let { sortIndex } = workItem;
+      if (results.length > 1) {
+        sortIndex = await maxSortIndexForJobService(tx, nextWorkflowStep.jobID, nextWorkflowStep.serviceID);
+      }
+      const newItems = results.map(result => {
+        sortIndex += 1;
+        return new WorkItem({
+          jobID: workItem.jobID,
+          serviceID: nextWorkflowStep.serviceID,
+          status: WorkItemStatus.READY,
+          stacCatalogLocation: result,
+          workflowStepIndex: nextWorkflowStep.stepIndex,
+          sortIndex,
         });
-        for (const batch of _.chunk(newItems, batchSize)) {
-          await WorkItem.insertBatch(tx, batch);
-        }
+      });
+      for (const batch of _.chunk(newItems, batchSize)) {
+        await WorkItem.insertBatch(tx, batch);
       }
     }
   }
-  return nextStep;
 }
 
 /**
@@ -517,6 +520,9 @@ async function updateWorkItemCounts(
 
 /**
  * Update job status/progress in response to a service provided work item update
+ * IMPORTANT: This asynchronous function is called without awaiting, so any errors must be
+ * handled in this function and no exceptions should be thrown since nothing will catch
+ * them.
  *
  * @param update - information about the work item update
  * @param operation - the DataOperation for the user's request
@@ -526,7 +532,8 @@ export async function handleWorkItemUpdate(
   update: WorkItemUpdate,
   operation: object,
   logger: Logger): Promise<void> {
-  const { workItemID, status, hits, results, scrollID, errorMessage } = update;
+  const { workItemID, hits, results, scrollID } = update;
+  let { errorMessage, status } = update;
   if (status === WorkItemStatus.SUCCESSFUL) {
     logger.info(`Updating work item ${workItemID} to ${status}`);
   }
@@ -536,128 +543,147 @@ export async function handleWorkItemUpdate(
   // Get the sizes of all the data items/granules returned for the WorkItem and STAC item links
   // when batching.
   // This needs to be done outside the transaction as it can be slow if there are many granules.
-  const outputItemSizes = await resultItemSizes(update, operation, logger);
+  let outputItemSizes;
+  try {
+    outputItemSizes = await resultItemSizes(update, operation, logger);
+  } catch (e) {
+    // TODO change this to not trap the error, just testing with concise
+    // logger.error('Could not determine result item sizes, assuming 0.');
+    logger.error(e);
+    status = WorkItemStatus.FAILED;
+    errorMessage = 'STAC catalog returned from service could not be parsed';
+    // outputItemSizes = results.map((_i) => 0);
+  }
 
-  await db.transaction(async (tx) => {
-    const job = await Job.byJobID(tx, jobID, false, true);
-    // lock the work item to we can update it - need to do this after locking jobs table above
-    // to avoid deadlocks
-    const workItem = await getWorkItemById(tx, workItemID, true);
-    const thisStep = await getWorkflowStepByJobIdStepIndex(tx, workItem.jobID, workItem.workflowStepIndex);
+  try {
+    await db.transaction(async (tx) => {
+      const job = await Job.byJobID(tx, jobID, false, true);
+      // lock the work item to we can update it - need to do this after locking jobs table above
+      // to avoid deadlocks
+      const workItem = await getWorkItemById(tx, workItemID, true);
+      const thisStep = await getWorkflowStepByJobIdStepIndex(tx, workItem.jobID, workItem.workflowStepIndex);
 
-    // If the job was already in a terminal state then send 409 response
-    // unless we are just canceling the work item
-    if (job.isComplete() && status !== WorkItemStatus.CANCELED) {
-      logger.warn(`Job was already ${job.status}.`);
-      // Note work item will stay in the running state, but the reaper will clean it up
-      return;
-    }
-
-    // Don't allow updates to work items that are already in a terminal state
-    if (COMPLETED_WORK_ITEM_STATUSES.includes(workItem.status)) {
-      logger.warn(`WorkItem ${workItemID} was already ${workItem.status}`);
-      return;
-    }
-
-    // retry failed work-items up to a limit
-    if (status === WorkItemStatus.FAILED) {
-      if (workItem.retryCount < env.workItemRetryLimit) {
-        logger.warn(`Retrying failed work-item ${workItemID}`);
-        workItem.retryCount += 1;
-        workItem.status = WorkItemStatus.READY;
-        await workItem.save(tx);
+      // If the job was already in a terminal state then send 409 response
+      // unless we are just canceling the work item
+      if (job.isComplete() && status !== WorkItemStatus.CANCELED) {
+        logger.warn(`Job was already ${job.status}.`);
+        // Note work item will stay in the running state, but the reaper will clean it up
         return;
-      } else {
-        logger.warn(`Retry limit of ${env.workItemRetryLimit} exceeded`);
-        logger.warn(`Updating work item for ${workItemID} to ${status} with message ${errorMessage}`);
-      }
-    }
-
-    // We calculate the duration of the work both in harmony and in the manager of the service pod.
-    // We tend to favor the harmony value as it is normally longer since it accounts for the extra
-    // overhead of communication with the pod. There is a problem with retries however in that
-    // the startTime gets reset, so if an earlier worker finishes and replies it will look like
-    // the whole thing was quicker (since our startTime has changed). So in that case we want to
-    // use the time reported by the service pod. Any updates from retries that happen later  will
-    // be ignored since the work item is already in a 'successful' state.
-    const harmonyDuration = Date.now() - workItem.startedAt.valueOf();
-    let duration = harmonyDuration;
-    if (update.duration) {
-      duration = Math.max(duration, update.duration);
-    }
-
-    logger.debug(`Work item duration (ms): ${duration}`);
-
-    let { totalItemsSize } = update;
-
-    if (!totalItemsSize && outputItemSizes?.length > 0) {
-      totalItemsSize = sum(outputItemSizes) / 1024 / 1024;
-    }
-
-    await updateWorkItemStatus(
-      tx,
-      workItemID,
-      status as WorkItemStatus,
-      duration,
-      totalItemsSize,
-      outputItemSizes);
-
-    const completedWorkItemCount = await workItemCountForStep(
-      tx, workItem.jobID, workItem.workflowStepIndex, COMPLETED_WORK_ITEM_STATUSES,
-    );
-    const allWorkItemsForStepComplete = (completedWorkItemCount == thisStep.workItemCount);
-
-    if (hits && job.numInputGranules > hits) {
-      job.numInputGranules = hits;
-      await job.save(tx);
-      await updateWorkItemCounts(tx, job);
-    }
-
-    const continueProcessing = await handleFailedWorkItems(tx, job, workItem, thisStep, status, logger, errorMessage);
-    if (continueProcessing) {
-      let nextStep = null;
-      if (status != WorkItemStatus.FAILED) {
-        nextStep = await createNextWorkItems(
-          tx,
-          logger,
-          workItem,
-          allWorkItemsForStepComplete,
-          results,
-          outputItemSizes);
       }
 
-      if (nextStep) {
-        if (results && results.length > 0) {
-          // set the scrollID for the next work item to the one we received from the update
-          workItem.scrollID = scrollID;
-          await maybeQueueQueryCmrWorkItem(tx, workItem, logger);
+      // Don't allow updates to work items that are already in a terminal state
+      if (COMPLETED_WORK_ITEM_STATUSES.includes(workItem.status)) {
+        logger.warn(`WorkItem ${workItemID} was already ${workItem.status}`);
+        return;
+      }
+
+      // retry failed work-items up to a limit
+      if (status === WorkItemStatus.FAILED) {
+        if (workItem.retryCount < env.workItemRetryLimit) {
+          logger.warn(`Retrying failed work-item ${workItemID}`);
+          workItem.retryCount += 1;
+          workItem.status = WorkItemStatus.READY;
+          await workItem.save(tx);
+          return;
         } else {
-          // Failed to create the next work items - fail the job rather than leaving it orphaned
-          // in the running state
-          logger.error('The work item update should have contained results to queue a next work item, but it did not.');
-          const message = 'Harmony internal failure: could not create the next work items for the request.';
-          await completeJob(tx, job, JobStatus.FAILED, logger, message);
+          logger.warn(`Retry limit of ${env.workItemRetryLimit} exceeded`);
+          logger.warn(`Updating work item for ${workItemID} to ${status} with message ${errorMessage}`);
         }
-      } else {
-        // Finished with the chain for this granule
-        if (status != WorkItemStatus.FAILED) {
-          await addJobLinksForFinishedWorkItem(tx, job, results, logger);
+      }
+
+      // We calculate the duration of the work both in harmony and in the manager of the service pod.
+      // We tend to favor the harmony value as it is normally longer since it accounts for the extra
+      // overhead of communication with the pod. There is a problem with retries however in that
+      // the startTime gets reset, so if an earlier worker finishes and replies it will look like
+      // the whole thing was quicker (since our startTime has changed). So in that case we want to
+      // use the time reported by the service pod. Any updates from retries that happen later  will
+      // be ignored since the work item is already in a 'successful' state.
+      const harmonyDuration = Date.now() - workItem.startedAt.valueOf();
+      let duration = harmonyDuration;
+      if (update.duration) {
+        duration = Math.max(duration, update.duration);
+      }
+
+      logger.debug(`Work item duration (ms): ${duration}`);
+
+      let { totalItemsSize } = update;
+
+      if (!totalItemsSize && outputItemSizes?.length > 0) {
+        totalItemsSize = sum(outputItemSizes) / 1024 / 1024;
+      }
+
+      await updateWorkItemStatus(
+        tx,
+        workItemID,
+        status as WorkItemStatus,
+        duration,
+        totalItemsSize,
+        outputItemSizes);
+
+      const completedWorkItemCount = await workItemCountForStep(
+        tx, workItem.jobID, workItem.workflowStepIndex, COMPLETED_WORK_ITEM_STATUSES,
+      );
+      const allWorkItemsForStepComplete = (completedWorkItemCount == thisStep.workItemCount);
+
+      if (hits && job.numInputGranules > hits) {
+        job.numInputGranules = hits;
+        await job.save(tx);
+        await updateWorkItemCounts(tx, job);
+      }
+
+      const continueProcessing = await handleFailedWorkItems(tx, job, workItem, thisStep, status, logger, errorMessage);
+      if (continueProcessing) {
+        const nextWorkflowStep = await getWorkflowStepByJobIdStepIndex(
+          tx, workItem.jobID, workItem.workflowStepIndex + 1,
+        );
+        if (nextWorkflowStep && (status != WorkItemStatus.FAILED || nextWorkflowStep?.isBatched)) {
+          await createNextWorkItems(
+            tx,
+            nextWorkflowStep,
+            logger,
+            workItem,
+            status,
+            allWorkItemsForStepComplete,
+            results,
+            outputItemSizes);
         }
-        // If all granules are finished mark the job as finished
-        job.completeBatch(thisStep.workItemCount);
-        if (allWorkItemsForStepComplete) {
-          const finalStatus = await getFinalStatusForJob(tx, job);
-          await completeJob(tx, job, finalStatus, logger);
-        } else {
-          // Special case to pause the job as soon as any single granule completes when in the previewing state
-          if (job.status === JobStatus.PREVIEWING) {
-            job.pause();
+
+        if (nextWorkflowStep) {
+          if (results && results.length > 0) {
+            // set the scrollID for the next work item to the one we received from the update
+            workItem.scrollID = scrollID;
+            await maybeQueueQueryCmrWorkItem(tx, workItem, logger);
+          } else {
+            // Failed to create the next work items - fail the job rather than leaving it orphaned
+            // in the running state
+            logger.error('The work item update should have contained results to queue a next work item, but it did not.');
+            const message = 'Harmony internal failure: could not create the next work items for the request.';
+            await completeJob(tx, job, JobStatus.FAILED, logger, message);
           }
-          await job.save(tx);
+        } else {
+          // Finished with the chain for this granule
+          if (status != WorkItemStatus.FAILED) {
+            await addJobLinksForFinishedWorkItem(tx, job, results, logger);
+          }
+          // If all granules are finished mark the job as finished
+          job.completeBatch(thisStep.workItemCount);
+          if (allWorkItemsForStepComplete) {
+            const finalStatus = await getFinalStatusForJob(tx, job);
+            await completeJob(tx, job, finalStatus, logger);
+          } else {
+            // Special case to pause the job as soon as any single granule completes when in the previewing state
+            if (job.status === JobStatus.PREVIEWING) {
+              job.pause();
+            }
+            await job.save(tx);
+          }
         }
       }
-    }
-  });
+    });
+  } catch (e) {
+    logger.error('CDD: Blew up');
+    logger.error(e);
+  }
 }
 
 /**
@@ -674,32 +700,36 @@ export async function updateWorkItem(req: HarmonyRequest, res: Response): Promis
   const { status, hits, results, scrollID, errorMessage, duration, operation, outputItemSizes } = req.body;
   const totalItemsSize = req.body.totalItemsSize ? parseFloat(req.body.totalItemsSize) : 0;
 
-  const update =
-  {
-    workItemID: parseInt(id),
-    status,
-    hits,
-    results,
-    scrollID,
-    errorMessage,
-    totalItemsSize,
-    outputItemSizes,
-    duration,
-  };
+  try {
+    const update = {
+      workItemID: parseInt(id),
+      status,
+      hits,
+      results,
+      scrollID,
+      errorMessage,
+      totalItemsSize,
+      outputItemSizes,
+      duration,
+    };
 
-  if (typeof global.it === 'function') {
-    // tests break if we don't await this
-    await handleWorkItemUpdate(update, operation, req.context.logger);
-  } else {
-    // asynchronously handle the update so that the service is not waiting for a response
-    // during a potentially long update. If the asynchronous update fails the work-item will
-    // eventually be retried by the timeout handler. In any case there is not much the service
-    // can do if the update fails, so it is OK for us to ignore the promise here. The service
-    // can still retry for network or similar failures, but we don't want it to retry for things
-    // like 409 errors.
+    if (typeof global.it === 'function') {
+      // tests break if we don't await this
+      await handleWorkItemUpdate(update, operation, req.context.logger);
+    } else {
+      // asynchronously handle the update so that the service is not waiting for a response
+      // during a potentially long update. If the asynchronous update fails the work-item will
+      // eventually be retried by the timeout handler. In any case there is not much the service
+      // can do if the update fails, so it is OK for us to ignore the promise here. The service
+      // can still retry for network or similar failures, but we don't want it to retry for things
+      // like 409 errors.
 
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    handleWorkItemUpdate(update, operation, req.context.logger);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      handleWorkItemUpdate(update, operation, req.context.logger);
+    }
+  } catch (e) {
+    req.context.logger.error(`Failed to update work item ${id}`);
+    req.context.logger.error(e);
   }
 
   // Return a success with no body

--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -642,7 +642,8 @@ export async function handleWorkItemUpdate(
             status,
             allWorkItemsForStepComplete,
             results,
-            outputItemSizes);
+            outputItemSizes,
+          );
         }
 
         if (nextWorkflowStep && status === WorkItemStatus.SUCCESSFUL) {
@@ -657,7 +658,7 @@ export async function handleWorkItemUpdate(
             const message = 'Harmony internal failure: could not create the next work items for the request.';
             await completeJob(tx, job, JobStatus.FAILED, logger, message);
           }
-        } else {
+        } else if (!nextWorkflowStep || allWorkItemsForStepComplete) {
           // Finished with the chain for this granule
           if (status != WorkItemStatus.FAILED) {
             await addJobLinksForFinishedWorkItem(tx, job, results, logger);
@@ -674,6 +675,8 @@ export async function handleWorkItemUpdate(
             }
             await job.save(tx);
           }
+        } else { // Currently only reach this condition for batched aggregation requests
+          await job.save(tx);
         }
       }
     });

--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -544,9 +544,6 @@ export async function handleWorkItemUpdate(
     logger.info(`Updating work item ${workItemID} to ${status}`);
   }
 
-  // if (workItemID == 5) {
-  //   console.log('CDD - this is it');
-  // }
   // get the jobID for the work item
   const jobID = await getJobIdForWorkItem(workItemID);
 
@@ -565,9 +562,6 @@ export async function handleWorkItemUpdate(
 
   try {
     await db.transaction(async (tx) => {
-      if (workItemID == 5) {
-        console.log('CDD - this is it');
-      }
       const job = await Job.byJobID(tx, jobID, false, true);
       // lock the work item to we can update it - need to do this after locking jobs table above
       // to avoid deadlocks
@@ -679,23 +673,18 @@ export async function handleWorkItemUpdate(
           }
           // If all granules are finished mark the job as finished
           job.completeBatch(thisStep.workItemCount);
-          // if (allWorkItemsForStepComplete) {
-          console.log(`CDD: Created work item is ${createdWorkItem}`);
           if (allWorkItemsForStepComplete && !createdWorkItem && (!nextWorkflowStep || nextWorkflowStep.workItemCount === 0)) {
-          // if (allWorkItemsForStepComplete && !createdWorkItem && !nextWorkflowStep) {
             const finalStatus = await getFinalStatusForJob(tx, job);
             await completeJob(tx, job, finalStatus, logger);
           } else {
-            console.log('CDD unexpected 1');
             // Either previewing or next step is a batched step and this item failed
-            // Special case to pause the job as soon as any single granule completes when in the previewing state
             if (job.status === JobStatus.PREVIEWING) {
+              // Special case to pause the job as soon as any single granule completes when in the previewing state
               job.pause();
             }
             await job.save(tx);
           }
         } else { // Currently only reach this condition for batched aggregation requests
-          console.log('CDD unexpected 2');
           await job.save(tx);
         }
       }

--- a/app/models/batch-item.ts
+++ b/app/models/batch-item.ts
@@ -100,6 +100,7 @@ export async function getItemUrlsForJobServiceBatch(
       serviceID,
       batchID,
     })
+    .whereNotNull('stacItemUrl')
     .orderBy('sortIndex', 'asc');
 
   const result = await query;

--- a/app/models/workflow-steps.ts
+++ b/app/models/workflow-steps.ts
@@ -242,3 +242,17 @@ export async function incrementWorkItemCount(tx: Transaction, jobID, stepIndex):
     .where({ jobID, stepIndex })
     .increment('workItemCount');
 }
+
+/**
+ * Decrement the number of expected work items for the step. Used during batching when prior step
+ * items fail and we end up with the final batch being empty.
+ *
+ * @param tx - the database transaction
+ * @param jobID - the job ID
+ * @param stepIndex - the current step index
+ */
+export async function decrementWorkItemCount(tx: Transaction, jobID, stepIndex): Promise<void> {
+  await tx(WorkflowStep.table)
+    .where({ jobID, stepIndex })
+    .decrement('workItemCount');
+}

--- a/app/util/aggregation-batch.ts
+++ b/app/util/aggregation-batch.ts
@@ -211,7 +211,7 @@ async function createCatalogAndWorkItemForBatch(
     await newWorkItem.save(tx);
     return true;
   } else {
-    logger.warn('Attempt to construct a work item for a batch, but there were no valid items in the batch. Decrementing the expected number of work items.');
+    logger.warn('Attempted to construct a work item for a batch, but there were no valid items in the batch. Decrementing the expected number of work items.');
     await decrementWorkItemCount(tx, jobID, stepIndex);
   }
   return false;
@@ -360,21 +360,19 @@ export async function handleBatching(
             // create STAC catalog and next work item for the current batch
             createdWorkItem = await createCatalogAndWorkItemForBatch(tx, workflowStep, currentBatch, logger) || createdWorkItem;
             currentBatch.isProcessed = true;
-            if (!allWorkItemsForStepComplete) {
-              // create a new batch
-              const newBatch = new Batch({
-                jobID,
-                serviceID,
-                batchID: currentBatch.batchID + 1,
-              });
-              await newBatch.save(tx);
+            // create a new batch
+            const newBatch = new Batch({
+              jobID,
+              serviceID,
+              batchID: currentBatch.batchID + 1,
+            });
+            await newBatch.save(tx);
 
-              // make the new batch the current batch
-              currentBatch = newBatch;
-              currentBatchCount = 0;
-              currentBatchSize = 0;
-              await incrementWorkItemCount(tx, jobID, stepIndex);
-            }
+            // make the new batch the current batch
+            currentBatch = newBatch;
+            currentBatchCount = 0;
+            currentBatchSize = 0;
+            await incrementWorkItemCount(tx, jobID, stepIndex);
           }
         } else {
           if (currentBatchSize + batchItem.itemSize > maxBatchSizeInBytes) {

--- a/app/util/aggregation-batch.ts
+++ b/app/util/aggregation-batch.ts
@@ -424,7 +424,6 @@ export async function handleBatching(
   // and create a new aggregating work item unless we already did above due to the batch
   // being full
   if (allWorkItemsForStepComplete && !currentBatch.isProcessed) {
-    console.log(`CDD - allWorkItemsForStepComplete ${allWorkItemsForStepComplete}, currentBatch.isProcessed ${currentBatch.isProcessed}, initial createdWorkItem ${createdWorkItem}`);
     createdWorkItem = await createCatalogAndWorkItemForBatch(tx, workflowStep, currentBatch, logger) || createdWorkItem;
   }
   return createdWorkItem;

--- a/app/util/aggregation-batch.ts
+++ b/app/util/aggregation-batch.ts
@@ -60,15 +60,6 @@ export async function sizeOfObject(url: string, token: string, logger: Logger): 
  * @param s3Url - the s3 url of the catalog
  */
 export async function readCatalogLinks(s3Url: string, logger: Logger): Promise<string[]> {
-//   logger.debug(`Reading STAC catalog ${s3Url}`);
-//   try {
-//     const items = await readCatalogItems(s3Url);
-//     return items.map((item) => item.assets.data.href);
-//   } catch (e) {
-//     logger.error(e);
-//   }
-//   return [];
-// }
   logger.debug(`Reading STAC catalog ${s3Url}`);
   const items = await readCatalogItems(s3Url);
   return items.map((item) => item.assets.data.href);
@@ -113,7 +104,6 @@ Promise<number[]> {
     const op = new DataOperation(operation, encrypter, decrypter);
     const token = op.unencryptedAccessToken;
     let index = 0;
-    // try {
     for (const catalogUrl of update.results) {
       const links = await exports.readCatalogLinks(catalogUrl, logger);
       // eslint-disable-next-line @typescript-eslint/no-loop-func
@@ -130,10 +120,6 @@ Promise<number[]> {
       }));
       outputItemSizes = outputItemSizes.concat(sizes);
     }
-    // } catch (e){
-    //   logger.error(e);
-    //   throw (e);
-    // }
   }
   return outputItemSizes;
 }

--- a/app/util/aggregation-batch.ts
+++ b/app/util/aggregation-batch.ts
@@ -243,7 +243,7 @@ export async function handleBatching(
   : Promise<boolean> {
   const { jobID, serviceID, stepIndex } = workflowStep;
   let { maxBatchInputs, maxBatchSizeInBytes } = workflowStep;
-  let createdWorkItem = false;
+  let didCreateWorkItem = false;
   maxBatchInputs = maxBatchInputs || env.maxBatchInputs;
   maxBatchSizeInBytes = maxBatchSizeInBytes || env.maxBatchSizeInBytes;
 
@@ -358,7 +358,7 @@ export async function handleBatching(
           // check to see if the batch is full
           if (currentBatchCount === maxBatchInputs || currentBatchSize === maxBatchSizeInBytes) {
             // create STAC catalog and next work item for the current batch
-            createdWorkItem = await createCatalogAndWorkItemForBatch(tx, workflowStep, currentBatch, logger) || createdWorkItem;
+            didCreateWorkItem = await createCatalogAndWorkItemForBatch(tx, workflowStep, currentBatch, logger) || didCreateWorkItem;
             currentBatch.isProcessed = true;
             // create a new batch
             const newBatch = new Batch({
@@ -383,7 +383,7 @@ export async function handleBatching(
             logger.error(`Batch construction is broken: current batch size: ${currentBatchSize}, item size: ${batchItem.itemSize}, max size: ${maxBatchSizeInBytes}, current batch count: ${currentBatchCount}, max inputs: ${maxBatchInputs}`);
           }
           // create STAC catalog and next work item for the current batch
-          createdWorkItem = await createCatalogAndWorkItemForBatch(tx, workflowStep, currentBatch, logger) || createdWorkItem;
+          didCreateWorkItem = await createCatalogAndWorkItemForBatch(tx, workflowStep, currentBatch, logger) || didCreateWorkItem;
           currentBatch.isProcessed = true;
 
           // create a new batch
@@ -424,7 +424,7 @@ export async function handleBatching(
   // and create a new aggregating work item unless we already did above due to the batch
   // being full
   if (allWorkItemsForStepComplete && !currentBatch.isProcessed) {
-    createdWorkItem = await createCatalogAndWorkItemForBatch(tx, workflowStep, currentBatch, logger) || createdWorkItem;
+    didCreateWorkItem = await createCatalogAndWorkItemForBatch(tx, workflowStep, currentBatch, logger) || didCreateWorkItem;
   }
-  return createdWorkItem;
+  return didCreateWorkItem;
 }

--- a/test/helpers/work-items.ts
+++ b/test/helpers/work-items.ts
@@ -194,7 +194,7 @@ export const hookGetWorkForService = hookBackendRequest.bind(this, getWorkForSer
  *
  * @param jobID - the job ID to which the STAC items belong
  * @param workItemID - the ID of the work item that generated the STAC items
- *  @param dataLinkCount - the number of data links to put in the STAC item
+ * @param dataLinkCount - the number of data links to put in the STAC item
  */
 export async function fakeServiceStacOutput(
   jobID: string,

--- a/test/ignore-errors.ts
+++ b/test/ignore-errors.ts
@@ -31,7 +31,7 @@ describe('when setting ignoreErrors=true', function () {
   let sizeOfObjectStub;
   before(async function () {
     sizeOfObjectStub = stub(aggregationBatch, 'sizeOfObject')
-      .callsFake(async (_) => 7000000000);
+      .callsFake(async (_) => 1);
     await truncateAll();
   });
 
@@ -134,6 +134,7 @@ describe('when setting ignoreErrors=true', function () {
           const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
           firstSwotItem = JSON.parse(res.text).workItem;
           firstSwotItem.status = WorkItemStatus.FAILED;
+          firstSwotItem.results = [];
           firstSwotItem.results = [];
 
           await updateWorkItem(this.backend, firstSwotItem);
@@ -676,4 +677,542 @@ describe('when setting ignoreErrors=true', function () {
     });
   });
 
+  describe('When a requesting concatenation for a service that batches aggregation requests', function () {
+    describe('when making a request for 3 granules and the first one fails while in progress', function () {
+      hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery, ...{ maxResults: 3, concatenate: true } } });
+      hookRedirect('joe');
+
+      before(async function () {
+        const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
+        const { workItem, maxCmrGranules } = JSON.parse(res.text);
+        expect(maxCmrGranules).to.equal(3);
+        workItem.status = WorkItemStatus.SUCCESSFUL;
+        workItem.results = [
+          getStacLocation(workItem, 'catalog0.json'),
+          getStacLocation(workItem, 'catalog1.json'),
+          getStacLocation(workItem, 'catalog2.json'),
+        ];
+        workItem.outputItemSizes = [1, 1, 1];
+        await fakeServiceStacOutput(workItem.jobID, workItem.id, 3);
+        await updateWorkItem(this.backend, workItem);
+        const currentWorkItems = (await getWorkItemsByJobId(db, workItem.jobID)).workItems;
+        expect(currentWorkItems.length).to.equal(4);
+        expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(3);
+      });
+
+      describe('when the first swot-reprojection service work item fails', function () {
+        let firstSwotItem;
+
+        before(async function () {
+          let shouldLoop = true;
+          // retrieve and fail work items until one exceeds the retry limit and actually gets marked as failed
+          while (shouldLoop) {
+            const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+            firstSwotItem = JSON.parse(res.text).workItem;
+            firstSwotItem.status = WorkItemStatus.FAILED;
+            firstSwotItem.results = [];
+
+            await updateWorkItem(this.backend, firstSwotItem);
+
+            // check to see if the work-item has failed completely
+            const workItem = await getWorkItemById(db, firstSwotItem.id);
+            shouldLoop = !(workItem.status === WorkItemStatus.FAILED);
+          }
+        });
+
+        it('changes the job status to running_with_errors', async function () {
+          const job = await Job.byJobID(db, firstSwotItem.jobID);
+          expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
+        });
+
+        it('does not construct a work item for netcdf-to-zarr when the first item fails', async function () {
+          const currentWorkItems = (await getWorkItemsByJobId(db, firstSwotItem.jobID)).workItems;
+          expect(currentWorkItems.length).to.equal(4);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.FAILED && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+        });
+
+        it('does not construct a work item for netcdf-to-zarr when the second item finishes', async function () {
+          const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id);
+          await updateWorkItem(this.backend, workItem);
+          const currentWorkItems = (await getWorkItemsByJobId(db, firstSwotItem.jobID)).workItems;
+          expect(currentWorkItems.length).to.equal(4);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.FAILED && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+        });
+
+        it('constructs a single netcdf-to-zarr work item when the last item succeeds', async function () {
+          const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id);
+          await updateWorkItem(this.backend, workItem);
+
+          const currentWorkItems = (await getWorkItemsByJobId(db, firstSwotItem.jobID)).workItems;
+          expect(currentWorkItems.length).to.equal(5);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'harmonyservices/netcdf-to-zarr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.FAILED && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+        });
+
+        it('sets the status to COMPLETE_WITH_ERRORS when the netcdf-to-zarr request completes', async function () {
+          const res = await getWorkForService(this.backend, 'harmonyservices/netcdf-to-zarr:latest');
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id);
+          await updateWorkItem(this.backend, workItem);
+
+
+          const job = await Job.byJobID(db, firstSwotItem.jobID);
+          expect(job.status).to.equal(JobStatus.COMPLETE_WITH_ERRORS);
+          expect(job.progress).to.equal(100);
+        });
+
+        it('includes the error details in the job status', async function () {
+          const response = await jobStatus(this.frontend, { jobID: firstSwotItem.jobID, username: 'joe' });
+          const job = JSON.parse(response.text);
+          const { errors } = job;
+          expect(errors.length).to.equal(1);
+          expect(errors[0].url).to.equal('https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/harmony_example/nc/001_00_8f00ff_global.nc');
+          expect(errors[0].message).to.include('failed with an unknown error');
+        });
+      });
+    });
+
+    describe('when making a request for 3 granules with 2 batches and one fails in the middle while in progress', function () {
+      hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery, ...{ maxResults: 3, concatenate: true } } });
+      hookRedirect('joe');
+
+      let batchSizeStub;
+      before(async function () {
+        batchSizeStub = stub(env, 'maxBatchInputs').get(() => 1);
+        const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
+        const { workItem, maxCmrGranules } = JSON.parse(res.text);
+        expect(maxCmrGranules).to.equal(3);
+        workItem.status = WorkItemStatus.SUCCESSFUL;
+        workItem.results = [
+          getStacLocation(workItem, 'catalog0.json'),
+          getStacLocation(workItem, 'catalog1.json'),
+          getStacLocation(workItem, 'catalog2.json'),
+        ];
+        workItem.outputItemSizes = [1, 1, 1];
+        await fakeServiceStacOutput(workItem.jobID, workItem.id, 3);
+        await updateWorkItem(this.backend, workItem);
+        const currentWorkItems = (await getWorkItemsByJobId(db, workItem.jobID)).workItems;
+        expect(currentWorkItems.length).to.equal(4);
+        expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(3);
+      });
+      after(function () {
+        batchSizeStub.restore();
+      });
+
+      describe('when the first swot-reprojection service work item succeeds', function () {
+        it('constructs a work item for netcdf-to-zarr', async function () {
+          const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id);
+          await updateWorkItem(this.backend, workItem);
+          const currentWorkItems = (await getWorkItemsByJobId(db, workItem.jobID)).workItems;
+          expect(currentWorkItems.length).to.equal(5);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'harmonyservices/netcdf-to-zarr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+        });
+      });
+
+      describe('when the second swot-reprojection service work item fails', function () {
+        let secondSwotItem;
+        before(async function () {
+          let shouldLoop = true;
+          // retrieve and fail work items until one exceeds the retry limit and actually gets marked as failed
+          while (shouldLoop) {
+            const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+            secondSwotItem = JSON.parse(res.text).workItem;
+            secondSwotItem.status = WorkItemStatus.FAILED;
+            secondSwotItem.results = [];
+
+            await updateWorkItem(this.backend, secondSwotItem);
+
+            // check to see if the work-item has failed completely
+            const workItem = await getWorkItemById(db, secondSwotItem.id);
+            shouldLoop = !(workItem.status === WorkItemStatus.FAILED);
+          }
+        });
+
+        it('changes the job status to running_with_errors', async function () {
+          const job = await Job.byJobID(db, secondSwotItem.jobID);
+          expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
+        });
+
+        it('does not construct another netcdf-to-zarr work item', async function () {
+          const currentWorkItems = (await getWorkItemsByJobId(db, secondSwotItem.jobID)).workItems;
+          expect(currentWorkItems.length).to.equal(5);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'harmonyservices/netcdf-to-zarr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.FAILED && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+        });
+
+        it('constructs a second netcdf-to-zarr work item when the last item succeeds', async function () {
+          const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id);
+          await updateWorkItem(this.backend, workItem);
+
+          const currentWorkItems = (await getWorkItemsByJobId(db, secondSwotItem.jobID)).workItems;
+          expect(currentWorkItems.length).to.equal(6);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'harmonyservices/netcdf-to-zarr:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.FAILED && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+        });
+
+        it('leaves the status as RUNNING_WITH_ERRORS when the first netcdf-to-zarr request completes', async function () {
+          const res = await getWorkForService(this.backend, 'harmonyservices/netcdf-to-zarr:latest');
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id);
+          await updateWorkItem(this.backend, workItem);
+
+
+          const job = await Job.byJobID(db, secondSwotItem.jobID);
+          expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
+        });
+
+        it('sets the status to COMPLETE_WITH_ERRORS when the second netcdf-to-zarr request completes', async function () {
+          const res = await getWorkForService(this.backend, 'harmonyservices/netcdf-to-zarr:latest');
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id);
+          await updateWorkItem(this.backend, workItem);
+
+
+          const job = await Job.byJobID(db, secondSwotItem.jobID);
+          expect(job.status).to.equal(JobStatus.COMPLETE_WITH_ERRORS);
+          expect(job.progress).to.equal(100);
+        });
+
+        it('includes the error details in the job status', async function () {
+          const response = await jobStatus(this.frontend, { jobID: secondSwotItem.jobID, username: 'joe' });
+          const job = JSON.parse(response.text);
+          const { errors } = job;
+          expect(errors.length).to.equal(1);
+          expect(errors[0].url).to.equal('https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/harmony_example/nc/001_00_8f00ff_global.nc');
+          expect(errors[0].message).to.include('failed with an unknown error');
+        });
+      });
+    });
+
+    describe('CDD when making a request for 3 granules with 2 batches and the last one of the first chain fails', function () {
+      hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery, ...{ maxResults: 3, concatenate: true } } });
+      hookRedirect('joe');
+
+      let batchSizeStub;
+      before(async function () {
+        batchSizeStub = stub(env, 'maxBatchInputs').get(() => 1);
+        const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
+        const { workItem, maxCmrGranules } = JSON.parse(res.text);
+        expect(maxCmrGranules).to.equal(3);
+        workItem.status = WorkItemStatus.SUCCESSFUL;
+        workItem.results = [
+          getStacLocation(workItem, 'catalog0.json'),
+          getStacLocation(workItem, 'catalog1.json'),
+          getStacLocation(workItem, 'catalog2.json'),
+        ];
+        workItem.outputItemSizes = [1, 1, 1];
+        await fakeServiceStacOutput(workItem.jobID, workItem.id, 3);
+        await updateWorkItem(this.backend, workItem);
+        const currentWorkItems = (await getWorkItemsByJobId(db, workItem.jobID)).workItems;
+        expect(currentWorkItems.length).to.equal(4);
+        expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(3);
+      });
+      after(function () {
+        batchSizeStub.restore();
+      });
+
+      describe('when the first swot-reprojection service work item succeeds', function () {
+        it('constructs a work item for netcdf-to-zarr', async function () {
+          const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id);
+          await updateWorkItem(this.backend, workItem);
+          const currentWorkItems = (await getWorkItemsByJobId(db, workItem.jobID)).workItems;
+          expect(currentWorkItems.length).to.equal(5);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'harmonyservices/netcdf-to-zarr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+        });
+      });
+
+      describe('when the second swot-reprojection service work item succeeds', function () {
+        it('constructs a work item for netcdf-to-zarr', async function () {
+          const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id);
+          await updateWorkItem(this.backend, workItem);
+          const currentWorkItems = (await getWorkItemsByJobId(db, workItem.jobID)).workItems;
+          expect(currentWorkItems.length).to.equal(6);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'harmonyservices/netcdf-to-zarr:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(2);
+        });
+      });
+
+      describe('when the last swot-reprojection service work item fails', function () {
+        let lastSwotItem;
+        before(async function () {
+          let shouldLoop = true;
+          // retrieve and fail work items until one exceeds the retry limit and actually gets marked as failed
+          while (shouldLoop) {
+            const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+            lastSwotItem = JSON.parse(res.text).workItem;
+            lastSwotItem.status = WorkItemStatus.FAILED;
+            lastSwotItem.results = [];
+
+            await updateWorkItem(this.backend, lastSwotItem);
+
+            // check to see if the work-item has failed completely
+            const workItem = await getWorkItemById(db, lastSwotItem.id);
+            shouldLoop = !(workItem.status === WorkItemStatus.FAILED);
+          }
+        });
+
+        it('changes the job status to running_with_errors', async function () {
+          const job = await Job.byJobID(db, lastSwotItem.jobID);
+          expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
+        });
+
+        it('does not construct another netcdf-to-zarr work item', async function () {
+          const currentWorkItems = (await getWorkItemsByJobId(db, lastSwotItem.jobID)).workItems;
+          expect(currentWorkItems.length).to.equal(6);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'harmonyservices/netcdf-to-zarr:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.FAILED && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+        });
+
+        it('leaves the status as RUNNING_WITH_ERRORS when the first netcdf-to-zarr request completes', async function () {
+          const res = await getWorkForService(this.backend, 'harmonyservices/netcdf-to-zarr:latest');
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id);
+          await updateWorkItem(this.backend, workItem);
+
+          const job = await Job.byJobID(db, lastSwotItem.jobID);
+          expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
+        });
+
+        it('sets the status to COMPLETE_WITH_ERRORS when the second netcdf-to-zarr request completes', async function () {
+          const res = await getWorkForService(this.backend, 'harmonyservices/netcdf-to-zarr:latest');
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id);
+          await updateWorkItem(this.backend, workItem);
+
+          const job = await Job.byJobID(db, lastSwotItem.jobID);
+          expect(job.status).to.equal(JobStatus.COMPLETE_WITH_ERRORS);
+          expect(job.progress).to.equal(100);
+        });
+
+        it('includes the error details in the job status', async function () {
+          const response = await jobStatus(this.frontend, { jobID: lastSwotItem.jobID, username: 'joe' });
+          const job = JSON.parse(response.text);
+          const { errors } = job;
+          expect(errors.length).to.equal(1);
+          expect(errors[0].url).to.equal('https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/harmony_example/nc/001_00_8f00ff_global.nc');
+          expect(errors[0].message).to.include('failed with an unknown error');
+        });
+      });
+    });
+
+    describe('when making a request for 4 granules with max allowed errors of 1 and two fail', function () {
+      hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery, ...{ maxResults: 4, concatenate: true } } });
+      hookRedirect('joe');
+
+      before(async function () {
+        stub(env, 'maxErrorsForJob').get(() => 1);
+        const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
+        const { workItem, maxCmrGranules } = JSON.parse(res.text);
+        expect(maxCmrGranules).to.equal(4);
+        workItem.status = WorkItemStatus.SUCCESSFUL;
+        workItem.results = [
+          getStacLocation(workItem, 'catalog0.json'),
+          getStacLocation(workItem, 'catalog1.json'),
+          getStacLocation(workItem, 'catalog2.json'),
+          getStacLocation(workItem, 'catalog3.json'),
+        ];
+        workItem.outputItemSizes = [1, 2, 3, 4];
+        await fakeServiceStacOutput(workItem.jobID, workItem.id, 4);
+        await updateWorkItem(this.backend, workItem);
+
+        const currentWorkItems = (await getWorkItemsByJobId(db, workItem.jobID)).workItems;
+        expect(currentWorkItems.length).to.equal(5);
+        expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+        expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(4);
+      });
+
+      describe('when the first granule completes successfully', function () {
+        let firstSwotItem;
+
+        before(async function () {
+          const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+
+          firstSwotItem = JSON.parse(res.text).workItem;
+          firstSwotItem.status = WorkItemStatus.SUCCESSFUL;
+          firstSwotItem.results = [getStacLocation(firstSwotItem, 'catalog.json')];
+          await fakeServiceStacOutput(firstSwotItem.jobID, firstSwotItem.id);
+          await updateWorkItem(this.backend, firstSwotItem);
+        });
+
+        it('leaves the job in the running state', async function () {
+          const job = await Job.byJobID(db, firstSwotItem.jobID);
+          expect(job.status).to.equal(JobStatus.RUNNING);
+        });
+      });
+
+      describe('when the second swot-reprojection service work item fails (first failure)', function () {
+        let secondSwotItem;
+
+        before(async function () {
+          let shouldLoop = true;
+          // retrieve and fail work items until one exceeds the retry limit and actually gets marked as failed
+          while (shouldLoop) {
+            const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+            secondSwotItem = JSON.parse(res.text).workItem;
+            secondSwotItem.status = WorkItemStatus.FAILED;
+            secondSwotItem.results = [];
+
+            await updateWorkItem(this.backend, secondSwotItem);
+
+            // check to see if the work-item has failed completely
+            const workItem = await getWorkItemById(db, secondSwotItem.id);
+            shouldLoop = !(workItem.status === WorkItemStatus.FAILED);
+          }
+        });
+
+        it('changes the job status to running_with_errors', async function () {
+          const job = await Job.byJobID(db, secondSwotItem.jobID);
+          expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
+        });
+
+        it('does not queue a zarr step for the work item that failed', async function () {
+          const currentWorkItems = (await getWorkItemsByJobId(db, secondSwotItem.jobID)).workItems;
+          expect(currentWorkItems.length).to.equal(5);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.FAILED && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+        });
+      });
+
+      describe('when the third swot-reprojection service work item fails resulting in a (second failure) for the job', function () {
+        let thirdSwotItem;
+
+        before(async function () {
+          let shouldLoop = true;
+          // retrieve and fail work items until one exceeds the retry limit and actually gets marked as failed
+          while (shouldLoop) {
+            const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+            thirdSwotItem = JSON.parse(res.text).workItem;
+            thirdSwotItem.status = WorkItemStatus.FAILED;
+            thirdSwotItem.results = [];
+            thirdSwotItem.errorMessage = 'Did not reach 88 MPH.';
+
+            await updateWorkItem(this.backend, thirdSwotItem);
+
+            // check to see if the work-item has failed completely
+            const workItem = await getWorkItemById(db, thirdSwotItem.id);
+            shouldLoop = !(workItem.status === WorkItemStatus.FAILED);
+          }
+        });
+
+        it('puts the job in a FAILED state', async function () {
+          const job = await Job.byJobID(db, thirdSwotItem.jobID);
+          expect(job.status).to.equal(JobStatus.FAILED);
+        });
+
+        it('includes the error details in the job status', async function () {
+          const response = await jobStatus(this.frontend, { jobID: thirdSwotItem.jobID, username: 'joe' });
+          const job = JSON.parse(response.text);
+          const { errors } = job;
+          expect(errors.length).to.equal(2);
+          expect(errors[0].url).to.equal('https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/harmony_example/nc/001_00_8f00ff_global.nc');
+          expect(errors[0].message).to.include('failed with an unknown error');
+          expect(errors[1].url).to.equal('https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/harmony_example/nc/001_00_8f00ff_global.nc');
+          expect(errors[1].message).to.include('Did not reach 88 MPH');
+        });
+
+        it('marks any remaining work items as canceled', async function () {
+          // job failure should trigger cancellation of any pending work items
+          const currentWorkItems = (await getWorkItemsByJobId(db, thirdSwotItem.jobID)).workItems;
+          expect(currentWorkItems.length).to.equal(5);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.CANCELED && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.FAILED && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+        });
+      });
+    });
+
+    describe('when making a request for 4 granules and query-cmr fails', function () {
+      hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery, ...{ maxResults: 4, concatenate: true } } });
+      hookRedirect('joe');
+
+      before(async function () {
+        let shouldLoop = true;
+        let workItem: WorkItem;
+        // retrieve and fail work items until one exceeds the retry limit and actually gets marked as failed
+        while (shouldLoop) {
+          const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
+          workItem = JSON.parse(res.text).workItem as WorkItem;
+          workItem.status = WorkItemStatus.FAILED;
+          workItem.results = [];
+          workItem.errorMessage = 'Bad scroll session';
+          await updateWorkItem(this.backend, workItem);
+          // check to see if the work-item has failed completely
+          workItem = await getWorkItemById(db, workItem.id);
+          shouldLoop = workItem.status != WorkItemStatus.FAILED;
+        }
+
+        this.workItem = workItem;
+      });
+
+      it('marks the work items as failed', async function () {
+        const currentWorkItems = (await getWorkItemsByJobId(db, this.workItem.jobID)).workItems;
+        expect(currentWorkItems.length).to.equal(1);
+        expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.FAILED && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+      });
+
+      it('marks the job as failed', async function () {
+        const job = await Job.byJobID(db, this.workItem.jobID);
+        expect(job.status).to.equal(JobStatus.FAILED);
+      });
+    });
+  });
 });

--- a/test/ignore-errors.ts
+++ b/test/ignore-errors.ts
@@ -373,8 +373,9 @@ describe('when setting ignoreErrors=true', function () {
     hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery, ...{ maxResults: 4 } } });
     hookRedirect('joe');
 
+    let maxErrorsStub;
     before(async function () {
-      stub(env, 'maxErrorsForJob').get(() => 1);
+      maxErrorsStub = stub(env, 'maxErrorsForJob').get(() => 1);
       const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
       const { workItem, maxCmrGranules } = JSON.parse(res.text);
       expect(maxCmrGranules).to.equal(4);
@@ -393,6 +394,9 @@ describe('when setting ignoreErrors=true', function () {
       expect(currentWorkItems.length).to.equal(5);
       expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
       expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(4);
+    });
+    after(function () {
+      maxErrorsStub.restore();
     });
 
     describe('when the first granule completes successfully', function () {
@@ -1051,12 +1055,156 @@ describe('when setting ignoreErrors=true', function () {
       });
     });
 
+    describe('when making a request for 3 granules with 2 batches and one item fails prior to aggregation and one aggregation item fails', function () {
+      hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery, ...{ maxResults: 3, concatenate: true } } });
+      hookRedirect('joe');
+
+      let batchSizeStub;
+      before(async function () {
+        batchSizeStub = stub(env, 'maxBatchInputs').get(() => 1);
+        const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
+        const { workItem, maxCmrGranules } = JSON.parse(res.text);
+        expect(maxCmrGranules).to.equal(3);
+        workItem.status = WorkItemStatus.SUCCESSFUL;
+        workItem.results = [
+          getStacLocation(workItem, 'catalog0.json'),
+          getStacLocation(workItem, 'catalog1.json'),
+          getStacLocation(workItem, 'catalog2.json'),
+        ];
+        workItem.outputItemSizes = [1, 1, 1];
+        await fakeServiceStacOutput(workItem.jobID, workItem.id, 3);
+        await updateWorkItem(this.backend, workItem);
+        const currentWorkItems = (await getWorkItemsByJobId(db, workItem.jobID)).workItems;
+        expect(currentWorkItems.length).to.equal(4);
+        expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(3);
+      });
+      after(function () {
+        batchSizeStub.restore();
+      });
+
+      describe('when the first swot-reprojection service work item succeeds', function () {
+        it('constructs a work item for netcdf-to-zarr', async function () {
+          const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id);
+          await updateWorkItem(this.backend, workItem);
+          const currentWorkItems = (await getWorkItemsByJobId(db, workItem.jobID)).workItems;
+          expect(currentWorkItems.length).to.equal(5);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'harmonyservices/netcdf-to-zarr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+        });
+      });
+
+      describe('when the second swot-reprojection service work item succeeds', function () {
+        it('constructs a work item for netcdf-to-zarr', async function () {
+          const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id);
+          await updateWorkItem(this.backend, workItem);
+          const currentWorkItems = (await getWorkItemsByJobId(db, workItem.jobID)).workItems;
+          expect(currentWorkItems.length).to.equal(6);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'harmonyservices/netcdf-to-zarr:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(2);
+        });
+      });
+
+      describe('when the last swot-reprojection service work item fails', function () {
+        let lastSwotItem;
+        before(async function () {
+          let shouldLoop = true;
+          // retrieve and fail work items until one exceeds the retry limit and actually gets marked as failed
+          while (shouldLoop) {
+            const res = await getWorkForService(this.backend, 'sds/swot-reproject:latest');
+            lastSwotItem = JSON.parse(res.text).workItem;
+            lastSwotItem.status = WorkItemStatus.FAILED;
+            lastSwotItem.results = [];
+
+            await updateWorkItem(this.backend, lastSwotItem);
+
+            // check to see if the work-item has failed completely
+            const workItem = await getWorkItemById(db, lastSwotItem.id);
+            shouldLoop = !(workItem.status === WorkItemStatus.FAILED);
+          }
+        });
+
+        it('changes the job status to running_with_errors', async function () {
+          const job = await Job.byJobID(db, lastSwotItem.jobID);
+          expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
+        });
+
+        it('does not construct another netcdf-to-zarr work item', async function () {
+          const currentWorkItems = (await getWorkItemsByJobId(db, lastSwotItem.jobID)).workItems;
+          expect(currentWorkItems.length).to.equal(6);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'harmonyservices/netcdf-to-zarr:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(2);
+          expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.FAILED && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(1);
+        });
+
+        it('leaves the status as RUNNING_WITH_ERRORS when the first netcdf-to-zarr request completes successfully', async function () {
+          const res = await getWorkForService(this.backend, 'harmonyservices/netcdf-to-zarr:latest');
+          const { workItem } = JSON.parse(res.text);
+          workItem.status = WorkItemStatus.SUCCESSFUL;
+          workItem.results = [getStacLocation(workItem, 'catalog.json')];
+          await fakeServiceStacOutput(workItem.jobID, workItem.id);
+          await updateWorkItem(this.backend, workItem);
+
+          const job = await Job.byJobID(db, lastSwotItem.jobID);
+          expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
+        });
+
+        describe('when the second netcdf-to-zarr-request-fails', async function () {
+          before(async function () {
+            let shouldLoop = true;
+            // retrieve and fail work items until one exceeds the retry limit and actually gets marked as failed
+            while (shouldLoop) {
+              const res = await getWorkForService(this.backend, 'harmonyservices/netcdf-to-zarr:latest');
+              const lastZarrItem = JSON.parse(res.text).workItem;
+              lastZarrItem.status = WorkItemStatus.FAILED;
+              lastZarrItem.results = [];
+              lastZarrItem.errorMessage = 'batch failed';
+
+              await updateWorkItem(this.backend, lastZarrItem);
+
+              // check to see if the work-item has failed completely
+              const workItem = await getWorkItemById(db, lastZarrItem.id);
+              shouldLoop = !(workItem.status === WorkItemStatus.FAILED);
+            }
+          });
+          it('sets the status to COMPLETE_WITH_ERRORS', async function () {
+            const job = await Job.byJobID(db, lastSwotItem.jobID);
+            expect(job.status).to.equal(JobStatus.COMPLETE_WITH_ERRORS);
+            expect(job.progress).to.equal(100);
+          });
+          it('includes both of the error details in the job status', async function () {
+            const response = await jobStatus(this.frontend, { jobID: lastSwotItem.jobID, username: 'joe' });
+            const job = JSON.parse(response.text);
+            const { errors } = job;
+            expect(errors.length).to.equal(2);
+            expect(errors[0].url).to.equal('https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/harmony_example/nc/001_00_8f00ff_global.nc');
+            expect(errors[0].message).to.include('failed with an unknown error');
+            expect(errors[1].url).to.equal('https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-staging/public/harmony_example/nc/001_00_8f00ff_global.nc');
+            expect(errors[1].message).to.include('batch failed');
+          });
+        });
+      });
+    });
+
     describe('when making a request for 4 granules with max allowed errors of 1 and two fail', function () {
       hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery, ...{ maxResults: 4, concatenate: true } } });
       hookRedirect('joe');
 
+      let maxErrorsStub;
       before(async function () {
-        stub(env, 'maxErrorsForJob').get(() => 1);
+        maxErrorsStub = stub(env, 'maxErrorsForJob').get(() => 1);
         const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:latest');
         const { workItem, maxCmrGranules } = JSON.parse(res.text);
         expect(maxCmrGranules).to.equal(4);
@@ -1075,6 +1223,9 @@ describe('when setting ignoreErrors=true', function () {
         expect(currentWorkItems.length).to.equal(5);
         expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.SUCCESSFUL && item.serviceID === 'harmonyservices/query-cmr:latest').length).to.equal(1);
         expect(currentWorkItems.filter((item) => item.status === WorkItemStatus.READY && item.serviceID === 'sds/swot-reproject:latest').length).to.equal(4);
+      });
+      after(function () {
+        maxErrorsStub.restore();
       });
 
       describe('when the first granule completes successfully', function () {

--- a/test/ignore-errors.ts
+++ b/test/ignore-errors.ts
@@ -135,7 +135,6 @@ describe('when setting ignoreErrors=true', function () {
           firstSwotItem = JSON.parse(res.text).workItem;
           firstSwotItem.status = WorkItemStatus.FAILED;
           firstSwotItem.results = [];
-          firstSwotItem.results = [];
 
           await updateWorkItem(this.backend, firstSwotItem);
 

--- a/test/ignore-errors.ts
+++ b/test/ignore-errors.ts
@@ -921,7 +921,7 @@ describe('when setting ignoreErrors=true', function () {
       });
     });
 
-    describe('CDD when making a request for 3 granules with 2 batches and the last one of the first chain fails', function () {
+    describe('when making a request for 3 granules with 2 batches and the last one of the first chain fails', function () {
       hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery, ...{ maxResults: 3, concatenate: true } } });
       hookRedirect('joe');
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1280

## Description
Updates batched aggregrations to be able to run successfully even if some items in prior steps fail or if some of the batched aggregations themselves fail when the user has requested `ignoreErrors=true`.

I've tested in the sandbox quite a bit with large requests with several failing items and verifying in the end the batched aggregations are created correctly and complete successfully.

## Local Test Steps
Submit the following request which has one successful and two failing granules:
http://localhost:3000/C1234208438-POCLOUD/ogc-api-coverages/1.0.0/collections/bathymetry/coverage/rangeset?concatenate=true&subset=lon(-160%3A160)&subset=lat(-80%3A80)&maxResults=3&skipPreview=true&ignoreErrors=true&granuleId=G1234495188-POCLOUD,G1234515613-POCLOUD,G1234515574-POCLOUD,G1234516982-POCLOUD,G1234518216-POCLOUD,G1234518228-POCLOUD,G1236679413-POCLOUD

Verify that the request eventually completes with errors and concise runs to produce the final output with just one granule.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)