### PR TITLE
HARMONY-369: Remove serverless from .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # package directories
 node_modules
 
-# Serverless directories
-.serverless
-
 # Temp and log files
 *.log
 tmp


### PR DESCRIPTION
## Jira Issue ID
HARMONY-369

## Description
Remove serverless from .gitignore since we do not use serverless.

## Local Test Steps
Check out this branch. Verify that you do not have a .serverless directory reported as untracked changes.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)