### PR TITLE
HARMONY-1449: Cluster autoscaler fix for nodes not scaling down because of local storage on prometheus pods.

### DIFF
--- a/config/alert-manager.yaml
+++ b/config/alert-manager.yaml
@@ -48,6 +48,8 @@ spec:
       name: alertmanager
       labels:
         app: alertmanager
+      annotations:
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
     spec:
       containers:
       - name: alertmanager

--- a/config/prometheus-adapter-helm-values.yaml
+++ b/config/prometheus-adapter-helm-values.yaml
@@ -16,3 +16,6 @@ rules:
       matches: "num_ready_work_items"
       as: "num_ready_work_items"
     metricsQuery: '<<.Series>>{<<.LabelMatchers>>}'
+
+# Annotations added to the pod
+podAnnotations: {"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"}

--- a/config/prometheus.yaml
+++ b/config/prometheus.yaml
@@ -137,6 +137,8 @@ spec:
     metadata:
       labels:
         app: prometheus
+      annotations:
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "true"
     spec:
       serviceAccountName: prometheus
       containers:


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1449

## Description
Added annotation to alertmanager and prometheus-adapter pods to allow cluster autoscaler to relocate the pods to scale down the running nodes.

## Local Test Steps
Run sandbox tests of a large request (e.g. http://internal-harmony-yliu10-frontend-1388673145.us-west-2.elb.amazonaws.com/C1234724470-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-45%3A45)&subset=lon(0%3A180)&maxResults=110000&skipPreview=true&ignoreErrors=true
) with a deployment of harmony-ci-cd with the cluster autoscaler branch (harmony-1449-1). Verify the alertmanager and prometheus-adapter pods have the `"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"` annotation set and after the test is run, the number of nodes are scaled back down to only 2.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)