### PR TITLE
HARMONY-1465: Update service runner to allow tests to use a subdirectory of /tmp

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "strict-npm-engines && eslint --ext .ts --ignore-pattern tasks . && nyc mocha && better-npm-audit audit && lerna run test",
     "test-fast": "TS_NODE_TRANSPILE_ONLY=true mocha",
     "coverage": "nyc mocha",
-    "start": "ts-node -r tsconfig-paths/register --require './app/tracing.ts' app/server.ts",
+    "start": "NODE_OPTIONS=--max-old-space-size=3096 ts-node -r tsconfig-paths/register --require './app/tracing.ts' app/server.ts",
     "start-dev": "strict-npm-engines && ts-node-dev --no-notify -r tsconfig-paths/register --watch app/views,public/js --respawn app/server",
     "start-dev-fast": "TS_NODE_TRANSPILE_ONLY=true ts-node-dev --no-notify -r tsconfig-paths/register --respawn --inspect=127.0.0.1:9229 app/server",
     "update-dev": "npm install && lerna run build && bin/restart-services",

--- a/tasks/service-runner/.mocharc.yml
+++ b/tasks/service-runner/.mocharc.yml
@@ -11,3 +11,4 @@ require:
   - tsconfig-paths/register
 recursive: true
 exit: true
+timeout: 5000

--- a/tasks/service-runner/app/service/service-metrics.ts
+++ b/tasks/service-runner/app/service/service-metrics.ts
@@ -26,7 +26,7 @@ async function _getHarmonyMetric(serviceID: string): Promise<string> {
 
   const metric_message = `# HELP num_ready_work_items Ready work items count for a harmony task-runner service.
 # TYPE num_ready_work_items gauge
-num_ready_work_items{service_id="${serviceID}"} ${response.data.availableWorkItems}`;
+num_ready_work_items{service_id="${serviceID}"} ${parseInt(response.data.availableWorkItems) + 1}`;
 
   return metric_message;
 }

--- a/tasks/service-runner/app/service/service-runner.ts
+++ b/tasks/service-runner/app/service/service-runner.ts
@@ -289,18 +289,22 @@ export async function runServiceFromPull(workItem: WorkItemRecord, workItemLogge
               resolve({ error: errMsg });
             }
           } catch (e) {
-            workItemLogger.error(`Unable to upload logs. Caught exception: ${e}`);
+            workItemLogger.error('Unable to upload logs. Caught exception:');
+            workItemLogger.error(e);
             resolve({ error: e.message });
           }
         },
       ).catch((e) => {
         clearTimeout(timeout);
-        workItemLogger.error(`Kubernetes client exec caught exception: ${e}`);
+        workItemLogger.error('Kubernetes client exec caught exception:');
+        workItemLogger.error(e);
         resolve({ error: e.message });
       });
     });
   } catch (e) {
-    workItemLogger.error(`runServiceFromPull caught exception: ${e}`);
+    workItemLogger.error('runServiceFromPull caught exception:');
+    workItemLogger.error(e);
+
     return { error: e.message };
   }
 }

--- a/tasks/service-runner/config/service-template.yaml
+++ b/tasks/service-runner/config/service-template.yaml
@@ -75,8 +75,6 @@ spec:
             value: "$WORKER_PORT"
           - name: HARMONY_SERVICE
             value: $SERVICE_IMAGE
-          - name: WORKING_DIR
-            value: $SERVICE_WORKING_DIR
           - name: INVOCATION_ARGS
             value: $SERVICE_INVOCATION_ARGS
           - name: MY_POD_NAME

--- a/tasks/service-runner/env-defaults
+++ b/tasks/service-runner/env-defaults
@@ -8,7 +8,7 @@ BACKEND_PORT=3001
 SCRIPT_FILE=__main__.py
 SCRIPT_DIR=/home
 NODE_ENV=development
-WORKING_DIR="/home"
+WORKING_DIR=/tmp
 LOG_LEVEL=debug
 # How long (in ms) to let a worker run on a work item before timing out and reporting an error
 # default is 4 hours

--- a/tasks/service-runner/test/helpers/env.ts
+++ b/tasks/service-runner/test/helpers/env.ts
@@ -1,3 +1,4 @@
 process.env.SHARED_SECRET_KEY = '_THIS_IS_MY_32_CHARS_SECRET_KEY_';
 process.env.NODE_ENV = 'test';
 process.env.ARTIFACT_BUCKET = 'stac-catalogs';
+process.env.WORKING_DIR = '/tmp/harmony';

--- a/tasks/service-runner/test/service-metrics.ts
+++ b/tasks/service-runner/test/service-metrics.ts
@@ -24,12 +24,12 @@ describe('Service Metrics', async function () {
     });
 
     describe('and harmony returns a valid metric', async function () {
-      it('returns a valid metric string', async function () {
+      it('returns a valid metric string with the metric value 1 higher than then number of available work items', async function () {
         mock.onGet().reply(200, { availableWorkItems: 0 });
         const res = await _getHarmonyMetric(serviceID);
         const expected_harmony_metric = `# HELP num_ready_work_items Ready work items count for a harmony task-runner service.
 # TYPE num_ready_work_items gauge
-num_ready_work_items{service_id="${serviceID}"} 0`;
+num_ready_work_items{service_id="${serviceID}"} 1`;
         expect(res).to.equal(expected_harmony_metric);
       });
     });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1465, HARMONY-1459, and HARMONY-1461

## Description
HARMONY-1465: Updated service runner to allow tests to use a subdirectory of /tmp - /tmp/harmony. I also updated the mocha configuration to allow a timeout of 5 seconds since some of the tests always take more than 3.5 seconds. Previously this 5 second timeout was only applied when using npm run test.

HARMONY-1461: Updated the harmony start task to allow 3GB of heap space for the node process.

HARMONY-1459: Updated the service metrics to always have one more pod than the current number of queued and in progress work items for a service

I built the image and deployed to my own sandbox environment to test.

## Local Test Steps
HARMONY-1465
1. Run `mocha` in the tasks/service-runner directory and verify everything passes.
2. Build the image with `npm run build`
3. Restart all of your services to use the new service-runner image with `bin/restart-services`
4. Start harmony
5. Submit a request and verify it completes successfully and the produced image is correct.

HARMONY-1461
I verified this change worked in production before. You can run `npm run start` and make sure that the process works fine. I'm not sure if there's a way to get the max allowed heap space information back about the process.

HARMONY-1465
You'll either need to deploy HPAs locally or to your own sandbox.
Submit a request and when the metrics are captured verify that the metrics reflect one more than the currently running pods.

For example with nothing running it used to report 0/1 (avg) for the TARGETS - now it will always report at least 1/1 (avg).


## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)