### PR TITLE
HARMONY-1396: As a harmony user, I want collection capabilities to include a link to the UMM-S record for any services connected to my collection via Harmony.

### DIFF
--- a/test/collection-capabilities.ts
+++ b/test/collection-capabilities.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash';
-import { currentApiVersion } from '../app/frontends/capabilities';
 import { expect } from 'chai';
+import { currentApiVersion } from '../app/frontends/capabilities';
 import { hookGetCollectionCapabilities } from './helpers/capabilities';
 import hookServersStartStop from './helpers/servers';
 

--- a/test/collection-capabilities.ts
+++ b/test/collection-capabilities.ts
@@ -1,5 +1,6 @@
-import { expect } from 'chai';
+import _ from 'lodash';
 import { currentApiVersion } from '../app/frontends/capabilities';
+import { expect } from 'chai';
 import { hookGetCollectionCapabilities } from './helpers/capabilities';
 import hookServersStartStop from './helpers/servers';
 
@@ -80,9 +81,20 @@ describe('Testing collection capabilities', function () {
 
         it('includes the correct services', function () {
           const capabilities = JSON.parse(this.res.text);
-          const serviceNames = capabilities.services.map((s) => s.name);
-          const expectedServices = ['nasa/harmony-gdal-adapter', 'harmony/netcdf-to-zarr', 'harmony/service-example'];
-          expect(serviceNames).to.eql(expectedServices);
+          const services_name_href = capabilities.services.map((s) => _.pick(s, ['name', 'href']));
+          const expectedServices = [{
+            'name': 'nasa/harmony-gdal-adapter',
+            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/S1245787332-EEDTEST',
+          },
+          {
+            'name': 'harmony/netcdf-to-zarr',
+            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/S1237980031-EEDTEST',
+          },
+          {
+            'name': 'harmony/service-example',
+            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/S1257851197-EEDTEST',
+          }];
+          expect(services_name_href).to.eql(expectedServices);
         });
 
         it('sets the variables field correctly', function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1396

## Description
As a harmony user, I want collection capabilities to include a link to the UMM-S record for any services connected to my collection via Harmony.

## Local Test Steps
Run harmony locally,

1) Verify `http://localhost:3000/capabilities?collectionId=C1233800302-EEDTEST` returns response with a capabilitiesVersion of '2' and services have a new `href` field with value of the umm-s CMR concept url.

2) Verify `http://localhost:3000/capabilities?collectionId=C1233800302-EEDTEST&version=2` returns the same result as above.

3) Verify `http://localhost:3000/capabilities?collectionId=C1233800302-EEDTEST&version=1` returns capabilitiesVersion of '1' and services without the `href` field.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)