### PR TITLE
HARMONY-1280: Fix issue with inconsistent status and workItem.status.

### DIFF
--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -621,6 +621,8 @@ export async function handleWorkItemUpdate(
         totalItemsSize,
         outputItemSizes);
 
+      workItem.status = status;
+
       const completedWorkItemCount = await workItemCountForStep(
         tx, workItem.jobID, workItem.workflowStepIndex, COMPLETED_WORK_ITEM_STATUSES,
       );


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1280

## Description
There was an issue with one of the changes made for a review comment that caused status to not be what was expected.

## Local Test Steps
Run the same request as the original PR and verify it eventually completes with errors ending with a successful concise work item which contains one granule. You can set `WORK_ITEM_RETRY_LIMIT=0` to speed things up.

http://localhost:3000/C1234208438-POCLOUD/ogc-api-coverages/1.0.0/collections/bathymetry/coverage/rangeset?concatenate=true&subset=lon(-160%3A160)&subset=lat(-80%3A80)&maxResults=3&skipPreview=true&ignoreErrors=true&granuleId=G1234495188-POCLOUD,G1234515613-POCLOUD,G1234515574-POCLOUD,G1234516982-POCLOUD,G1234518216-POCLOUD,G1234518228-POCLOUD,G1236679413-POCLOUD

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)