### PR TITLE
HARMONY-1474: As a harmony user, I would like to be able to provide a list of Variable CMR concept IDs when requesting variable subsetting

### DIFF
--- a/app/markdown/apis.md
+++ b/app/markdown/apis.md
@@ -28,7 +28,7 @@ As such it accepts parameters in the URL path as well as query parameters.
 | parameter | description |
 |-----------|-------------|
 | collection | (required) This is the NASA EOSDIS collection or data product. There are two options for inputting a collection of interest:<br/>1. Provide a concept ID, which is an ID provided in the Common Metadata Repository (CMR) metadata<br/>2. Use the data product short name, e.g. SENTINEL-1_INTERFEROGRAMS. Must be URL encoded. |
-| variable | (required) Names of the UMM-Var variables to be retrieved, or "all" to retrieve all variables.<br/> Multiple variables may be retrieved by separating them with a comma. |
+| variable | (required) Names or concept ids of the UMM-Var variables to be retrieved, or "all" to retrieve all variables.<br/> Multiple variables may be retrieved by separating them with a comma. |
 ---
 **Table {{tableCounter}}** - Harmony OGC Coverages API URL path (required) parameters
 

--- a/app/schemas/ogc-api-coverages/1.0.0/ogc-api-coverages-v1.0.0.yml
+++ b/app/schemas/ogc-api-coverages/1.0.0/ogc-api-coverages-v1.0.0.yml
@@ -711,7 +711,7 @@ components:
       name: collectionId
       in: path
       description: |-
-        Names of the UMM-Var variables to be retrieved, or "all" to retrieve all variables within the CMR collection(s).
+        Names or concept ids of the UMM-Var variables to be retrieved, or "all" to retrieve all variables within the CMR collection(s).
         Multiple variables may be retrieved by separating them with a comma.  This API interprets OGC "collections" to be
         equivalent to CMR "variables" which produces some overloading in the name.  In this document, a "collection" is
         a CMR / UMM-Var variable and a "CMR collection" is a CMR / UMM-C collection.

--- a/app/util/variables.ts
+++ b/app/util/variables.ts
@@ -78,13 +78,13 @@ export function fullPath(v: CmrUmmVariable): string {
 }
 
 /**
- * Returns true if the path matches the variable name or full path (GroupPath/Name)
+ * Returns true if the string value matches the given variable's name or concept id
  * @param v - The variable to check
- * @param p - The path to check. Can be a full path or variable name
- * @returns true if path matches variable name or full path
+ * @param s - The string to match against the variable's name or concept id
+ * @returns true if given value matches variable name or concept id
  */
-function doesPathMatch(v: CmrUmmVariable, p: string): boolean {
-  return p === v.umm.Name;
+function doesPathMatch(v: CmrUmmVariable, s: string): boolean {
+  return s === v.umm.Name || s === v.meta['concept-id'];
 }
 
 const coordinateType = 'COORDINATE';
@@ -146,7 +146,11 @@ export function parseVariables(
         const variable = collection.variables.find((v) => doesPathMatch(v, variableId));
         if (variable) {
           missingVariables.delete(variableId);
-          variables.push(variable);
+          // only add the variable to the list if it does not exist.
+          // This is to guard against when variable name mixed with concept id that references the same variable
+          if (variables.find(v => v.meta['concept-id'] === variable.meta['concept-id']) === undefined) {
+            variables.push(variable);
+          }
         }
       }
       variableInfo.push({ collectionId: collection.id, shortName: collection.short_name,

--- a/public/notebook-example.html
+++ b/public/notebook-example.html
@@ -14398,7 +14398,7 @@ components:
       name: collectionId
       in: path
       description: |-
-        Names of the UMM-Var variables to be retrieved, or &#34;all&#34; to retrieve all variables within the CMR collection(s).
+        Names or concept ids of the UMM-Var variables to be retrieved, or &#34;all&#34; to retrieve all variables within the CMR collection(s).
         Multiple variables may be retrieved by separating them with a comma.  This API interprets OGC &#34;collections&#34; to be
         equivalent to CMR &#34;variables&#34; which produces some overloading in the name.  In this document, a &#34;collection&#34; is
         a CMR / UMM-Var variable and a &#34;CMR collection&#34; is a CMR / UMM-C collection.


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1474

## Description
As a harmony user, I would like to be able to provide a list of Variable CMR concept IDs when requesting variable subsetting

## Local Test Steps
Run harmony locally, then run the following requests:
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/V1233801695-EEDTEST/coverage/rangeset?subset=lat(20:60)&subset=lon(-140:-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG:31975&format=image/png

http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/V1233801695-EEDTEST,V1233801696-EEDTEST/coverage/rangeset?subset=lat(20:60)&subset=lon(-140:-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG:31975&format=image/png

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)