### PR TITLE
HARMONY-1383: Add type of Catalog to the STAC catalog generated for harmony requests

### DIFF
--- a/app/frontends/stac-catalog.ts
+++ b/app/frontends/stac-catalog.ts
@@ -8,6 +8,8 @@ export interface SerializableCatalog {
 
   title: string;
 
+  type: string;
+
   description: string;
 
   links: JobLink[];
@@ -36,6 +38,8 @@ class HarmonyCatalog implements SerializableCatalog {
 
   title: string;
 
+  type: string;
+
   description: string;
 
   links: JobLink[];
@@ -50,6 +54,7 @@ class HarmonyCatalog implements SerializableCatalog {
     this.id = id;
     this.stac_version = '1.0.0';
     this.title = title;
+    this.type = 'Catalog';
     this.description = description;
     this.links = [];
   }
@@ -78,7 +83,7 @@ class HarmonyCatalog implements SerializableCatalog {
    * @returns - STAC Catalog JSON
    */
   toJSON(): SerializableCatalog {
-    const paths = ['id', 'stac_version', 'title', 'description', 'links'];
+    const paths = ['id', 'stac_version', 'title', 'type', 'description', 'links'];
     return pick(this, paths) as SerializableCatalog;
   }
 }

--- a/test/stac/stac.ts
+++ b/test/stac/stac.ts
@@ -144,6 +144,7 @@ describe('STAC catalog route', function () {
           ]);
           expect(catalog.stac_version).to.equal('1.0.0');
           expect(catalog.title).to.include('Harmony output for ');
+          expect(catalog.type).to.equal('Catalog');
         });
       });
       describe('when the linkType is invalid', function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1383

## Description
Adds a type field with a value of 'Catalog' to the STAC catalog returned in the harmony job results when a request is completed.

This fixes a bug when trying to open a catalog using Pystac client.

## Local Test Steps
Start harmony locally and submit a request (must be async so that a catalog will be created in the end). For example http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset/?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng&forceAsync=true

Set up a python environment and then:

1. `pip install pystac_client`
2. `python`
3. `from pystac_client import Client`
4. `catalog = Client.open('http://localhost:3000/stac/<request_id>')`
5.  Verify no errors from the open command.
6. `catalog.id` returns the request ID
7. `catalog.links` returns a list of STAC catalog links

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)