### PR TITLE
HARMONY-619: Add env for release_version for use in web pages

### DIFF
--- a/app/util/env.ts
+++ b/app/util/env.ts
@@ -113,6 +113,7 @@ interface HarmonyEnv {
   putWorkSampleRatio: number;
   getMetricsSampleRatio: number;
   openTelemetryUrl: string;
+  releaseVersion: string;
 }
 
 // special cases

--- a/app/util/version.ts
+++ b/app/util/version.ts
@@ -1,8 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import env from './env';
 
-const packageBuf = fs.readFileSync(path.join(__dirname, '../../package.json'));
-const { version } = JSON.parse(packageBuf.toString('utf-8'));
+const version = env.releaseVersion;
 
-// HARMONY-619 will add proper versioning
 export default version;

--- a/env-defaults
+++ b/env-defaults
@@ -207,6 +207,9 @@ GET_METRICS_SAMPLE_RATIO=0.01
 # The url for the open telemetry exporter daemon
 OPEN_TELEMETRY_URL=http://localhost:4318/v1/traces
 
+# Bamboo release
+RELEASE_VERSION=0.0.0
+
 ###########################################################################
 #                             Service Config                              #
 #                                                                         #


### PR DESCRIPTION
## Jira Issue ID
HARMONY-619

## Description
Add env var for release version to be used in web pages.

## Local Test Steps
1. check out this branch
2. set RELEASE_VERION to 1.0.0 in your .env file
3. run harmony locally
4. load  http://localhost:3000
5. verify that the bottom of the page shows version 1.0.0

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)