### PR TITLE
Harmony 1339 enable container health checks

### DIFF
--- a/tasks/service-runner/tsconfig.json
+++ b/tasks/service-runner/tsconfig.json
@@ -12,5 +12,5 @@
       "outDir": "built"
   },
   "typeRoots": ["./node_modules/@types"],
-  "include": ["./**/*"]
+  "include": ["./app", "./test"]
 }


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1339

## Description
Enables container health checks and removes 'request' module to eliminate a security vulnerability.

## Local Test Steps
* Build query-cmr and service-runner images
* Run bin/restart-services
* Use `kubectl describe` to verify that the various pods have a 'liveness probe' defined and the at that the pods stay up.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~