### PR TITLE
Harmony 1494 - Add pagination info under paging links

### DIFF
--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -247,10 +247,14 @@ export async function getJobs(
     const lastPage = pageLinks.find((l) => l.rel === 'last');
     const nextPage = pageLinks.find((l) => l.rel === 'next');
     const previousPage = pageLinks.find((l) => l.rel === 'prev');
+    const paginationInfo = { from: (pagination.from + 1).toLocaleString(),
+      to: pagination.to.toLocaleString(), total: pagination.total.toLocaleString(),
+      currentPage: pagination.currentPage.toLocaleString(), lastPage: pagination.lastPage.toLocaleString() };
     res.render('workflow-ui/jobs/index', {
       version,
       page,
       limit,
+      paginationInfo, // formatted for display
       currentUser: req.user,
       isAdminRoute,
       jobs,
@@ -462,10 +466,14 @@ export async function getWorkItemsTable(
     const lastPage = pageLinks.find((l) => l.rel === 'last');
     const nextPage = pageLinks.find((l) => l.rel === 'next');
     const previousPage = pageLinks.find((l) => l.rel === 'prev');
+    const paginationInfo = { from: (pagination.from + 1).toLocaleString(),
+      to: pagination.to.toLocaleString(), total: pagination.total.toLocaleString(),
+      currentPage: pagination.currentPage.toLocaleString(), lastPage: pagination.lastPage.toLocaleString() };
     setPagingHeaders(res, pagination);
     res.render('workflow-ui/job/work-items-table', {
       isAdminOrLogViewer,
       canShowRetryColumn: job.belongsToOrIsAdmin(req.user, isAdmin),
+      paginationInfo,
       job,
       statusClass: statusClass[job.status],
       workItems,

--- a/app/views/workflow-ui/job/work-items-table.mustache.html
+++ b/app/views/workflow-ui/job/work-items-table.mustache.html
@@ -27,12 +27,4 @@
     </tbody>
 </table>
 
-<nav aria-label="Page navigation" class="bg-white d-flex flex-column align-items-center py-2 sticky-paging">
-    <ul class="pagination px-0 mx-auto">
-        {{#links}}
-        <li class="page-item {{linkDisabled}}">
-            <a class="page-link" href="{{linkHref}}" title="{{linkTitle}}">{{linkTitle}}</a>
-        </li>
-        {{/links}}
-    </ul>
-</nav>
+{{> workflow-ui/paging }}

--- a/app/views/workflow-ui/jobs/index.mustache.html
+++ b/app/views/workflow-ui/jobs/index.mustache.html
@@ -77,15 +77,7 @@
             </div>
             <div class="col-10" id="jobs-table-container">
                 {{> workflow-ui/jobs/jobs-table}}
-                <nav aria-label="Page navigation" class="bg-white d-flex flex-column align-items-center py-2 sticky-paging">
-                    <ul class="pagination px-0 mx-auto">
-                        {{#links}}
-                        <li class="page-item {{linkDisabled}}">
-                            <a class="page-link" href="{{linkHref}}" title="{{linkTitle}}">{{linkTitle}}</a>
-                        </li>
-                        {{/links}}
-                    </ul>
-                </nav>
+                {{> workflow-ui/paging}}
             </div>
         </div>
     </div>

--- a/app/views/workflow-ui/paging.mustache.html
+++ b/app/views/workflow-ui/paging.mustache.html
@@ -1,0 +1,12 @@
+<nav aria-label="Page navigation" class="bg-white d-flex flex-column align-items-center py-2 sticky-paging">
+    <ul class="pagination px-0 mx-auto mb-1">
+        {{#links}}
+        <li class="page-item {{linkDisabled}}">
+            <a class="page-link" href="{{linkHref}}" title="{{linkTitle}}">{{linkTitle}}</a>
+        </li>
+        {{/links}}
+    </ul>
+    <small class="text-muted">
+        {{paginationInfo.from}}-{{paginationInfo.to}} of {{paginationInfo.total}} (p. {{paginationInfo.currentPage}} of {{paginationInfo.lastPage}})
+    </small>
+</nav>

--- a/test/workflow-ui/jobs.ts
+++ b/test/workflow-ui/jobs.ts
@@ -282,13 +282,18 @@ describe('Workflow UI jobs route', function () {
       it('returns a disabled link to the first page', function () {
         const listing = this.res.text;
         expect(listing).to.contain(renderNavLink('', 'first', false));
-      });it('returns a disabled link to the last page', function () {
+      });
+      it('returns a disabled link to the last page', function () {
         const listing = this.res.text;
         expect(listing).to.contain(renderNavLink('', 'last', false));
       });
       it('returns only one job', function () {
         const listing = this.res.text;
         expect((listing.match(/job-table-row/g) || []).length).to.equal(1);
+      });
+      it('contains paging info', function () {
+        const listing = this.res.text;
+        expect(listing).to.contain('2-2 of 3 (p. 2 of 3)');
       });
     });
 

--- a/test/workflow-ui/work-items-table.ts
+++ b/test/workflow-ui/work-items-table.ts
@@ -400,6 +400,14 @@ describe('Workflow UI work items table route', function () {
         });
       });
 
+      describe('who requests page 2 of the work items table, with a limit of 2', function () {
+        hookWorkflowUIWorkItems({ username: 'bo', jobID: targetJob.jobID, query: { limit: 2, page: 2 } });
+        it('contains paging info', function () {
+          const listing = this.res.text;
+          expect(listing).to.contain('3-4 of 6 (p. 2 of 3)');
+        });
+      });
+
       describe('who filters by status IN [RUNNING]', function () {
         hookWorkflowUIWorkItems({ username: 'bo', jobID: targetJob.jobID, query: { tableFilter: '[{"value":"status: running","dbValue":"running","field":"status"}]' } });
         it('returns only running work items', function () {


### PR DESCRIPTION
## Jira Issue ID
harmony-1494

## Description
Adds pagination info under paging links.

<img width="269" alt="Screenshot 2023-07-07 at 10 27 49 AM" src="https://github.com/nasa/harmony/assets/34752045/b60e528d-7016-431a-9a40-6a7acf8dcb19">

## Local Test Steps
Take a look at the pagination info under the paging links in the workflow user interface. Make sure of that they make sense.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)