### PR TITLE
HARMONY-1464: Use capabilities endpoint in Harmony API introduction

### DIFF
--- a/docs/Harmony API introduction.ipynb
+++ b/docs/Harmony API introduction.ipynb
@@ -252,12 +252,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Determine service availability\n",
     "\n",
-    "We will determine what services are available for the `harmony_example` collection based on the services.yml file available in the Harmony repository. "
+    "We will determine what services are available for the `harmony_example` collection based on the Harmony capabilities endpoint. "
    ]
   },
   {
@@ -269,17 +270,9 @@
    },
    "outputs": [],
    "source": [
-    "# download the services.yml file from github\n",
-    "yml_path = local_dir + '/services.yml'\n",
-    "services_yml_github_raw_url = 'https://raw.githubusercontent.com/nasa/harmony/main/config/services.yml'\n",
-    "r = requests.get(services_yml_github_raw_url, stream=True)\n",
-    "with open(yml_path, 'wb') as fd:\n",
-    "    for chunk in r.iter_content(chunk_size=128):\n",
-    "        fd.write(chunk)\n",
-    "\n",
-    "with open(yml_path, 'r') as yml:\n",
-    "    data = yml.read()\n",
-    "    print(data)"
+    "capabilities_url = f'https://harmony.uat.earthdata.nasa.gov/capabilities?collectionId={harmony_collection_id}'\n",
+    "r = requests.get(capabilities_url)\n",
+    "r.json()['services']"
    ]
   },
   {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1464

## Description
The sample notebook we link to from our landing page had a cell that reads the services.yml file from github to get a collection/service association. We replaced that with a call to /capabilities.

## Local Test Steps
- Run the modified cell
- You should see an array of services

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)