### PR TITLE
Harmony 1336 - Fix batching with chain and maxResults=1

### DIFF
--- a/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/app/backends/workflow-orchestration/work-item-updates.ts
@@ -453,8 +453,8 @@ async function createNextWorkItems(
       // use the sort index from the previous step's work item unless the service was
       // query-cmr, in which case we start from the previous highest sort index for this step
       // NOTE: This is only valid if the work-items for this multi-output step are worked
-      // sequentially, as with query-cmr. If they are worked in parallel then we need a
-      // different approach.
+      // sequentially and have consistently ordered outputs, as with query-cmr.
+      // If they are worked in parallel then we need a different approach.
       let { sortIndex } = workItem;
       let shouldIncrementSortIndex = false;
       if (QUERY_CMR_SERVICE_REGEX.test(workItem.serviceID)) {

--- a/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/app/backends/workflow-orchestration/work-item-updates.ts
@@ -455,7 +455,7 @@ async function createNextWorkItems(
       // NOTE: This is only valid if the work-items for this multi-output step are worked
       // sequentially, as with query-cmr. If they are worked in parallel then we need a
       // different approach.
-      let { sortIndex } = workItem;
+      let sortIndex = workItem.sortIndex - 1;
       if (results.length > 1) {
         sortIndex = await maxSortIndexForJobService(tx, nextWorkflowStep.jobID, nextWorkflowStep.serviceID);
       }

--- a/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/app/backends/workflow-orchestration/work-item-updates.ts
@@ -456,7 +456,7 @@ async function createNextWorkItems(
       // sequentially, as with query-cmr. If they are worked in parallel then we need a
       // different approach.
       let sortIndex = workItem.sortIndex - 1;
-      if (results.length > 1) {
+      if (QUERY_CMR_SERVICE_REGEX.test(workItem.serviceID)) {
         sortIndex = await maxSortIndexForJobService(tx, nextWorkflowStep.jobID, nextWorkflowStep.serviceID);
       }
       const newItems = results.map(result => {

--- a/app/util/aggregation-batch.ts
+++ b/app/util/aggregation-batch.ts
@@ -264,7 +264,7 @@ export async function handleBatching(
   }
 
   // Create new batch items for the STAC items in the results. This looping only works for
-  // query-cmr (currently) because query-cmr items do not have sort indices and so we can
+  // query-cmr (currently) because query-cmr items do not impart their sort indices and so we can
   // just increment the sort index by 1 for each item returned. If an intermediate step has
   // a sort index and can produce multiple outputs from a single work item we'll need to
   // change this logic.

--- a/app/util/aggregation-batch.ts
+++ b/app/util/aggregation-batch.ts
@@ -264,7 +264,8 @@ export async function handleBatching(
   }
 
   // Create new batch items for the STAC items in the results. This looping only works for
-  // query-cmr (currently) because query-cmr items do not impart their sort indices and so we can
+  // query-cmr (currently) because query-cmr items do not impart their sort indices
+  // and are worked sequentially and with the same output ordering, and so we can
   // just increment the sort index by 1 for each item returned. If an intermediate step has
   // a sort index and can produce multiple outputs from a single work item we'll need to
   // change this logic.

--- a/test/helpers/work-items.ts
+++ b/test/helpers/work-items.ts
@@ -194,13 +194,16 @@ export const hookGetWorkForService = hookBackendRequest.bind(this, getWorkForSer
  *
  * @param jobID - the job ID to which the STAC items belong
  * @param workItemID - the ID of the work item that generated the STAC items
+ * @param granuleCount - the number of granular outputs
  * @param dataLinkCount - the number of data links to put in the STAC item
+ * @param useParent - Whether the STAC Output should use a parent catalog like the CMR task
  */
 export async function fakeServiceStacOutput(
   jobID: string,
   workItemID: number,
   granuleCount = 1,
-  dataLinkCount = 2): Promise<void> {
+  dataLinkCount = 2,
+  useParent = false): Promise<void> {
   const s3 = objectStoreForProtocol('s3');
   const workItem = {
     id: workItemID, jobID,
@@ -260,7 +263,7 @@ export async function fakeServiceStacOutput(
     } };
   }
 
-  if (granuleCount > 1) {
+  if (granuleCount > 1 || useParent) {
     const catalogOfCatalogs = [];
     for (let i = 0; i < granuleCount; i++) {
       catalogOfCatalogs.push(`catalog${i}.json`);

--- a/test/helpers/work-items.ts
+++ b/test/helpers/work-items.ts
@@ -194,9 +194,9 @@ export const hookGetWorkForService = hookBackendRequest.bind(this, getWorkForSer
  *
  * @param jobID - the job ID to which the STAC items belong
  * @param workItemID - the ID of the work item that generated the STAC items
- * @param granuleCount - the number of granular outputs
+ * @param granuleCount - the number of granule outputs
  * @param dataLinkCount - the number of data links to put in the STAC item
- * @param useParent - Whether the STAC Output should use a parent catalog like the CMR task
+ * @param useParent - whether the STAC Output should use a parent catalog like the CMR task
  */
 export async function fakeServiceStacOutput(
   jobID: string,


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1336

## Description
This fixes a bug that arises in batched service chains with maxResults=1. The logic was miscalculating the sortIndex.

There was another, possibly related bug that was stated in the ticket. However, after testing again with James in a deployed environment it was decided that that particular bug may no longer exist. I will verify again as well in SIT once merged.

I tried my best to update a couple of comments but please feel free to weigh in.

## Local Test Steps
(Images can be pulled from GHCR)
docker pull ghcr.io/podaac/l2ss-py:sit
docker pull ghcr.io/podaac/concise:sit

Issue a request for the l2ss-concise chain with maxResults=1 
http://localhost:3000/C1234724470-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lon(-160%3A160)&subset=lat(-80%3A80)&maxResults=1&concatenate=true&skipPreview=true

Verify successful completion of the request.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)