### PR TITLE
Harmony 1295 first last buttons

### DIFF
--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -121,6 +121,8 @@ export async function getJobs(
     const { data: jobs, pagination } = await Job.queryAll(db, jobQuery, false, page, limit);
     setPagingHeaders(res, pagination);
     const pageLinks = getPagingLinks(req, pagination);
+    const firstPage = pageLinks.find((l) => l.rel === 'first');
+    const lastPage = pageLinks.find((l) => l.rel === 'last');
     const nextPage = pageLinks.find((l) => l.rel === 'next');
     const previousPage = pageLinks.find((l) => l.rel === 'prev');
     res.render('workflow-ui/jobs/index', {
@@ -173,8 +175,10 @@ export async function getJobs(
       selectedFilters: tableFilter.originalValues,
       // job table paging buttons HTML
       links: [
+        { ...firstPage, linkTitle: 'first' },
         { ...previousPage, linkTitle: 'previous' },
         { ...nextPage, linkTitle: 'next' },
+        { ...lastPage, linkTitle: 'last' },
       ],
       linkDisabled() { return (this.href ? '' : 'disabled'); },
       linkHref() { return (this.href || ''); },
@@ -321,6 +325,8 @@ export async function getWorkItemsTable(
     }
     const { workItems, pagination } = await queryAll(db, itemQuery, page, limit);
     const pageLinks = getPagingLinks(req, pagination);
+    const firstPage = pageLinks.find((l) => l.rel === 'first');
+    const lastPage = pageLinks.find((l) => l.rel === 'last');
     const nextPage = pageLinks.find((l) => l.rel === 'next');
     const previousPage = pageLinks.find((l) => l.rel === 'prev');
     setPagingHeaders(res, pagination);
@@ -332,8 +338,10 @@ export async function getWorkItemsTable(
       workItems,
       ...workItemRenderingFunctions(job, isAdmin, req.user),
       links: [
+        { ...firstPage, linkTitle: 'first' },
         { ...previousPage, linkTitle: 'previous' },
         { ...nextPage, linkTitle: 'next' },
+        { ...lastPage, linkTitle: 'last' },
       ],
       linkDisabled() { return (this.href ? '' : 'disabled'); },
       linkHref() {

--- a/test/workflow-ui/helpers.ts
+++ b/test/workflow-ui/helpers.ts
@@ -1,0 +1,22 @@
+import * as mustache from 'mustache';
+
+//
+// Helper functions for workflow-ui tests
+//
+
+/**
+ * Render a navigation prev/next/first/last page link
+ * @param path - the path portion of the url for the link
+ * @param title - The title for the link
+ * @param enabled - If true the link is enabled - defaults to true
+ * @returns A string for the html for the link
+ */
+export function renderNavLink(
+  path: String,
+  title: String,
+  enabled = true,
+): String {
+  const link = enabled ? 'http:&#x2F;&#x2F;127.0.0.1:4000{{path}}' : '';
+  const template = `<a class="page-link" href="${link}" title="{{title}}">{{title}}</a>`;
+  return mustache.render(template, { path, title });
+}

--- a/test/workflow-ui/jobs.ts
+++ b/test/workflow-ui/jobs.ts
@@ -9,6 +9,7 @@ import { buildJob } from '../helpers/jobs';
 import { workflowUIJobs, hookWorkflowUIJobs, hookAdminWorkflowUIJobs } from '../helpers/workflow-ui';
 import env from '../../app/util/env';
 import { auth } from '../helpers/auth';
+import { renderNavLink } from './helpers';
 
 // Example jobs to use in tests
 const woodyJob1 = buildJob({
@@ -161,7 +162,18 @@ describe('Workflow UI jobs route', function () {
       hookWorkflowUIJobs({ username: 'woody', limit: 1 });
       it('returns a link to the next page', function () {
         const listing = this.res.text;
-        expect(listing).to.contain(mustache.render('{{nextLink}}', { nextLink: '/workflow-ui?limit=1&page=2' }));
+        expect(listing).to.contain(renderNavLink('/workflow-ui?limit=1&page=2', 'next'));
+      });
+      it('returns a disabled link to the previous page', function () {
+        const listing = this.res.text;
+        expect(listing).to.contain(renderNavLink('', 'previous', false));
+      });
+      it('returns a disabled link to the first page', function () {
+        const listing = this.res.text;
+        expect(listing).to.contain(renderNavLink('', 'first', false));
+      });it('returns a link to the last page', function () {
+        const listing = this.res.text;
+        expect(listing).to.contain(renderNavLink('/workflow-ui?limit=1&page=3', 'last'));
       });
       it('returns only one job', function () {
         const listing = this.res.text;
@@ -199,8 +211,39 @@ describe('Workflow UI jobs route', function () {
       hookWorkflowUIJobs({ username: 'woody', limit: 1, page: 2 });
       it('returns a link to the next and previous page', function () {
         const listing = this.res.text;
-        expect(listing).to.contain(mustache.render('{{nextLink}}', { nextLink: '/workflow-ui?limit=1&page=1' }));
-        expect(listing).to.contain(mustache.render('{{prevLink}}', { prevLink: '/workflow-ui?limit=1&page=3' }));
+        expect(listing).to.contain(renderNavLink('/workflow-ui?limit=1&page=1', 'previous'));
+        expect(listing).to.contain(renderNavLink('/workflow-ui?limit=1&page=3', 'next'));
+      });
+      it('returns a disabled link to the first page', function () {
+        const listing = this.res.text;
+        expect(listing).to.contain(renderNavLink('', 'first', false));
+      });it('returns a disabled link to the last page', function () {
+        const listing = this.res.text;
+        expect(listing).to.contain(renderNavLink('', 'last', false));
+      });
+      it('returns only one job', function () {
+        const listing = this.res.text;
+        expect((listing.match(/job-table-row/g) || []).length).to.equal(1);
+      });
+    });
+
+    describe('who has 3 jobs and asks for page 3, with a limit of 1', function () {
+      hookWorkflowUIJobs({ username: 'woody', limit: 1, page: 3 });
+      it('returns a disabled link to the next page', function () {
+        const listing = this.res.text;
+        expect(listing).to.contain(renderNavLink('', 'next', false));
+      });
+      it('returns a link to the previous page', function () {
+        const listing = this.res.text;
+        expect(listing).to.contain(renderNavLink('/workflow-ui?limit=1&page=2', 'previous'));
+      });
+      it('returns a link to the first page', function () {
+        const listing = this.res.text;
+        expect(listing).to.contain(renderNavLink('/workflow-ui?limit=1&page=1', 'first'));
+      });
+      it('returns a disabled link to the last page', function () {
+        const listing = this.res.text;
+        expect(listing).to.contain(renderNavLink('', 'last', false));
       });
       it('returns only one job', function () {
         const listing = this.res.text;

--- a/test/workflow-ui/work-items-table.ts
+++ b/test/workflow-ui/work-items-table.ts
@@ -40,11 +40,15 @@ const item2 = buildWorkItem(
   { jobID: targetJob.jobID, workflowStepIndex: 1, serviceID: step1ServiceId, status: WorkItemStatus.SUCCESSFUL },
 );
 const item3 = buildWorkItem(
+  { jobID: targetJob.jobID, workflowStepIndex: 1, serviceID: step1ServiceId, status: WorkItemStatus.SUCCESSFUL },
+);
+const item4 = buildWorkItem(
   { jobID: targetJob.jobID, workflowStepIndex: 2, serviceID: step2ServiceId, status: WorkItemStatus.RUNNING },
 );
 const retryingWorkItem = buildWorkItem(
   { jobID: targetJob.jobID, workflowStepIndex: 2, serviceID: step2ServiceId, status: WorkItemStatus.RUNNING, retryCount: 1 },
 );
+
 
 // use to test functionality related to job sharing
 const collectionWithEULAFalseAndGuestReadTrue = 'C1233800302-EEDTEST';
@@ -95,6 +99,7 @@ describe('Workflow UI work items table route', function () {
       await item1.save(this.trx);
       await item2.save(this.trx);
       await item3.save(this.trx);
+      await item4.save(this.trx);
       await retryingWorkItem.save(this.trx);
       await step1.save(this.trx);
       await step2.save(this.trx);
@@ -265,6 +270,11 @@ describe('Workflow UI work items table route', function () {
           ['limit=1', 'page=2', `tableFilter=${encodeURIComponent(successfulFilter)}`].forEach((param) => expect(listing).to.contain(
             mustache.render('{{param}}', { param })));
         });
+        it('returns a link to the last page', function () {
+          const listing = this.res.text;
+          ['limit=1', 'page=3', `tableFilter=${encodeURIComponent(successfulFilter)}`].forEach((param) => expect(listing).to.contain(
+            mustache.render('{{param}}', { param })));
+        });
         it('returns only one work item', function () {
           const listing = this.res.text;
           expect(listing).to.contain(mustache.render('<td>{{id}}</td>', { id: 1 }));
@@ -286,6 +296,29 @@ describe('Workflow UI work items table route', function () {
         it('returns only one work item', function () {
           const listing = this.res.text;
           expect(listing).to.contain(mustache.render('<td>{{id}}</td>', { id: 2 }));
+          expect((listing.match(/work-item-table-row/g) || []).length).to.equal(1);
+        });
+        it('returns a SUCCESSFUL work item', function () {
+          const listing = this.res.text;
+          expect(listing).to.contain(`<span class="badge bg-success">${WorkItemStatus.SUCCESSFUL.valueOf()}</span>`);
+        });
+      });
+
+      describe('who requests page 3 of the work items table, with a limit of 1 and status IN [SUCCESSFUL]', function () {
+        hookWorkflowUIWorkItems({ username: 'bo', jobID: targetJob.jobID, query: { limit: 1, page: 3, tableFilter: successfulFilter } });
+        it('returns a link to the previous page', function () {
+          const listing = this.res.text;
+          ['limit=1', 'page=2', `tableFilter=${encodeURIComponent(successfulFilter)}`].forEach((param) => expect(listing).to.contain(
+            mustache.render('{{param}}', { param })));
+        });
+        it('returns a link to the first page', function () {
+          const listing = this.res.text;
+          ['limit=1', 'page=1', `tableFilter=${encodeURIComponent(successfulFilter)}`].forEach((param) => expect(listing).to.contain(
+            mustache.render('{{param}}', { param })));
+        });
+        it('returns only one work item', function () {
+          const listing = this.res.text;
+          expect(listing).to.contain(mustache.render('<td>{{id}}</td>', { id: 3 }));
           expect((listing.match(/work-item-table-row/g) || []).length).to.equal(1);
         });
         it('returns a SUCCESSFUL work item', function () {
@@ -346,7 +379,7 @@ describe('Workflow UI work items table route', function () {
           query: { disallowStatus: 'on', tableFilter: '[{"value":"status: running","dbValue":"running","field":"status"}]' } });
         it('returns only non-running work items', function () {
           const listing = this.res.text;
-          expect((listing.match(/work-item-table-row/g) || []).length).to.equal(2);
+          expect((listing.match(/work-item-table-row/g) || []).length).to.equal(3);
           expect(listing).to.not.contain(`<span class="badge bg-danger">${WorkItemStatus.FAILED.valueOf()}</span>`);
           expect(listing).to.contain(`<span class="badge bg-success">${WorkItemStatus.SUCCESSFUL.valueOf()}</span>`);
           expect(listing).to.not.contain(`<span class="badge bg-secondary">${WorkItemStatus.CANCELED.valueOf()}</span>`);

--- a/test/workflow-ui/work-items-table.ts
+++ b/test/workflow-ui/work-items-table.ts
@@ -169,7 +169,7 @@ describe('Workflow UI work items table route', function () {
             .forEach((stepIndex) => expect(listing).to.contain(mustache.render('<th scope="row">{{stepIndex}}</th>', { stepIndex })));
           [1, 2, 3]
             .forEach((id) => expect(listing).to.contain(mustache.render('<td>{{id}}</td>', { id })));
-          expect((listing.match(/work-item-table-row/g) || []).length).to.equal(4);
+          expect((listing.match(/work-item-table-row/g) || []).length).to.equal(5);
         });
         it('return useful but nonsensitive information about docker images', function () {
           const listing = this.res.text;
@@ -204,7 +204,7 @@ describe('Workflow UI work items table route', function () {
         hookWorkflowUIWorkItems({ username: 'adam', jobID: targetJob.jobID });
         it('returns links for the other user\'s work item logs for retrying and completed work items', async function () {
           const listing = this.res.text;
-          expect((listing.match(/logs-button/g) || []).length).to.equal(3);
+          expect((listing.match(/logs-button/g) || []).length).to.equal(4);
         });
         it('does return a column for the work item logs', async function () {
           const listing = this.res.text;
@@ -354,11 +354,11 @@ describe('Workflow UI work items table route', function () {
             ));
           [1, 2, 3]
             .forEach((id) => expect(listing).to.contain(mustache.render('<td>{{id}}</td>', { id })));
-          expect((listing.match(/work-item-table-row/g) || []).length).to.equal(4);
+          expect((listing.match(/work-item-table-row/g) || []).length).to.equal(5);
         });
         it('returns links for the (completed) and currently running work item logs', async function () {
           const listing = this.res.text;
-          expect((listing.match(/logs-button/g) || []).length).to.equal(3);
+          expect((listing.match(/logs-button/g) || []).length).to.equal(4);
         });
         it('does return a column for the work item logs', async function () {
           const listing = this.res.text;


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1295

## Description
Add first/last page links

## Local Test Steps
* Run a job with multiple granules
* Access the workflow-ui and set the limit and page parameter to 1. 
* Verify that the first/last page links exist and work as you move through them. The 'first' should be ghosted on the first and second page, while the 'last' link should be ghosted on the last and second to last page.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~