### PR TITLE
HARMONY-1394: Updated service termination without error message failure message to be more user friendly.

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,7 +1,12 @@
 {
  "1091410": {
     "active": true,
-    "notes": "Ignored since we don't expose the vunlerability and their is no fix",
+    "notes": "Ignored since we don't expose the vunlerability and there is no fix",
     "expiry": "2023-09-01"
+  },
+  "1091459": {
+    "active": true,
+    "notes": "Ignored since no upgrade or patch available",
+    "expiry": "2023-09-23"
   }
 }

--- a/tasks/service-runner/.nsprc
+++ b/tasks/service-runner/.nsprc
@@ -1,7 +1,12 @@
 {
  "1091410": {
     "active": true,
-    "notes": "Ignored since we don't expose the vunlerability and their is no fix",
+    "notes": "Ignored since we don't expose the vunlerability and there is no fix",
     "expiry": "2023-09-01"
+  },
+  "1091459": {
+    "active": true,
+    "notes": "Ignored since no upgrade or patch available",
+    "expiry": "2023-09-23"
   }
 }

--- a/tasks/service-runner/app/service/service-runner.ts
+++ b/tasks/service-runner/app/service/service-runner.ts
@@ -27,7 +27,7 @@ export interface ServiceResponse {
 // how long to let a worker run before giving up
 const { workerTimeout } = env;
 
-// service exist code for Out Of Memory error
+// service exit code for Out Of Memory error
 const OOM_EXIT_CODE = '137';
 
 /**

--- a/tasks/service-runner/app/service/service-runner.ts
+++ b/tasks/service-runner/app/service/service-runner.ts
@@ -27,6 +27,9 @@ export interface ServiceResponse {
 // how long to let a worker run before giving up
 const { workerTimeout } = env;
 
+// service exist code for Out Of Memory error
+const OOM_EXIT_CODE = '137';
+
 /**
  * A writable stream that is passed to the k8s exec call for the worker container.
  * Captures, logs and stores the logs of the worker container's execution.
@@ -108,7 +111,7 @@ async function _getStacCatalogs(dir: string): Promise<string[]> {
 function _getErrorMessageOfStatus(status: k8s.V1Status, msg = 'Unknown error'): string {
   const exitCode = status.details?.causes?.find(i => i.reason === 'ExitCode');
   let errorMsg = null;
-  if (exitCode?.message === '137') {
+  if (exitCode?.message === OOM_EXIT_CODE) {
     errorMsg = 'Service failed due to running out of memory';
   }
   return (errorMsg ? errorMsg : msg);

--- a/tasks/service-runner/app/workers/pull-worker.ts
+++ b/tasks/service-runner/app/workers/pull-worker.ts
@@ -105,7 +105,7 @@ async function _doWork(
   const newWorkItem = workItem;
   workItemLogger.debug('Calling work function');
   // work items with a scrollID are only for the query-cmr service
-  const serviceResponse = newWorkItem.scrollID ? 
+  const serviceResponse = newWorkItem.scrollID ?
     await runQueryCmrFromPull(newWorkItem, maxCmrGranules, workItemLogger) :
     await runServiceFromPull(newWorkItem, workItemLogger);
   workItemLogger.debug('Finished work');


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1394

## Description
Updated service termination without error message failure message to be more user friendly.

## Local Test Steps
Configure local harmony to talk to CMR PROD to reproduce the error easier. 
Note: you need to re-build the service-runner image and restart local services.
To make the request fail faster, add `WORK_ITEM_RETRY_LIMIT=0` to your .env file.

Verify `http://localhost:3000/C2251464384-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&maxResults=1000000&skipPreview=true&subset=lat(-90%3A90)&subset=lon(-180%3A180)&granuleId=G2634017742-POCLOUD` will result in error like:
`WorkItem [1286] failed with error: podaac/l2ss-py:2.4.0: Service failed due to running out of memory` 
rather than 
`WorkItem [1286] failed with error: podaac/l2ss-py:2.4.0: Unexpected token ' in JSON at position 1`

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)