### PR TITLE
HARMONY-1401: Support the version parameter on the collection capabilities endpoint

### DIFF
--- a/test/collection-capabilities.ts
+++ b/test/collection-capabilities.ts
@@ -19,7 +19,7 @@ describe('Testing collection capabilities', function () {
           expect(this.res.status).to.equal(200);
         });
 
-        it('includes all of the expected fields in the response', function () {
+        it('includes all of the expected fields in the response according to the default version', function () {
           const expectedFields = [
             'conceptId', 'shortName', 'variableSubset', 'bboxSubset', 'shapeSubset',
             'concatenate', 'reproject', 'outputFormats', 'services', 'variables',
@@ -138,6 +138,38 @@ describe('Testing collection capabilities', function () {
         expect(JSON.parse(this.res.text)).to.eql({
           code: 'harmony.RequestValidationError',
           description: 'Error: Must specify only one of collectionId or shortName, not both',
+        });
+      });
+    });
+
+    describe('specifying a version parameter', function () {
+      describe('specifying version 1', function () {
+        hookGetCollectionCapabilities({ collectionId: 'C1234088182-EEDTEST', version: 1 });
+        it('returns a 200 success status code', function () {
+          expect(this.res.status).to.equal(200);
+        });
+
+        it('includes all of the expected fields in the version 1 response', function () {
+          const expectedFields = [
+            'conceptId', 'shortName', 'variableSubset', 'bboxSubset', 'shapeSubset',
+            'concatenate', 'reproject', 'outputFormats', 'services', 'variables',
+          ];
+          const capabilities = JSON.parse(this.res.text);
+          expect(Object.keys(capabilities)).to.eql(expectedFields);
+        });
+      });
+
+      describe('specifying a version that does not exist', function () {
+        hookGetCollectionCapabilities({ collectionId: 'C1234088182-EEDTEST', version: 'bad_version' });
+        it('returns a 400 status code', function () {
+          expect(this.res.status).to.equal(400);
+        });
+
+        it('returns an error message indicating the version was invalid', function () {
+          expect(JSON.parse(this.res.text)).to.eql({
+            code: 'harmony.RequestValidationError',
+            description: 'Error: Invalid API version bad_version, supported versions: 1',
+          });
         });
       });
     });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1401

## Description
Adds support for the version parameter on the collection capabilities endpoint. As we make changes to the response format, we do NOT want to break clients relying on an older version of the response.

## Local Test Steps
Right now there's only a single version 1 supported. Will be more useful to compare once version 2 is added, but you can still sanity check the parameter is handled correctly:

* No version specified returns the current version: http://localhost:3000/capabilities?collectionId=C1225776654-ASF
* You can explicitly specify the version: http://localhost:3000/capabilities?collectionId=C1225776654-ASF&version=1
* If you specify a version that does not exist you get a 400 error back:  http://localhost:3000/capabilities?collectionId=C1225776654-ASF&version=bad

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)