### PR TITLE
HARMONY-1397: As a harmony user, I want collection capabilities to include a link to the CMR UMM-Var record for each variable.

### DIFF
--- a/app/frontends/capabilities.ts
+++ b/app/frontends/capabilities.ts
@@ -2,15 +2,20 @@ import HarmonyRequest from '../models/harmony-request';
 import { Response, NextFunction } from 'express';
 import { keysToLowerCase } from '../util/object';
 import { NotFoundError, RequestValidationError } from '../util/errors';
-import { CmrCollection, getCollectionsByIds, getCollectionsByShortName, getVariablesForCollection } from '../util/cmr';
+import { CmrCollection, getCollectionsByIds, getCollectionsByShortName, getVariablesForCollection, CmrUmmVariable } from '../util/cmr';
 import { addCollectionsToServicesByAssociation } from '../middleware/service-selection';
 import _ from 'lodash';
 import { ServiceConfig } from '../models/services/base-service';
 import { harmonyCollections } from '../models/services';
 import { listToText } from '../util/string';
 
-const currentApiVersion = '1';
-const supportedApiVersions = ['1'];
+export const currentApiVersion = '2';
+const supportedApiVersions = ['1', '2'];
+
+interface VariableV2 {
+  name: string;
+  href: string;
+}
 
 interface CollectionCapabilitiesV1 {
   conceptId: string;
@@ -23,9 +28,24 @@ interface CollectionCapabilitiesV1 {
   outputFormats: string[];
   services: ServiceConfig<unknown>[];
   variables: string[];
+  capabilitiesVersion: string;
 }
 
-type CollectionCapabilities = CollectionCapabilitiesV1;
+interface CollectionCapabilitiesV2 {
+  conceptId: string;
+  shortName: string;
+  variableSubset: boolean;
+  bboxSubset: boolean;
+  shapeSubset: boolean;
+  concatenate: boolean;
+  reproject: boolean;
+  outputFormats: string[];
+  services: ServiceConfig<unknown>[];
+  variables: VariableV2[];
+  capabilitiesVersion: string;
+}
+
+type CollectionCapabilities = CollectionCapabilitiesV1 | CollectionCapabilitiesV2;
 
 /**
  * Loads the collection info from CMR using short name or concept ID passed into the harmony
@@ -48,8 +68,8 @@ async function loadCollectionInfo(req: HarmonyRequest): Promise<CmrCollection> {
     collections = await getCollectionsByIds([collectionid], req.accessToken);
     if (collections.length === 0) {
       const message = `${collectionid} must be a CMR collection identifier, but `
-      + 'we could not find a matching collection. Please make sure the collection ID '
-      + 'is correct and that you have access to it.';
+        + 'we could not find a matching collection. Please make sure the collection ID '
+        + 'is correct and that you have access to it.';
       throw new NotFoundError(message);
     }
     pickedCollection = collections[0];
@@ -57,7 +77,7 @@ async function loadCollectionInfo(req: HarmonyRequest): Promise<CmrCollection> {
     collections = await getCollectionsByShortName(shortname, req.accessToken);
     if (collections.length === 0) {
       const message = `Unable to find collection short name ${shortname} in the CMR. Please `
-      + ' make sure the short name is correct and that you have access to the collection.';
+        + ' make sure the short name is correct and that you have access to the collection.';
       throw new NotFoundError(message);
     }
     pickedCollection = collections[0];
@@ -73,6 +93,18 @@ async function loadCollectionInfo(req: HarmonyRequest): Promise<CmrCollection> {
 }
 
 /**
+ * Returns the variables representation in capabilities version 2 format.
+ *
+ * @param variable - the CMR umm-var object
+ * @returns the variables representation in capabilities version 2 format
+ */
+function getVariableV2(variable: CmrUmmVariable): VariableV2 {
+  const name = variable.umm.Name;
+  const href = `${process.env.CMR_ENDPOINT}/search/concepts/${variable.meta['concept-id']}`;
+  return { name, href };
+}
+
+/**
  * Resolves to a CollectionCapabilitiesV1 object detailing the harmony transformation capabilities
  * for the given collection in version 1 of the JSON format.
  *
@@ -81,12 +113,13 @@ async function loadCollectionInfo(req: HarmonyRequest): Promise<CmrCollection> {
  */
 async function getCollectionCapabilitiesV1(collection: CmrCollection)
   : Promise<CollectionCapabilitiesV1> {
+  const capabilitiesVersion = '1';
   const allServiceConfigs = addCollectionsToServicesByAssociation([collection]);
   const matchingServices = allServiceConfigs.filter((config) =>
     config.collections.map((c) => c.id).includes(collection.id));
   const variables = collection.variables.map((v) => v.umm.Name);
   const variableSubset = variables.length > 0
-     && matchingServices.some((s) => s.capabilities.subsetting.variable === true);
+    && matchingServices.some((s) => s.capabilities.subsetting.variable === true);
   const bboxSubset = matchingServices.some((s) => s.capabilities.subsetting.bbox === true);
   const shapeSubset = matchingServices.some((s) => s.capabilities.subsetting.shape === true);
   const concatenate = matchingServices.some((s) => s.capabilities.concatenation === true);
@@ -95,8 +128,40 @@ async function getCollectionCapabilitiesV1(collection: CmrCollection)
   const conceptId = collection.id;
   const shortName = collection.short_name;
   const services = matchingServices.map((s) => _.pick(s, ['name', 'capabilities']));
-  const capabilities = { conceptId, shortName, variableSubset, bboxSubset, shapeSubset,
-    concatenate, reproject, outputFormats: Array.from(outputFormats), services, variables,
+  const capabilities = {
+    conceptId, shortName, variableSubset, bboxSubset, shapeSubset,
+    concatenate, reproject, outputFormats: Array.from(outputFormats), services, variables, capabilitiesVersion,
+  };
+  return capabilities;
+}
+
+/**
+ * Resolves to a CollectionCapabilitiesV2 object detailing the harmony transformation capabilities
+ * for the given collection in version 2 of the JSON format.
+ *
+ * @param collection - the CMR collection
+ * @returns a promise resolving to the version 2 collection capabilities
+ */
+async function getCollectionCapabilitiesV2(collection: CmrCollection)
+  : Promise<CollectionCapabilitiesV2> {
+  const capabilitiesVersion = '2';
+  const allServiceConfigs = addCollectionsToServicesByAssociation([collection]);
+  const matchingServices = allServiceConfigs.filter((config) =>
+    config.collections.map((c) => c.id).includes(collection.id));
+  const variables = collection.variables.map((v) => getVariableV2(v));
+  const variableSubset = variables.length > 0
+    && matchingServices.some((s) => s.capabilities.subsetting.variable === true);
+  const bboxSubset = matchingServices.some((s) => s.capabilities.subsetting.bbox === true);
+  const shapeSubset = matchingServices.some((s) => s.capabilities.subsetting.shape === true);
+  const concatenate = matchingServices.some((s) => s.capabilities.concatenation === true);
+  const reproject = matchingServices.some((s) => s.capabilities.reprojection === true);
+  const outputFormats = new Set(matchingServices.flatMap((s) => s.capabilities.output_formats));
+  const conceptId = collection.id;
+  const shortName = collection.short_name;
+  const services = matchingServices.map((s) => _.pick(s, ['name', 'capabilities']));
+  const capabilities = {
+    conceptId, shortName, variableSubset, bboxSubset, shapeSubset,
+    concatenate, reproject, outputFormats: Array.from(outputFormats), services, variables, capabilitiesVersion,
   };
   return capabilities;
 }
@@ -112,10 +177,11 @@ async function getCollectionCapabilitiesV1(collection: CmrCollection)
 function chooseCapabilitiesFunction(version: string): ((string) => Promise<CollectionCapabilities>) {
   if (version === '1') {
     return getCollectionCapabilitiesV1;
+  } else if (version === '2') {
+    return getCollectionCapabilitiesV2;
   }
 
-  const message = `Invalid API version ${version}, supported versions: ` +
-    + listToText(supportedApiVersions);
+  const message = `Invalid API version ${version}, supported versions: ${listToText(supportedApiVersions)}`;
   throw new RequestValidationError(message);
 }
 

--- a/test/collection-capabilities.ts
+++ b/test/collection-capabilities.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { currentApiVersion } from '../app/frontends/capabilities';
 import { hookGetCollectionCapabilities } from './helpers/capabilities';
 import hookServersStartStop from './helpers/servers';
 
@@ -11,6 +12,12 @@ describe('Testing collection capabilities', function () {
     }, {
       description: 'with a valid shortName configured for harmony',
       query: { shortName: 'harmony_example' },
+    }, {
+      description: 'with a valid collectionId configured for harmony and latest version',
+      query: { collectionId: 'C1234088182-EEDTEST', version: currentApiVersion },
+    }, {
+      description: 'with a valid shortName configured for harmony and latest version',
+      query: { shortName: 'harmony_example', version: currentApiVersion },
     }];
     for (const test of tests) {
       describe(test.description, function () {
@@ -22,7 +29,7 @@ describe('Testing collection capabilities', function () {
         it('includes all of the expected fields in the response according to the default version', function () {
           const expectedFields = [
             'conceptId', 'shortName', 'variableSubset', 'bboxSubset', 'shapeSubset',
-            'concatenate', 'reproject', 'outputFormats', 'services', 'variables',
+            'concatenate', 'reproject', 'outputFormats', 'services', 'variables', 'capabilitiesVersion',
           ];
           const capabilities = JSON.parse(this.res.text);
           expect(Object.keys(capabilities)).to.eql(expectedFields);
@@ -80,8 +87,28 @@ describe('Testing collection capabilities', function () {
 
         it('sets the variables field correctly', function () {
           const capabilities = JSON.parse(this.res.text);
-          const expectedVariables = ['alpha_var', 'blue_var', 'green_var', 'red_var'];
+          const expectedVariables = [{
+            'name': 'alpha_var',
+            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088190-EEDTEST',
+          },
+          {
+            'name': 'blue_var',
+            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088189-EEDTEST',
+          },
+          {
+            'name': 'green_var',
+            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088188-EEDTEST',
+          },
+          {
+            'name': 'red_var',
+            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088187-EEDTEST',
+          }];
           expect(capabilities.variables).to.eql(expectedVariables);
+        });
+
+        it('includes the correct capabilitiesVersion', function () {
+          const capabilities = JSON.parse(this.res.text);
+          expect(capabilities.capabilitiesVersion).to.equal(currentApiVersion);
         });
       });
     }
@@ -152,10 +179,71 @@ describe('Testing collection capabilities', function () {
         it('includes all of the expected fields in the version 1 response', function () {
           const expectedFields = [
             'conceptId', 'shortName', 'variableSubset', 'bboxSubset', 'shapeSubset',
-            'concatenate', 'reproject', 'outputFormats', 'services', 'variables',
+            'concatenate', 'reproject', 'outputFormats', 'services', 'variables', 'capabilitiesVersion',
           ];
           const capabilities = JSON.parse(this.res.text);
           expect(Object.keys(capabilities)).to.eql(expectedFields);
+        });
+
+        it('sets the conceptId field correctly in the version 1 response', function () {
+          const capabilities = JSON.parse(this.res.text);
+          expect(capabilities.conceptId).to.equal('C1234088182-EEDTEST');
+        });
+
+        it('sets the shortName field correctly in the version 1 response', function () {
+          const capabilities = JSON.parse(this.res.text);
+          expect(capabilities.shortName).to.equal('harmony_example');
+        });
+
+        it('sets the variableSubset field correctly in the version 1 response', function () {
+          const capabilities = JSON.parse(this.res.text);
+          expect(capabilities.variableSubset).to.equal(true);
+        });
+
+        it('sets the bboxSubset field correctly in the version 1 response', function () {
+          const capabilities = JSON.parse(this.res.text);
+          expect(capabilities.bboxSubset).to.equal(true);
+        });
+
+        it('sets the shapeSubset field correctly in the version 1 response', function () {
+          const capabilities = JSON.parse(this.res.text);
+          expect(capabilities.shapeSubset).to.equal(true);
+        });
+
+        it('sets the concatenate field correctly in the version 1 response', function () {
+          const capabilities = JSON.parse(this.res.text);
+          expect(capabilities.concatenate).to.equal(true);
+        });
+
+        it('sets the reproject field correctly in the version 1 response', function () {
+          const capabilities = JSON.parse(this.res.text);
+          expect(capabilities.reproject).to.equal(true);
+        });
+
+        it('sets the outputFormats field correctly in the version 1 response', function () {
+          const capabilities = JSON.parse(this.res.text);
+          const expectedFormats = [
+            'application/x-netcdf4', 'image/tiff', 'image/png', 'image/gif', 'application/x-zarr',
+          ];
+          expect(capabilities.outputFormats).to.eql(expectedFormats);
+        });
+
+        it('includes the correct services in the version 1 response', function () {
+          const capabilities = JSON.parse(this.res.text);
+          const serviceNames = capabilities.services.map((s) => s.name);
+          const expectedServices = ['nasa/harmony-gdal-adapter', 'harmony/netcdf-to-zarr', 'harmony/service-example'];
+          expect(serviceNames).to.eql(expectedServices);
+        });
+
+        it('sets the variables field correctly in the version 1 response', function () {
+          const capabilities = JSON.parse(this.res.text);
+          const expectedVariables = ['alpha_var', 'blue_var', 'green_var', 'red_var'];
+          expect(capabilities.variables).to.eql(expectedVariables);
+        });
+
+        it('includes the correct capabilitiesVersion in the version 1 response', function () {
+          const capabilities = JSON.parse(this.res.text);
+          expect(capabilities.capabilitiesVersion).to.equal('1');
         });
       });
 
@@ -168,7 +256,7 @@ describe('Testing collection capabilities', function () {
         it('returns an error message indicating the version was invalid', function () {
           expect(JSON.parse(this.res.text)).to.eql({
             code: 'harmony.RequestValidationError',
-            description: 'Error: Invalid API version bad_version, supported versions: 1',
+            description: 'Error: Invalid API version bad_version, supported versions: 1 and 2',
           });
         });
       });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1397

## Description
As a harmony user, I want collection capabilities to include a link to the CMR UMM-Var record for each variable.

## Local Test Steps
Run harmony locally, 
1) verify http://localhost:3000/capabilities?collectionId=C1233800302-EEDTEST returns response with a `capabilitiesVersion` of `'2'` and variables in the format of: 
variables: [
{
name: "alpha_var",
href: "https://cmr.uat.earthdata.nasa.gov/search/concepts/V1233801717-EEDTEST"
},
{
name: "blue_var",
href: "https://cmr.uat.earthdata.nasa.gov/search/concepts/V1233801716-EEDTEST"
},
{
name: "green_var",
href: "https://cmr.uat.earthdata.nasa.gov/search/concepts/V1233801696-EEDTEST"
},
{
name: "red_var",
href: "https://cmr.uat.earthdata.nasa.gov/search/concepts/V1233801695-EEDTEST"
}
]

2) Verify `http://localhost:3000/capabilities?collectionId=C1233800302-EEDTEST&version=2` returns the same result as above.

3) verify `http://localhost:3000/capabilities?collectionId=C1233800302-EEDTEST&version=1` returns `capabilitiesVersion` of `'1'` and variables in the format of: 
variables: [
"alpha_var",
"blue_var",
"green_var",
"red_var"
]

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)