### PR TITLE
HARMONY-1335: Show a logs button for work items in the running state currently being retried

### DIFF
--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -270,7 +270,8 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
     workflowItemUpdatedAt(): string { return this.updatedAt.getTime(); },
     workflowItemLogsButton(): string {
       const isComplete = [WorkItemStatus.FAILED, WorkItemStatus.SUCCESSFUL].indexOf(this.status) > -1;
-      if (!isComplete || !isAdmin || this.serviceID.includes('query-cmr')) return '';
+      const logsAvailable = isComplete || this.retryCount > 0;
+      if (!logsAvailable || !isAdmin || this.serviceID.includes('query-cmr')) return '';
       const logsUrl = `/admin/workflow-ui/${job.jobID}/${this.id}/logs`;
       return `<a type="button" target="__blank" class="btn btn-light btn-sm logs-button" href="${logsUrl}"` +
         ' title="view logs"><i class="bi bi-body-text"></i></a>';


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1335

## Description
When work items are in the running state, but have been retried at least once that will mean they have failed at least once and there are logs associated with that failed attempt. This makes sure that we show the logs button for those items so that we can easily bring up the logs.

## Local Test Steps
Testing with this request: http://localhost:3000/C1234208438-POCLOUD/ogc-api-coverages/1.0.0/collections/bathymetry/coverage/rangeset?concatenate=true&subset=lon(-160%3A160)&subset=lat(-80%3A80)&maxResults=3&skipPreview=true&ignoreErrors=true&granuleId=G1234495188-POCLOUD,G1234515613-POCLOUD,G1234515574-POCLOUD,G1234516982-POCLOUD,G1234518216-POCLOUD,G1234518228-POCLOUD,G1236679413-POCLOUD

The second and third work items will fail. Bring up the workflow-ui and navigate to that job as an admin and verify that you can see the logs button while the work items are still running but have had at least one retry.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)