### PR TITLE
HARMONY-1220: Note that results are outside of Harmony's control

### DIFF
--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -15,7 +15,7 @@ import { getRequestMetric } from '../../util/metrics';
 import { getRequestUrl } from '../../util/url';
 import HarmonyRequest from '../harmony-request';
 import UserWork from '../user-work';
-import { sanitizeImage } from '../../util/string';
+import { joinTexts, sanitizeImage } from '../../util/string';
 
 export interface ServiceCapabilities {
   concatenation?: boolean;
@@ -328,6 +328,12 @@ export default abstract class BaseService<ServiceParamType> {
     }
     if (this.operation.message && !skipPreview) {
       job.setMessage(this.operation.message, JobStatus.RUNNING);
+    }
+    if (this.operation.destinationUrl) {
+      const destinationWarningSuccessful = 'The results have been placed in the requested custom destination. Any further changes to the result files or their location are outside of Harmony\'s control.';
+      const destinationWarningRunning = 'Once results are sent to the requested destination, any changes to the result files or their location are outside of Harmony\'s control.';
+      job.setMessage(joinTexts(job.getMessage(JobStatus.SUCCESSFUL), destinationWarningSuccessful), JobStatus.SUCCESSFUL);
+      job.setMessage(joinTexts(job.getMessage(JobStatus.RUNNING), destinationWarningRunning), JobStatus.RUNNING);
     }
     job.addStagingBucketLink(this.operation.stagingLocation);
     return job;

--- a/app/util/string.ts
+++ b/app/util/string.ts
@@ -39,8 +39,7 @@ export function listToText(items: string[], joinWord = Conjunction.AND): string 
 export function joinTexts(...items: string[]): string {
   const result = [];
   for (const item of items) {
-    let resultItem = item;
-    resultItem = resultItem.trim();
+    let resultItem = item.trim();
     if (!/[.!?]$/m.test(resultItem)) {
       resultItem += '.';
     }

--- a/app/util/string.ts
+++ b/app/util/string.ts
@@ -30,6 +30,26 @@ export function listToText(items: string[], joinWord = Conjunction.AND): string 
 }
 
 /**
+ * Join sentences or paragraphs (in the specified order) ensuring periods
+ * are inserted if no punctuation is present, and a space between texts.
+ *
+ * @param items - The items to join
+ * @returns The resulting textual string
+ */
+export function joinTexts(...items: string[]): string {
+  const result = [];
+  for (const item of items) {
+    let resultItem = item;
+    resultItem = resultItem.trim();
+    if (!/[.!?]$/m.test(resultItem)) {
+      resultItem += '.';
+    }
+    result.push(resultItem);
+  }
+  return result.join(' ');
+}
+
+/**
  * Truncates a string to the specified number of characters. The last
  * three characters are replaced with '...'.
  *

--- a/bin/start-postgres-localstack
+++ b/bin/start-postgres-localstack
@@ -81,9 +81,9 @@ UPLOAD_BUCKET=${UPLOAD_BUCKET:-local-upload-bucket}
 
 # Creates buckets in localstack
 localstack_startup_script="
-awslocal s3 mb s3://${STAGING_BUCKET}
-awslocal s3 mb s3://${ARTIFACT_BUCKET}
-awslocal s3 mb s3://${UPLOAD_BUCKET}
+awslocal s3 mb s3://${STAGING_BUCKET} --region us-west-2
+awslocal s3 mb s3://${ARTIFACT_BUCKET} --region us-west-2
+awslocal s3 mb s3://${UPLOAD_BUCKET} --region us-west-2
 awslocal s3api put-bucket-acl --bucket ${ARTIFACT_BUCKET} --acl public-read" # allows us to view STAC files: localhost:4572/{ARTIFACT_BUCKET}/{jobId}/{workItemId}/outputs/
 
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1220

## Description
When a user requests an S3 destinationUrl for a request the message field in the job status indicates that the storage is external to harmony.

## Local Test Steps
Add the `destinationUrl` param to a request and make sure the job message says something about the storage being external to harmony.
Note this will only be for JobStatus.RUNNING,SUCCESSFUL.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)