### PR TITLE
HARMONY-1347: Fix deadlock issue when canceling requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ built
 # Dev and test databases
 db/*.sqlite3
 db/*-journal
+db/*sqbpro
 
 # Quokka repl/playground
 playground.ts

--- a/app/util/job.ts
+++ b/app/util/job.ts
@@ -73,7 +73,6 @@ export async function completeJob(
     const failed = isFailureStatus(finalStatus);
     job.updateStatus(finalStatus, message);
     await job.save(tx);
-    await deleteUserWorkForJob(tx, job.jobID);
     if (failed) {
       const numUpdated = await updateWorkItemStatusesByJobId(
         tx, job.jobID, [WorkItemStatus.READY, WorkItemStatus.RUNNING], WorkItemStatus.CANCELED,
@@ -81,6 +80,7 @@ export async function completeJob(
       const itemMeta: WorkItemMeta = { workItemStatus: WorkItemStatus.CANCELED, workItemAmount: numUpdated, workItemEvent: 'statusUpdate' };
       logger.info(`Updated work items to ${WorkItemStatus.CANCELED} for completed job.`, itemMeta);
     }
+    await deleteUserWorkForJob(tx, job.jobID);
 
     // Grab the operation from the first step which will be the full operation
     const initialStep = await getWorkflowStepByJobIdStepIndex(tx, job.jobID, 1);


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1347

## Description
I saw database deadlocks when canceling large requests that had many active pods polling for work. This PR changes things so that we query the tables in the same order when polling for work and canceling a request to prevent deadlocks.

## Local Test Steps
I tested this out in my sandbox. I reproduced the problem and then deployed the code change and verified the request canceled without problem even with 50 active pods polling for work. You can regression test canceling requests locally.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)