### PR TITLE
HARMONY-1446: Change defaults for queue urls to work with Harmony in a box

### DIFF
--- a/docs/guides/develop.md
+++ b/docs/guides/develop.md
@@ -112,6 +112,8 @@ Specifically, you will need to add the following to your .env file:
 Mac OS X
 ```
 LOCALSTACK_HOST=localhost
+WORK_ITEM_UPDATE_QUEUE_URL=http://localstack:4566/queue/work-item-update-queue
+LARGE_WORK_ITEM_UPDATE_QUEUE_URL=http://localstack:4566/queue/large-work-item-update-queue
 BACKEND_HOST=host.docker.internal
 CALLBACK_URL_ROOT=http://host.docker.internal:3001
 ```
@@ -119,6 +121,8 @@ CALLBACK_URL_ROOT=http://host.docker.internal:3001
 Linux
 ```
 LOCALSTACK_HOST=localhost
+WORK_ITEM_UPDATE_QUEUE_URL=http://localstack:4566/queue/work-item-update-queue
+LARGE_WORK_ITEM_UPDATE_QUEUE_URL=http://localstack:4566/queue/large-work-item-update-queue
 BACKEND_HOST=localhost
 CALLBACK_URL_ROOT=http://localhost:3001
 ```

--- a/env-defaults
+++ b/env-defaults
@@ -143,10 +143,10 @@ DATABASE_URL=
 UPLOAD_BUCKET=local-upload-bucket
 
 # SQS queue used to process work item updates
-WORK_ITEM_UPDATE_QUEUE_URL=http://localhost:4566/queue/work-item-update-queue
+WORK_ITEM_UPDATE_QUEUE_URL=http://localstack:4566/queue/work-item-update-queue
 
 # SQS queue used to process work item updates
-LARGE_WORK_ITEM_UPDATE_QUEUE_URL=http://localhost:4566/queue/large-work-item-update-queue
+LARGE_WORK_ITEM_UPDATE_QUEUE_URL=http://localstack:4566/queue/large-work-item-update-queue
 
 # maximum number of items to pull from the queue at once for the large item queue (to avoid visibility timeouts)
 # if this is set to greater than 10 (the SQS max) then 10 will be used instead


### PR DESCRIPTION

## Jira Issue ID
HARMONY-1446

## Description
Changes the defaults for the queue urls in env-defaults to work with Harmony in a box

## Local Test Steps
1. Check out this branch
2. run `npm run build` to build the harmony image
3. run `./bin/start-harmony`
4. verify that harmony is running using `kubectl get pods -n harmony`
5. Execute a query using curl  or Insomnia against localhost:3000

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~