### PR TITLE
DAS-1841 - Remove incorrect UMM-S record from NetCDF-to-Zarr service chain.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -1023,7 +1023,6 @@ https://cmr.uat.earthdata.nasa.gov:
           STAGING_PATH: public/harmony/netcdf-to-zarr
     umm_s:
       - S1237980031-EEDTEST # Just NetCDF-to-Zarr
-      - S1240999847-EEDTEST # NetCDF-to-Zarr + swotrepr
       - S1241248230-POCLOUD # PODDAC just netcdf to zarr
     collections:
       - id: C1234410736-POCLOUD


### PR DESCRIPTION
## Jira Issue ID

DAS-1841

## Description

This PR is some final clean-up for EEDTEST metadata records in `services.yml`. I spotted that the NetCDF-to-Zarr service chain also listed the UMM-S record for the combined service of NetCDF-to-Zarr and the Swath Projector. This PR removes that incorrect reference.

## Local Test Steps

* Build this branch of Harmony locally with Harmony-in-a-Box.
* Run the following requests to ensure they route correctly:

```
# Should route to the NetCDF-to-Zarr service only:
localhost:3000/C1233860183-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&maxResults=1&format=application%2Fx-zarr&skipPreview=true

# Should route to the service chain with both the Swath Projector and the NetCDF-to-Zarr service:
localhost:3000/C1233860183-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&maxResults=1&format=application%2Fx-zarr&outputCrs=EPSG%3A4326&skipPreview=true
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* ~~Tests added/updated (if needed) and passing~~
* ~~Documentation updated (if needed)~~