### PR TITLE
HARMONY-1467: Added missing collections configuration for service-example in services.yml

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -500,6 +500,7 @@ https://cmr.earthdata.nasa.gov:
           STAGING_PATH: public/harmony/service-example
     umm_s:
       - S2685815868-XYZ_PROV
+    collections: []
     capabilities:
       subsetting:
         bbox: true


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1467

## Description
Added missing collections configuration for service-example in services.yml

## Local Test Steps
Change .env setting to point local dev to PROD and also add `PODAAC_L2_SUBSETTER_LIMITS_MEMORY=8Gi`. Verify 
http://localhost:3000/C1940473819-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=1&subset=lat(30%3A90)&subset=lon(-180%3A-100)
now runs successfully.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)