### PR TITLE
Harmony 1419 fix docker build james

### DIFF
--- a/kubernetes-services/work-scheduler/Dockerfile
+++ b/kubernetes-services/work-scheduler/Dockerfile
@@ -1,7 +1,8 @@
-FROM node:16-alpine
+FROM node:16-bookworm
 
-RUN apk update
-RUN apk add bash vim curl git python3 postgresql-client make gcc g++ libc-dev libpq-dev
+# RUN apk update
+# RUN apk add bash vim curl git python3 postgresql-client make gcc g++ libc-dev libpq-dev
+RUN apt-get install bash curl git python3 make gcc g++ libc-dev libpq-dev
 RUN git config --global url."https://".insteadOf ssh://
 
 RUN mkdir -p /harmony-work-scheduler

--- a/kubernetes-services/work-scheduler/Dockerfile
+++ b/kubernetes-services/work-scheduler/Dockerfile
@@ -1,8 +1,6 @@
-FROM node:16-bookworm
+FROM node:16-buster
 
-# RUN apk update
-# RUN apk add bash vim curl git python3 postgresql-client make gcc g++ libc-dev libpq-dev
-RUN apt-get install bash curl git python3 make gcc g++ libc-dev libpq-dev
+RUN apt-get update && apt-get -y install postgresql
 RUN git config --global url."https://".insteadOf ssh://
 
 RUN mkdir -p /harmony-work-scheduler

--- a/kubernetes-services/work-scheduler/Dockerfile.mac
+++ b/kubernetes-services/work-scheduler/Dockerfile.mac
@@ -1,0 +1,13 @@
+FROM node:16-alpine
+
+RUN apk update
+RUN apk add bash vim curl git python3 postgresql-client make gcc g++ libc-dev libpq-dev
+RUN git config --global url."https://".insteadOf ssh://
+
+RUN mkdir -p /harmony-work-scheduler
+RUN mkdir -p /tmp/metadata
+COPY built env-defaults package.json package-lock.json /harmony-work-scheduler/
+WORKDIR /harmony-work-scheduler
+RUN npm ci
+
+ENTRYPOINT [ "node", "kubernetes-services/work-scheduler/app/server.js"]

--- a/kubernetes-services/work-scheduler/package.json
+++ b/kubernetes-services/work-scheduler/package.json
@@ -11,7 +11,7 @@
     "test-fast": "TS_NODE_TRANSPILE_ONLY=true mocha",
     "lint": "eslint --ext .ts .",
     "coverage": "nyc mocha",
-    "build": "tsc && docker build --tag harmonyservices/work-scheduler:${VERSION:-latest} .",
+    "build": "tsc && docker build -f Dockerfile.mac --tag harmonyservices/work-scheduler:${VERSION:-latest} .",
     "build-m1": "tsc && docker build --platform linux/amd64 --tag harmonyservices/work-scheduler:${VERSION:-latest} .",
     "publish": "docker push harmonyservices/work-scheduler:${VERSION:-latest}"
   },


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1419

## Description
Fixes Docker build in Bamboo

## Local Test Steps
1. Checkout this branch
2. Verify that you can still build the scheduler image for local and sandbox deployments
```
cd kubenetes-services/work-scheduler
npm run build
npm run build-m1
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)