### PR TITLE
HARMONY-1352: Added job status link to workflow ui jobID; Updated README based on provider feedback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ Linux Only (Handled automatically by Docker Desktop)
 kubectl port-forward service/harmony 3000:3000 -n harmony
 ```
 
-**NOTE** The workflow listener will fail repeatedly (restarts every 30 seconds) when Harmony is run
-in Kubernetes on Linux. This is a known bug and is to addressed in Jira ticket HARMONY-849.
+End of Linux Only
 
 Harmony should now be running in your Kubernetes cluster as the `harmony` service in the `harmony` namespace.
 

--- a/app/views/workflow-ui/job/index.mustache.html
+++ b/app/views/workflow-ui/job/index.mustache.html
@@ -46,7 +46,7 @@
                 {{^isAdminRoute}}
                 <li class="breadcrumb-item"><a href="/workflow-ui">Jobs</a></li>
                 {{/isAdminRoute}}
-                <li class="breadcrumb-item active" aria-current="page">{{job.jobID}}</li>
+                <li class="breadcrumb-item active" aria-current="page"><a href="/jobs/{{job.jobID}}">{{job.jobID}}</a></li>
             </ol>
             <div id="job-state-links-container" data-is-admin-or-owner="{{isAdminOrOwner}}">
                 <!-- job state change links will go here -->

--- a/app/views/workflow-ui/job/index.mustache.html
+++ b/app/views/workflow-ui/job/index.mustache.html
@@ -42,11 +42,12 @@
             <ol class="breadcrumb p-0 m-0">
                 {{#isAdminRoute}}
                 <li class="breadcrumb-item"><a href="/admin/workflow-ui">Jobs</a></li>
+                <li class="breadcrumb-item active" aria-current="page">{{job.jobID}} (<a href="/admin/jobs/{{job.jobID}}">Job Status</a>)</li>
                 {{/isAdminRoute}}
                 {{^isAdminRoute}}
                 <li class="breadcrumb-item"><a href="/workflow-ui">Jobs</a></li>
+                <li class="breadcrumb-item active" aria-current="page">{{job.jobID}} (<a href="/jobs/{{job.jobID}}">Job Status</a>)</li>
                 {{/isAdminRoute}}
-                <li class="breadcrumb-item active" aria-current="page"><a href="/jobs/{{job.jobID}}">{{job.jobID}}</a></li>
             </ol>
             <div id="job-state-links-container" data-is-admin-or-owner="{{isAdminOrOwner}}">
                 <!-- job state change links will go here -->

--- a/test/workflow-ui/job.ts
+++ b/test/workflow-ui/job.ts
@@ -69,7 +69,7 @@ describe('Workflow UI job route', function () {
         });
         it('returns HTML with the job ID included', function () {
           const listing = this.res.text;
-          expect(listing).to.contain(mustache.render('{{req}}', { req: nonShareableJob.jobID }));
+          expect(listing).to.contain(mustache.render('<a href="/jobs/{{req}}">{{req}}</a>', { req: nonShareableJob.jobID }));
         });
         it('returns a breadcrumb that includes the non-admin path', async function () {
           const listing = this.res.text;
@@ -133,7 +133,7 @@ describe('Workflow UI job route', function () {
         hookAdminWorkflowUIJob({ jobID: nonShareableJob.jobID, username: 'adam' });
         it('returns a job for any user', async function () {
           const listing = this.res.text;
-          expect(listing).to.contain(mustache.render('{{req}}', { req: nonShareableJob.jobID }));
+          expect(listing).to.contain(mustache.render('<a href="/jobs/{{req}}">{{req}}</a>', { req: nonShareableJob.jobID }));
         });
         it('returns a breadcrumb that includes the admin path', async function () {
           const listing = this.res.text;

--- a/test/workflow-ui/job.ts
+++ b/test/workflow-ui/job.ts
@@ -69,7 +69,7 @@ describe('Workflow UI job route', function () {
         });
         it('returns HTML with the job ID included', function () {
           const listing = this.res.text;
-          expect(listing).to.contain(mustache.render('<a href="/jobs/{{req}}">{{req}}</a>', { req: nonShareableJob.jobID }));
+          expect(listing).to.contain(mustache.render('{{req}} (<a href="/jobs/{{req}}">Job Status</a>)', { req: nonShareableJob.jobID }));
         });
         it('returns a breadcrumb that includes the non-admin path', async function () {
           const listing = this.res.text;
@@ -133,7 +133,7 @@ describe('Workflow UI job route', function () {
         hookAdminWorkflowUIJob({ jobID: nonShareableJob.jobID, username: 'adam' });
         it('returns a job for any user', async function () {
           const listing = this.res.text;
-          expect(listing).to.contain(mustache.render('<a href="/jobs/{{req}}">{{req}}</a>', { req: nonShareableJob.jobID }));
+          expect(listing).to.contain(mustache.render('{{req}} (<a href="/admin/jobs/{{req}}">Job Status</a>)', { req: nonShareableJob.jobID }));
         });
         it('returns a breadcrumb that includes the admin path', async function () {
           const listing = this.res.text;


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1352

## Description
Updated README based on provider feedback.
Added job status link to workflow ui jobID.

## Local Test Steps
Verify README file is updated with `End of Linux Only` for the section that is only Linux related.
Run Harmony locally, submit a request and verify the `(Job Status)` in the job details page is now a link to the job's status page and click on it lead the user to the job's status page.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)