### PR TITLE
HARMONY-1221: Remove dataExpiration from job status and expire from STAC item when destinationUrl is set

### DIFF
--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -356,7 +356,7 @@ export class Job extends DBRecord implements JobRecord {
   collectionIds: string[];
 
   ignoreErrors: boolean;
-  
+
   destination_url?: string;
 
   /**
@@ -1041,6 +1041,9 @@ export class Job extends DBRecord implements JobRecord {
       numInputGranules: this.numInputGranules,
       jobID: this.jobID,
     };
+    // need this line to prevent null values fro showing up in data expiration field
+    Object.keys(serializedJob).forEach((k) => serializedJob[k] == null && delete serializedJob[k]);
+
     if (urlRoot && linkType !== 'none') {
       serializedJob.links = serializedJob.links.map((link) => {
         const serializedLink = link.serialize();
@@ -1067,12 +1070,17 @@ export class Job extends DBRecord implements JobRecord {
   /**
    *  Computes and returns the date the data produced by the job will expire based on `createdAt`
    *
-   * @returns the date the data produced by the job will expire
+   * @returns the date the data produced by the job will expire, or null if there is no expiration
    */
   getDataExpiration(): Date {
-    const expiration = new Date(this.createdAt);
-    expiration.setUTCDate(expiration.getUTCDate() + EXPIRATION_DAYS);
-    return expiration;
+    let result = null;
+    if (!this.destination_url) {
+      const expiration = new Date(this.createdAt);
+      expiration.setUTCDate(expiration.getUTCDate() + EXPIRATION_DAYS);
+      result = expiration;
+    }
+
+    return result;
   }
 
 

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -1028,7 +1028,7 @@ export class Job extends DBRecord implements JobRecord {
    * @returns an object with the serialized job fields.
    */
   serialize(urlRoot?: string, linkType?: string): JobForDisplay {
-    const serializedJob: JobForDisplay = {
+    let serializedJob: JobForDisplay = {
       username: this.username,
       status: this.status,
       message: this.message,
@@ -1042,7 +1042,7 @@ export class Job extends DBRecord implements JobRecord {
       jobID: this.jobID,
     };
     // need this line to prevent null values from showing up in data expiration field
-    Object.keys(serializedJob).forEach((k) => serializedJob[k] == null && delete serializedJob[k]);
+    serializedJob = removeEmptyProperties(serializedJob) as JobForDisplay;
 
     if (urlRoot && linkType !== 'none') {
       serializedJob.links = serializedJob.links.map((link) => {

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -1041,7 +1041,7 @@ export class Job extends DBRecord implements JobRecord {
       numInputGranules: this.numInputGranules,
       jobID: this.jobID,
     };
-    // need this line to prevent null values fro showing up in data expiration field
+    // need this line to prevent null values from showing up in data expiration field
     Object.keys(serializedJob).forEach((k) => serializedJob[k] == null && delete serializedJob[k]);
 
     if (urlRoot && linkType !== 'none') {

--- a/test/destination-url.ts
+++ b/test/destination-url.ts
@@ -22,7 +22,7 @@ const reprojectAndZarrQuery = {
 
 /**
  * Verify the test result has a 400 status code and an error message that is the same as the given expectedError.
- * 
+ *
  * @param context - the test context
  * @param expectedError - the expected error message
  * @throws AssertionError: - if the result status is not 400 or the error messaged is not as expected
@@ -39,7 +39,7 @@ function verifyValidationError(context: Context, expectedError: string): void {
 describe('when setting destinationUrl on ogc request', function () {
   const collection = 'C1233800302-EEDTEST';
   hookServersStartStop();
-  
+
   describe('when making a request with a valid destinationUrl', function () {
     hookGetBucketRegion('us-west-2');
     hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery } });
@@ -48,6 +48,10 @@ describe('when setting destinationUrl on ogc request', function () {
 
     it('returns 200 status code for the job', async function () {
       expect(this.res.status).to.equal(200);
+    });
+
+    it('does not include the dataExpiration field in the job status', function () {
+      expect(this.res.body.dataExpiration).to.be.undefined;
     });
 
     it('sets the destination_url on the job in db', async function () {
@@ -59,7 +63,7 @@ describe('when setting destinationUrl on ogc request', function () {
   describe('when making a request with an invalid destinationUrl with invalid S3 url format', function () {
     StubService.hook({ params: { status: 'successful' } });
     hookRangesetRequest('1.0.0', collection, 'all', { query: { destinationUrl: 'abcd' } });
-    
+
     it('returns 400 status code for invalid s3 url format', async function () {
       verifyValidationError(this, "Error: Invalid destinationUrl 'abcd', must start with s3://");
     });
@@ -68,7 +72,7 @@ describe('when setting destinationUrl on ogc request', function () {
   describe('when making a request with an invalid destinationUrl with multiple s3 locations', function () {
     StubService.hook({ params: { status: 'successful' } });
     hookRangesetRequest('1.0.0', collection, 'all', { query: { destinationUrl: 's3://abcd,s3://edfg' } });
-    
+
     it('returns 400 status code for multiple s3 locations which the middleware will concatenate with comma', async function () {
       verifyValidationError(this, "Error: Invalid destinationUrl 's3://abcd,s3://edfg', only one s3 location is allowed.");
     });
@@ -78,7 +82,7 @@ describe('when setting destinationUrl on ogc request', function () {
     hookGetBucketRegion('us-west-2');
     StubService.hook({ params: { status: 'successful' } });
     hookRangesetRequest('1.0.0', collection, 'all', { query: { destinationUrl: 's3://non-existent-bucket/abcd' } });
-    
+
     it('returns 400 status code for nonexistent s3 bucket', async function () {
       verifyValidationError(this, "Error: The specified bucket 'non-existent-bucket' does not exist.");
     });
@@ -88,7 +92,7 @@ describe('when setting destinationUrl on ogc request', function () {
     hookGetBucketRegion('us-west-2');
     StubService.hook({ params: { status: 'successful' } });
     hookRangesetRequest('1.0.0', collection, 'all', { query: { destinationUrl: 's3://' } });
-    
+
     it('returns 400 status code for no s3 bucket', async function () {
       verifyValidationError(this, 'Error: Invalid destinationUrl, no s3 bucket is provided.');
     });
@@ -98,7 +102,7 @@ describe('when setting destinationUrl on ogc request', function () {
     hookGetBucketRegion('us-west-2');
     StubService.hook({ params: { status: 'successful' } });
     hookRangesetRequest('1.0.0', collection, 'all', { query: { destinationUrl: 's3://invalid,bucket' } });
-    
+
     it('returns 400 status code for invalid bucket name', async function () {
       verifyValidationError(this, "Error: The specified bucket 'invalid,bucket' is not valid.");
     });
@@ -108,7 +112,7 @@ describe('when setting destinationUrl on ogc request', function () {
     hookGetBucketRegion('us-west-2');
     StubService.hook({ params: { status: 'successful' } });
     hookRangesetRequest('1.0.0', collection, 'all', { query: { destinationUrl: 's3://no-permission' } });
-    
+
     it('returns 400 status code when no permission to get bucket location', async function () {
       verifyValidationError(this, "Error: Do not have permission to get bucket location of the specified bucket 'no-permission'.");
     });
@@ -119,7 +123,7 @@ describe('when setting destinationUrl on ogc request', function () {
     hookUpload();
     StubService.hook({ params: { status: 'successful' } });
     hookRangesetRequest('1.0.0', collection, 'all', { query: { destinationUrl: 's3://no-write-permission' } });
-    
+
     it('returns 400 status code when not writable', async function () {
       verifyValidationError(this, "Error: Do not have write permission to the specified s3 location: 's3://no-write-permission'.");
     });


### PR DESCRIPTION


## Jira Issue ID
HARMONY-1221

## Description
Removes the data expirations fields from the status page and the STAC items if the destinationUrl parameter is set

## Local Test Steps
1. Create a custom staging bucket in localstack
aws --endpoint-url=http://localhost:4566 s3 mb s3://my-staging-bucket
2. Check out this branch
3. Run harmony
4. Issue the following query
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?format=image%2Fpng&granuleName=001_*&destinationUrl=s3%3A%2F%2Fmy-staging-bucket
5. Verify that the status page does not have the `dataExpiration` field
6. When the job is finished, refresh the status page then follow the link to the STAC catalog. Append '/0' to the url of the STAC catalog to get the first STAC item back. Verify that the timestamps do not include an 'expires' field.
7. Repeat the above, but remove the destinationUrl parameter and verify that the `dataExperiation` field and `expires` field are back

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~