### PR TITLE
Harmony 1323, 1324 - Add kibana pod logs links to workflow ui work items page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # package directories
 node_modules
 
-# Serverless directories
-.serverless
-
 # Temp and log files
 *.log
 tmp

--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -60,8 +60,10 @@ export async function getWork(
     workItem = await getNextWorkItem(tx, serviceID as string);
     if (workItem) {
       logger.debug(`Sending work item ${workItem.id} to pod ${podName}`);
-      workItem.runnerIds.push(podId as string);
-      await workItem.save(tx);
+      if (podId) {
+        workItem.runnerIds.push(podId as string);
+        await workItem.save(tx);
+      }
       if (workItem && QUERY_CMR_SERVICE_REGEX.test(workItem.serviceID)){
         maxCmrGranules = await calculateQueryCmrLimit(tx, workItem, logger);
         res.send({ workItem, maxCmrGranules });

--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -52,7 +52,7 @@ export async function getWork(
   req: HarmonyRequest, res: Response, next: NextFunction, tryCount = 1,
 ): Promise<void> {
   const { logger } = req.context;
-  const { serviceID, podName } = req.query;
+  const { serviceID, podName, podId } = req.query;
 
   let workItem: WorkItem, maxCmrGranules: number;
 
@@ -60,6 +60,8 @@ export async function getWork(
     workItem = await getNextWorkItem(tx, serviceID as string);
     if (workItem) {
       logger.debug(`Sending work item ${workItem.id} to pod ${podName}`);
+      workItem.runnerIds.push(podId as string);
+      await workItem.save(tx);
       if (workItem && QUERY_CMR_SERVICE_REGEX.test(workItem.serviceID)){
         maxCmrGranules = await calculateQueryCmrLimit(tx, workItem, logger);
         res.send({ workItem, maxCmrGranules });

--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -57,13 +57,9 @@ export async function getWork(
   let workItem: WorkItem, maxCmrGranules: number;
 
   await db.transaction(async (tx) => {
-    workItem = await getNextWorkItem(tx, serviceID as string);
+    workItem = await getNextWorkItem(tx, serviceID as string, podId as string);
     if (workItem) {
       logger.debug(`Sending work item ${workItem.id} to pod ${podName}`);
-      if (podId) {
-        workItem.runnerIds.push(podId as string);
-        await workItem.save(tx);
-      }
       if (workItem && QUERY_CMR_SERVICE_REGEX.test(workItem.serviceID)){
         maxCmrGranules = await calculateQueryCmrLimit(tx, workItem, logger);
         res.send({ workItem, maxCmrGranules });

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -264,7 +264,11 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
   badgeClasses[WorkItemStatus.SUCCESSFUL] = 'success';
   badgeClasses[WorkItemStatus.RUNNING] = 'info';
   return {
-    workflowItemRunnerIds(): string { return (this.runnerIds.join(', ')); },
+    workflowItemRunnerIds(): string { 
+      return this.runnerIds.map((runnerId: string) => {
+        return `<li><a class="dropdown-item" href="#">${runnerId}</a></li>`;
+      }).join(''); 
+    },
     workflowItemBadge(): string { return badgeClasses[this.status]; },
     workflowItemStep(): string { return sanitizeImage(this.serviceID); },
     workflowItemCreatedAt(): string { return this.createdAt.getTime(); },

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -266,7 +266,7 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
   return {
     workflowItemRunners(): string { 
       return this.runners.map((runner: { id: string, startedAt: number }) => {
-        return `<li><a class="dropdown-item" href="#">${runner.id} ${runner.startedAt}</a></li>`;
+        return `<li><a class="dropdown-item" href="#">${runner.id} ${(new Date(runner.startedAt)).toISOString()}</a></li>`;
       }).join(''); 
     },
     workflowItemBadge(): string { return badgeClasses[this.status]; },

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -271,8 +271,8 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
     workflowItemPodLogs(): string {
       if (!this.runners || this.runners.length < 1) return '';
       return this.runners.map((runner: { id: string, startedAt: number }, i: number) => {
-        const to = this.status === WorkItemStatus.RUNNING ? 'now' : this.updatedAt.toISOString();
         const from = (new Date(runner.startedAt)).toISOString();
+        const to = this.status === WorkItemStatus.RUNNING ? 'now' : this.updatedAt.toISOString();
         const url = `${env.metricsEndpoint}?_g=(filters:!(),refreshInterval:(pause:!t,value:0),` +
           `time:(from:'${from}',to:'${to}'))` +
           `&_a=(columns:!(),filters:!(),index:${env.metricsIndex},interval:auto,` +

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -272,11 +272,12 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
       if (!this.runners || this.runners.length < 1) return '';
       return this.runners.map((runner: { id: string, startedAt: number }, i: number) => {
         const to = this.status === WorkItemStatus.RUNNING ? 'now' : this.updatedAt.toISOString();
-        const url = env.metricsEndpoint
-          .replace('{{from}}', (new Date(runner.startedAt)).toISOString())  
-          .replace('{{to}}', to)
-          .replace('{{query}}', encodeURIComponent(`kubernetes.pod_id: "${runner.id}"`));
-        return `<a class="pod-logs-link" href="${url}" target="__blank" title="logs for run/try number ${i}">${i}</a>&nbsp;`;
+        const url = `${env.metricsEndpoint}?_g=(filters:!(),refreshInterval:(pause:!t,value:0),` +
+          `time:(from:'${(new Date(runner.startedAt)).toISOString()}',to:'${to}'))` +
+          `&_a=(columns:!(),filters:!(),index:${env.metricsIndex},interval:auto,` +
+          `query:(language:kuery,query:'${encodeURIComponent(`kubernetes.pod_id: "${runner.id}"`)}'),` +
+          "sort:!(!('@timestamp',desc)))";
+        return `<a class="pod-logs-link" href="${url}" target="__blank" title="logs for run number ${i + 1}">${i + 1}</a>&nbsp;`;
       }).join(''); 
     },
     workflowItemBadge(): string { return badgeClasses[this.status]; },

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -272,6 +272,8 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
         const url = env.metricsEndpoint
           .replace('{{from}}', (new Date(runner.startedAt)).toISOString())  
           .replace('{{to}}', to)
+          // TODO - generalize query parameter construction so that it works for app logs as well (requestId=...)
+          // searchKey, searchValue
           .replaceAll('{{podId}}', runner.id);
         return `
         <div class="dropdown">

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -265,11 +265,9 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
   badgeClasses[WorkItemStatus.RUNNING] = 'info';
   return {
     workflowItemPodLogs(): string {
-      if (this.status === WorkItemStatus.READY) return '';
       if (!this.runners || this.runners.length < 1) return '';
-      const isDone = [WorkItemStatus.FAILED, WorkItemStatus.SUCCESSFUL, WorkItemStatus.CANCELED].indexOf(this.status) > -1;
       return this.runners.map((runner: { id: string, startedAt: number }, i: number) => {
-        const to = isDone ? this.updatedAt.toISOString() : 'now';
+        const to = this.status === WorkItemStatus.RUNNING ? 'now' : this.updatedAt.toISOString();
         const url = env.metricsEndpoint
           .replace('{{from}}', (new Date(runner.startedAt)).toISOString())  
           .replace('{{to}}', to)

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -264,22 +264,23 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
   badgeClasses[WorkItemStatus.SUCCESSFUL] = 'success';
   badgeClasses[WorkItemStatus.RUNNING] = 'info';
   return {
-    workflowItemRunners(): string { 
+    workflowItemPodLogs(): string {
+      if (this.status === WorkItemStatus.READY) return '';
+      if (!this.runners || this.runners.length < 1) return '';
+      const isDone = [WorkItemStatus.FAILED, WorkItemStatus.SUCCESSFUL, WorkItemStatus.CANCELED].indexOf(this.status) > -1;
       return this.runners.map((runner: { id: string, startedAt: number }, i: number) => {
-        const isComplete = [WorkItemStatus.FAILED, WorkItemStatus.SUCCESSFUL].indexOf(this.status) > -1;
-        if (!isComplete && (this.status != WorkItemStatus.RUNNING)) return '';
-        const to = isComplete ? this.updatedAt.toISOString() : 'now';
+        const to = isDone ? this.updatedAt.toISOString() : 'now';
         const url = env.metricsEndpoint
           .replace('{{from}}', (new Date(runner.startedAt)).toISOString())  
           .replace('{{to}}', to)
           .replace('{{query}}', encodeURIComponent(`kubernetes.pod_id: "${runner.id}"`));
         return `
         <div class="dropdown">
-          <button id="dropdownMenuLink" class="btn btn-light btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">
+          <button id="dropdownMenuLink" class="btn btn-light btn-sm dropdown-toggle" type="button" data-toggle="dropdown">
           </button>
           <ul class="dropdown-menu">
             <li>
-              <a class="dropdown-item" href="${url}" target="__blank">
+              <a class="dropdown-item pod-logs-link" href="${url}" target="__blank">
                 <span class="badge bg-dark">try number</span> ${i}&nbsp;&nbsp;
                 <span class="badge bg-dark">pod</span> ${runner.id}
               </a>

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -272,9 +272,7 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
         const url = env.metricsEndpoint
           .replace('{{from}}', (new Date(runner.startedAt)).toISOString())  
           .replace('{{to}}', to)
-          // TODO - generalize query parameter construction so that it works for app logs as well (requestId=...)
-          // searchKey, searchValue
-          .replaceAll('{{podId}}', runner.id);
+          .replace('{{query}}', encodeURIComponent(`kubernetes.pod_id: "${runner.id}"`));
         return `
         <div class="dropdown">
           <button id="dropdownMenuLink" class="btn btn-light btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -264,6 +264,7 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
   badgeClasses[WorkItemStatus.SUCCESSFUL] = 'success';
   badgeClasses[WorkItemStatus.RUNNING] = 'info';
   return {
+    workflowItemRunnerIds(): string { return (this.runnerIds.join(', ')); },
     workflowItemBadge(): string { return badgeClasses[this.status]; },
     workflowItemStep(): string { return sanitizeImage(this.serviceID); },
     workflowItemCreatedAt(): string { return this.createdAt.getTime(); },

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -272,19 +272,7 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
           .replace('{{from}}', (new Date(runner.startedAt)).toISOString())  
           .replace('{{to}}', to)
           .replace('{{query}}', encodeURIComponent(`kubernetes.pod_id: "${runner.id}"`));
-        return `
-        <div class="dropdown">
-          <button id="dropdownMenuLink" class="btn btn-light btn-sm dropdown-toggle" type="button" data-toggle="dropdown">
-          </button>
-          <ul class="dropdown-menu">
-            <li>
-              <a class="dropdown-item pod-logs-link" href="${url}" target="__blank">
-                <span class="badge bg-dark">try number</span> ${i}&nbsp;&nbsp;
-                <span class="badge bg-dark">pod</span> ${runner.id}
-              </a>
-            </li>
-          </ul>
-        </div>`;
+        return `<a class="pod-logs-link" href="${url}" target="__blank" title="logs for run/try number ${i}">${i}</a>&nbsp;`;
       }).join(''); 
     },
     workflowItemBadge(): string { return badgeClasses[this.status]; },

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -272,8 +272,9 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
       if (!this.runners || this.runners.length < 1) return '';
       return this.runners.map((runner: { id: string, startedAt: number }, i: number) => {
         const to = this.status === WorkItemStatus.RUNNING ? 'now' : this.updatedAt.toISOString();
+        const from = (new Date(runner.startedAt)).toISOString();
         const url = `${env.metricsEndpoint}?_g=(filters:!(),refreshInterval:(pause:!t,value:0),` +
-          `time:(from:'${(new Date(runner.startedAt)).toISOString()}',to:'${to}'))` +
+          `time:(from:'${from}',to:'${to}'))` +
           `&_a=(columns:!(),filters:!(),index:${env.metricsIndex},interval:auto,` +
           `query:(language:kuery,query:'${encodeURIComponent(`kubernetes.pod_id: "${runner.id}"`)}'),` +
           "sort:!(!('@timestamp',desc)))";

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -278,7 +278,7 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
           `&_a=(columns:!(),filters:!(),index:${env.metricsIndex},interval:auto,` +
           `query:(language:kuery,query:'${encodeURIComponent(`kubernetes.pod_id: "${runner.id}"`)}'),` +
           "sort:!(!('@timestamp',desc)))";
-        return `<a class="pod-logs-link" href="${url}" target="__blank" title="logs for run number ${i + 1}">${i + 1}</a>&nbsp;`;
+        return `<a class="pod-logs-link" href="${url}" target="__blank" title="pod ${runner.id} logs for run number ${i + 1}">${i + 1}</a>&nbsp;`;
       }).join(''); 
     },
     workflowItemBadge(): string { return badgeClasses[this.status]; },

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -264,9 +264,9 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
   badgeClasses[WorkItemStatus.SUCCESSFUL] = 'success';
   badgeClasses[WorkItemStatus.RUNNING] = 'info';
   return {
-    workflowItemRunnerIds(): string { 
-      return this.runnerIds.map((runnerId: string) => {
-        return `<li><a class="dropdown-item" href="#">${runnerId}</a></li>`;
+    workflowItemRunners(): string { 
+      return this.runners.map((runner: { id: string, startedAt: number }) => {
+        return `<li><a class="dropdown-item" href="#">${runner.id} ${runner.startedAt}</a></li>`;
       }).join(''); 
     },
     workflowItemBadge(): string { return badgeClasses[this.status]; },

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -265,8 +265,27 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, requestUser: str
   badgeClasses[WorkItemStatus.RUNNING] = 'info';
   return {
     workflowItemRunners(): string { 
-      return this.runners.map((runner: { id: string, startedAt: number }) => {
-        return `<li><a class="dropdown-item" href="#">${runner.id} ${(new Date(runner.startedAt)).toISOString()}</a></li>`;
+      return this.runners.map((runner: { id: string, startedAt: number }, i: number) => {
+        const isComplete = [WorkItemStatus.FAILED, WorkItemStatus.SUCCESSFUL].indexOf(this.status) > -1;
+        if (!isComplete && (this.status != WorkItemStatus.RUNNING)) return '';
+        const to = isComplete ? this.updatedAt.toISOString() : 'now';
+        const url = env.metricsEndpoint
+          .replace('{{from}}', (new Date(runner.startedAt)).toISOString())  
+          .replace('{{to}}', to)
+          .replaceAll('{{podId}}', runner.id);
+        return `
+        <div class="dropdown">
+          <button id="dropdownMenuLink" class="btn btn-light btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">
+          </button>
+          <ul class="dropdown-menu">
+            <li>
+              <a class="dropdown-item" href="${url}" target="__blank">
+                <span class="badge bg-dark">try number</span> ${i}&nbsp;&nbsp;
+                <span class="badge bg-dark">pod</span> ${runner.id}
+              </a>
+            </li>
+          </ul>
+        </div>`;
       }).join(''); 
     },
     workflowItemBadge(): string { return badgeClasses[this.status]; },

--- a/app/models/work-item-interface.ts
+++ b/app/models/work-item-interface.ts
@@ -74,8 +74,9 @@ export interface WorkItemRecord {
   // The position of the work item output in any following aggregation
   sortIndex: number;
 
-  // Ids of any runners (pods) that have worked on this item
-  runnerIds: string[];
+  // Any runners (pods) that have worked on this item
+  // includes the id of the runner and the start time in milliseconds since epoch
+  runners: { id: string, startedAt: number }[];
 }
 
 export interface WorkItemQuery {

--- a/app/models/work-item-interface.ts
+++ b/app/models/work-item-interface.ts
@@ -73,6 +73,9 @@ export interface WorkItemRecord {
 
   // The position of the work item output in any following aggregation
   sortIndex: number;
+
+  // Ids of any runners (pods) that have worked on this item
+  runnerIds: string[];
 }
 
 export interface WorkItemQuery {

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -84,7 +84,7 @@ export default class WorkItem extends DBRecord implements WorkItemRecord {
    * @param record - the work item record to mutate
    * @returns the work item record, ready to be saved
    */
-  prepareForSave(record: Record<string, unknown>): Record<string, unknown>  {
+  serializeForSave(record: Record<string, unknown>): Record<string, unknown>  {
     record.runners = JSON.stringify(this.runners || []);
     return record;
   }
@@ -95,7 +95,7 @@ export default class WorkItem extends DBRecord implements WorkItemRecord {
    * @param transaction - The transaction to use for saving the job link
    */
   async save(transaction: Transaction): Promise<void> {
-    const record: Record<string, unknown> = this.prepareForSave(_.pick(this, serializedFields));
+    const record: Record<string, unknown> = this.serializeForSave(_.pick(this, serializedFields));
     await super.save(transaction, record);
   }
 
@@ -118,7 +118,7 @@ export default class WorkItem extends DBRecord implements WorkItemRecord {
    * @param workItems - The work items to save
    */
   static async insertBatch(transaction: Transaction, workItems: WorkItem[]): Promise<void> {
-    const fieldsList = workItems.map(item => item.prepareForSave(_.pick(item, serializedFields)));
+    const fieldsList = workItems.map(item => item.serializeForSave(_.pick(item, serializedFields)));
     await super.insertBatch(transaction, workItems, fieldsList);
   }
 

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -228,7 +228,7 @@ export async function getNextWorkItem(
                 status: WorkItemStatus.RUNNING,
                 updatedAt: startedAt,
                 startedAt,
-                runnerIds: workItem.runnerIds,
+                runnerIds: JSON.stringify(workItem.runnerIds),
               })
               .where({ id: workItemData.id });
             // need to update the job otherwise long running jobs won't count against

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -143,6 +143,7 @@ const tableFields = serializedFields.map((field) => `w.${field}`);
  * Returns the next work item to process for a service
  * @param tx - the transaction to use for querying
  * @param serviceID - the service ID looking for the next item to work
+ * @param podId - the id of the pod that is looking for a work item to process
  *
  * @returns A promise with the work item to process or null if none
  */

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -73,6 +73,9 @@ export default class WorkItem extends Record implements WorkItemRecord {
   // The position of the work item output in any following aggregation
   sortIndex: number;
 
+  // Ids of any runners (pods) that have worked on this item
+  runnerIds: string[];
+
   /**
    * Saves the work item to the database using the given transaction.
    *

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -81,10 +81,10 @@ export default class WorkItem extends DBRecord implements WorkItemRecord {
    * Prepare a record for saving.
    * (Can be useful if the record needs massaging before saving,
    * e.g. for fields that need to be converted between stringified JSON text and object.)
-   * @param record - the work item record to mutate
    * @returns the work item record, ready to be saved
    */
-  serializeForSave(record: Record<string, unknown>): Record<string, unknown>  {
+  serializeForSave(): Record<string, unknown>  {
+    const record: Record<string, unknown> = _.pick(this, serializedFields);
     record.runners = JSON.stringify(this.runners || []);
     return record;
   }
@@ -95,7 +95,7 @@ export default class WorkItem extends DBRecord implements WorkItemRecord {
    * @param transaction - The transaction to use for saving the job link
    */
   async save(transaction: Transaction): Promise<void> {
-    const record: Record<string, unknown> = this.serializeForSave(_.pick(this, serializedFields));
+    const record: Record<string, unknown> = this.serializeForSave();
     await super.save(transaction, record);
   }
 
@@ -118,7 +118,7 @@ export default class WorkItem extends DBRecord implements WorkItemRecord {
    * @param workItems - The work items to save
    */
   static async insertBatch(transaction: Transaction, workItems: WorkItem[]): Promise<void> {
-    const fieldsList = workItems.map(item => item.serializeForSave(_.pick(item, serializedFields)));
+    const fieldsList = workItems.map(item => item.serializeForSave());
     await super.insertBatch(transaction, workItems, fieldsList);
   }
 

--- a/app/util/env.ts
+++ b/app/util/env.ts
@@ -73,6 +73,7 @@ interface HarmonyEnv {
   builtInTaskVersion: string;
   callbackUrlRoot: string;
   cmrEndpoint: string;
+  metricsEndpoint: string;
   cmrMaxPageSize: number;
   defaultPodGracePeriodSecs: number;
   defaultJobListPageSize: number;

--- a/app/util/env.ts
+++ b/app/util/env.ts
@@ -74,6 +74,7 @@ interface HarmonyEnv {
   callbackUrlRoot: string;
   cmrEndpoint: string;
   metricsEndpoint: string;
+  metricsIndex: string;
   cmrMaxPageSize: number;
   defaultPodGracePeriodSecs: number;
   defaultJobListPageSize: number;

--- a/app/views/workflow-ui/job/work-item-table-row.mustache.html
+++ b/app/views/workflow-ui/job/work-item-table-row.mustache.html
@@ -5,11 +5,7 @@
   <td><span class="badge bg-{{workflowItemBadge}}">{{status}}</span></td>
   {{#isAdmin}}
   <td>{{{workflowItemLogsButton}}}</td>
-  {{/isAdmin}}
-  {{#isAdmin}}
-  <td>
-    {{{workflowItemPodLogs}}}
-  </td>
+  <td>{{{workflowItemPodLogs}}}</td>
   {{/isAdmin}}
   {{#canShowRetryColumn}}
   <td>{{{workflowItemRetryButton}}}</td>

--- a/app/views/workflow-ui/job/work-item-table-row.mustache.html
+++ b/app/views/workflow-ui/job/work-item-table-row.mustache.html
@@ -8,13 +8,7 @@
   {{/isAdmin}}
   {{#isAdmin}}
   <td>
-    <div class="dropdown">
-      <button id="dropdownMenuLink" class="btn btn-light btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">
-      </button>
-      <ul class="dropdown-menu">
-        {{{workflowItemRunners}}}
-      </ul>
-    </div>
+    {{{workflowItemRunners}}}
   </td>
   {{/isAdmin}}
   {{#canShowRetryColumn}}

--- a/app/views/workflow-ui/job/work-item-table-row.mustache.html
+++ b/app/views/workflow-ui/job/work-item-table-row.mustache.html
@@ -1,18 +1,26 @@
 <tr id="item-{{id}}" class="work-item-table-row">
-    <th scope="row">{{workflowStepIndex}}</th>
-    <td>{{workflowItemStep}}</td>
-    <td>{{id}}</td>
-    {{#isAdmin}}
-    <td>{{workflowItemRunnerIds}}</td>
-    {{/isAdmin}}
-    <td><span class="badge bg-{{workflowItemBadge}}">{{status}}</span></td>
-    {{#isAdmin}}
-    <td>{{{workflowItemLogsButton}}}</td>
-    {{/isAdmin}}
-    {{#canShowRetryColumn}}
-    <td>{{{workflowItemRetryButton}}}</td>
-    {{/canShowRetryColumn}}
-    <td>{{{retryCount}}}</td>
-    <td class="date-td" data-time="{{workflowItemCreatedAt}}"></td>
-    <td class="date-td" data-time="{{workflowItemUpdatedAt}}"></td>
+  <th scope="row">{{workflowStepIndex}}</th>
+  <td>{{workflowItemStep}}</td>
+  <td>{{id}}</td>
+  <td><span class="badge bg-{{workflowItemBadge}}">{{status}}</span></td>
+  {{#isAdmin}}
+  <td>{{{workflowItemLogsButton}}}</td>
+  {{/isAdmin}}
+  {{#isAdmin}}
+  <td>
+    <div class="dropdown">
+      <button id="dropdownMenuLink" class="btn btn-light btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">
+      </button>
+      <ul class="dropdown-menu">
+        {{{workflowItemRunnerIds}}}
+      </ul>
+    </div>
+  </td>
+  {{/isAdmin}}
+  {{#canShowRetryColumn}}
+  <td>{{{workflowItemRetryButton}}}</td>
+  {{/canShowRetryColumn}}
+  <td>{{{retryCount}}}</td>
+  <td class="date-td" data-time="{{workflowItemCreatedAt}}"></td>
+  <td class="date-td" data-time="{{workflowItemUpdatedAt}}"></td>
 </tr>

--- a/app/views/workflow-ui/job/work-item-table-row.mustache.html
+++ b/app/views/workflow-ui/job/work-item-table-row.mustache.html
@@ -12,7 +12,7 @@
       <button id="dropdownMenuLink" class="btn btn-light btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">
       </button>
       <ul class="dropdown-menu">
-        {{{workflowItemRunnerIds}}}
+        {{{workflowItemRunners}}}
       </ul>
     </div>
   </td>

--- a/app/views/workflow-ui/job/work-item-table-row.mustache.html
+++ b/app/views/workflow-ui/job/work-item-table-row.mustache.html
@@ -8,7 +8,7 @@
   {{/isAdmin}}
   {{#isAdmin}}
   <td>
-    {{{workflowItemRunners}}}
+    {{{workflowItemPodLogs}}}
   </td>
   {{/isAdmin}}
   {{#canShowRetryColumn}}

--- a/app/views/workflow-ui/job/work-item-table-row.mustache.html
+++ b/app/views/workflow-ui/job/work-item-table-row.mustache.html
@@ -2,6 +2,9 @@
     <th scope="row">{{workflowStepIndex}}</th>
     <td>{{workflowItemStep}}</td>
     <td>{{id}}</td>
+    {{#isAdmin}}
+    <td>{{workflowItemRunnerIds}}</td>
+    {{/isAdmin}}
     <td><span class="badge bg-{{workflowItemBadge}}">{{status}}</span></td>
     {{#isAdmin}}
     <td>{{{workflowItemLogsButton}}}</td>

--- a/app/views/workflow-ui/job/work-items-table.mustache.html
+++ b/app/views/workflow-ui/job/work-items-table.mustache.html
@@ -8,12 +8,12 @@
             <th scope="col">stepIndex</th>
             <th scope="col">stepName</th>
             <th scope="col">id</th>
-            {{#isAdmin}}
-            <th scope="col">runnerIds</th>
-            {{/isAdmin}}
             <th scope="col">status</th>
             {{#isAdmin}}
-            <th scope="col">logs</th>
+            <th scope="col">s3logs <i class="bi bi-info-circle" title="An aggregate view of the worker container logs for all invocations of the service, stored in s3."></i></th>
+            {{/isAdmin}}
+            {{#isAdmin}}
+            <th scope="col">podLogs</th>
             {{/isAdmin}}
             {{#canShowRetryColumn}}
             <th scope="col">retry</th>

--- a/app/views/workflow-ui/job/work-items-table.mustache.html
+++ b/app/views/workflow-ui/job/work-items-table.mustache.html
@@ -10,10 +10,10 @@
             <th scope="col">id</th>
             <th scope="col">status</th>
             {{#isAdmin}}
-            <th scope="col">s3logs <i class="bi bi-info-circle" title="An aggregate view of the worker container logs for all invocations of the service, stored in s3."></i></th>
+            <th scope="col">logs <i class="bi bi-info-circle" title="An aggregate view of the worker container logs for all invocations of the service, stored in s3."></i></th>
             {{/isAdmin}}
             {{#isAdmin}}
-            <th scope="col">podLogs</th>
+            <th scope="col">podLogs <i class="bi bi-info-circle" title="Link(s) to the logs dashboard for each pod that has worked on this item."></i></th>
             {{/isAdmin}}
             {{#canShowRetryColumn}}
             <th scope="col">retry</th>

--- a/app/views/workflow-ui/job/work-items-table.mustache.html
+++ b/app/views/workflow-ui/job/work-items-table.mustache.html
@@ -11,8 +11,6 @@
             <th scope="col">status</th>
             {{#isAdmin}}
             <th class="helpful-th" scope="col" title="An aggregate JSON list of worker container logs for all invocations of the service.">logs</th>
-            {{/isAdmin}}
-            {{#isAdmin}}
             <th class="helpful-th" scope="col" title="Link(s) to the logs dashboard for each pod that has worked on this item.">podLogs</th>
             {{/isAdmin}}
             {{#canShowRetryColumn}}

--- a/app/views/workflow-ui/job/work-items-table.mustache.html
+++ b/app/views/workflow-ui/job/work-items-table.mustache.html
@@ -8,6 +8,9 @@
             <th scope="col">stepIndex</th>
             <th scope="col">stepName</th>
             <th scope="col">id</th>
+            {{#isAdmin}}
+            <th scope="col">runnerIds</th>
+            {{/isAdmin}}
             <th scope="col">status</th>
             {{#isAdmin}}
             <th scope="col">logs</th>

--- a/app/views/workflow-ui/job/work-items-table.mustache.html
+++ b/app/views/workflow-ui/job/work-items-table.mustache.html
@@ -10,7 +10,7 @@
             <th scope="col">id</th>
             <th scope="col">status</th>
             {{#isAdmin}}
-            <th scope="col">logs <i class="bi bi-info-circle" title="An aggregate view of the worker container logs for all invocations of the service, stored in s3."></i></th>
+            <th scope="col">logs <i class="bi bi-info-circle" title="An aggregate JSON list of worker container logs for all invocations of the service."></i></th>
             {{/isAdmin}}
             {{#isAdmin}}
             <th scope="col">podLogs <i class="bi bi-info-circle" title="Link(s) to the logs dashboard for each pod that has worked on this item."></i></th>

--- a/app/views/workflow-ui/job/work-items-table.mustache.html
+++ b/app/views/workflow-ui/job/work-items-table.mustache.html
@@ -10,10 +10,10 @@
             <th scope="col">id</th>
             <th scope="col">status</th>
             {{#isAdmin}}
-            <th scope="col">logs <i class="bi bi-info-circle" title="An aggregate JSON list of worker container logs for all invocations of the service."></i></th>
+            <th class="helpful-th" scope="col" title="An aggregate JSON list of worker container logs for all invocations of the service.">logs</th>
             {{/isAdmin}}
             {{#isAdmin}}
-            <th scope="col">podLogs <i class="bi bi-info-circle" title="Link(s) to the logs dashboard for each pod that has worked on this item."></i></th>
+            <th class="helpful-th" scope="col" title="Link(s) to the logs dashboard for each pod that has worked on this item.">podLogs</th>
             {{/isAdmin}}
             {{#canShowRetryColumn}}
             <th scope="col">retry</th>

--- a/bin/deploy-services
+++ b/bin/deploy-services
@@ -8,6 +8,15 @@ source ".env"
 set +a
 eval "$env_save"
 
+if [ "$NODE_ENV" == "development" ]; then
+  current_context=$(kubectl config current-context)
+  if [ "$current_context" != "docker-desktop" ] && [ "$current_context" != "minikube" ]; then
+    echo 'ERROR: Attempting to use a non-local k8s context while deploying to a development environment.'
+    echo "$current_context"
+    exit 1
+  fi
+fi
+
 . ./bin/create-k8s-config-maps-and-secrets
 
 # create the query-cmr service

--- a/bin/deploy-services
+++ b/bin/deploy-services
@@ -8,13 +8,12 @@ source ".env"
 set +a
 eval "$env_save"
 
-if [ "$NODE_ENV" == "development" ]; then
-  current_context=$(kubectl config current-context)
-  if [ "$current_context" != "docker-desktop" ] && [ "$current_context" != "minikube" ]; then
-    echo 'ERROR: Attempting to use a non-local k8s context while deploying to a development environment.'
-    echo "$current_context"
-    exit 1
-  fi
+
+current_context=$(kubectl config current-context)
+if [ "$current_context" != "docker-desktop" ] && [ "$current_context" != "minikube" ]; then
+  echo 'ERROR: Attempting to use a non-local k8s context while deploying to a development environment.'
+  echo "$current_context"
+  exit 1
 fi
 
 . ./bin/create-k8s-config-maps-and-secrets

--- a/bin/restart-services
+++ b/bin/restart-services
@@ -7,6 +7,13 @@ source ".env"
 set +a
 eval "$env_save"
 
+current_context=$(kubectl config current-context)
+if [ "$current_context" != "docker-desktop" ] && [ "$current_context" != "minikube" ]; then
+  echo 'ERROR: Attempting to use a non-local k8s context while deploying to a development environment.'
+  echo "$current_context"
+  exit 1
+fi
+
 for service in ${LOCALLY_DEPLOYED_SERVICES//,/ } query-cmr
 do
     echo "stopping $service"

--- a/db/db.sql
+++ b/db/db.sql
@@ -56,6 +56,7 @@ CREATE TABLE `work_items` (
   `retryCount` integer not null default 0,
   `duration` float not null default -1.0,
   `sortIndex` integer not null default 0,
+  `runnerIds` text not null,
   `startedAt` datetime,
   `createdAt` datetime not null,
   `updatedAt` datetime not null,

--- a/db/db.sql
+++ b/db/db.sql
@@ -56,7 +56,7 @@ CREATE TABLE `work_items` (
   `retryCount` integer not null default 0,
   `duration` float not null default -1.0,
   `sortIndex` integer not null default 0,
-  `runnerIds` text not null,
+  `runners` text not null,
   `startedAt` datetime,
   `createdAt` datetime not null,
   `updatedAt` datetime not null,

--- a/db/migrations/20221121160725_add_runner_ids_to_work_items.js
+++ b/db/migrations/20221121160725_add_runner_ids_to_work_items.js
@@ -1,16 +1,16 @@
 exports.up = async function (knex) {
   return knex.schema.alterTable('work_items', async (t) => {
-    t.text('runnerIds').defaultTo('[]');
+    t.text('runners').defaultTo('[]');
   })
     .then(() => {
       return knex.schema.alterTable('work_items', async (t) => {
-        t.text('runnerIds').notNullable().alter();
+        t.text('runners').notNullable().alter();
       })
     });
 }
 
 exports.down = async function (knex) {
   await knex.schema.alterTable('work_items', async (t) => {
-    t.dropColumn('runnerIds');
+    t.dropColumn('runners');
   });
 }

--- a/db/migrations/20221121160725_add_runner_ids_to_work_items.js
+++ b/db/migrations/20221121160725_add_runner_ids_to_work_items.js
@@ -1,0 +1,16 @@
+exports.up = async function (knex) {
+  return knex.schema.alterTable('work_items', async (t) => {
+    t.text('runnerIds').defaultTo('[]');
+  })
+    .then(() => {
+      return knex.schema.alterTable('work_items', async (t) => {
+        t.text('runnerIds').notNullable().alter();
+      })
+    });
+}
+
+exports.down = async function (knex) {
+  await knex.schema.alterTable('work_items', async (t) => {
+    t.dropColumn('runnerIds');
+  });
+}

--- a/env-defaults
+++ b/env-defaults
@@ -60,6 +60,10 @@ CALLBACK_URL_ROOT=http://harmony:3001
 # The CMR Endpoint to use (e.g. URL for local, SIT, UAT, or production)
 CMR_ENDPOINT=https://cmr.uat.earthdata.nasa.gov
 
+# The Metrics Endpoint to use (e.g. URL for SIT, UAT, or production)
+# Should contain placeholders like {{podId}}, {{from}}, and {{to}}, which are replaced at runtime.
+METRICS_ENDPOINT=http://localhost:3000?podId={{podId}}&from={{from}}&to={{to}}
+
 # For testing: Whether to use Localstack instead of AWS S3.  Options are "true" or "false".
 USE_LOCALSTACK=true
 

--- a/env-defaults
+++ b/env-defaults
@@ -61,8 +61,8 @@ CALLBACK_URL_ROOT=http://harmony:3001
 CMR_ENDPOINT=https://cmr.uat.earthdata.nasa.gov
 
 # The Metrics Endpoint to use (e.g. URL for SIT, UAT, or production)
-# Should contain placeholders like {{podId}}, {{from}}, and {{to}}, which are replaced at runtime.
-METRICS_ENDPOINT=http://localhost:3000?podId={{podId}}&from={{from}}&to={{to}}
+# Should contain placeholders like {{query}}, {{from}}, and {{to}}, which are replaced at runtime.
+METRICS_ENDPOINT=http://localhost:3000?query={{query}}&from={{from}}&to={{to}}
 
 # For testing: Whether to use Localstack instead of AWS S3.  Options are "true" or "false".
 USE_LOCALSTACK=true

--- a/env-defaults
+++ b/env-defaults
@@ -60,9 +60,11 @@ CALLBACK_URL_ROOT=http://harmony:3001
 # The CMR Endpoint to use (e.g. URL for local, SIT, UAT, or production)
 CMR_ENDPOINT=https://cmr.uat.earthdata.nasa.gov
 
-# The Metrics Endpoint to use (e.g. URL for SIT, UAT, or production)
-# Should contain placeholders like {{query}}, {{from}}, and {{to}}, which are replaced at runtime.
-METRICS_ENDPOINT=http://localhost:3000?query={{query}}&from={{from}}&to={{to}}
+# The Metrics Endpoint (Kibana) to use (linked to from the Workflow UI)
+METRICS_ENDPOINT=
+
+# The Metrics index to query (via the METRICS_ENDPOINT)
+METRICS_INDEX=
 
 # For testing: Whether to use Localstack instead of AWS S3.  Options are "true" or "false".
 USE_LOCALSTACK=true

--- a/public/css/workflow-ui/default.css
+++ b/public/css/workflow-ui/default.css
@@ -1,3 +1,7 @@
 .table-filter {
     --tag-inset-shadow-size: 2em;
 }
+
+.helpful-th {
+    cursor: help;
+}

--- a/tasks/service-runner/app/util/env.ts
+++ b/tasks/service-runner/app/util/env.ts
@@ -66,6 +66,7 @@ interface HarmonyEnv {
   awsDefaultRegion: string;
   useLocalstack: boolean;
   localstackHost: string;
+  myPodUid: string;
 }
 
 // special cases

--- a/tasks/service-runner/app/workers/pull-worker.ts
+++ b/tasks/service-runner/app/workers/pull-worker.ts
@@ -46,6 +46,7 @@ logger.debug(`INVOCATION_ARGS: ${env.invocationArgs}`);
  */
 async function _pullWork(): Promise<{ item?: WorkItemRecord; status?: number; error?: string, maxCmrGranules?: number }> {
   try {
+    console.log(env.myPodUid);
     const response = await axiosGetWork
       .get(workUrl, {
         params: { serviceID: env.harmonyService, podName: env.myPodName },

--- a/tasks/service-runner/app/workers/pull-worker.ts
+++ b/tasks/service-runner/app/workers/pull-worker.ts
@@ -46,10 +46,9 @@ logger.debug(`INVOCATION_ARGS: ${env.invocationArgs}`);
  */
 async function _pullWork(): Promise<{ item?: WorkItemRecord; status?: number; error?: string, maxCmrGranules?: number }> {
   try {
-    console.log(env.myPodUid);
     const response = await axiosGetWork
       .get(workUrl, {
-        params: { serviceID: env.harmonyService, podName: env.myPodName },
+        params: { serviceID: env.harmonyService, podName: env.myPodName, podId: env.myPodUid },
         responseType: 'json',
         validateStatus(status) {
           return status === 404 || (status >= 200 && status < 400);

--- a/tasks/service-runner/config/query-cmr-sidecar.yaml
+++ b/tasks/service-runner/config/query-cmr-sidecar.yaml
@@ -76,6 +76,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: MY_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           - name: MY_POD_IP
             valueFrom:
               fieldRef:

--- a/tasks/service-runner/config/service-template.yaml
+++ b/tasks/service-runner/config/service-template.yaml
@@ -84,6 +84,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: MY_POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           - name: MY_POD_IP
             valueFrom:
               fieldRef:

--- a/tasks/service-runner/test/pull-worker.ts
+++ b/tasks/service-runner/test/pull-worker.ts
@@ -150,8 +150,7 @@ describe('Pull Worker', async function () {
           jobID: '123',
           serviceID: 'abc',
           workflowStepIndex: 0,
-          scrollID: 1234,
-          operation: { requestID: 'foo' },
+          scrollID: '1234',
           id: 1,
         });
         it('calls runQueryCmrFromPull', async function () {
@@ -165,7 +164,6 @@ describe('Pull Worker', async function () {
           jobID: '123',
           serviceID: 'abc',
           workflowStepIndex: 1,
-          operation: { requestID: 'foo' },
           id: 1,
         });
         it('calls runServiceFromPull', async function () {

--- a/tasks/service-runner/test/service-runner.ts
+++ b/tasks/service-runner/test/service-runner.ts
@@ -99,9 +99,9 @@ describe('Service Runner', function () {
   describe('uploadLogs', function () {
     describe('with text logs', function () {
       const itemRecord0: WorkItemRecord = { id: 0, jobID: '123', serviceID: '', sortIndex: 0,
-        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date() };
+        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(), runnerIds: [] };
       const itemRecord1: WorkItemRecord = { id: 1, jobID: '123', serviceID: '', sortIndex: 0,
-        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date() };
+        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(), runnerIds: [] };
       const s3 = objectStoreForProtocol('s3');
       before(async function () {
         // One of the items will have its log file written to twice
@@ -136,9 +136,9 @@ describe('Service Runner', function () {
     });
     describe('with JSON logs', function () {
       const itemRecord0: WorkItemRecord = { id: 2, jobID: '123', serviceID: '', sortIndex: 0,
-        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date() };
+        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(), runnerIds: [] };
       const itemRecord1: WorkItemRecord = { id: 3, jobID: '123', serviceID: '', sortIndex: 0,
-        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date() };
+        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(), runnerIds: [] };
       const s3 = objectStoreForProtocol('s3');
       before(async function () {
         // One of the items will have its log file written to twice
@@ -203,8 +203,7 @@ describe('Service Runner', function () {
         jobID: '123',
         serviceID: 'abc',
         workflowStepIndex: 0,
-        scrollID: 1234,
-        operation: { requestID: 'foo' },
+        scrollID: '1234',
         id: 1,
       });
       it('returns an error message', async function () {
@@ -221,7 +220,6 @@ describe('Service Runner', function () {
         jobID: '123',
         serviceID: 'abc',
         workflowStepIndex: 1,
-        operation: { requestID: 'foo' },
         id: 1,
       });
       beforeEach(function () {

--- a/tasks/service-runner/test/service-runner.ts
+++ b/tasks/service-runner/test/service-runner.ts
@@ -99,9 +99,9 @@ describe('Service Runner', function () {
   describe('uploadLogs', function () {
     describe('with text logs', function () {
       const itemRecord0: WorkItemRecord = { id: 0, jobID: '123', serviceID: '', sortIndex: 0,
-        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(), runnerIds: [] };
+        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(), runners: [] };
       const itemRecord1: WorkItemRecord = { id: 1, jobID: '123', serviceID: '', sortIndex: 0,
-        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(), runnerIds: [] };
+        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(), runners: [] };
       const s3 = objectStoreForProtocol('s3');
       before(async function () {
         // One of the items will have its log file written to twice
@@ -136,9 +136,9 @@ describe('Service Runner', function () {
     });
     describe('with JSON logs', function () {
       const itemRecord0: WorkItemRecord = { id: 2, jobID: '123', serviceID: '', sortIndex: 0,
-        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(), runnerIds: [] };
+        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(), runners: [] };
       const itemRecord1: WorkItemRecord = { id: 3, jobID: '123', serviceID: '', sortIndex: 0,
-        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(), runnerIds: [] };
+        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(), runners: [] };
       const s3 = objectStoreForProtocol('s3');
       before(async function () {
         // One of the items will have its log file written to twice

--- a/test/helpers/work-items.ts
+++ b/test/helpers/work-items.ts
@@ -59,6 +59,7 @@ export async function rawSaveWorkItem(tx: Transaction, fields: Partial<WorkItemR
   }
 
   [workItem.id] = await stmt;
+
   return workItem;
 }
 

--- a/test/helpers/work-items.ts
+++ b/test/helpers/work-items.ts
@@ -53,13 +53,12 @@ export function buildWorkItem(fields: Partial<WorkItemRecord> = {}): WorkItem {
 export async function rawSaveWorkItem(tx: Transaction, fields: Partial<WorkItemRecord> = {}): Promise<WorkItem> {
   const workItem = buildWorkItem(fields);
   let stmt = tx((workItem.constructor as RecordConstructor).table)
-    .insert(workItem);
+    .insert({ ...workItem, runners: '[]' });
   if (db.client.config.client === 'pg') {
     stmt = stmt.returning('id'); // Postgres requires this to return the id of the inserted record
   }
 
   [workItem.id] = await stmt;
-
   return workItem;
 }
 
@@ -184,7 +183,7 @@ export function hookWorkItemUpdateEach(
  * @returns The response
  */
 export function getWorkForService(app: Application, serviceID: string): Test {
-  return request(app).get('/service/work').query({ serviceID });
+  return request(app).get('/service/work').query({ serviceID, podName: 'a-service', podId: 'pod-x-y-z' });
 }
 
 export const hookGetWorkForService = hookBackendRequest.bind(this, getWorkForService);

--- a/test/work-items/work-backends.ts
+++ b/test/work-items/work-backends.ts
@@ -148,7 +148,7 @@ describe('Work Backends', function () {
         expect(Object.keys(this.res.body.workItem)).to.eql([
           'id', 'jobID', 'createdAt', 'retryCount', 'updatedAt', 'scrollID', 'serviceID', 'status',
           'stacCatalogLocation', 'totalItemsSize', 'workflowStepIndex', 'duration',
-          'startedAt', 'sortIndex', 'operation',
+          'startedAt', 'sortIndex', 'runners', 'operation',
         ]);
       });
 

--- a/test/workflow-ui/work-items-table.ts
+++ b/test/workflow-ui/work-items-table.ts
@@ -57,6 +57,8 @@ const shareableJob = buildJob({
   collectionIds: [collectionWithEULAFalseAndGuestReadTrue],
 });
 
+const logsTableHeader = '>logs</th>';
+
 describe('Workflow UI work items table route', function () {
   hookServersStartStop({ skipEarthdataLogin: false });
 
@@ -179,7 +181,7 @@ describe('Workflow UI work items table route', function () {
         });
         it('does not return a column for the work item logs', async function () {
           const listing = this.res.text;
-          expect(listing).to.not.contain(mustache.render('<th scope="col">logs</th>', {}));
+          expect(listing).to.not.contain(mustache.render(logsTableHeader, {}));
         });
         it('returns retry buttons for their RUNNING work items', async function () {
           const listing = this.res.text;
@@ -199,7 +201,7 @@ describe('Workflow UI work items table route', function () {
         });
         it('does return a column for the work item logs', async function () {
           const listing = this.res.text;
-          expect(listing).to.contain(mustache.render('<th scope="col">logs</th>', {}));
+          expect(listing).to.contain(mustache.render(logsTableHeader, {}));
         });
         it('returns retry buttons for the other user\'s RUNNING work items', async function () {
           const listing = this.res.text;
@@ -225,7 +227,7 @@ describe('Workflow UI work items table route', function () {
         });
         it('does not return a column for the work item logs', async function () {
           const listing = this.res.text;
-          expect(listing).to.not.contain(mustache.render('<th scope="col">logs</th>', {}));
+          expect(listing).to.not.contain(mustache.render(logsTableHeader, {}));
         });
         it('does not return retry buttons for the other user\'s RUNNING work items', async function () {
           const listing = this.res.text;
@@ -325,7 +327,7 @@ describe('Workflow UI work items table route', function () {
         });
         it('does return a column for the work item logs', async function () {
           const listing = this.res.text;
-          expect(listing).to.contain(mustache.render('<th scope="col">logs</th>', {}));
+          expect(listing).to.contain(mustache.render(logsTableHeader, {}));
         });
         it('returns retry buttons for the RUNNING work items', async function () {
           const listing = this.res.text;

--- a/test/workflow-ui/work-items-table.ts
+++ b/test/workflow-ui/work-items-table.ts
@@ -370,8 +370,7 @@ describe('Workflow UI work items table route', function () {
       });
 
       describe('when the admin retrieves work items with a total of four runs', function () {
-        hookWorkflowUIWorkItems({ username: 'adam', jobID: otherJob.jobID, 
-          query: { disallowStatus: 'on', tableFilter: '[{"value":"status: ready","dbValue":"ready","field":"status"}]' } });
+        hookWorkflowUIWorkItems({ username: 'adam', jobID: otherJob.jobID });
         it('returns pod logs links for each runner (pod) of each work item', function () {
           const listing = this.res.text;
           expect((listing.match(/pod-logs-link/g) || []).length).to.equal(4);

--- a/test/workflow-ui/work-items-table.ts
+++ b/test/workflow-ui/work-items-table.ts
@@ -116,8 +116,8 @@ describe('Workflow UI work items table route', function () {
       const otherItem2 = buildWorkItem({ jobID: otherJob.jobID, status: WorkItemStatus.FAILED,
         runners: [{ id: 'runner1', startedAt: 10 }] });
       await otherItem2.save(this.trx);
-      const otherItem3 = buildWorkItem({ jobID: otherJob.jobID, status: WorkItemStatus.SUCCESSFUL,
-        runners: [{ id: 'runner1', startedAt: 20 }, { id: 'runner2', startedAt: 50 }] });
+      const otherItem3 = buildWorkItem({ jobID: otherJob.jobID, status: WorkItemStatus.RUNNING,
+        runners: [{ id: 'runner1', startedAt: 20 }, { id: 'runner2', startedAt: 1669655221941 }] });
       await otherItem3.save(this.trx);
       const otherItem4 = buildWorkItem({ jobID: otherJob.jobID, status: WorkItemStatus.READY,
         runners: [] });
@@ -411,6 +411,14 @@ describe('Workflow UI work items table route', function () {
         it('returns pod logs links for each runner (pod) of each work item', function () {
           const listing = this.res.text;
           expect((listing.match(/pod-logs-link/g) || []).length).to.equal(4);
+        });
+      });
+
+      describe('when the admin filters otherJob\'s items by status IN [RUNNING]', function () {
+        hookWorkflowUIWorkItems({ username: 'adam', jobID: otherJob.jobID,
+          query: { tableFilter: '[{"value":"status: running","dbValue":"running","field":"status"}]' } });
+        it('sets the appropriate time range query parameter for the metrics url', function () {
+          expect(this.res.text).to.contain("from:'2022-11-28T17:07:01.941Z',to:'now'");
         });
       });
 

--- a/test/workflow-ui/work-items-table.ts
+++ b/test/workflow-ui/work-items-table.ts
@@ -369,16 +369,7 @@ describe('Workflow UI work items table route', function () {
         });
       });
 
-      describe('when the admin filters by status IN [READY]', function () {
-        hookWorkflowUIWorkItems({ username: 'adam', jobID: otherJob.jobID, 
-          query: { tableFilter: '[{"value":"status: ready","dbValue":"ready","field":"status"}]' } });
-        it('returns no pod logs links', function () {
-          const listing = this.res.text;
-          expect((listing.match(/pod-logs-link/g) || []).length).to.equal(0);
-        });
-      });
-
-      describe('when the admin filters by status NOT IN [READY]', function () {
+      describe('when the admin retrieves work items with a total of four runs', function () {
         hookWorkflowUIWorkItems({ username: 'adam', jobID: otherJob.jobID, 
           query: { disallowStatus: 'on', tableFilter: '[{"value":"status: ready","dbValue":"ready","field":"status"}]' } });
         it('returns pod logs links for each runner (pod) of each work item', function () {

--- a/test/workflow-ui/work-items-table.ts
+++ b/test/workflow-ui/work-items-table.ts
@@ -183,6 +183,10 @@ describe('Workflow UI work items table route', function () {
           const listing = this.res.text;
           expect(listing).to.not.contain(mustache.render(logsTableHeader, {}));
         });
+        it('does not return a column for the pod logs', async function () {
+          const listing = this.res.text;
+          expect(listing).to.not.contain(mustache.render('>podLogs</th>', {}));
+        });
         it('returns retry buttons for their RUNNING work items', async function () {
           const listing = this.res.text;
           expect((listing.match(/retry-button/g) || []).length).to.equal(1);
@@ -328,6 +332,10 @@ describe('Workflow UI work items table route', function () {
         it('does return a column for the work item logs', async function () {
           const listing = this.res.text;
           expect(listing).to.contain(mustache.render(logsTableHeader, {}));
+        });
+        it('does return a column for the pod logs', async function () {
+          const listing = this.res.text;
+          expect(listing).to.contain(mustache.render('>podLogs</th>', {}));
         });
         it('returns retry buttons for the RUNNING work items', async function () {
           const listing = this.res.text;


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1323, HARMONY-1324

## Description
Adds a column to the work items table of the workflow UI for accessing pod logs in Kibana. It will show an individual link corresponding to each run/try/retry (0, 1, 2, etc).
<img width="1425" alt="Screen Shot 2022-11-25 at 4 17 50 PM" src="https://user-images.githubusercontent.com/34752045/204056102-6ba1c412-49fa-45ae-8a0f-8b6166708b8c.png">

## Local Test Steps
Rebuild service-runner.

Paste the below variable in your .env file: 

`METRICS_ENDPOINT='<METRICS BASE>?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'{{from}}',to:'{{to}}'))&_a=(columns:!(),filters:!(),index:<INDEX>,interval:auto,query:(language:kuery,query:'{{query}}'),sort:!(!('@timestamp',desc)))'`

We won't actually be able to successfully see any logs since our local logs won't go to the metrics logs dashboards, but it will be helpful to see how `{{to}}`, `{{from}}`, and `{{query}}` are replaced in this string and, when the link is clicked via the UI, to see how Kibana uses these values in the dashboard.

Browse to the actual SIT metrics logs dashboard first to see what the actual base URL and index values look like.

Replace `<METRICS BASE>` with the actual base metrics URL (e.g. `https://base-url/s/space-identifier/app/discover#/`) for SIT. Replace `<INDEX>` with the actual index ID. 

Run a request and periodically kill the worker container to simulate retries so that you can see multiple pod logs links. Follow the links and see if the filters are applied in Kibana as you would expect. Note that we use GMT timezone in the URL, but you may see some times in EST (subtracts 5 hours from GMT) on your dashboard.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)