### PR TITLE
HARMONY-1319: Redirect when workflow-ui routes end in a slash

### DIFF
--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -449,3 +449,23 @@ export async function retry(
     next(e);
   }
 }
+
+/**
+ * Middleware to redirect any requests to /workflow-ui/ or /admin/workflow-ui/ to the same endpoint
+ * with the trailing slash removed.
+ *
+ * @param req - The client request
+ * @param res - The client response
+ * @param next - The next function in the middleware chain
+ *
+ */
+export function redirectWithoutTrailingSlash(
+  req: HarmonyRequest, res: Response, next: NextFunction,
+): void {
+  if (req.path.endsWith('workflow-ui/')) {
+    const url = req.url.slice(req.path.length);
+    res.redirect(301, req.path.slice(0, -1) + url);
+  } else {
+    next();
+  }
+}

--- a/app/models/harmony-request.ts
+++ b/app/models/harmony-request.ts
@@ -1,5 +1,4 @@
-import { NextFunction, Request } from 'express';
-import { ServerResponse } from 'http';
+import { Response, NextFunction, Request } from 'express';
 import { CmrCollection } from '../util/cmr';
 import RequestContext from './request-context';
 import DataOperation from './data-operation';
@@ -26,7 +25,7 @@ export default interface HarmonyRequest extends Request {
  *
  */
 export function addRequestContextToOperation(
-  req: HarmonyRequest, res: ServerResponse, next: NextFunction,
+  req: HarmonyRequest, res: Response, next: NextFunction,
 ): void {
   const { operation, context } = req;
 

--- a/app/routers/router.ts
+++ b/app/routers/router.ts
@@ -191,6 +191,14 @@ export default function router({ skipEarthdataLogin = 'false' }: RouterConfig): 
   result.use(logged(postServiceConcatenationHandler));
   result.use(logged(cmrGranuleLocator));
   result.use(logged(addRequestContextToOperation));
+  result.use(function (req, res, next) {
+    if (req.path.endsWith('workflow-ui/')) {
+      const query = req.url.slice(req.path.length);
+      res.redirect(301, req.path.slice(0, -1) + query);
+    } else {
+      next();
+    }
+  });
 
   result.get('/', asyncHandler(landingPage));
   result.get('/versions', asyncHandler(getVersions));

--- a/app/routers/router.ts
+++ b/app/routers/router.ts
@@ -13,7 +13,7 @@ import earthdataLoginOauthAuthorizer from '../middleware/earthdata-login-oauth-a
 import admin from '../middleware/admin';
 import wmsFrontend from '../frontends/wms';
 import { getJobsListing, getJobStatus, cancelJob, resumeJob, pauseJob, skipJobPreview } from '../frontends/jobs';
-import { getJobs, getJob, getWorkItemsTable, getJobLinks, getWorkItemLogs, retry, getWorkItemTableRow } from '../frontends/workflow-ui';
+import { getJobs, getJob, getWorkItemsTable, getJobLinks, getWorkItemLogs, retry, getWorkItemTableRow, redirectWithoutTrailingSlash } from '../frontends/workflow-ui';
 import { getStacCatalog, getStacItem } from '../frontends/stac';
 import { getServiceResult } from '../frontends/service-results';
 import cmrGranuleLocator from '../middleware/cmr-granule-locator';
@@ -191,14 +191,7 @@ export default function router({ skipEarthdataLogin = 'false' }: RouterConfig): 
   result.use(logged(postServiceConcatenationHandler));
   result.use(logged(cmrGranuleLocator));
   result.use(logged(addRequestContextToOperation));
-  result.use(function (req, res, next) {
-    if (req.path.endsWith('workflow-ui/')) {
-      const query = req.url.slice(req.path.length);
-      res.redirect(301, req.path.slice(0, -1) + query);
-    } else {
-      next();
-    }
-  });
+  result.use(logged(redirectWithoutTrailingSlash));
 
   result.get('/', asyncHandler(landingPage));
   result.get('/versions', asyncHandler(getVersions));


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1319

## Description
We had a bug when visiting the workflow-ui page that if the URL used was workflow-ui/ the job links that were generated were all incorrect with a double workflow-ui/workflow-ui in them. This fixes the issue by redirecting from workflow-ui/ to workflow-ui and admin/workflow-ui/ to admin/workflow-ui.

## Local Test Steps
Submit at least one job in your local environment.
Navigate to http://localhost:3000/workflow-ui/ and verify you are redirected to http://localhost:3000/workflow-ui.
Click on the link to open the details for your job and verify that it takes you to the work items page for that job instead of a broken 404 link.

Repeat the same for http://localhost:3000/admin/workflow-ui/

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)