### PR TITLE
HARMONY-1470: Fixed bug when choosing service with concatenation.

### DIFF
--- a/app/models/services/index.ts
+++ b/app/models/services/index.ts
@@ -831,10 +831,7 @@ export function chooseServiceConfig(
   configs: ServiceConfig<unknown>[] = serviceConfigs,
 ): ServiceConfig<unknown> {
   let serviceConfig = filterServiceConfigs(operation, context, configs, allFilterFns);
-  // if we are asked to concatenate, but no matching concat service is available then throw an error
-  if (serviceConfig.name === 'noOpService' && operation.shouldConcatenate) {
-    throw new NotFoundError('no matching service');
-  }
+
   if (serviceConfig.name === 'noOpService' && !requiresStrictCapabilitiesMatching(operation, context)) {
     // if we couldn't find a matching service, make a best effort to find a service that
     // can do part of what the operation requested
@@ -844,5 +841,11 @@ export function chooseServiceConfig(
       serviceConfig.message = bestEffortMessage;
     }
   }
+
+  // if we are asked to concatenate, but no matching concat service is available then throw an error
+  if (serviceConfig.name === 'noOpService' && operation.shouldConcatenate) {
+    throw new NotFoundError('no matching service');
+  }
+
   return serviceConfig;
 }

--- a/test/models/services.ts
+++ b/test/models/services.ts
@@ -82,6 +82,18 @@ describe('services.chooseServiceConfig and services.buildService', function () {
             },
           },
         },
+        {
+          name: 'netcdf-service',
+          type: { name: 'turbo' },
+          collections: [{ id: collectionId }],
+          capabilities: {
+            output_formats: ['application/x-netcdf4'],
+            concatenation: true,
+            subsetting: {
+              temporal: true,
+            },
+          },
+        },
       ];
     });
 
@@ -275,6 +287,20 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       it('indicates the reason for choosing the no op service is the combination of reprojection and reformatting', function () {
         const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
         expect(serviceConfig.message).to.equal('the requested combination of operations: reprojection and reformatting to application/x-netcdf4 on C123-TEST is unsupported');
+      });
+    });
+
+    describe('and the request needs concatenation', function () {
+      beforeEach(function () {
+        this.operation.temporal = ['2022-01-05T01:00:00Z', '2023-01-05T01:00:00Z'];
+        this.operation.boundingRectangle = [0, 0, 10, 10];
+        this.operation.outputFormat = 'application/x-netcdf4';
+        this.operation.model.concatenate = true;
+      });
+
+      it('chooses the service that supports concatenation and netcdf-4 format', function () {
+        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        expect(serviceConfig.name).to.equal('netcdf-service');
       });
     });
   });

--- a/test/models/services.ts
+++ b/test/models/services.ts
@@ -90,7 +90,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
             output_formats: ['application/x-netcdf4'],
             concatenation: true,
             subsetting: {
-              temporal: true,
+              temporal: false,
             },
           },
         },


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1470

## Description
Fixed bug when choosing service with concatenation.

## Local Test Steps
Set up local dev environment to point to PROD, submit the following request and verify that it is going to the `harmony/netcdf-to-zarr` service rather than fail with `no matching service` error.

When I test locally the request fails within the `harmony/netcdf-to-zarr` service with error:
```
2023-05-26T18:02:01.066Z [debug]: 2023-05-26 18:02:01,055 [ERROR] [harmony-service.process_items_many_to_one:119] Download failed: processes exit codes: [0, 0, 0, 0, 0, -9]
Traceback (most recent call last):
  File "/opt/harmony-netcdf-to-zarr/harmony_netcdf_to_zarr/adapter.py", line 93, in process_items_many_to_one
    local_file_paths = download_granules(netcdf_urls, workdir,
  File "/opt/harmony-netcdf-to-zarr/harmony_netcdf_to_zarr/download_utilities.py", line 56, in download_granules
    monitor_processes(processes, shared_namespace, error_notice='Download failed')
  File "/opt/harmony-netcdf-to-zarr/harmony_netcdf_to_zarr/process_utilities.py", line 30, in monitor_processes
    raise RuntimeError(f'{error_notice}: processes exit codes: {exit_codes}')
RuntimeError: Download failed: processes exit codes: [0, 0, 0, 0, 0, -9]
```
but this is outside of the scope of Harmony and needs to be looked into by the `harmony/netcdf-to-zarr` service provider.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)