### PR TITLE
Harmony 296 - STAC validators

### DIFF
--- a/docs/Harmony Feature Examples.ipynb
+++ b/docs/Harmony Feature Examples.ipynb
@@ -413,6 +413,14 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Harmony STAC outputs can be validated via https://staclint.com/"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/tasks/query-cmr/app/stac/cmr-catalog.ts
+++ b/tasks/query-cmr/app/stac/cmr-catalog.ts
@@ -102,6 +102,7 @@ export default class CmrStacCatalog extends StacCatalog {
           properties: {
             start_datetime: granule.time_start,
             end_datetime: granule.time_end,
+            datetime: null,
           },
         });
         this.children.push(item);

--- a/tasks/query-cmr/app/stac/cmr-catalog.ts
+++ b/tasks/query-cmr/app/stac/cmr-catalog.ts
@@ -102,7 +102,7 @@ export default class CmrStacCatalog extends StacCatalog {
           properties: {
             start_datetime: granule.time_start,
             end_datetime: granule.time_end,
-            datetime: null,
+            datetime: granule.time_start,
           },
         });
         this.children.push(item);


### PR DESCRIPTION
## Jira Issue ID
HARMONY-296

## Description
According to the issue "STAC validators show our catalogs and items as invalid". I took the STAC outputs (items, catalogs) generated from our services and the STAC output generated from our STAC endpoint and ran them through one of the validators referenced in the ticket. 

There was only one issue/failure (missing datetime property) which I have attempted to fix in this PR. https://github.com/radiantearth/stac-spec/blob/v1.0.0-beta.2/item-spec/item-spec.md#properties-object

I decided to set the property to null since we don't currently use it, but if it's more appropriate to fill it with a value we could perhaps use `temporal.start` (like in our STAC endpoint) https://github.com/nasa/harmony/blob/main/app/frontends/stac-item.ts#L156.

## Local Test Steps
- run any request
- run a STAC item artifact (e.g. granule_G1245649517-EEDTEST_0000000.json) from your local artifact bucket (likely http://localhost:4566/local-artifact-bucket) through this validator https://staclint.com/
- it should tell you that the item is invalid due to a missing datetime property
- rebuild the query-CMR image and restart your services
- run any request
- run a STAC item artifact through the validator again
- it should tell you that the item is valid

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)