### PR TITLE
Harmony 773 - Add state to Harmony OAuth handshakes to avoid CSRF issues

### DIFF
--- a/app/middleware/earthdata-login-oauth-authorizer.ts
+++ b/app/middleware/earthdata-login-oauth-authorizer.ts
@@ -3,7 +3,7 @@ import simpleOAuth2, { OAuthClient, Token } from 'simple-oauth2';
 import { RequestHandler, NextFunction } from 'express';
 import { cookieOptions, setCookiesForEdl } from '../util/cookies';
 import { listToText } from '../util/string';
-import { ForbiddenError } from '../util/errors';
+import { ForbiddenError, RequestValidationError } from '../util/errors';
 import HarmonyRequest from '../models/harmony-request';
 import env from '../util/env';
 
@@ -44,9 +44,12 @@ const oauthOptions = {
  */
 async function handleCodeValidation(oauth2: OAuthClient, req, res, _next): Promise<void> {
   const { state } = req.signedCookies;
+
+  console.log('check if state matches');
+  console.log(req.query.state, state);
+
   if (state !== req.query.state) {
-    res.status(422).send('Invalid Request');
-    return;
+    throw new RequestValidationError();
   }
   
   const tokenConfig = {
@@ -108,6 +111,7 @@ function handleNeedsAuthorized(oauth2: OAuthClient, req, res, _next): void {
     state,
   });
   
+  console.log('add state to url');
   console.log(state);
   console.log(url);
   

--- a/app/middleware/earthdata-login-oauth-authorizer.ts
+++ b/app/middleware/earthdata-login-oauth-authorizer.ts
@@ -43,6 +43,12 @@ const oauthOptions = {
  * @param _next - The next function in the middleware chain
  */
 async function handleCodeValidation(oauth2: OAuthClient, req, res, _next): Promise<void> {
+  const { state } = req.signedCookies;
+  if (state !== req.query.state) {
+    res.status(422).send('Invalid Request');
+    return;
+  }
+  
   const tokenConfig = {
     code: req.query.code,
     redirect_uri: process.env.OAUTH_REDIRECT_URI,
@@ -95,12 +101,16 @@ function handleLogout(oauth2: OAuthClient, req, res, _next): void {
  * @param _next - The next function in the middleware chain
  */
 function handleNeedsAuthorized(oauth2: OAuthClient, req, res, _next): void {
+  const state = setCookiesForEdl(req, res, cookieOptions);
+  
   const url = oauth2.authorizationCode.authorizeURL({
     redirect_uri: process.env.OAUTH_REDIRECT_URI,
+    state,
   });
-
-  setCookiesForEdl(req, res, cookieOptions);
-
+  
+  console.log(state);
+  console.log(url);
+  
   res.redirect(303, url);
 }
 

--- a/app/middleware/earthdata-login-oauth-authorizer.ts
+++ b/app/middleware/earthdata-login-oauth-authorizer.ts
@@ -45,9 +45,6 @@ const oauthOptions = {
 async function handleCodeValidation(oauth2: OAuthClient, req, res, _next): Promise<void> {
   const { state } = req.signedCookies;
 
-  console.log('check if state matches');
-  console.log(req.query.state, state);
-
   if (state !== req.query.state) {
     throw new RequestValidationError();
   }
@@ -110,10 +107,6 @@ function handleNeedsAuthorized(oauth2: OAuthClient, req, res, _next): void {
     redirect_uri: process.env.OAUTH_REDIRECT_URI,
     state,
   });
-  
-  console.log('add state to url');
-  console.log(state);
-  console.log(url);
   
   res.redirect(303, url);
 }

--- a/test/earthdata-login.ts
+++ b/test/earthdata-login.ts
@@ -236,8 +236,8 @@ describe('Earthdata Login', function () {
             .query({ code: 'abc123', state: 'xyz' });
         });
         
-        // in this case, the state query parameter will be compared against an undefined
-        // state cookie (handleNeedsAuthorized, which sets the cookie has not been called)
+        // In this case, the state query parameter will be compared against an undefined
+        // state cookie. (handleNeedsAuthorized, which sets the cookie has not been called.)
         it('returns an invalid request status code', function () {
           expect(this.res.statusCode).to.equal(400);
         });

--- a/test/earthdata-login.ts
+++ b/test/earthdata-login.ts
@@ -228,6 +228,20 @@ describe('Earthdata Login', function () {
           expect(this.res.headers['set-cookie'][0]).to.include('validated');
         });
       });
+
+      describe('and the provided state does not match the state cookie', function () {
+        beforeEach(async function () {
+          this.res = await request(this.frontend)
+            .get('/oauth2/redirect')
+            .query({ code: 'abc123', state: 'xyz' });
+        });
+        
+        // in this case, the state query parameter will be compared against an undefined
+        // state cookie (handleNeedsAuthorized, which sets the cookie has not been called)
+        it('returns an invalid request status code', function () {
+          expect(this.res.statusCode).to.equal(400);
+        });
+      });
     });
 
     describe('When Earthdata login does not validate the provided code', function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-773

## Description
Protects against Cross-Site Request Forgery by adding a state parameter check to our OAuth flow.

## Local Test Steps
- Make sure you can still make a valid request
- Next, simulate a CSRF issue:
- Remove whatever browser history you need in order to force a redirect to EDL login (or use a browser you don't use frequently/are not already logged in to EDL)
- In app/middleware/earthdata-login-oauth-authorizer.ts, modify `req.query.state` to something like `'xyz'` to simulate an incorrect state:
```
if (state !== req.query.state) { // modify this
  throw new RequestValidationError();
}
```
- Make any request
- Login to EDL
- Harmony should return a 400 status

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)