### PR TITLE
HARMONY-1369: Truncate job-error message before saving

### DIFF
--- a/app/models/job-error.ts
+++ b/app/models/job-error.ts
@@ -1,3 +1,4 @@
+import { truncateString } from '../util/string';
 import db, { Transaction } from '../util/db';
 import Record from './record';
 
@@ -33,7 +34,7 @@ export default class JobError extends Record {
     super(fields);
     this.jobID = fields.jobID;
     this.url = fields.url;
-    this.message = fields.message;
+    this.message = truncateString(fields.message, 4096);
   }
 
   /**


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1369

## Description
This is a follow up to a bug fix that did not completely address all  of the underlying issues https://github.com/nasa/harmony/pull/336. The initial bug fix truncated the job error message before saving in order to avoid exceeding the postgres column limits. However, under these particular failure conditions, there was also another database record (`job_error`) being saved which had a `message` field that was not being truncated to adhere to its column character limits of 4096.

## Local Test Steps
In [workflow-orchestration.ts#L494](https://github.com/nasa/harmony/blob/main/app/backends/workflow-orchestration.ts#L494), set this outer if statement to `true` so that it always triggers -- otherwise you might not be able to simulate the original conditions seen in production, which require triggering a call to `addErrorForWorkItem`.
```
// CHANGE THE LINE BELOW TO: if(true)
if (QUERY_CMR_SERVICE_REGEX.test(workItem.serviceID)) {
        // Fail the request if query-cmr fails to populate granules
        continueProcessing = false;
        if (!jobMessage) {
          jobMessage = `WorkItem [${workItem.id}] failed to query CMR for granule information`;
        }
      } else {
        const url = await getWorkItemUrl(workItem, logger);
        if (!jobMessage) {
          jobMessage = `WorkItem [${workItem.id}] failed with an unknown error`;
        }
        await addErrorForWorkItem(tx, job, url, jobMessage);
      }
```
Also in [workflow-orchestration.ts#L753](https://github.com/nasa/harmony/blob/main/app/backends/workflow-orchestration.ts#L753) in `updateWorkItem`  set `status: WorkItemStatus.FAILED,` and `errorMessage: "something greater than 4096 chars..."`

Set `WORK_ITEM_RETRY_LIMIT=1` in .env

Submit a test job http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=2

The job should fail gracefully without any unexpected logic being triggered.

If you want to simulate the error that we were seeing in production, leave all of the changes mentioned above but revert the changes from this PR which truncate the job_error message. Then submit another test job.

You should see in the logs:
> error: insert into "job_errors" ("createdAt", "jobID", "message", "updatedAt", "url") values ($1, $2, $3, $4, $5) returning "id" - value too long for type character varying(4096)


## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)