### PR TITLE
HARMONY-1214: Add destinationUrl parameter to harmony api.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ define the environment variables needed to run the service and execute the local
 You can do this with the following steps:
 
 1. Build the image for your service
+
 2. Add entries into the `env-defaults` file for your service. See the `HARMONY_SERVICE_EXAMPLE`
    entries for examples. Be sure to prefix the entries with the name of your service.
    Set the value for the `INVOCATION_ARGS` environment variable. This should be how you would run
@@ -150,12 +151,13 @@ You can do this with the following steps:
   ```shell
   MY_SERVICE_INVOCATION_ARGS='python -m my-service'
   ```
+
 3. Add an entry for your service (lowercase) to the `.env` file:
 ```shell
 LOCALLY_DEPLOYED_SERVICES=my-service
 ```
-Note that the name used must be the kebab case version of the environment variable prefix used
-in `env-defaults`.
+Note that the name used must be the kebab case version of the environment variable prefix used in `env-defaults`.
+
 4. Run
 ```bash
 ./bin/deploy-services
@@ -173,7 +175,7 @@ To use Earthdata Login with a locally running Harmony, you must first set up a n
 3. Add the necessary Required Application Group
 4. Update .env with credentials
 
-You must select "401" as the application type for Harmony to work correctly with command line clients and clients like QGIS.  You will also need to add the "eosdis_enterprise" group to the list of required application groups in order for CMR searches issued by Harmony to be able to use your Earthdata Login tokens.  Update `OAUTH_CLIENT_ID` and `OAUTH_PASSWORD` in .env with the information from your Earthdata Login application. Additional information including other OAUTH values to use when creating the application can be found in the example/dotenv file in this repository.
+You must select "401" as the application type for Harmony to work correctly with command line clients and clients like QGIS. Set the redirect URL to http://localhost:3000/oauth2/redirect for local Harmony. Leave Required User information empty. Redirect Time for Earthdata Login Splash page (in seconds): 3 seconds. Check the checkbox for By checking this box, I confirm that my application is compatible with EDL policy. Leave the other checkbox unchecked. Then create the new application. After the application is created, you can use the "manage" -> "App Groups" tab to add the "EOSDIS Enterprise" group to the application. This "EOSDIS Enterprise" group will allow CMR searches issued by Harmony to be able to use your Earthdata Login tokens.  Update `OAUTH_CLIENT_ID`, `OAUTH_UID` and `OAUTH_PASSWORD` in .env with the information from your Earthdata Login application. 
 
 
 ### Software Requirements
@@ -202,7 +204,7 @@ Optional:
 * [awscli-local](https://github.com/localstack/awscli-local) - CLI helpers for interacting with localstack
 * [Python](https://www.python.org) version 3.7 - Useful for locally running and testing harmony-docker and other backend services
 
-## Running Harmony (Not From Quick Start)
+## Running Harmony For Local Dev (Not From Quick Start)
 
 ### Set up Environment
 If you have not yet cloned the Harmony repository, run

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ To use Earthdata Login with a locally running Harmony, you must first set up a n
 3. Add the necessary Required Application Group
 4. Update .env with credentials
 
-You must select "401" as the application type for Harmony to work correctly with command line clients and clients like QGIS. Set the redirect URL to http://localhost:3000/oauth2/redirect for local Harmony. Leave Required User information empty. Redirect Time for Earthdata Login Splash page (in seconds): 3 seconds. Check the checkbox for By checking this box, I confirm that my application is compatible with EDL policy. Leave the other checkbox unchecked. Then create the new application. After the application is created, you can use the "manage" -> "App Groups" tab to add the "EOSDIS Enterprise" group to the application. This "EOSDIS Enterprise" group will allow CMR searches issued by Harmony to be able to use your Earthdata Login tokens.  Update `OAUTH_CLIENT_ID`, `OAUTH_UID` and `OAUTH_PASSWORD` in .env with the information from your Earthdata Login application. 
+You must select "401" as the application type for Harmony to work correctly with command line clients and clients like QGIS. Set the redirect URL to http://localhost:3000/oauth2/redirect for local Harmony. Leave `Required User Information` and `Redirect Time for Earthdata Login Splash page` empty. Check the checkbox for `By checking this box, I confirm that my application is compatible with EDL policy`. Leave the other checkbox unchecked. Then create the new application. After the application is created, you can use the "manage" -> "App Groups" tab to add the "EOSDIS Enterprise" group to the application. This "EOSDIS Enterprise" group will allow CMR searches issued by Harmony to be able to use your Earthdata Login tokens.  Update `OAUTH_CLIENT_ID`, `OAUTH_UID` and `OAUTH_PASSWORD` in .env with the information from your Earthdata Login application. 
 
 
 ### Software Requirements
@@ -204,7 +204,7 @@ Optional:
 * [awscli-local](https://github.com/localstack/awscli-local) - CLI helpers for interacting with localstack
 * [Python](https://www.python.org) version 3.7 - Useful for locally running and testing harmony-docker and other backend services
 
-## Running Harmony For Local Dev (Not From Quick Start)
+## Running Harmony For Local Development (Not From Quick Start)
 
 ### Set up Environment
 If you have not yet cloned the Harmony repository, run

--- a/app/frontends/ogc-coverages/get-coverage-rangeset.ts
+++ b/app/frontends/ogc-coverages/get-coverage-rangeset.ts
@@ -67,6 +67,7 @@ export default function getCoverageRangeset(
   if (query.ignoreerrors) {
     operation.ignoreErrors = true;
   }
+  operation.destinationUrl = query.destinationurl;
   try {
     const subset = parseSubsetParams(wrap(query.subset));
     operation.dimensions = [];

--- a/app/models/data-operation.ts
+++ b/app/models/data-operation.ts
@@ -289,6 +289,8 @@ export default class DataOperation {
 
   ignoreErrors?: boolean;
 
+  destinationUrl: string;
+
   /**
    * Creates an instance of DataOperation.
    *

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -68,7 +68,7 @@ export interface JobRecord {
   updatedAt?: Date | number;
   numInputGranules: number;
   collectionIds: string[];
-  destination_url: string;
+  destination_url?: string;
 }
 
 /**
@@ -357,7 +357,7 @@ export class Job extends DBRecord implements JobRecord {
 
   ignoreErrors: boolean;
   
-  destination_url: string;
+  destination_url?: string;
 
   /**
    * Get the job message for the current status.

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -21,7 +21,7 @@ const { awsDefaultRegion } = env;
 
 export const jobRecordFields = [
   'username', 'status', 'message', 'progress', 'createdAt', 'updatedAt', 'request',
-  'numInputGranules', 'jobID', 'requestId', 'batchesCompleted', 'isAsync', 'ignoreErrors',
+  'numInputGranules', 'jobID', 'requestId', 'batchesCompleted', 'isAsync', 'ignoreErrors', 'destination_url',
 ];
 
 const stagingBucketTitle = `Results in AWS S3. Access from AWS ${awsDefaultRegion} with keys from /cloud-access.sh`;
@@ -68,6 +68,7 @@ export interface JobRecord {
   updatedAt?: Date | number;
   numInputGranules: number;
   collectionIds: string[];
+  destination_url: string;
 }
 
 /**
@@ -355,6 +356,8 @@ export class Job extends DBRecord implements JobRecord {
   collectionIds: string[];
 
   ignoreErrors: boolean;
+  
+  destination_url: string;
 
   /**
    * Get the job message for the current status.

--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -321,6 +321,7 @@ export default abstract class BaseService<ServiceParamType> {
       message: message,
       collectionIds: this.operation.collectionIds,
       ignoreErrors: this.operation.ignoreErrors,
+      destination_url: this.operation.destinationUrl,
     });
     if (this.operation.message) {
       job.setMessage(this.operation.message, JobStatus.SUCCESSFUL);

--- a/app/models/services/no-op-service.ts
+++ b/app/models/services/no-op-service.ts
@@ -63,6 +63,7 @@ export default class NoOpService extends BaseService<void> {
       links,
       request: getRequestUrl(req),
       numInputGranules: this.operation.cmrHits,
+      destination_url: this.operation.destinationUrl,
     });
     const serializedJob = job.serialize(getRequestRoot(req));
     // No-op service response should look like a job, but doesn't actually create one

--- a/app/models/services/no-op-service.ts
+++ b/app/models/services/no-op-service.ts
@@ -63,7 +63,6 @@ export default class NoOpService extends BaseService<void> {
       links,
       request: getRequestUrl(req),
       numInputGranules: this.operation.cmrHits,
-      destination_url: this.operation.destinationUrl,
     });
     const serializedJob = job.serialize(getRequestRoot(req));
     // No-op service response should look like a job, but doesn't actually create one

--- a/app/schemas/ogc-api-coverages/1.0.0/ogc-api-coverages-v1.0.0.yml
+++ b/app/schemas/ogc-api-coverages/1.0.0/ogc-api-coverages-v1.0.0.yml
@@ -330,6 +330,7 @@ paths:
       - $ref: '#/components/parameters/maxResults'
       - $ref: '#/components/parameters/skipPreview'
       - $ref: '#/components/parameters/ignoreErrors'
+      - $ref: '#/components/parameters/destinationUrl'
       responses:
         "200":
           description: A coverage's range set.
@@ -366,6 +367,7 @@ paths:
       - $ref: '#/components/parameters/maxResults'
       - $ref: '#/components/parameters/skipPreview'
       - $ref: '#/components/parameters/ignoreErrors'
+      - $ref: '#/components/parameters/destinationUrl'
       requestBody:
         content:
           multipart/form-data:
@@ -902,3 +904,10 @@ components:
       required: false
       schema:
         type: boolean
+    destinationUrl:
+      name: destinationUrl
+      in: query
+      description: destination url specified by the client, currently only s3 link url is supported
+      required: false
+      schema:
+        type: string

--- a/db/db.sql
+++ b/db/db.sql
@@ -15,7 +15,8 @@ CREATE TABLE `jobs` (
   `isAsync` boolean,
   `numInputGranules` integer not null default 0,
   `collectionIds` text not null,
-  `ignoreErrors` boolean not null
+  `ignoreErrors` boolean not null,
+  `destination_url` varchar(8192)
 );
 
 CREATE TABLE `job_links` (

--- a/db/migrations/20230123180001_add_destination_url_to_jobs.js
+++ b/db/migrations/20230123180001_add_destination_url_to_jobs.js
@@ -1,0 +1,12 @@
+// Add destination_url to jobs table for putting results in user specified S3 bucket
+exports.up = function (knex) {
+  return knex.schema.alterTable('jobs', async (t) => {
+    t.string('destination_url', 8192);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.alterTable('jobs', async (t) => {
+    t.dropColumn('destination_url');
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8357,9 +8357,9 @@
       }
     },
     "node_modules/cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
     "node_modules/copyfiles": {
@@ -26800,9 +26800,9 @@
       "dev": true
     },
     "cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
     "copyfiles": {

--- a/tasks/service-runner/package-lock.json
+++ b/tasks/service-runner/package-lock.json
@@ -1092,9 +1092,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "node_modules/cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
     "node_modules/core-util-is": {
@@ -5191,9 +5191,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "cookiejar": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
-      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
     },
     "core-util-is": {

--- a/test/destination-url.ts
+++ b/test/destination-url.ts
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+import { Job } from '../app/models/job';
+import { hookTransaction } from './helpers/db';
+import { hookRedirect } from './helpers/hooks';
+import { hookRangesetRequest } from './helpers/ogc-api-coverages';
+import hookServersStartStop from './helpers/servers';
+
+const reprojectAndZarrQuery = {
+  maxResults: 1,
+  outputCrs: 'EPSG:4326',
+  interpolation: 'near',
+  scaleExtent: '0,2500000.3,1500000,3300000',
+  scaleSize: '1.1,2',
+  format: 'application/x-zarr',
+  ignoreErrors: true,
+  concatenate: false,
+  destinationUrl: 's3://dummy',
+};
+
+describe('when setting destinationUrl on ogc request', function () {
+  const collection = 'C1233800302-EEDTEST';
+  hookServersStartStop();
+
+  describe('when making a request with a valid destinationUrl', function () {
+    hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery } });
+    hookRedirect('anonymous');
+    hookTransaction();
+
+    it('returns 200 status code for the job', async function () {
+      expect(this.res.status).to.equal(200);
+    });
+
+    it('sets the destination_url on the job in db', async function () {
+      const retrieved = await Job.forUser(this.trx, 'anonymous');
+      expect(retrieved.data[0].destination_url).to.eq('s3://dummy');
+    });
+  });
+});


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1214

## Description
Add destinationUrl parameter to harmony api. This is the first step of adding support of user specified s3 destination url. It only saves the provided destinationUrl in the jobs table. Followup tickets will add support for validations and staging using the destination url.

## Local Test Steps
curl -Ln -bj "http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?granuleId=G1233800343-EEDTEST&destinationUrl=s3://dummy" -o ~/Downloads/output.tif

and verify the request completes successfully and the `destination_url` field in jobs table is populated with `s3://dummy` as indicated in the request parameter.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)