### PR TITLE
HARMONY-1382: Replaced Introduction notebook test data that depend on external data provider with Harmony's own staged data to make the notebook more robust.

### DIFF
--- a/docs/Harmony API introduction.ipynb
+++ b/docs/Harmony API introduction.ipynb
@@ -279,10 +279,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "According to the services.yml, our `C1233800302-EEDTEST` collection is associated with the `harmony/gdal` service with bounding box and variable subsetting, reprojection, and reformatting. We will request these services below. "
+    "According to the services.yml, our `harmony_example` collection is associated with the `harmony/gdal` service with bounding box and variable subsetting, reprojection, and reformatting. We will request these services below. "
    ]
   },
   {
@@ -417,12 +418,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For EOSDIS collections without associated Harmony transformation services, the Harmony API can still be utilized to access data through the provided data access links. Before we request services for `harmony_example`, We will use `ATL08`, or the \"ATLAS/ICESat-2 L3A Land and Vegetation Height\" data product, as an example of this \"no processing\" request. Note that this collection has restricted access and therefore cannot be queried for collection ID like above without passing Earthdata Login credentials. For convenience the collection ID was predetermined for this example: `C1229246405-NSIDC_TS1`.\n",
+    "For EOSDIS collections without associated Harmony transformation services, the Harmony API can still be utilized to access data through the provided data access links. Before we request services for `harmony_example`, We will use `MYD13Q1`, or the \"MODIS/Aqua Vegetation Indices 16-Day L3 Global 250m SIN Grid V061\" data product, as an example of this \"no processing\" request. \n",
     "\n",
-    "The URL for requesting `ATLO8` is printed below. In this simple case, the entire data product is requested. The request response is also printed below, which includes information such as JobID, data access links, associated granule IDs, request messages, and status:"
+    "The URL for requesting `MYD13Q1` is printed below. In this simple case, the entire data product is requested. The request response is also printed below, which includes information such as JobID, data access links, associated granule IDs, request messages, and status:"
    ]
   },
   {
@@ -435,7 +437,7 @@
    "outputs": [],
    "source": [
     "noProcConfig = {\n",
-    "    'is2collection_id': 'C1229246405-NSIDC_TS1',\n",
+    "    'is2collection_id': 'C1256583785-EEDTEST',\n",
     "    'ogc-api-coverages_version': '1.0.0'\n",
     "}\n",
     "\n",
@@ -471,10 +473,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instead of requesting the entire `ATL08` collection, we can also specify a single granule ID to download. For convenience, the first granule returned in the request above is queried separately to demonstrate this single granule request:"
+    "Instead of requesting the entire `MYD13Q1` collection, we can also specify a single granule ID to download. For convenience, the first granule returned in the request above is queried separately to demonstrate this single granule request:"
    ]
   },
   {
@@ -493,7 +496,7 @@
     "\n",
     "# Update noProcConfig\n",
     "noProcConfig = {\n",
-    "    'is2collection_id': 'C1229246405-NSIDC_TS1',\n",
+    "    'is2collection_id': 'C1256583785-EEDTEST',\n",
     "    'ogc-api-coverages_version': '1.0.0',\n",
     "    'variable': 'all',\n",
     "    'granuleID': granuleID\n",
@@ -1506,7 +1509,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -1524,7 +1527,7 @@
   },
   "vscode": {
    "interpreter": {
-    "hash": "341b7d2e50a6ee8d836f143dcf87119dfe72f0053ce895c8752bf7a40b324b52"
+    "hash": "d0b323d74a2eccdefaacaf33c041ca03218ebb6c9aa84851ec587afd8a56d428"
    }
   }
  },


### PR DESCRIPTION
## Jira Issue ID
General

## Description
Replaced Introduction notebook test data that depend on external data provider with Harmony's own staged data to make the notebook more robust.

## Local Test Steps
Run Introduction notebook locally or in Colab, verify the section with `no-op` that used to depend on NSIDC_TS1 data now works. 

## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)