### PR TITLE
HARMONY-1423: As a harmony user, I want to be able to retrieve harmony STAC catalogs for requests without requiring EDL authentication.

### DIFF
--- a/app/frontends/stac.ts
+++ b/app/frontends/stac.ts
@@ -44,9 +44,7 @@ async function handleStacRequest(
       if (!job) {
         throw new NotFoundError(`Unable to find job ${jobId}`);
       }
-      if (!(await job.canViewJob(req.user, req.context.isAdminAccess, req.accessToken))) {
-        throw new NotFoundError();
-      }
+
       if (job.status === 'successful') {
         if (stacDataLinks.length) {
           job.links = stacDataLinks;

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -942,7 +942,7 @@ export class Job extends DBRecord implements JobRecord {
 
   /**
    * Return whether a user can access this job and its results.
-   * (Called whenever a request is made to frontend jobs or STAC endpoints)
+   * (Called whenever a request is made to frontend jobs endpoints)
    * @param requestingUserName - the person we're checking permissions for
    * @param isAdminAccess - whether the requesting user should be treated as an admin
    * (e.g. req.context.isAdminAccess or user is in the admin group)

--- a/app/routers/router.ts
+++ b/app/routers/router.ts
@@ -132,7 +132,6 @@ const authorizedRoutes = [
   '/jobs*',
   '/logs*',
   '/service-results/*',
-  '/stac*',
   '/workflow-ui*',
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7661,9 +7661,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001422",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz",
-      "integrity": "sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==",
+      "version": "1.0.30001481",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
+      "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
       "dev": true,
       "funding": [
         {
@@ -7673,6 +7673,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -26590,9 +26594,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001422",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz",
-      "integrity": "sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==",
+      "version": "1.0.30001481",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
+      "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
       "dev": true
     },
     "caseless": {

--- a/test/helpers/stac.ts
+++ b/test/helpers/stac.ts
@@ -10,7 +10,7 @@ import { auth } from './auth';
  * @param query - Query parameters object for the GET request
  * @returns An awaitable object that resolves to the request response
  */
-export function stacCatalog(
+function stacCatalog(
   app: Express.Application,
   jobId: string,
   query: object = {},
@@ -27,7 +27,7 @@ export function stacCatalog(
  * @param query - Query parameters object for the GET request
  * @returns An awaitable object that resolves to the request response
  */
-export function stacItem(
+function stacItem(
   app: Express.Application,
   jobId: string,
   index: number,

--- a/test/jobs/job-sharing.ts
+++ b/test/jobs/job-sharing.ts
@@ -127,14 +127,14 @@ describe('Sharing job results with someone other than its owner', function () {
       });
       describe('Accessing the STAC Catalog page', function () {
         hookStacCatalog(jobIDWithEULATrueAndGuestReadTrue, notJobOwner);
-        it('returns a 404 response', function () {
-          expect(this.res.statusCode).to.equal(404);
+        it('returns a 200 response', function () {
+          expect(this.res.statusCode).to.equal(200);
         });
       });
       describe('Accessing the STAC Item page', function () {
         hookStacItem(jobIDWithEULATrueAndGuestReadTrue, 0, notJobOwner);
-        it('returns a 404 response', function () {
-          expect(this.res.statusCode).to.equal(404);
+        it('returns a 200 response', function () {
+          expect(this.res.statusCode).to.equal(200);
         });
       });
     });
@@ -148,14 +148,14 @@ describe('Sharing job results with someone other than its owner', function () {
       });
       describe('Accessing the STAC Catalog page', function () {
         hookStacCatalog(jobIDWithEULAFalseAndGuestReadFalse, notJobOwner);
-        it('returns a 404 response', function () {
-          expect(this.res.statusCode).to.equal(404);
+        it('returns a 200 response', function () {
+          expect(this.res.statusCode).to.equal(200);
         });
       });
       describe('Accessing the STAC Item page', function () {
         hookStacItem(jobIDWithEULAFalseAndGuestReadFalse, 0, notJobOwner);
-        it('returns a 404 response', function () {
-          expect(this.res.statusCode).to.equal(404);
+        it('returns a 200 response', function () {
+          expect(this.res.statusCode).to.equal(200);
         });
       });
     });
@@ -169,14 +169,14 @@ describe('Sharing job results with someone other than its owner', function () {
       });
       describe('Accessing the STAC Catalog page', function () {
         hookStacCatalog(jobIDWithEULANonexistent, notJobOwner);
-        it('returns a 404 response', function () {
-          expect(this.res.statusCode).to.equal(404);
+        it('returns a 200 response', function () {
+          expect(this.res.statusCode).to.equal(200);
         });
       });
       describe('Accessing the STAC Item page', function () {
         hookStacItem(jobIDWithEULANonexistent, 0, notJobOwner);
-        it('returns a 404 response', function () {
-          expect(this.res.statusCode).to.equal(404);
+        it('returns a 200 response', function () {
+          expect(this.res.statusCode).to.equal(200);
         });
       });
     });
@@ -190,14 +190,14 @@ describe('Sharing job results with someone other than its owner', function () {
       });
       describe('Accessing the STAC Catalog page', function () {
         hookStacCatalog(jobIDWithNoCollections, notJobOwner);
-        it('returns a 404 response', function () {
-          expect(this.res.statusCode).to.equal(404);
+        it('returns a 200 response', function () {
+          expect(this.res.statusCode).to.equal(200);
         });
       });
       describe('Accessing the STAC Item page', function () {
         hookStacItem(jobIDWithNoCollections, 0, notJobOwner);
-        it('returns a 404 response', function () {
-          expect(this.res.statusCode).to.equal(404);
+        it('returns a 200 response', function () {
+          expect(this.res.statusCode).to.equal(200);
         });
       });
     });
@@ -213,14 +213,14 @@ describe('Sharing job results with someone other than its owner', function () {
       });
       describe('Accessing the STAC Catalog page', function () {
         hookStacCatalog(jobIDWithMultipleCollections, notJobOwner);
-        it('returns a 404 response', function () {
-          expect(this.res.statusCode).to.equal(404);
+        it('returns a 200 response', function () {
+          expect(this.res.statusCode).to.equal(200);
         });
       });
       describe('Accessing the STAC Item page', function () {
         hookStacItem(jobIDWithMultipleCollections, 0, notJobOwner);
-        it('returns a 404 response', function () {
-          expect(this.res.statusCode).to.equal(404);
+        it('returns a 200 response', function () {
+          expect(this.res.statusCode).to.equal(200);
         });
       });
     });

--- a/test/stac/stac-item.ts
+++ b/test/stac/stac-item.ts
@@ -5,7 +5,7 @@ import itReturnsTheExpectedStacResponse from '../helpers/stac-item';
 import { buildJob } from '../helpers/jobs';
 import hookServersStartStop from '../helpers/servers';
 import { hookTransaction } from '../helpers/db';
-import { stacItem, hookStacItem } from '../helpers/stac';
+import { hookStacItem } from '../helpers/stac';
 import { JobStatus } from '../../app/models/job';
 
 const runningJob = buildJob({
@@ -111,19 +111,6 @@ describe('STAC item route', function () {
     this.trx.commit();
   });
   const jobId = runningJob.requestId;
-  describe('For a user who is not logged in', function () {
-    before(async function () {
-      this.res = await stacItem(this.frontend, jobId, 0).redirects(0);
-    });
-    it('redirects to Earthdata Login', function () {
-      expect(this.res.statusCode).to.equal(303);
-      expect(this.res.headers.location).to.include(process.env.OAUTH_HOST);
-    });
-
-    it('sets the "redirect" cookie to the originally-requested resource', function () {
-      expect(this.res.headers['set-cookie'][0]).to.include(encodeURIComponent(`/stac/${jobId}`));
-    });
-  });
 
   describe('For a non-existent job ID', function () {
     const unknownRequest = uuid();
@@ -314,6 +301,180 @@ describe('STAC item route', function () {
       describe('when the item index is out of bounds', function () {
         const completedJobId = completedJob.requestId;
         hookStacItem(completedJobId, 100, 'joe');
+        it('returns an HTTP bad request response', function () {
+          expect(this.res.statusCode).to.equal(400);
+        });
+
+        it('returns a JSON error response', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.RequestValidationError',
+            description: 'Error: STAC item index is out of bounds',
+          });
+        });
+      });
+    });
+  });
+
+  describe('For a guest user who does not own the job', function () {
+    describe('when the job is incomplete', function () {
+      hookStacItem(jobId, 0);
+      it('returns an HTTP conflict response', function () {
+        expect(this.res.statusCode).to.equal(409);
+      });
+
+      it('returns a JSON error response', function () {
+        const response = JSON.parse(this.res.text);
+        expect(response).to.eql({
+          code: 'harmony.ConflictError',
+          description: `Error: Job ${jobId} is not complete`,
+        });
+      });
+    });
+
+    describe('When the job is complete and has a destination url set', async function () {
+      const completedJobId = completedJobWithDestinationUrl.requestId;
+
+      describe('when an item is requested', function () {
+        hookStacItem(completedJobId, 0);
+
+        it('returns a STAC item without an "expires" field', async function () {
+          const item = JSON.parse(this.res.text);
+          expect(item.properties.expires).to.be.undefined;
+        });
+      });
+    });
+
+    describe('when the job is complete', function () {
+      describe('when the service does not supply the necessary fields', async function () {
+        const completedJobId = completedNonStacJob.requestId;
+        hookStacItem(completedJobId, 0);
+
+        it('returns an HTTP not found response', function () {
+          expect(this.res.statusCode).to.equal(404);
+        });
+
+        it('returns a JSON error response', function () {
+          const response = JSON.parse(this.res.text);
+          expect(response).to.eql({
+            code: 'harmony.NotFoundError',
+            description: `Error: Service did not provide STAC items for job ${completedJobId}`,
+          });
+        });
+      });
+
+      describe('when the service supplies the necessary fields for the 0th item', async function () {
+        const completedJobId = completedJob.requestId;
+
+        const expectedItemWithoutAssetsOrLinks = {
+          id: `${completedJob.requestId}_0`,
+          stac_version: '1.0.0',
+          title: `Harmony output #0 in job ${completedJob.requestId}`,
+          description: 'Harmony out for http://example.com/harmony?job=completedJob',
+          type: 'Feature',
+          stac_extensions: [
+            'https://stac-extensions.github.io/timestamps/v1.0.0/schema.json',
+          ],
+
+          bbox: [-10, -10, 10, 10],
+          geometry: { type: 'Polygon', coordinates: [[[-10, -10], [-10, 10], [10, 10], [10, -10], [-10, -10]]] },
+          // `links` added later
+          properties: {
+            // `created` and `expires` properties added later
+            license: 'various',
+            start_datetime: '2020-01-01T00:00:00.000Z',
+            end_datetime: '2020-01-01T01:00:00.000Z',
+            datetime: '2020-01-01T00:00:00.000Z',
+          },
+        };
+
+        // HARMONY-770 AC 2
+        describe('when linkType is not set', function () {
+          hookStacItem(completedJobId, 0);
+          itReturnsTheExpectedStacResponse(
+            completedJob,
+            expectedItemWithoutAssetsOrLinks,
+          );
+        });
+
+        // HARMONY-770 AC 7
+        describe('when linkType is s3', function () {
+          hookStacItem(completedJobId, 0, null, { linkType: 's3' });
+          itReturnsTheExpectedStacResponse(
+            completedJob,
+            expectedItemWithoutAssetsOrLinks,
+            's3',
+          );
+        });
+
+        // HARMONY-770 AC 6
+        describe('when linkType is http', function () {
+          hookStacItem(completedJobId, 0, null, { linkType: 'http' });
+          itReturnsTheExpectedStacResponse(
+            completedJob,
+            expectedItemWithoutAssetsOrLinks,
+            'http',
+          );
+        });
+
+        // HARMONY-770 AC 6
+        describe('when linkType is https', function () {
+          hookStacItem(completedJobId, 0, null, { linkType: 'https' });
+          itReturnsTheExpectedStacResponse(
+            completedJob,
+            expectedItemWithoutAssetsOrLinks,
+            'https',
+          );
+        });
+      });
+
+      describe('when the service supplies the necessary fields for the nth item', async function () {
+        const completedJobId = completedJob.requestId;
+        const expectedItemWithoutAssetsOrLinks = {
+          id: `${completedJob.requestId}_1`,
+          stac_version: '1.0.0',
+          title: `Harmony output #1 in job ${completedJob.requestId}`,
+          description: 'Harmony out for http://example.com/harmony?job=completedJob',
+          type: 'Feature',
+          stac_extensions: [
+            'https://stac-extensions.github.io/timestamps/v1.0.0/schema.json',
+          ],
+          bbox: [-10, -10, 10, 10],
+          geometry: { type: 'Polygon', coordinates: [[[-10, -10], [-10, 10], [10, 10], [10, -10], [-10, -10]]] },
+          // `links` added later
+          properties: {
+            // `created` and `expires` properties added later
+            license: 'various',
+            start_datetime: '2020-01-01T00:00:00.000Z',
+            end_datetime: '2020-01-01T01:00:00.000Z',
+            datetime: '2020-01-01T00:00:00.000Z',
+          },
+        };
+
+        describe('when the nth item is requested', function () {
+          hookStacItem(completedJobId, 1);
+          itReturnsTheExpectedStacResponse(
+            completedJob,
+            expectedItemWithoutAssetsOrLinks,
+          );
+        });
+      });
+
+      describe('when the linkType is invalid', function () {
+        const completedJobId = completedJob.requestId;
+        hookStacItem(completedJobId, 0, null, { linkType: 'foo' });
+        // HARMONY-770 AC 8
+        it('returns a 400 status', function () {
+          expect(this.res.error.status).to.equal(400);
+        });
+        it('returns an informative error', function () {
+          expect(this.res.error.text).to.match(/^{"code":"harmony.RequestValidationError","description":"Error: Invalid linkType 'foo' must be http, https, or s3"}/);
+        });
+      });
+
+      describe('when the item index is out of bounds', function () {
+        const completedJobId = completedJob.requestId;
+        hookStacItem(completedJobId, 100);
         it('returns an HTTP bad request response', function () {
           expect(this.res.statusCode).to.equal(400);
         });

--- a/test/stac/stac-item.ts
+++ b/test/stac/stac-item.ts
@@ -142,351 +142,180 @@ describe('STAC item route', function () {
     });
   });
 
-  describe('For a logged-in user who owns the job', function () {
-    describe('when the job is incomplete', function () {
-      hookStacItem(jobId, 0, 'joe');
-      it('returns an HTTP conflict response', function () {
-        expect(this.res.statusCode).to.equal(409);
-      });
-
-      it('returns a JSON error response', function () {
-        const response = JSON.parse(this.res.text);
-        expect(response).to.eql({
-          code: 'harmony.ConflictError',
-          description: `Error: Job ${jobId} is not complete`,
-        });
-      });
-    });
-
-    describe('When the job is complete and has a destination url set', async function () {
-      const completedJobId = completedJobWithDestinationUrl.requestId;
-
-      describe('when an item is requested', function () {
-        hookStacItem(completedJobId, 0, 'joe');
-
-        it('returns a STAC item without an "expires" field', async function () {
-          const item = JSON.parse(this.res.text);
-          expect(item.properties.expires).to.be.undefined;
-        });
-      });
-    });
-
-    describe('when the job is complete', function () {
-      describe('when the service does not supply the necessary fields', async function () {
-        const completedJobId = completedNonStacJob.requestId;
-        hookStacItem(completedJobId, 0, 'joe');
-
-        it('returns an HTTP not found response', function () {
-          expect(this.res.statusCode).to.equal(404);
+  // test with user who owns the job and a guest user who doesn't own the job
+  for (const userName of ['joe', null]) {
+    describe('For a logged-in user who owns the job', function () {
+      describe('when the job is incomplete', function () {
+        hookStacItem(jobId, 0, userName);
+        it('returns an HTTP conflict response', function () {
+          expect(this.res.statusCode).to.equal(409);
         });
 
         it('returns a JSON error response', function () {
           const response = JSON.parse(this.res.text);
           expect(response).to.eql({
-            code: 'harmony.NotFoundError',
-            description: `Error: Service did not provide STAC items for job ${completedJobId}`,
+            code: 'harmony.ConflictError',
+            description: `Error: Job ${jobId} is not complete`,
           });
         });
       });
 
-      describe('when the service supplies the necessary fields for the 0th item', async function () {
-        const completedJobId = completedJob.requestId;
+      describe('When the job is complete and has a destination url set', async function () {
+        const completedJobId = completedJobWithDestinationUrl.requestId;
 
-        const expectedItemWithoutAssetsOrLinks = {
-          id: `${completedJob.requestId}_0`,
-          stac_version: '1.0.0',
-          title: `Harmony output #0 in job ${completedJob.requestId}`,
-          description: 'Harmony out for http://example.com/harmony?job=completedJob',
-          type: 'Feature',
-          stac_extensions: [
-            'https://stac-extensions.github.io/timestamps/v1.0.0/schema.json',
-          ],
+        describe('when an item is requested', function () {
+          hookStacItem(completedJobId, 0, userName);
 
-          bbox: [-10, -10, 10, 10],
-          geometry: { type: 'Polygon', coordinates: [[[-10, -10], [-10, 10], [10, 10], [10, -10], [-10, -10]]] },
-          // `links` added later
-          properties: {
-            // `created` and `expires` properties added later
-            license: 'various',
-            start_datetime: '2020-01-01T00:00:00.000Z',
-            end_datetime: '2020-01-01T01:00:00.000Z',
-            datetime: '2020-01-01T00:00:00.000Z',
-          },
-        };
-
-        // HARMONY-770 AC 2
-        describe('when linkType is not set', function () {
-          hookStacItem(completedJobId, 0, 'joe');
-          itReturnsTheExpectedStacResponse(
-            completedJob,
-            expectedItemWithoutAssetsOrLinks,
-          );
-        });
-
-        // HARMONY-770 AC 7
-        describe('when linkType is s3', function () {
-          hookStacItem(completedJobId, 0, 'joe', { linkType: 's3' });
-          itReturnsTheExpectedStacResponse(
-            completedJob,
-            expectedItemWithoutAssetsOrLinks,
-            's3',
-          );
-        });
-
-        // HARMONY-770 AC 6
-        describe('when linkType is http', function () {
-          hookStacItem(completedJobId, 0, 'joe', { linkType: 'http' });
-          itReturnsTheExpectedStacResponse(
-            completedJob,
-            expectedItemWithoutAssetsOrLinks,
-            'http',
-          );
-        });
-
-        // HARMONY-770 AC 6
-        describe('when linkType is https', function () {
-          hookStacItem(completedJobId, 0, 'joe', { linkType: 'https' });
-          itReturnsTheExpectedStacResponse(
-            completedJob,
-            expectedItemWithoutAssetsOrLinks,
-            'https',
-          );
-        });
-      });
-
-      describe('when the service supplies the necessary fields for the nth item', async function () {
-        const completedJobId = completedJob.requestId;
-        const expectedItemWithoutAssetsOrLinks = {
-          id: `${completedJob.requestId}_1`,
-          stac_version: '1.0.0',
-          title: `Harmony output #1 in job ${completedJob.requestId}`,
-          description: 'Harmony out for http://example.com/harmony?job=completedJob',
-          type: 'Feature',
-          stac_extensions: [
-            'https://stac-extensions.github.io/timestamps/v1.0.0/schema.json',
-          ],
-          bbox: [-10, -10, 10, 10],
-          geometry: { type: 'Polygon', coordinates: [[[-10, -10], [-10, 10], [10, 10], [10, -10], [-10, -10]]] },
-          // `links` added later
-          properties: {
-            // `created` and `expires` properties added later
-            license: 'various',
-            start_datetime: '2020-01-01T00:00:00.000Z',
-            end_datetime: '2020-01-01T01:00:00.000Z',
-            datetime: '2020-01-01T00:00:00.000Z',
-          },
-        };
-
-        describe('when the nth item is requested', function () {
-          hookStacItem(completedJobId, 1, 'joe');
-          itReturnsTheExpectedStacResponse(
-            completedJob,
-            expectedItemWithoutAssetsOrLinks,
-          );
-        });
-      });
-
-      describe('when the linkType is invalid', function () {
-        const completedJobId = completedJob.requestId;
-        hookStacItem(completedJobId, 0, 'joe', { linkType: 'foo' });
-        // HARMONY-770 AC 8
-        it('returns a 400 status', function () {
-          expect(this.res.error.status).to.equal(400);
-        });
-        it('returns an informative error', function () {
-          expect(this.res.error.text).to.match(/^{"code":"harmony.RequestValidationError","description":"Error: Invalid linkType 'foo' must be http, https, or s3"}/);
-        });
-      });
-
-      describe('when the item index is out of bounds', function () {
-        const completedJobId = completedJob.requestId;
-        hookStacItem(completedJobId, 100, 'joe');
-        it('returns an HTTP bad request response', function () {
-          expect(this.res.statusCode).to.equal(400);
-        });
-
-        it('returns a JSON error response', function () {
-          const response = JSON.parse(this.res.text);
-          expect(response).to.eql({
-            code: 'harmony.RequestValidationError',
-            description: 'Error: STAC item index is out of bounds',
-          });
-        });
-      });
-    });
-  });
-
-  describe('For a guest user who does not own the job', function () {
-    describe('when the job is incomplete', function () {
-      hookStacItem(jobId, 0);
-      it('returns an HTTP conflict response', function () {
-        expect(this.res.statusCode).to.equal(409);
-      });
-
-      it('returns a JSON error response', function () {
-        const response = JSON.parse(this.res.text);
-        expect(response).to.eql({
-          code: 'harmony.ConflictError',
-          description: `Error: Job ${jobId} is not complete`,
-        });
-      });
-    });
-
-    describe('When the job is complete and has a destination url set', async function () {
-      const completedJobId = completedJobWithDestinationUrl.requestId;
-
-      describe('when an item is requested', function () {
-        hookStacItem(completedJobId, 0);
-
-        it('returns a STAC item without an "expires" field', async function () {
-          const item = JSON.parse(this.res.text);
-          expect(item.properties.expires).to.be.undefined;
-        });
-      });
-    });
-
-    describe('when the job is complete', function () {
-      describe('when the service does not supply the necessary fields', async function () {
-        const completedJobId = completedNonStacJob.requestId;
-        hookStacItem(completedJobId, 0);
-
-        it('returns an HTTP not found response', function () {
-          expect(this.res.statusCode).to.equal(404);
-        });
-
-        it('returns a JSON error response', function () {
-          const response = JSON.parse(this.res.text);
-          expect(response).to.eql({
-            code: 'harmony.NotFoundError',
-            description: `Error: Service did not provide STAC items for job ${completedJobId}`,
+          it('returns a STAC item without an "expires" field', async function () {
+            const item = JSON.parse(this.res.text);
+            expect(item.properties.expires).to.be.undefined;
           });
         });
       });
 
-      describe('when the service supplies the necessary fields for the 0th item', async function () {
-        const completedJobId = completedJob.requestId;
+      describe('when the job is complete', function () {
+        describe('when the service does not supply the necessary fields', async function () {
+          const completedJobId = completedNonStacJob.requestId;
+          hookStacItem(completedJobId, 0, userName);
 
-        const expectedItemWithoutAssetsOrLinks = {
-          id: `${completedJob.requestId}_0`,
-          stac_version: '1.0.0',
-          title: `Harmony output #0 in job ${completedJob.requestId}`,
-          description: 'Harmony out for http://example.com/harmony?job=completedJob',
-          type: 'Feature',
-          stac_extensions: [
-            'https://stac-extensions.github.io/timestamps/v1.0.0/schema.json',
-          ],
+          it('returns an HTTP not found response', function () {
+            expect(this.res.statusCode).to.equal(404);
+          });
 
-          bbox: [-10, -10, 10, 10],
-          geometry: { type: 'Polygon', coordinates: [[[-10, -10], [-10, 10], [10, 10], [10, -10], [-10, -10]]] },
-          // `links` added later
-          properties: {
+          it('returns a JSON error response', function () {
+            const response = JSON.parse(this.res.text);
+            expect(response).to.eql({
+              code: 'harmony.NotFoundError',
+              description: `Error: Service did not provide STAC items for job ${completedJobId}`,
+            });
+          });
+        });
+
+        describe('when the service supplies the necessary fields for the 0th item', async function () {
+          const completedJobId = completedJob.requestId;
+
+          const expectedItemWithoutAssetsOrLinks = {
+            id: `${completedJob.requestId}_0`,
+            stac_version: '1.0.0',
+            title: `Harmony output #0 in job ${completedJob.requestId}`,
+            description: 'Harmony out for http://example.com/harmony?job=completedJob',
+            type: 'Feature',
+            stac_extensions: [
+              'https://stac-extensions.github.io/timestamps/v1.0.0/schema.json',
+            ],
+
+            bbox: [-10, -10, 10, 10],
+            geometry: { type: 'Polygon', coordinates: [[[-10, -10], [-10, 10], [10, 10], [10, -10], [-10, -10]]] },
+            // `links` added later
+            properties: {
             // `created` and `expires` properties added later
-            license: 'various',
-            start_datetime: '2020-01-01T00:00:00.000Z',
-            end_datetime: '2020-01-01T01:00:00.000Z',
-            datetime: '2020-01-01T00:00:00.000Z',
-          },
-        };
+              license: 'various',
+              start_datetime: '2020-01-01T00:00:00.000Z',
+              end_datetime: '2020-01-01T01:00:00.000Z',
+              datetime: '2020-01-01T00:00:00.000Z',
+            },
+          };
 
-        // HARMONY-770 AC 2
-        describe('when linkType is not set', function () {
-          hookStacItem(completedJobId, 0);
-          itReturnsTheExpectedStacResponse(
-            completedJob,
-            expectedItemWithoutAssetsOrLinks,
-          );
+          // HARMONY-770 AC 2
+          describe('when linkType is not set', function () {
+            hookStacItem(completedJobId, 0, userName);
+            itReturnsTheExpectedStacResponse(
+              completedJob,
+              expectedItemWithoutAssetsOrLinks,
+            );
+          });
+
+          // HARMONY-770 AC 7
+          describe('when linkType is s3', function () {
+            hookStacItem(completedJobId, 0, userName, { linkType: 's3' });
+            itReturnsTheExpectedStacResponse(
+              completedJob,
+              expectedItemWithoutAssetsOrLinks,
+              's3',
+            );
+          });
+
+          // HARMONY-770 AC 6
+          describe('when linkType is http', function () {
+            hookStacItem(completedJobId, 0, userName, { linkType: 'http' });
+            itReturnsTheExpectedStacResponse(
+              completedJob,
+              expectedItemWithoutAssetsOrLinks,
+              'http',
+            );
+          });
+
+          // HARMONY-770 AC 6
+          describe('when linkType is https', function () {
+            hookStacItem(completedJobId, 0, userName, { linkType: 'https' });
+            itReturnsTheExpectedStacResponse(
+              completedJob,
+              expectedItemWithoutAssetsOrLinks,
+              'https',
+            );
+          });
         });
 
-        // HARMONY-770 AC 7
-        describe('when linkType is s3', function () {
-          hookStacItem(completedJobId, 0, null, { linkType: 's3' });
-          itReturnsTheExpectedStacResponse(
-            completedJob,
-            expectedItemWithoutAssetsOrLinks,
-            's3',
-          );
-        });
-
-        // HARMONY-770 AC 6
-        describe('when linkType is http', function () {
-          hookStacItem(completedJobId, 0, null, { linkType: 'http' });
-          itReturnsTheExpectedStacResponse(
-            completedJob,
-            expectedItemWithoutAssetsOrLinks,
-            'http',
-          );
-        });
-
-        // HARMONY-770 AC 6
-        describe('when linkType is https', function () {
-          hookStacItem(completedJobId, 0, null, { linkType: 'https' });
-          itReturnsTheExpectedStacResponse(
-            completedJob,
-            expectedItemWithoutAssetsOrLinks,
-            'https',
-          );
-        });
-      });
-
-      describe('when the service supplies the necessary fields for the nth item', async function () {
-        const completedJobId = completedJob.requestId;
-        const expectedItemWithoutAssetsOrLinks = {
-          id: `${completedJob.requestId}_1`,
-          stac_version: '1.0.0',
-          title: `Harmony output #1 in job ${completedJob.requestId}`,
-          description: 'Harmony out for http://example.com/harmony?job=completedJob',
-          type: 'Feature',
-          stac_extensions: [
-            'https://stac-extensions.github.io/timestamps/v1.0.0/schema.json',
-          ],
-          bbox: [-10, -10, 10, 10],
-          geometry: { type: 'Polygon', coordinates: [[[-10, -10], [-10, 10], [10, 10], [10, -10], [-10, -10]]] },
-          // `links` added later
-          properties: {
+        describe('when the service supplies the necessary fields for the nth item', async function () {
+          const completedJobId = completedJob.requestId;
+          const expectedItemWithoutAssetsOrLinks = {
+            id: `${completedJob.requestId}_1`,
+            stac_version: '1.0.0',
+            title: `Harmony output #1 in job ${completedJob.requestId}`,
+            description: 'Harmony out for http://example.com/harmony?job=completedJob',
+            type: 'Feature',
+            stac_extensions: [
+              'https://stac-extensions.github.io/timestamps/v1.0.0/schema.json',
+            ],
+            bbox: [-10, -10, 10, 10],
+            geometry: { type: 'Polygon', coordinates: [[[-10, -10], [-10, 10], [10, 10], [10, -10], [-10, -10]]] },
+            // `links` added later
+            properties: {
             // `created` and `expires` properties added later
-            license: 'various',
-            start_datetime: '2020-01-01T00:00:00.000Z',
-            end_datetime: '2020-01-01T01:00:00.000Z',
-            datetime: '2020-01-01T00:00:00.000Z',
-          },
-        };
+              license: 'various',
+              start_datetime: '2020-01-01T00:00:00.000Z',
+              end_datetime: '2020-01-01T01:00:00.000Z',
+              datetime: '2020-01-01T00:00:00.000Z',
+            },
+          };
 
-        describe('when the nth item is requested', function () {
-          hookStacItem(completedJobId, 1);
-          itReturnsTheExpectedStacResponse(
-            completedJob,
-            expectedItemWithoutAssetsOrLinks,
-          );
-        });
-      });
-
-      describe('when the linkType is invalid', function () {
-        const completedJobId = completedJob.requestId;
-        hookStacItem(completedJobId, 0, null, { linkType: 'foo' });
-        // HARMONY-770 AC 8
-        it('returns a 400 status', function () {
-          expect(this.res.error.status).to.equal(400);
-        });
-        it('returns an informative error', function () {
-          expect(this.res.error.text).to.match(/^{"code":"harmony.RequestValidationError","description":"Error: Invalid linkType 'foo' must be http, https, or s3"}/);
-        });
-      });
-
-      describe('when the item index is out of bounds', function () {
-        const completedJobId = completedJob.requestId;
-        hookStacItem(completedJobId, 100);
-        it('returns an HTTP bad request response', function () {
-          expect(this.res.statusCode).to.equal(400);
+          describe('when the nth item is requested', function () {
+            hookStacItem(completedJobId, 1, userName);
+            itReturnsTheExpectedStacResponse(
+              completedJob,
+              expectedItemWithoutAssetsOrLinks,
+            );
+          });
         });
 
-        it('returns a JSON error response', function () {
-          const response = JSON.parse(this.res.text);
-          expect(response).to.eql({
-            code: 'harmony.RequestValidationError',
-            description: 'Error: STAC item index is out of bounds',
+        describe('when the linkType is invalid', function () {
+          const completedJobId = completedJob.requestId;
+          hookStacItem(completedJobId, 0, userName, { linkType: 'foo' });
+          // HARMONY-770 AC 8
+          it('returns a 400 status', function () {
+            expect(this.res.error.status).to.equal(400);
+          });
+          it('returns an informative error', function () {
+            expect(this.res.error.text).to.match(/^{"code":"harmony.RequestValidationError","description":"Error: Invalid linkType 'foo' must be http, https, or s3"}/);
+          });
+        });
+
+        describe('when the item index is out of bounds', function () {
+          const completedJobId = completedJob.requestId;
+          hookStacItem(completedJobId, 100, userName);
+          it('returns an HTTP bad request response', function () {
+            expect(this.res.statusCode).to.equal(400);
+          });
+
+          it('returns a JSON error response', function () {
+            const response = JSON.parse(this.res.text);
+            expect(response).to.eql({
+              code: 'harmony.RequestValidationError',
+              description: 'Error: STAC item index is out of bounds',
+            });
           });
         });
       });
     });
-  });
+  }
 });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1423

## Description
As a harmony user, I want to be able to retrieve harmony STAC catalogs for requests without requiring EDL authentication.
There has to be some kind of documentation that needs to be updated, but I can't find any.

## Local Test Steps
Submit a harmony request and see it run to completion successfully.
`curl "http://localhost:3000/stac/<job-id>"` and verify you can retrieve the stac catalog of the job.
`curl "http://localhost:3000/stac/<job-id>/<item-index>"` and verify you can retrieve the stac item of the job.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)