### PR TITLE
HARMONY-1404: Add trigger to tables to set updatedAt when row is updated

### DIFF
--- a/db/knexfile.js
+++ b/db/knexfile.js
@@ -33,4 +33,11 @@ module.exports = {
     migrations,
     acquireConnectionTimeout: 120000, // Allow adequate warmup of serverless aurora
   },
+
+  onUpdateTrigger: table => `
+    CREATE TRIGGER ${table}_updated_at
+    BEFORE UPDATE ON ${table}
+    FOR EACH ROW
+    EXECUTE PROCEDURE on_update_timestamp();
+  `
 };

--- a/db/migrations/20230328193141_add_function_update_timestamp.js
+++ b/db/migrations/20230328193141_add_function_update_timestamp.js
@@ -1,0 +1,19 @@
+const ON_UPDATE_TIMESTAMP_FUNCTION = `
+  CREATE OR REPLACE FUNCTION on_update_timestamp()
+  RETURNS trigger AS $$
+  BEGIN
+    NEW."updatedAt" = now();
+    RETURN NEW;
+  END;
+$$ language 'plpgsql';
+`
+
+const DROP_ON_UPDATE_TIMESTAMP_FUNCTION = `DROP FUNCTION on_update_timestamp`
+
+exports.up = function(knex) {
+  return knex.raw(ON_UPDATE_TIMESTAMP_FUNCTION)
+};
+
+exports.down = function(knex) {
+  return knex.raw(DROP_ON_UPDATE_TIMESTAMP_FUNCTION)
+};

--- a/db/migrations/20230328194902_add_update_trigger_to_tables.js
+++ b/db/migrations/20230328194902_add_update_trigger_to_tables.js
@@ -1,0 +1,23 @@
+const { onUpdateTrigger } = require('../knexfile');
+
+exports.up = function(knex) {
+  return knex.raw(onUpdateTrigger('batch_items'))
+  .then(() => knex.raw(onUpdateTrigger('batches')))
+  .then(() => knex.raw(onUpdateTrigger('job_errors')))
+  .then(() => knex.raw(onUpdateTrigger('job_links')))
+  .then(() => knex.raw(onUpdateTrigger('jobs')))
+  .then(() => knex.raw(onUpdateTrigger('user_work')))
+  .then(() => knex.raw(onUpdateTrigger('work_items')))
+  .then(() => knex.raw(onUpdateTrigger('workflow_steps')));
+};
+
+exports.down = function(knex) {
+  return  knex.raw('DROP TRIGGER IF EXISTS batch_items_updated_at ON batch_items')
+  .then(() => knex.raw('DROP TRIGGER IF EXISTS batches_updated_at ON batches'))
+  .then(() => knex.raw('DROP TRIGGER IF EXISTS job_errors_updated_at ON job_errors'))
+  .then(() => knex.raw('DROP TRIGGER IF EXISTS job_links_updated_at ON job_links'))
+  .then(() => knex.raw('DROP TRIGGER IF EXISTS jobs_updated_at ON jobs'))
+  .then(() => knex.raw('DROP TRIGGER IF EXISTS user_work_updated_at ON user_work'))
+  .then(() => knex.raw('DROP TRIGGER IF EXISTS work_items_updated_at ON work_items'))
+  .then(() => knex.raw('DROP TRIGGER IF EXISTS workflow_steps_updated_at ON workflow_steps'));
+};


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1404

## Description
Adds trigger to Postgres to set updatedAt to the current time when a row is updated. This trigger is set for all tables.

## Local Test Steps
1. checkout this branch (harmony-1404-updatedAt)
2. run the migrations
3. Run harmony locally
4. Verify that harmony queries still work
5. Use dbViz to select a row from the `jobs` table
6. Use dbViz to insert a row into the `user_work` table using the `jobID` from the row in `jobs`
7. Use dbViz to select the row from `user_work` (there should be only one row in the table)
8. Use dbViz to update the row by setting `ready_count` to some value.
9. Select the row again and verify that `updatedAt` has been updated.
10. (optional) try updating rows for other tables, e.g., `jobs` and verify that `updatedAt` get set to the current time

NOTE: there are no automated tests for this as we don't use Postgres when running tests.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~