### PR TITLE
HARMONY-1217: Add destinationUrl parameter validation to make sure it is writable by Harmony.

### DIFF
--- a/app/util/object-store.ts
+++ b/app/util/object-store.ts
@@ -15,7 +15,7 @@ const pipeline = util.promisify(stream.pipeline);
 const createTmpFileName = util.promisify(tmp.tmpName);
 const readFile = util.promisify(fs.readFile);
 
-interface BucketParams {
+export interface BucketParams {
   Bucket: string;
   Key: string;
 }

--- a/test/helpers/object-store.ts
+++ b/test/helpers/object-store.ts
@@ -122,7 +122,7 @@ export function hookGetBucketRegion(
 }
 
 /**
- * Adds before / after hooks to Upload
+ * Adds before / after hooks to upload
  */
 export function hookUpload(): void {
   let stubUpload;


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1217

## Description
As a user, I want Harmony to immediately return an error when I try to submit a request with a destination specified that Harmony cannot write to, so I can ensure I have set up appropriate cross-account access permissions

As part of the write permission validation, Harmony will push a file named `harmony-job-status-link` under <destinationUrl>/<harmony-request-id> with the jobs status link as its content.

## Local Test Steps
This has to be tested outside of local stack. e.g.
http://internal-harmony-yliu10-frontend-xxx.us-west-2.elb.amazonaws.com/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?granuleId=G1233800343-EEDTEST&format=image%2Fpng&destinationUrl=s3%3A%2F%2Fyliu10-sit-no-write-permission-test%2Fabc

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)