### PR TITLE
HARMONY-1357: As a Harmony user I want to store my results in my own S3 bucket.

### DIFF
--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -1050,7 +1050,7 @@ export class Job extends DBRecord implements JobRecord {
         let { href } = serializedLink;
         const { title, type, rel, bbox, temporal } = serializedLink;
         // Leave the S3 output staging location as an S3 link
-        if (rel !== 's3-access') {
+        if (rel !== 's3-access' && !this.destination_url) {
           href = createPublicPermalink(href, urlRoot, type, linkType);
         }
         return removeEmptyProperties({ href, title, type, rel, bbox, temporal });

--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -216,7 +216,7 @@ export default abstract class BaseService<ServiceParamType> {
       destPath = destPath.endsWith('/') ? destPath.slice(0, -1) : destPath;
       return defaultObjectStore().getUrlString(destPath, requestId + '/');
     } 
-    return defaultObjectStore().getUrlString(env.stagingBucket, 'public/' + requestId + '/');
+    return defaultObjectStore().getUrlString(env.stagingBucket, `public/${requestId}/`);
   }
 
   /**

--- a/app/models/services/base-service.ts
+++ b/app/models/services/base-service.ts
@@ -190,7 +190,7 @@ export default abstract class BaseService<ServiceParamType> {
 
     if (!this.operation.stagingLocation) {
       const prefix = `public/${config.name || this.constructor.name}/${uuid()}/`;
-      this.operation.stagingLocation = defaultObjectStore().getUrlString(env.stagingBucket, prefix);
+      this.operation.stagingLocation = defaultObjectStore().getUrlString(env.artifactBucket, prefix);
     }
   }
 
@@ -202,6 +202,21 @@ export default abstract class BaseService<ServiceParamType> {
    */
   get capabilities(): ServiceCapabilities {
     return this.config.capabilities;
+  }
+
+  /**
+   * Returns the final staging location of the service.
+   *
+   * @returns the final staging location of the service
+   */
+  finalStagingLocation() : string {
+    const { requestId, destinationUrl } = this.operation;
+    if (destinationUrl) {
+      let destPath = destinationUrl.substring(5);
+      destPath = destPath.endsWith('/') ? destPath.slice(0, -1) : destPath;
+      return defaultObjectStore().getUrlString(destPath, requestId + '/');
+    } 
+    return defaultObjectStore().getUrlString(env.stagingBucket, 'public/' + requestId + '/');
   }
 
   /**
@@ -335,7 +350,9 @@ export default abstract class BaseService<ServiceParamType> {
       job.setMessage(joinTexts(job.getMessage(JobStatus.SUCCESSFUL), destinationWarningSuccessful), JobStatus.SUCCESSFUL);
       job.setMessage(joinTexts(job.getMessage(JobStatus.RUNNING), destinationWarningRunning), JobStatus.RUNNING);
     }
-    job.addStagingBucketLink(this.operation.stagingLocation);
+    if (!this.operation.destinationUrl) {
+      job.addStagingBucketLink(this.finalStagingLocation());
+    }
     return job;
   }
 
@@ -394,10 +411,14 @@ export default abstract class BaseService<ServiceParamType> {
   protected _createWorkflowSteps(): WorkflowStep[] {
     const workflowSteps = [];
     if (this.config.steps) {
+      const numSteps = this.config.steps.length;
       let i = 0;
       this.config.steps.forEach(((step) => {
         if (stepRequired(step, this.operation)) {
           i += 1;
+          if (i === numSteps) {
+            this.operation.stagingLocation = this.finalStagingLocation();
+          }
           workflowSteps.push(new WorkflowStep({
             jobID: this.operation.requestId,
             serviceID: serviceImageToId(step.image),

--- a/test/helpers/job-status.ts
+++ b/test/helpers/job-status.ts
@@ -14,7 +14,6 @@ import { S3ObjectStore } from '../../app/util/object-store';
  */
 export function itReturnsUnchangedDataLinksForZarr(
   s3Uri: string,
-  serviceName = 'harmony/example',
 ): void {
   it('returns the S3 URL', function () {
     const job = new Job(JSON.parse(this.res.text));
@@ -26,8 +25,8 @@ export function itReturnsUnchangedDataLinksForZarr(
     const job = new Job(JSON.parse(this.res.text));
     const bucketLinks = job.getRelatedLinks('s3-access');
     expect(bucketLinks.length).to.equal(1);
-    const urlRegex = new RegExp(`^s3://${env.stagingBucket}/public/${serviceName}/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/$`);
-    expect(bucketLinks[0].href).to.match(urlRegex);
+    const stagingLocation = `s3://${env.stagingBucket}/public/${job.jobID}/`;
+    expect(bucketLinks[0].href).to.equal(stagingLocation);
     expect(bucketLinks[0].title).to.equal('Results in AWS S3. Access from AWS us-west-2 with keys from /cloud-access.sh');
   });
 

--- a/test/models/services.ts
+++ b/test/models/services.ts
@@ -831,5 +831,49 @@ describe('createWorkflowSteps', function () {
     it('creates a third and final workflow step for the shapefile subsetter', function () {
       expect(steps[2].serviceID).to.equal('shapefile subsetter');
     });
+
+    it('first step uses artifact bucket as the staging location', function () {
+      const { stagingLocation } = JSON.parse(steps[0].operation);
+      expect(stagingLocation).to.include('s3://local-artifact-bucket/public/shapefile-tiff-netcdf-service/');
+    });
+
+    it('second step uses artifact bucket as the staging location', function () {
+      const { stagingLocation } = JSON.parse(steps[1].operation);
+      expect(stagingLocation).to.include('s3://local-artifact-bucket/public/shapefile-tiff-netcdf-service/');
+    });
+
+    it('last step uses staging bucket as the staging location', function () {
+      const { stagingLocation } = JSON.parse(steps[2].operation);
+      expect(stagingLocation).to.include('s3://local-staging-bucket/public/');
+    });
+  });
+
+  describe('when operation with destinationUrl', function () {
+    const destUrlOperation = _.cloneDeep(operation);
+    destUrlOperation.boundingRectangle = [1, 2, 3, 4];
+    destUrlOperation.geojson = 'interesting shape';
+    destUrlOperation.destinationUrl = 's3://dummy/p1';
+    const service = new StubService(config, {}, destUrlOperation);
+    const steps = service.createWorkflowSteps();
+
+    it('creates three workflow steps', function () {
+      expect(steps.length).to.equal(3);
+    });
+
+    it('first step uses artifact bucket as the staging location', function () {
+      const { stagingLocation } = JSON.parse(steps[0].operation);
+      expect(stagingLocation).to.include('s3://local-artifact-bucket/public/shapefile-tiff-netcdf-service/');
+    });
+
+    it('second step uses artifact bucket as the staging location', function () {
+      const { stagingLocation } = JSON.parse(steps[1].operation);
+      console.log(`===stage: ${stagingLocation}`);
+      expect(stagingLocation).to.include('s3://local-artifact-bucket/public/shapefile-tiff-netcdf-service/');
+    });
+
+    it('last step uses destinationUrl as the staging location', function () {
+      const { stagingLocation } = JSON.parse(steps[2].operation);
+      expect(stagingLocation).to.include('s3://dummy/p1');
+    });
   });
 });

--- a/test/models/services.ts
+++ b/test/models/services.ts
@@ -832,17 +832,17 @@ describe('createWorkflowSteps', function () {
       expect(steps[2].serviceID).to.equal('shapefile subsetter');
     });
 
-    it('first step uses artifact bucket as the staging location', function () {
+    it('uses the artifact bucket as the staging location for the first step', function () {
       const { stagingLocation } = JSON.parse(steps[0].operation);
       expect(stagingLocation).to.include('s3://local-artifact-bucket/public/shapefile-tiff-netcdf-service/');
     });
 
-    it('second step uses artifact bucket as the staging location', function () {
+    it('uses the artifact bucket as the staging location for the second step', function () {
       const { stagingLocation } = JSON.parse(steps[1].operation);
       expect(stagingLocation).to.include('s3://local-artifact-bucket/public/shapefile-tiff-netcdf-service/');
     });
 
-    it('last step uses staging bucket as the staging location', function () {
+    it('uses the staging bucket as the staging location for the last step', function () {
       const { stagingLocation } = JSON.parse(steps[2].operation);
       expect(stagingLocation).to.include('s3://local-staging-bucket/public/');
     });
@@ -860,18 +860,17 @@ describe('createWorkflowSteps', function () {
       expect(steps.length).to.equal(3);
     });
 
-    it('first step uses artifact bucket as the staging location', function () {
+    it('uses the artifact bucket as the staging location for the first step', function () {
       const { stagingLocation } = JSON.parse(steps[0].operation);
       expect(stagingLocation).to.include('s3://local-artifact-bucket/public/shapefile-tiff-netcdf-service/');
     });
 
-    it('second step uses artifact bucket as the staging location', function () {
+    it('uses the artifact bucket as the staging location for the second step', function () {
       const { stagingLocation } = JSON.parse(steps[1].operation);
-      console.log(`===stage: ${stagingLocation}`);
       expect(stagingLocation).to.include('s3://local-artifact-bucket/public/shapefile-tiff-netcdf-service/');
     });
 
-    it('last step uses destinationUrl as the staging location', function () {
+    it('uses the destinationUrl as the staging location for the last step', function () {
       const { stagingLocation } = JSON.parse(steps[2].operation);
       expect(stagingLocation).to.include('s3://dummy/p1');
     });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1357

## Description
This PR completes the normal workflow of putting OGC request results in the user specified s3 bucket.
Changes made:

1. Changed normal workflow orchestration to put intermediary results in the artifacts bucket rather than the staging bucket so that the intermediary results are not leaked to the client user. The existing naming convention of intermediary results remains the same. e.g. `s3://local-artifact-bucket/public/podaac/l2-subsetter-concise/0b6a7a69-2084-4265-bfd7-02f92f3f5cb6/315/JA1_GPS_2PeP220_111_20071231_005214_20071231_014826_bathymetry_subsetted.nc4`.

2. Changed normal workflow orchestration to put the final result in the staging bucket using a new naming convention: `<stagingLocation>/public/<jobId>/<stepId>/...`.

3. When destinationUrl is present, put the final result in the specified destinationUrl location: `<destinationUrl>/<jobId>/<stepId>/...`.

4. Changed STAC result links to not include cloud access JSON and sh links when destinationUrl is present.

## Local Test Steps
1. Set up the necessary services locally to run a multi-step OGC request. e.g. 
```
curl -Ln -bj "http://localhost:3000/C1234208438-POCLOUD/ogc-api-coverages/1.0.0/collections/bathymetry/coverage/rangeset?concatenate=true&subset=lon(-160%3A160)&subset=lat(-80%3A80)&skipPreview=true&maxResults=3"
```
verify that the request is successful and the intermediary results are placed into the artifacts bucket (see Description above for detail) and only the final result is placed in the staging bucket. 
verify the result STAC has the correct links to the final staging location.

2. Run the same multi-step OGC request with a valid destinationUrl that has the correct permissions set up. e.g. 
```
curl -Ln -bj "http://localhost:3000/C1234208438-POCLOUD/ogc-api-coverages/1.0.0/collections/bathymetry/coverage/rangeset?concatenate=true&subset=lon(-160%3A160)&subset=lat(-80%3A80)&skipPreview=true&maxResults=3&destinationUrl=s3://test-bucket/www"
```
verify that the request is successful and the intermediary results are placed into the artifacts bucket (see Description above for detail) and only the final result is placed in the destinationUrl (see Description above for detail). 

verify under destinationUrl, there is a path created with the requestId of the above request and a file named `harmony-job-status-link` is placed there. Verify the content of the file `harmony-job-status-link` is the job status link of the above request. e.g. `https://harmony.sit.earthdata.nasa.gov/jobs/1f215d92-0bd8-4255-9530-516deb147690`.

verify the job status link shows the result STAC with the correct link to the final result in the destinationUrl location and there is no cloud access JSON and sh links.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)