### PR TITLE
HARMONY-1269: Add missing ws types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@types/simple-oauth2": "^2.5.5",
         "@types/tmp": "^0.2.3",
         "@types/uuid": "^8.3.1",
+        "@types/ws": "^6.0.1",
         "@types/xmldom": "^0.1.31",
         "ajv": "^8.8.0",
         "ajv-formats": "^2.1.1",
@@ -4246,6 +4247,14 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
       "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg=="
+    },
+    "node_modules/@types/ws": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
+      "integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/xmldom": {
       "version": "0.1.31",
@@ -21664,6 +21673,14 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
       "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg=="
+    },
+    "@types/ws": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.4.tgz",
+      "integrity": "sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/xmldom": {
       "version": "0.1.31",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   "author": "NASA EOSDIS Harmony team",
   "license": "Apache-2.0",
   "dependencies": {
+    "@types/ws": "^6.0.1",
     "@kubernetes/client-node": "^0.17.1",
     "@mapbox/geojson-rewind": "^0.5.0",
     "@tmcw/togeojson": "^4.2.0",


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1269

## Description
Until this fix https://github.com/kubernetes-client/javascript/pull/890 becomes available, this PR should resolve the "missing types" error we encounter in bamboo ("error TS2688: Cannot find type definition file for 'ws'"). Look at the Bamboo logs for recent harmony service builds and search for "ws" -- you will see the aforementioned error. 

Note that this was reproducible locally for me as well but not for James.

## Local Test Steps
Remove `node_modules` for harmony and service-runner
`npm install` in the project root directory
`cd tasks/service-runner`
`npm run build` (should finish without issues)

## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)