### PR TITLE
HARMONY-1403: Work failer crashes Harmony when number of work items is too high.

### DIFF
--- a/app/backends/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration.ts
@@ -558,11 +558,13 @@ async function updateWorkItemCounts(
  * handled in this function and no exceptions should be thrown since nothing will catch
  * them.
  *
+ * @param jobId - job id
  * @param update - information about the work item update
  * @param operation - the DataOperation for the user's request
  * @param logger - the Logger for the request
  */
-export async function handleWorkItemUpdate(
+export async function handleWorkItemUpdateWithJobId(
+  jobID: string,
   update: WorkItemUpdate,
   operation: object,
   logger: Logger): Promise<void> {
@@ -572,9 +574,6 @@ export async function handleWorkItemUpdate(
   if (status === WorkItemStatus.SUCCESSFUL) {
     logger.info(`Updating work item ${workItemID} to ${status}`);
   }
-
-  // get the jobID for the work item
-  const jobID = await getJobIdForWorkItem(workItemID);
 
   // Get the sizes of all the data items/granules returned for the WorkItem and STAC item links
   // when batching.
@@ -734,6 +733,26 @@ export async function handleWorkItemUpdate(
     logger.error(`Work item update failed for work item ${workItemID} and status ${status}`);
     logger.error(e);
   }
+}
+
+/**
+ * Update job status/progress in response to a service provided work item update
+ * IMPORTANT: This asynchronous function is called without awaiting, so any errors must be
+ * handled in this function and no exceptions should be thrown since nothing will catch
+ * them.
+ *
+ * @param update - information about the work item update
+ * @param operation - the DataOperation for the user's request
+ * @param logger - the Logger for the request
+ */
+export async function handleWorkItemUpdate(
+  update: WorkItemUpdate,
+  operation: object,
+  logger: Logger): Promise<void> {
+  const { workItemID } = update;
+  // get the jobID for the work item
+  const jobID = await getJobIdForWorkItem(workItemID);
+  await handleWorkItemUpdateWithJobId(jobID, update, operation, logger);
 }
 
 /**

--- a/app/util/env.ts
+++ b/app/util/env.ts
@@ -113,6 +113,7 @@ interface HarmonyEnv {
   putWorkSampleRatio: number;
   getMetricsSampleRatio: number;
   openTelemetryUrl: string;
+  workFailerBatchSize: number;
   releaseVersion: string;
 }
 

--- a/env-defaults
+++ b/env-defaults
@@ -198,6 +198,9 @@ MAX_BATCH_INPUTS=1000000000000
 # The upper limit on the combined sizes of all the files in a batch
 MAX_BATCH_SIZE_IN_BYTES=5000000000
 
+# The batch size used by work-failer. Set it to 0 will effectively disable work-failer.
+WORK_FAILER_BATCH_SIZE=1000
+
 # The fraction of back-end get work requests we want to trace with open telemetry
 GET_WORK_SAMPLE_RATIO=0.01
 # The fraction of back-end put work result requests we want to trace with open telemetry

--- a/test/workers/work-failer.ts
+++ b/test/workers/work-failer.ts
@@ -19,13 +19,13 @@ const workFailer = new WorkFailer(config);
 
 // 11 hours -- any RUNNING items that haven't been updatedAt for this long should get picked up
 // by the WorkFailer
-const failDurationMinutes = 11 * 60; 
+const failDurationMinutes = 11 * 60;
 
 describe('WorkFailer', function () {
   let retryLimit: number;
 
   // WorkItem initial createAt/updatedAt dates
-  // (which should determine which items get picked up 
+  // (which should determine which items get picked up
   // by the WorkFailer)
   const oldDate = '1/1/2000'; // "old" work items will get created on this date
   const newDate = '1/30/2000'; // "new" work items will get created on this date
@@ -85,7 +85,7 @@ describe('WorkFailer', function () {
     readyItemJobItem2 = buildWorkItem({ jobID: readyItemJob.jobID, status: WorkItemStatus.READY, workflowStepIndex: 0 });
     await readyItemJobItem2.save(this.trx);
     await buildWorkflowStep({ jobID: readyItemJobItem2.jobID, stepIndex: 0 }).save(this.trx);
-    
+
     await this.trx.commit();
     MockDate.reset();
   });
@@ -97,14 +97,11 @@ describe('WorkFailer', function () {
   });
 
   describe('.handleWorkItemUpdates', async function () {
-    let initialResponse: {
-      workItemIds: number[];
-      jobIds: string[];
-    };
+    let oldItems = [];
     it('proccesses work item updates for items that are RUNNING and have not been updated for the specified duration', async function () {
       MockDate.set('1/2/2000'); // some items should now be a day old
-      initialResponse = await workFailer.handleWorkItemUpdates(failDurationMinutes);
-      
+      await workFailer.handleWorkItemUpdates(failDurationMinutes);
+
       // check that both old items were re-queued
       const twoOldJobItems = (await getWorkItemsByJobId(db, twoOldJob.jobID)).workItems;
       expect(twoOldJobItems.filter((item) => item.status === WorkItemStatus.READY).length).to.equal(2);
@@ -117,8 +114,8 @@ describe('WorkFailer', function () {
       expect(oneOldJobItems.filter((item) => item.status === WorkItemStatus.RUNNING).length).to.equal(1);
       expect(oneOldJobItems.filter((item) => item.retryCount === 0).length).to.equal(1);
 
-      expect(initialResponse.jobIds.length).to.equal(2);
-      expect(initialResponse.workItemIds.length).to.equal(3);
+      oldItems = twoOldJobItems;
+      oldItems = oldItems.concat(oneOldJobItems.filter((item) => item.status === WorkItemStatus.READY));
     });
 
     it('does not proccess old work items that are in the READY state', async function () {
@@ -126,26 +123,17 @@ describe('WorkFailer', function () {
       const readyItemJobItems = (await getWorkItemsByJobId(db, readyItemJob.jobID)).workItems;
       const readyItem = readyItemJobItems.filter((item) => item.status === WorkItemStatus.READY)[0];
       expect(readyItem.id === readyItemJobItem2.id);
-      
-      // check that the old READY item was not processed by the WorkFailer
-      expect(!initialResponse.jobIds.includes(readyItemJob.jobID));
-      expect(!initialResponse.workItemIds.includes(readyItem.id));
     });
 
     it('does not proccess jobs without long-running work items', async function () {
-      expect(!initialResponse.jobIds.includes(noneOldJob.jobID));
-      expect(!initialResponse.workItemIds.includes(noneOldJob.id));
-    });
-
-    it('should not find any items to proccess upon immediate subsequent invocation', async function () {
-      const subsequentResponse = await workFailer.handleWorkItemUpdates(failDurationMinutes);
-      expect(subsequentResponse.jobIds.length).to.equal(0);
-      expect(subsequentResponse.workItemIds.length).to.equal(0);
+      const noneOldJobItems = (await getWorkItemsByJobId(db, noneOldJob.jobID)).workItems;
+      expect(noneOldJobItems.filter((item) => item.status === WorkItemStatus.RUNNING).length).to.equal(1);
+      expect(noneOldJobItems.filter((item) => item.retryCount === 0).length).to.equal(1);
     });
 
     // This continues the tests from above,
     // simulating items being picked up by services and the work failer
-    [ 
+    [
       // twoOldJob
       [twoOldJob, 2, '1/2/2000', '1/3/2000', [WorkItemStatus.READY, WorkItemStatus.READY], 2, JobStatus.RUNNING],
       [twoOldJob, 3, '1/3/2000', '1/4/2000', [WorkItemStatus.READY, WorkItemStatus.READY], 2,  JobStatus.RUNNING],
@@ -162,14 +150,15 @@ describe('WorkFailer', function () {
       workItemStatuses, // The item statuses that we expect after the work failer runs
       numItemUpdates,  // The number of work items that we expect to be processed on each invocation of the work failer
       jobStatus, // The job status that we expect to see after the work failer runs
-    ]: 
+    ]:
     [Job, number, string, string, WorkItemStatus[], number, JobStatus]) => {
       it(`keeps processing updates for old items, triggering retries until exhausted (running date: ${runningDate}, jobID: ${job.jobID})`, async () => {
         // simulate that job's old items are RUNNING again
         MockDate.set(runningDate);
         let items = (await getWorkItemsByJobId(db, job.jobID)).workItems;
+
         for (const item of items) {
-          if (!initialResponse.workItemIds.includes(item.id)){
+          if (!oldItems.map(i => {return i.id;}).includes(item.id)){
             // only simulating for the "old" items as specified in the before hook
             continue;
           }
@@ -181,23 +170,19 @@ describe('WorkFailer', function () {
         // have been running for a whole day and should get picked up again by the WorkFailer
         MockDate.set(failerDate);
 
-        const response = await workFailer.handleWorkItemUpdates(failDurationMinutes);
-        
+        await workFailer.handleWorkItemUpdates(failDurationMinutes);
+
         items = (await getWorkItemsByJobId(db, job.jobID)).workItems;
-        
+
         // check that the item retry count was updated appropriately
         expect(items.filter((item) => item.retryCount === retryCount).length).to.equal(numItemUpdates);
-        
+
         // check that the item status was updated appropriately
         workItemStatuses.forEach((status) => {
           const index = items.findIndex((item) => item.status === status);
           expect(index > -1);
           items.splice(index, 1); // 2nd parameter means remove one item only
         });
-        
-        // check that the work failer processed only this job and its items
-        expect(response.jobIds.length).to.equal(1);
-        expect(response.workItemIds.length).to.equal(numItemUpdates);
 
         // check that the job status was appropriately updated as a result of the item updates
         job = await Job.byJobID(db, job.jobID);


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1403

## Description
This PR changed how work failer processes expired work items. Rather than retrieving all expired work items into memory at once (which caused OOM error in PROD), the new approach retrieves the expired work items in a configurable batch size and processes all the expired work items in batches. 
It eliminated the unnecessary processing summary that does nothing but asking for trouble for large payload.
It also eliminated the unnecessary retrieval of jobID step that was executed for each expired work item in the processing.

## Local Test Steps
Reproduced the PROD OOM problem in Sandbox and verified the fix worked in `harmony-yliu10-cluster`(http://internal-harmony-yliu10-frontend-1281553417.us-west-2.elb.amazonaws.com).

NOTE: James's recent code change to add trigger on `updatedAt` made it impossible to update `updatedAt` to an older timestamp. You need to disable the trigger on work_items table to set the desired condition to trigger expired work items.

Here are the steps to recreate the problem in Sandbox if you care:
1) Submit a couple large requests (2.3 million granules each) in Sandbox.
2) Update some of the work items status from `ready` to `running` and `startedAt` set to an old timestamp. e.g.
`update  work_items set status='running', "startedAt"='2018-06-11 02:00:00'::timestamp AT TIME ZONE 'America/Denver', "updatedAt"='2018-06-11 02:00:00'::timestamp AT TIME ZONE 'America/Denver' where "jobID"='xxxxx' and id > 337748 and id < 347748 and status='ready'`
3) The way Harmony calculate the duration of step execution takes the `startedAt` field into consideration and makes getting work items expired tricky. I ended up hack the last line of `app/models/work-item.ts` from `return threshold;` to `return 7200000;` to make the above updated work items expire.

Then deploy the code from main branch with the code change in step 3, I was able to reproduce the OOM error and then deploy my branch also with the code change in step 3, verified that there is no OOM errors, the expired work items are correctly moved to `ready` state to be retried.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)