### PR TITLE
HARMONY-1413: Add temporal subsetting capability matching

### DIFF
--- a/app/models/data-operation.ts
+++ b/app/models/data-operation.ts
@@ -929,6 +929,9 @@ export default class DataOperation {
       if (!fieldsToInclude.includes('dimensionSubset')) {
         delete toWrite.subset.dimensions;
       }
+      if (!fieldsToInclude.includes('temporalSubset')) {
+        delete toWrite.temporal;
+      }
     }
 
     return JSON.stringify(toWrite);

--- a/app/models/services/index.ts
+++ b/app/models/services/index.ts
@@ -701,7 +701,7 @@ const requiredFilterFns = [
   filterOutputFormatMatches,
 ];
 
-const bestEffortMessage = 'Data in output files may extend outside the spatial bounds you requested.';
+const bestEffortMessage = 'Data in output files may extend outside the spatial and temporal bounds you requested.';
 
 /**
  * Returns true if the collectionId has available backends

--- a/config/services.yml
+++ b/config/services.yml
@@ -55,6 +55,7 @@ https://cmr.earthdata.nasa.gov:
       concatenation: true
       concatenate_by_default: true
       subsetting:
+        temporal: true
         bbox: true
         variable: true
         multiple_variable: false
@@ -62,7 +63,7 @@ https://cmr.earthdata.nasa.gov:
         - text/csv
     steps:
       - image: !Env ${GIOVANNI_ADAPTER_IMAGE}
-        operations: ['concatenate', 'variableSubset']
+        operations: ['concatenate', 'variableSubset', 'temporalSubset']
 
   - name: harmony/service-example
     description: |
@@ -135,6 +136,7 @@ https://cmr.earthdata.nasa.gov:
       - id: C1996881752-POCLOUD
     capabilities:
       subsetting:
+        temporal: true
         bbox: true
         variable: true
         shape: true
@@ -227,6 +229,7 @@ https://cmr.earthdata.nasa.gov:
     capabilities:
       concatenation: true
       subsetting:
+        temporal: true
         bbox: true
         variable: true
       output_formats:
@@ -235,9 +238,9 @@ https://cmr.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
-        operations: ['spatialSubset', 'variableSubset']
+        operations: ['spatialSubset', 'variableSubset', 'temporalSubset']
         conditional:
-          exists: ['spatialSubset', 'variableSubset']
+          exists: ['spatialSubset', 'variableSubset', 'temporalSubset']
       - image: !Env ${PODAAC_CONCISE_IMAGE}
         is_batched: true
         operations: ['concatenate']
@@ -260,8 +263,9 @@ https://cmr.earthdata.nasa.gov:
     umm_s:
       - S2232210365-ORNL_CLOUD
     collections: []
-    capabilities:  # The Trajectory Subsetter also supports temporal subsetting
+    capabilities:
       subsetting:
+        temporal: true
         bbox: true
         shape: true
         variable: true
@@ -270,7 +274,7 @@ https://cmr.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${TRAJECTORY_SUBSETTER_IMAGE}
-        operations: ['variableSubset', 'spatialSubset', 'shapefileSubset']
+        operations: ['variableSubset', 'spatialSubset', 'shapefileSubset', 'temporalSubset']
 
   - name: sds/HOSS-geographic
     description: |
@@ -294,6 +298,7 @@ https://cmr.earthdata.nasa.gov:
     collections: []
     capabilities:
       subsetting:
+        temporal: true
         bbox: true
         dimension: true
         shape: true
@@ -304,7 +309,7 @@ https://cmr.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${VAR_SUBSETTER_IMAGE}
-        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset']
+        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset', 'temporalSubset']
       - image: !Env ${SDS_MASKFILL_IMAGE}
         operations: ['shapefileSubset']
         conditional:
@@ -331,6 +336,7 @@ https://cmr.earthdata.nasa.gov:
     collections: []
     capabilities:
       subsetting:
+        temporal: true
         bbox: true
         dimension: true
         shape: true
@@ -341,7 +347,7 @@ https://cmr.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${VAR_SUBSETTER_IMAGE}
-        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset']
+        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset', 'temporalSubset']
       - image: !Env ${SDS_MASKFILL_IMAGE}
         operations: ['shapefileSubset', 'spatialSubset']
         conditional:
@@ -374,6 +380,7 @@ https://cmr.earthdata.nasa.gov:
       - id: C1996881146-POCLOUD
     capabilities:
       subsetting:
+        temporal: true
         shape: true
         bbox: true
         variable: true
@@ -540,6 +547,7 @@ https://cmr.uat.earthdata.nasa.gov:
       concatenation: true
       concatenate_by_default: true
       subsetting:
+        temporal: true
         bbox: true
         variable: true
         multiple_variable: false
@@ -547,7 +555,7 @@ https://cmr.uat.earthdata.nasa.gov:
         - text/csv
     steps:
       - image: !Env ${GIOVANNI_ADAPTER_IMAGE}
-        operations: ['concatenate', 'variableSubset']
+        operations: ['concatenate', 'variableSubset', 'temporalSubset']
 
   - name: harmony/service-example
     description: |
@@ -627,6 +635,7 @@ https://cmr.uat.earthdata.nasa.gov:
       - id: C1245508858-LARC_ASDC
     capabilities:
       subsetting:
+        temporal: true
         bbox: true
         variable: true
         shape: true
@@ -708,6 +717,7 @@ https://cmr.uat.earthdata.nasa.gov:
     capabilities:
       concatenation: true
       subsetting:
+        temporal: true
         bbox: true
         variable: true
       output_formats:
@@ -716,9 +726,9 @@ https://cmr.uat.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
-        operations: ['spatialSubset', 'variableSubset']
+        operations: ['spatialSubset', 'variableSubset', 'temporalSubset']
         conditional:
-          exists: ['spatialSubset', 'variableSubset']
+          exists: ['spatialSubset', 'variableSubset', 'temporalSubset']
       - image: !Env ${PODAAC_CONCISE_IMAGE}
         is_batched: true
         operations: ['concatenate']
@@ -846,8 +856,9 @@ https://cmr.uat.earthdata.nasa.gov:
     umm_s:
       - S1242315633-EEDTEST
     collections: []
-    capabilities:  # The Trajectory Subsetter also supports temporal subsetting
+    capabilities:
       subsetting:
+        temporal: true
         bbox: true
         shape: true
         variable: true
@@ -856,7 +867,7 @@ https://cmr.uat.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${TRAJECTORY_SUBSETTER_IMAGE}
-        operations: ['variableSubset', 'spatialSubset', 'shapefileSubset']
+        operations: ['variableSubset', 'spatialSubset', 'shapefileSubset', 'temporalSubset']
 
   # This is an example service and backend from example/http-backend.js mounted by
   # the frontend callback server.
@@ -912,6 +923,7 @@ https://cmr.uat.earthdata.nasa.gov:
       - id: C1238621141-POCLOUD
     capabilities:
       subsetting:
+        temporal: true
         shape: true
         bbox: true
         variable: true
@@ -948,6 +960,7 @@ https://cmr.uat.earthdata.nasa.gov:
     collections: []
     capabilities:
       subsetting:
+        temporal: true
         bbox: true
         dimension: true
         shape: true
@@ -958,7 +971,7 @@ https://cmr.uat.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${VAR_SUBSETTER_IMAGE}
-        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset']
+        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset', 'temporalSubset']
       - image: !Env ${SDS_MASKFILL_IMAGE}
         operations: ['shapefileSubset']
         conditional:
@@ -985,6 +998,7 @@ https://cmr.uat.earthdata.nasa.gov:
     collections: []
     capabilities:
       subsetting:
+        temporal: true
         bbox: true
         dimension: true
         shape: true
@@ -995,7 +1009,7 @@ https://cmr.uat.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${VAR_SUBSETTER_IMAGE}
-        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset']
+        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset', 'temporalSubset']
       - image: !Env ${SDS_MASKFILL_IMAGE}
         operations: ['shapefileSubset', 'spatialSubset']
         conditional:
@@ -1082,6 +1096,7 @@ https://cmr.uat.earthdata.nasa.gov:
       concatenation: true
       concatenate_by_default: false
       subsetting:
+        temporal: true
         bbox: true
         variable: true
       output_formats:
@@ -1089,9 +1104,9 @@ https://cmr.uat.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
-        operations: ['spatialSubset', 'variableSubset']
+        operations: ['spatialSubset', 'variableSubset', 'temporalSubset']
         conditional:
-          exists: ['spatialSubset', 'variableSubset']
+          exists: ['spatialSubset', 'variableSubset', 'temporalSubset']
       - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
         is_batched: false
         operations: ['reformat', 'concatenate']

--- a/fixtures/cmr.uat.earthdata.nasa.gov-443/168019939864260976
+++ b/fixtures/cmr.uat.earthdata.nasa.gov-443/168019939864260976
@@ -1,0 +1,30 @@
+POST /search/granules.json
+accept: application/json
+content-type: multipart/form-data; boundary=----------------------------012345678901234567890123
+accept-encoding: gzip,deflate
+body: ------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"collection_concept_id\"\r\n\r\nC1233800302-EEDTEST\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"page_size\"\r\n\r\n100\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"temporal\"\r\n\r\n2020-01-02T00:00:00.000Z,2020-01-02T01:00:00.000Z\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"concept_id\"\r\n\r\nG1233800352-EEDTEST\r\n------------------------------012345678901234567890123--\r\n
+
+HTTP/1.1 200 OK
+content-type: application/json;charset=utf-8
+transfer-encoding: chunked
+connection: close
+vary: Accept-Encoding
+date: Thu, 30 Mar 2023 18:03:18 GMT
+x-frame-options: SAMEORIGIN
+access-control-allow-origin: *
+x-xss-protection: 1; mode=block
+cmr-request-id: 01cfb4f6-bcac-421e-85fb-5cde686f94e8
+strict-transport-security: max-age=31536000
+cmr-search-after: ["eedtest",1577923200000,1233800352]
+cmr-hits: 1
+access-control-expose-headers: CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out, CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+x-content-type-options: nosniff
+cmr-took: 70
+x-request-id: Vfhiq1eGB5e7djiMRaWKiIn-fWf26vrFio4phPKlRZNHZiWMWTiOug==
+server: ServerTokens ProductOnly
+x-cache: Miss from cloudfront
+via: 1.1 074df32306fddeb7d54ca41312e6888e.cloudfront.net (CloudFront)
+x-amz-cf-pop: IAD89-P2
+x-amz-cf-id: Vfhiq1eGB5e7djiMRaWKiIn-fWf26vrFio4phPKlRZNHZiWMWTiOug==
+
+{"feed":{"updated":"2023-03-30T18:03:18.659Z","id":"https://cmr.uat.earthdata.nasa.gov:443/search/granules.json","title":"ECHO granule metadata","entry":[{"producer_granule_id":"002_00_3200ff_global","boxes":["-90 -180 90 180"],"time_start":"2020-01-02T00:00:00.000Z","updated":"2020-02-25T21:43:11.000Z","dataset_id":"Harmony Example Data","data_center":"EEDTEST","title":"002_00_3200ff_global","coordinate_system":"CARTESIAN","day_night_flag":"BOTH","time_end":"2020-01-02T01:59:59.000Z","id":"G1233800352-EEDTEST","original_format":"UMM_JSON","granule_size":"1.3663883209228516","browse_flag":false,"collection_concept_id":"C1233800302-EEDTEST","online_access_flag":true,"links":[{"rel":"http://esipfed.org/ns/fedsearch/1.1/data#","type":"application/x-netcdf","hreflang":"en-US","href":"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/nc/002_00_3200ff_global.nc"},{"rel":"http://esipfed.org/ns/fedsearch/1.1/data#","type":"image/tiff","hreflang":"en-US","href":"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/tiff/002_00_3200ff_global.tif"}]}]}}

--- a/test/models/data-operation.ts
+++ b/test/models/data-operation.ts
@@ -11,7 +11,7 @@ const expectedOutput = parseSchemaFile(`valid-operation-v${versions[0]}.json`);
 // The fields that all operations should contain
 const baseFields = new Set([
   'client', 'callback', 'stagingLocation', 'sources', 'format', 'user', 'accessToken',
-  'subset', 'isSynchronous', 'requestId', 'temporal', 'version', 'concatenate',
+  'subset', 'isSynchronous', 'requestId', 'version', 'concatenate',
 ]);
 
 describe('DataOperation', () => {
@@ -96,6 +96,10 @@ describe('DataOperation', () => {
           expect(JSON.parse(serializedOperation).sources[0].variables).to.be.undefined;
         });
 
+        it('does not include temporal for the operation', () => {
+          expect(JSON.parse(serializedOperation).temporal).to.be.undefined;
+        });
+
         it('includes all of the base fields for the operation', () => {
           expect(new Set(Object.keys(JSON.parse(serializedOperation)))).to.eql(baseFields);
         });
@@ -118,6 +122,10 @@ describe('DataOperation', () => {
           expect(JSON.parse(serializedOperation).sources[0].variables).to.be.undefined;
         });
 
+        it('does not include temporal for the operation', () => {
+          expect(JSON.parse(serializedOperation).temporal).to.be.undefined;
+        });
+
         it('includes all of the base fields for the operation', () => {
           expect(new Set(Object.keys(JSON.parse(serializedOperation)))).to.eql(baseFields);
         });
@@ -138,6 +146,10 @@ describe('DataOperation', () => {
 
         it('includes variables for the operation', () => {
           expect(JSON.parse(serializedOperation).sources[0].variables).to.eql(expectedOutput.sources[0].variables);
+        });
+
+        it('does not include temporal for the operation', () => {
+          expect(JSON.parse(serializedOperation).temporal).to.be.undefined;
         });
 
         it('includes all of the base fields for the operation', () => {
@@ -166,8 +178,12 @@ describe('DataOperation', () => {
           expect(JSON.parse(serializedOperation).sources[0].variables).to.be.undefined;
         });
 
-        it('includes all of the base fields for the operation and the subset field', () => {
-          expect(new Set(Object.keys(JSON.parse(serializedOperation)))).to.eql(new Set(baseFields.add('subset')) );
+        it('does not include temporal for the operation', () => {
+          expect(JSON.parse(serializedOperation).temporal).to.be.undefined;
+        });
+
+        it('includes all of the base fields for the operation', () => {
+          expect(new Set(Object.keys(JSON.parse(serializedOperation)))).to.eql(baseFields);
         });
       });
 
@@ -192,8 +208,38 @@ describe('DataOperation', () => {
           expect(JSON.parse(serializedOperation).sources[0].variables).to.be.undefined;
         });
 
-        it('includes all of the base fields for the operation and the subset field', () => {
-          expect(new Set(Object.keys(JSON.parse(serializedOperation)))).to.eql(new Set(baseFields.add('subset')) );
+        it('does not include temporal for the operation', () => {
+          expect(JSON.parse(serializedOperation).temporal).to.be.undefined;
+        });
+
+        it('includes all of the base fields for the operation', () => {
+          expect(new Set(Object.keys(JSON.parse(serializedOperation)))).to.eql(baseFields);
+        });
+      });
+
+      describe('temporalSubset', () => {
+        const serializedOperation = validOperation.serialize(CURRENT_SCHEMA_VERSION, ['temporalSubset']);
+
+        it('includes the temporal for the operation', () => {
+          expect(JSON.parse(serializedOperation).temporal).to.eql(expectedOutput.temporal);
+        });
+
+        it('does not include reprojection fields for the operation', () => {
+          const parsedOperation = JSON.parse(serializedOperation);
+          expect(parsedOperation.format.crs).to.be.undefined;
+          expect(parsedOperation.format.srs).to.be.undefined;
+        });
+
+        it('does not include reformatting fields for the operation', () => {
+          expect(JSON.parse(serializedOperation).format.mime).to.be.undefined;
+        });
+
+        it('does not include variables for the operation', () => {
+          expect(JSON.parse(serializedOperation).sources[0].variables).to.be.undefined;
+        });
+
+        it('includes all of the base fields for the operation and the temporal field', () => {
+          expect(new Set(Object.keys(JSON.parse(serializedOperation)))).to.eql(new Set(baseFields).add('temporal'));
         });
       });
 
@@ -218,14 +264,19 @@ describe('DataOperation', () => {
           expect(JSON.parse(serializedOperation).sources[0].variables).to.eql(expectedOutput.sources[0].variables);
         });
 
-        it('includes all of the base fields for the operation and the subset field', () => {
-          expect(new Set(Object.keys(JSON.parse(serializedOperation)))).to.eql(new Set(baseFields.add('subset')) );
+        it('does not include temporal for the operation', () => {
+          expect(JSON.parse(serializedOperation).temporal).to.be.undefined;
+        });
+
+        it('includes all of the base fields for the operation', () => {
+          expect(new Set(Object.keys(JSON.parse(serializedOperation)))).to.eql(baseFields);
         });
       });
 
       describe('all fields requested', () => {
         const serializedOperation = validOperation.serialize(
-          CURRENT_SCHEMA_VERSION, ['spatialSubset', 'variableSubset', 'reformat', 'reproject', 'shapefileSubset', 'dimensionSubset'],
+          CURRENT_SCHEMA_VERSION,
+          ['spatialSubset', 'variableSubset', 'reformat', 'reproject', 'shapefileSubset', 'dimensionSubset', 'temporalSubset'],
         );
 
         it('includes all of the fields for the operation', () => {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1413

## Description
Add the ability to specify a service supports temporal subsetting. When a request includes a temporal range first attempt to match to those services that support temporal subsetting. If no service can be found that supports everything in the request then relax the condition to not require a service that supports temporal subsetting similar to the way we handle spatial subsetting.

## Local Test Steps
Verify that http://localhost:3000/C1245618475-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&subset=time(%222020-01-01T00%3A00%3A00%22%3A%222020-01-31T23%3A59%3A59%22)&maxResults=1 goes to the HOSS service instead of the regridder service (note it looks like there's an association missing for this collection right now to the regridding service - need to get that in to make this a valid test).

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)