### PR TITLE
HARMONY-1219: Added detailed error message regarding s3 bucket setup and link to get the bucket policy.

### DIFF
--- a/app/middleware/parameter-validation.ts
+++ b/app/middleware/parameter-validation.ts
@@ -33,7 +33,7 @@ function bucketInstruction(req: HarmonyRequest, destinationUrl: string): string 
   const bucketPolicyUrl = `${getRequestRoot(req)}/staging-bucket-policy?bucketPath=${destinationUrl}`;
   const instructions = [`The s3 bucket must be created in the ${awsDefaultRegion} region with 'ACL disabled' which is the default Object Ownership setting in AWS S3.`,
     'The s3 bucket also must have the proper bucket policy in place to allow Harmony to access the bucket.',
-    'You can retrieve the bucket policy to set on the s3 bucket by calling the Harmony staging-bucket-policy endpoint with the s3 bucket path where the OGC result will be staged in. e.g.',
+    'You can retrieve the bucket policy to set on your s3 bucket by calling:',
     bucketPolicyUrl];
   return instructions.join(' ');
 }
@@ -68,7 +68,7 @@ async function validateBucketIsInRegion(req: HarmonyRequest, destinationUrl: str
   try {
     const bucketRegion = await defaultObjectStore().getBucketRegion(bucketName);
     if (bucketRegion != awsDefaultRegion) {
-      throw new RequestValidationError(`Destination bucket '${bucketName}' must be in the '${awsDefaultRegion}' region, but was in '${bucketRegion}'.`);
+      throw new RequestValidationError(`Destination bucket '${bucketName}' must be in the '${awsDefaultRegion}' region, but was in '${bucketRegion}'. ${(bucketInstruction(req, destinationUrl))}`);
     }
   } catch (e) {
     if (e.name === 'NoSuchBucket') {

--- a/app/middleware/parameter-validation.ts
+++ b/app/middleware/parameter-validation.ts
@@ -31,11 +31,11 @@ const validLinkTypeValues = ['http', 'https', 's3'];
  */
 function bucketInstruction(req: HarmonyRequest, destinationUrl: string): string {
   const bucketPolicyUrl = `${getRequestRoot(req)}/staging-bucket-policy?bucketPath=${destinationUrl}`;
-  const instructions = [`The s3 bucket must be created in the ${awsDefaultRegion} region with 'ACL disabled' which is the default Object Ownership setting in AWS S3.`,
-    'The s3 bucket also must have the proper bucket policy in place to allow Harmony to access the bucket.',
-    'You can retrieve the bucket policy to set on your s3 bucket by calling:',
-    bucketPolicyUrl];
-  return instructions.join(' ');
+  return `The S3 bucket must be created in the ${awsDefaultRegion} region with 'ACLs disabled' `
+  + 'which is the default Object Ownership setting in AWS S3. '
+  + 'The S3 bucket also must have the proper bucket policy in place to allow Harmony to access the bucket. '
+  + 'You can retrieve the bucket policy to set on your S3 bucket by calling: '
+  + bucketPolicyUrl;
 }
 
 /**
@@ -62,7 +62,7 @@ async function validateBucketIsInRegion(req: HarmonyRequest, destinationUrl: str
   // previous validation has guaranteed that destinationUrl must start with 's3://'
   const bucketName = destinationUrl.substring(5).split('/')[0];
   if (bucketName === '') {
-    throw new RequestValidationError('Invalid destinationUrl, no s3 bucket is provided.');
+    throw new RequestValidationError('Invalid destinationUrl, no S3 bucket is provided.');
   }
 
   try {
@@ -97,14 +97,14 @@ async function validateDestinationUrlWritable(req: HarmonyRequest, destinationUr
     await defaultObjectStore().upload(statusLink, statusUrl, null, 'text/plain');
   } catch (e) {
     if (e.name === 'AccessDenied') {
-      throw new RequestValidationError(`Do not have write permission to the specified s3 location: '${destinationUrl}'. ${bucketInstruction(req, destinationUrl)}`);
+      throw new RequestValidationError(`Do not have write permission to the specified S3 location: '${destinationUrl}'. ${bucketInstruction(req, destinationUrl)}`);
     }
     throw e;
   }
 }
 
 /**
- * Validate that the value provided for the `destinationUrl` parameter is an `s3` url in the format of `s3://<bucket>/<path>` is in the same AWS region
+ * Validate that the value provided for the `destinationUrl` parameter is an `S3` url in the format of `s3://<bucket>/<path>` is in the same AWS region
  *
  * @param req - The client request
  */
@@ -117,7 +117,7 @@ async function validateDestinationUrlParameter(req: HarmonyRequest): Promise<voi
     }
     // this check is added to provide a more user friendly error message when more than one destinationUrl values are provided
     if (destUrl.includes(',s3://')) {
-      throw new RequestValidationError(`Invalid destinationUrl '${destUrl}', only one s3 location is allowed.`);
+      throw new RequestValidationError(`Invalid destinationUrl '${destUrl}', only one S3 location is allowed.`);
     }
     
     await validateBucketIsInRegion(req, destUrl);

--- a/test/destination-url.ts
+++ b/test/destination-url.ts
@@ -43,7 +43,7 @@ function verifyValidationError(context: Context, expectedError: string): void {
  * @returns the expected bucket setup instruction
  */
 function expectedInstruction(destinationUrl: string): string {
-  const generalInstruction = "The s3 bucket must be created in the us-west-2 region with 'ACL disabled' which is the default Object Ownership setting in AWS S3. The s3 bucket also must have the proper bucket policy in place to allow Harmony to access the bucket. You can retrieve the bucket policy to set on the s3 bucket by calling the Harmony staging-bucket-policy endpoint with the s3 bucket path where the OGC result will be staged in. e.g. http://127.0.0.1:4000/staging-bucket-policy?bucketPath=";
+  const generalInstruction = "The s3 bucket must be created in the us-west-2 region with 'ACL disabled' which is the default Object Ownership setting in AWS S3. The s3 bucket also must have the proper bucket policy in place to allow Harmony to access the bucket. You can retrieve the bucket policy to set on your s3 bucket by calling: http://127.0.0.1:4000/staging-bucket-policy?bucketPath=";
   return `${generalInstruction}${destinationUrl}`;
 }
 
@@ -156,10 +156,12 @@ describe('when setting destinationUrl on ogc request', function () {
   describe('when making a request with an invalid destinationUrl with bucket in a different region', function () {
     hookGetBucketRegion('us-east-1');
     StubService.hook({ params: { status: 'successful' } });
-    hookRangesetRequest('1.0.0', collection, 'all', { query: { destinationUrl: 's3://abcd/p1' } });
+    const destUrl = 's3://abcd/p1';
+    hookRangesetRequest('1.0.0', collection, 'all', { query: { destinationUrl: destUrl } });
 
     it('returns 400 status code for bucket in different region', async function () {
-      verifyValidationError(this, "Error: Destination bucket 'abcd' must be in the 'us-west-2' region, but was in 'us-east-1'.");
+      const expectedError = `Error: Destination bucket 'abcd' must be in the 'us-west-2' region, but was in 'us-east-1'. ${expectedInstruction(destUrl)}`;
+      verifyValidationError(this, expectedError);
     });
   });
 });

--- a/test/destination-url.ts
+++ b/test/destination-url.ts
@@ -43,8 +43,11 @@ function verifyValidationError(context: Context, expectedError: string): void {
  * @returns the expected bucket setup instruction
  */
 function expectedInstruction(destinationUrl: string): string {
-  const generalInstruction = "The s3 bucket must be created in the us-west-2 region with 'ACL disabled' which is the default Object Ownership setting in AWS S3. The s3 bucket also must have the proper bucket policy in place to allow Harmony to access the bucket. You can retrieve the bucket policy to set on your s3 bucket by calling: http://127.0.0.1:4000/staging-bucket-policy?bucketPath=";
-  return `${generalInstruction}${destinationUrl}`;
+  return "The S3 bucket must be created in the us-west-2 region with 'ACLs disabled' "
+  + 'which is the default Object Ownership setting in AWS S3. '
+  + 'The S3 bucket also must have the proper bucket policy in place to allow Harmony to access the bucket. '
+  + 'You can retrieve the bucket policy to set on your S3 bucket by calling: '
+  + `http://127.0.0.1:4000/staging-bucket-policy?bucketPath=${destinationUrl}`;
 }
 
 describe('when setting destinationUrl on ogc request', function () {
@@ -84,17 +87,17 @@ describe('when setting destinationUrl on ogc request', function () {
     StubService.hook({ params: { status: 'successful' } });
     hookRangesetRequest('1.0.0', collection, 'all', { query: { destinationUrl: 'abcd' } });
 
-    it('returns 400 status code for invalid s3 url format', async function () {
+    it('returns 400 status code for invalid S3 url format', async function () {
       verifyValidationError(this, "Error: Invalid destinationUrl 'abcd', must start with s3://");
     });
   });
 
-  describe('when making a request with an invalid destinationUrl with multiple s3 locations', function () {
+  describe('when making a request with an invalid destinationUrl with multiple S3 locations', function () {
     StubService.hook({ params: { status: 'successful' } });
     hookRangesetRequest('1.0.0', collection, 'all', { query: { destinationUrl: 's3://abcd,s3://edfg' } });
 
-    it('returns 400 status code for multiple s3 locations which the middleware will concatenate with comma', async function () {
-      verifyValidationError(this, "Error: Invalid destinationUrl 's3://abcd,s3://edfg', only one s3 location is allowed.");
+    it('returns 400 status code for multiple S3 locations which the middleware will concatenate with comma', async function () {
+      verifyValidationError(this, "Error: Invalid destinationUrl 's3://abcd,s3://edfg', only one S3 location is allowed.");
     });
   });
 
@@ -103,18 +106,18 @@ describe('when setting destinationUrl on ogc request', function () {
     StubService.hook({ params: { status: 'successful' } });
     hookRangesetRequest('1.0.0', collection, 'all', { query: { destinationUrl: 's3://non-existent-bucket/abcd' } });
 
-    it('returns 400 status code for nonexistent s3 bucket', async function () {
+    it('returns 400 status code for nonexistent S3 bucket', async function () {
       verifyValidationError(this, "Error: The specified bucket 'non-existent-bucket' does not exist.");
     });
   });
 
-  describe('when making a request with an invalid destinationUrl with no s3 bucket', function () {
+  describe('when making a request with an invalid destinationUrl with no S3 bucket', function () {
     hookGetBucketRegion('us-west-2');
     StubService.hook({ params: { status: 'successful' } });
     hookRangesetRequest('1.0.0', collection, 'all', { query: { destinationUrl: 's3://' } });
 
-    it('returns 400 status code for no s3 bucket', async function () {
-      verifyValidationError(this, 'Error: Invalid destinationUrl, no s3 bucket is provided.');
+    it('returns 400 status code for no S3 bucket', async function () {
+      verifyValidationError(this, 'Error: Invalid destinationUrl, no S3 bucket is provided.');
     });
   });
 
@@ -140,7 +143,7 @@ describe('when setting destinationUrl on ogc request', function () {
     });
   });
 
-  describe('when making a request to s3 url that is not writable', function () {
+  describe('when making a request to S3 url that is not writable', function () {
     hookGetBucketRegion('us-west-2');
     hookUpload();
     StubService.hook({ params: { status: 'successful' } });
@@ -148,7 +151,7 @@ describe('when setting destinationUrl on ogc request', function () {
     hookRangesetRequest('1.0.0', collection, 'all', { query: { destinationUrl: destUrl } });
 
     it('returns 400 status code when not writable', async function () {
-      const expectedError = `Error: Do not have write permission to the specified s3 location: '${destUrl}'. ${expectedInstruction(destUrl)}`;
+      const expectedError = `Error: Do not have write permission to the specified S3 location: '${destUrl}'. ${expectedInstruction(destUrl)}`;
       verifyValidationError(this, expectedError);
     });
   });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1219

## Description
Added detailed error message regarding s3 bucket setup and link to get the bucket policy to relevant s3 bucket validation errors.

## Local Test Steps
Must be tested outside of localstack. e.g.
- No permission to get bucket location:
http://internal-harmony-yliu10-frontend-xxx.us-west-2.elb.amazonaws.com/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?granuleId=G1233800343-EEDTEST&format=image%2Fpng&destinationUrl=s3%3A%2F%2Fyliu10-no-permission%2Fabc

- No write permission to the bucket location:
http://internal-harmony-yliu10-frontend-xxx.us-west-2.elb.amazonaws.com/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?granuleId=G1233800343-EEDTEST&format=image%2Fpng&destinationUrl=s3%3A%2F%2Fyliu10-sit-no-write-permission-test%2Fabc

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)