### PR TITLE
Add production UMM-S record for HGA.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -313,6 +313,8 @@ https://cmr.earthdata.nasa.gov:
         env:
           <<: *default-turbo-env
           STAGING_PATH: public/nasa/harmony-gdal-adapter
+    umm_s:
+      - S2606110201-XYZ_PROV
     collections:
       - id: C1595422627-ASF
       - id: C1214354031-ASF


### PR DESCRIPTION
## Jira Issue ID

N/A

## Description

This PR adds a reference to a new UMM-S record for HGA in production (there previously wasn't one). This will enable DAACs to associate collections with this UMM-S record, and not need to include them in `services.yml` directly.

## Local Test Steps

* This cannot be directly tested outside of production prior to deployment.
* A sanity check would be to ensure there isn't a typo in the UMM-S concept ID by using the following query:

```
https://cmr.earthdata.nasa.gov/search/services.umm_json?concept_id=<concept ID copied from PR>
```

## PR Acceptance Checklist
* ~~Acceptance criteria met~~
* ~~Tests added/updated (if needed) and passing~~
* [x] Documentation updated (if needed) - Amy has updated the Harmony wiki page listing UMM-S references for all services.