### PR TITLE
HARMONY-1222: Add job status link file to user specified s3 destinationUrl location.

### DIFF
--- a/test/destination-url.ts
+++ b/test/destination-url.ts
@@ -3,7 +3,7 @@ import { Context } from 'mocha';
 import { Job } from '../app/models/job';
 import { hookTransaction } from './helpers/db';
 import { hookRedirect } from './helpers/hooks';
-import { hookGetBucketRegion, hookUpload } from './helpers/object-store';
+import { getObjectText, hookGetBucketRegion, hookUpload } from './helpers/object-store';
 import { hookRangesetRequest } from './helpers/ogc-api-coverages';
 import hookServersStartStop from './helpers/servers';
 import StubService from './helpers/stub-service';
@@ -48,6 +48,15 @@ describe('when setting destinationUrl on ogc request', function () {
 
     it('returns 200 status code for the job', async function () {
       expect(this.res.status).to.equal(200);
+    });
+
+    it('the job has harmony-job-status-link file created with the job status link', async function () {
+      expect(this.res.status).to.equal(200);
+      const jobId = JSON.parse(this.res.text).jobID;
+      const s3Url = 's3://dummy/p1/' + jobId + '/harmony-job-status-link';
+      const statusLink = await getObjectText(s3Url);
+      // this.res.request.url is the job status link
+      expect(statusLink).to.equal(this.res.request.url);
     });
 
     it('sets the destination_url on the job in db', async function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1222

## Description
As a user, I want a file to be placed in my bucket that includes a link to the job status URL for this request, so I can track the status.

Since the code to push a file named `harmony-job-status-link` under `<destinationUrl>/<harmony-request-id>` with the jobs status link as its content has already been added as part of HARMONY-1217. This PR just adds the test to verify the content of the `harmony-job-status-link` file.

## Local Test Steps
This has to be tested outside of local stack. e.g.
http://internal-harmony-yliu10-frontend-xxx.us-west-2.elb.amazonaws.com/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?granuleId=G1233800343-EEDTEST&format=image%2Fpng&destinationUrl=s3%3A%2F%2Fyliu10-harmony-sandbox-staging/public

Then verify `s3://yliu10-harmony-sandbox-staging/public/<job id>/harmony-job-status-link` has content with the link to the job's status page.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)