### PR TITLE
HARMONY-1379: Fixed confusing error message when harmony rangeset request URL is invalid.

### DIFF
--- a/app/routers/router.ts
+++ b/app/routers/router.ts
@@ -200,8 +200,8 @@ export default function router({ skipEarthdataLogin = 'false' }: RouterConfig): 
   result.get('/versions', asyncHandler(getVersions));
   result.use('/docs/api', swaggerUi.serve, swaggerUi.setup(yaml.load(ogcCoverageApi.openApiContent), { customJs: '/js/docs/analytics-tag.js' }));
   result.get(collectionPrefix('wms'), asyncHandler(service(serviceInvoker)));
-  result.get(/^.*?\/ogc-api-coverages\/.*?\/collections\/.*?\/coverage\/rangeset/, asyncHandler(service(serviceInvoker)));
-  result.post(/^.*?\/ogc-api-coverages\/.*?\/collections\/.*?\/coverage\/rangeset/, asyncHandler(service(serviceInvoker)));
+  result.get(/^.*?\/ogc-api-coverages\/.*?\/collections\/.*?\/coverage\/rangeset$/, asyncHandler(service(serviceInvoker)));
+  result.post(/^.*?\/ogc-api-coverages\/.*?\/collections\/.*?\/coverage\/rangeset$/, asyncHandler(service(serviceInvoker)));
   result.get('/jobs', asyncHandler(getJobsListing));
   result.get('/jobs/:jobID', asyncHandler(getJobStatus));
 

--- a/test/routing.ts
+++ b/test/routing.ts
@@ -88,6 +88,16 @@ describe('Routing', function () {
     html: false,
   });
 
+  describeErrorCondition({
+    condition: 'invalid rangeset in the URL path',
+    path: `/${validCollection}/ogc-api-coverages/${version}/collections/all/coverage/rangeset123`,
+    message: {
+      code: 'harmony.NotFoundError',
+      description: 'Error: The requested page was not found.',
+    },
+    html: false,
+  });
+
   describe('/schemas', function () {
     it('serves files from app/schemas', async function () {
       const res = await request(this.frontend).get('/schemas/data-operation/0.10.0/data-operation-v0.10.0.json');


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1379

## Description
Fixed confusing error message when harmony rangeset request URL is invalid.

## Local Test Steps
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset123?granuleId=G1233800343-EEDTEST

verify the returned status code is 404 with error message: 
`{"code":"harmony.NotFoundError","description":"Error: The requested page was not found."}`

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)