### PR TITLE
HARMONY-611: Ensure the data operation temporal field always uses strings

### DIFF
--- a/app/frontends/ogc-coverages/util/subset-parameter-parsing.ts
+++ b/app/frontends/ogc-coverages/util/subset-parameter-parsing.ts
@@ -1,4 +1,4 @@
-import { TemporalRange } from '../../../models/data-operation';
+import { TemporalStringRange } from '../../../models/data-operation';
 import { ParameterParseError } from '../../../util/parameter-parsing';
 
 const rangeSeparator = ':';
@@ -281,15 +281,15 @@ export function subsetParamsToBbox(
  */
 export function subsetParamsToTemporal(
   values: { lat?: Range<number>; lon?: Range<number>; time?: Range<Date> },
-): TemporalRange {
+): TemporalStringRange {
   const { time } = values;
-  const temporal: TemporalRange = {};
+  const temporal: TemporalStringRange = {};
   if (time) {
     if (time.min) {
-      temporal.start = time.min;
+      temporal.start = time.min.toISOString();
     }
     if (time.max) {
-      temporal.end = time.max;
+      temporal.end = time.max.toISOString();
     }
   }
   return temporal;

--- a/app/models/data-operation.ts
+++ b/app/models/data-operation.ts
@@ -223,15 +223,9 @@ function validator(): Ajv {
   }
   return _validator;
 }
-
-export interface TemporalRange {
-  start?: Date;
-  end?: Date;
-}
-
 export interface TemporalStringRange {
-  start?: string | Date;
-  end?: string | Date;
+  start?: string;
+  end?: string;
 }
 export interface HarmonyGranule {
   id: string;
@@ -670,17 +664,10 @@ export default class DataOperation {
    * Sets the temporal range to be acted upon by services, `{ start, end }`, storing each time
    * as a string expressed in RFC-3339 format
    *
-   * @param The - [ start, end ] temporal range
+   * @param temporalRange - [ start, end ] temporal range
    */
   set temporal(temporalRange: TemporalStringRange) {
-    const { start, end } = temporalRange;
-    this.model.temporal = {};
-    if (start) {
-      this.model.temporal.start = (typeof start === 'string') ? start : (start as Date).toISOString();
-    }
-    if (end) {
-      this.model.temporal.end = (typeof end === 'string') ? end : (end as Date).toISOString();
-    }
+    this.model.temporal = temporalRange;
   }
 
   /**

--- a/app/util/metrics.ts
+++ b/app/util/metrics.ts
@@ -118,11 +118,11 @@ export function getRequestMetric(
   }
 
   if (rangeBeginDateTime) {
-    metric.rangeBeginDateTime = rangeBeginDateTime as string;
+    metric.rangeBeginDateTime = rangeBeginDateTime;
   }
 
   if (rangeEndDateTime) {
-    metric.rangeEndDateTime = rangeEndDateTime as string;
+    metric.rangeEndDateTime = rangeEndDateTime;
   }
 
   return metric;

--- a/test/ogc-api-coverages/subset-parameter-parsing.ts
+++ b/test/ogc-api-coverages/subset-parameter-parsing.ts
@@ -345,19 +345,19 @@ describe('OGC API Coverages - Utilities', function () {
     it('returns temporal information with start and end when passed both a min and max', function () {
       expect(subsetParamsToTemporal({
         time: { min: new Date('2001-05-01T12:35:00Z'), max: new Date('2002-07-01T13:18:55Z') },
-      })).to.eql({ start: new Date('2001-05-01T12:35:00Z'), end: new Date('2002-07-01T13:18:55Z') });
+      })).to.eql({ start: '2001-05-01T12:35:00.000Z', end: '2002-07-01T13:18:55.000Z' });
     });
 
     it('returns temporal information without a start when passed only a max', function () {
       expect(subsetParamsToTemporal({
         time: { min: undefined, max: new Date('2002-07-01T13:18:55Z') },
-      })).to.eql({ end: new Date('2002-07-01T13:18:55Z') });
+      })).to.eql({ end: '2002-07-01T13:18:55.000Z' });
     });
 
     it('returns temporal information without a end when passed only a min', function () {
       expect(subsetParamsToTemporal({
         time: { min: new Date('2001-05-01T12:35:00Z'), max: undefined },
-      })).to.eql({ start: new Date('2001-05-01T12:35:00Z') });
+      })).to.eql({ start: '2001-05-01T12:35:00.000Z' });
     });
 
     it('returns an empty object when both min and max are undefined', function () {
@@ -371,7 +371,7 @@ describe('OGC API Coverages - Utilities', function () {
         lat: { min: -10, max: 10.5 },
         lon: { min: -20, max: 20.5 },
         time: { min: new Date('2001-05-01T12:35:00Z'), max: new Date('2002-07-01T13:18:55Z') },
-      })).to.eql({ start: new Date('2001-05-01T12:35:00Z'), end: new Date('2002-07-01T13:18:55Z') });
+      })).to.eql({ start: '2001-05-01T12:35:00.000Z', end: '2002-07-01T13:18:55.000Z' });
     });
   });
 });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-611

## Description
The temporal field was constructed using strings sometimes and Dates sometimes. This PR changes it to always use strings simplifying some logic.

## Local Test Steps
Set TEXT_LOGGER=false
Submit a request that has temporal subsetting and verify it completes successfully: http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(-5%3A5)&subset=lon(-10%3A10)&subset=time(%221902-07-31T00%3A00%3A00.000Z%22%3A%222020-08-31T10%3A00%3A00.000Z%22)&maxResults=2

Verify that the temporal range is logged correcting in the logs within the operation field:

```
"temporal":{"end":"2020-08-31T10:00:00.000Z","start":"1902-07-31T00:00:00.000Z"}
```

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)