### PR TITLE
HARMONY-900-2: Revert addition of shareable field to job JSON

### DIFF
--- a/app/frontends/jobs.ts
+++ b/app/frontends/jobs.ts
@@ -188,7 +188,6 @@ export async function getJobStatus(
     const pagingLinks = getPagingLinks(req, pagination).map((link) => new JobLink(link));
     job.links = job.links.concat(pagingLinks);
     const jobForDisplay = getJobForDisplay(job, urlRoot, linkType, errors);
-    jobForDisplay.shareable = isJobShareable;
     res.send(jobForDisplay);
   } catch (e) {
     req.context.logger.error(e);

--- a/app/models/job.ts
+++ b/app/models/job.ts
@@ -101,8 +101,6 @@ export class JobForDisplay {
 
   errors?: JobError[];
 
-  shareable?: boolean;
-
 }
 
 export interface JobQuery {

--- a/test/helpers/jobs.ts
+++ b/test/helpers/jobs.ts
@@ -16,10 +16,10 @@ export const adminUsername = 'adam';
 
 export const expectedJobKeys = [
   'username', 'status', 'message', 'progress', 'createdAt', 'updatedAt', 'dataExpiration',
-  'links', 'request', 'numInputGranules', 'jobID', 'shareable',
+  'links', 'request', 'numInputGranules', 'jobID',
 ];
 
-export const expectedNoOpJobKeys = expectedJobKeys.filter((k) => k !== 'jobID' && k !== 'shareable');
+export const expectedNoOpJobKeys = expectedJobKeys.filter((k) => k !== 'jobID');
 
 const exampleProps = {
   username: 'anonymous',

--- a/test/jobs/job-sharing.ts
+++ b/test/jobs/job-sharing.ts
@@ -104,12 +104,6 @@ describe('Sharing job results with someone other than its owner', function () {
           expect(this.res.statusCode).to.equal(200);
         });
       });
-      describe('Accessing the job shareable property', function () {
-        hookJobStatus({ jobID: jobIDWithEULAFalseAndGuestReadTrue, username: 'adam' });
-        it('is shareable according to the shareable property', function () {
-          expect(JSON.parse(this.res.text).shareable).to.equal(true);
-        });
-      });
       describe('Accessing the STAC Catalog page', function () {
         hookStacCatalog(jobIDWithEULAFalseAndGuestReadTrue, notJobOwner);
         it('returns a 200 response', function () {
@@ -129,12 +123,6 @@ describe('Sharing job results with someone other than its owner', function () {
         hookJobStatus({ jobID: jobIDWithEULATrueAndGuestReadTrue, username: notJobOwner });
         it('returns a 404 response', function () {
           expect(this.res.statusCode).to.equal(404);
-        });
-      });
-      describe('Accessing the job shareable property', function () {
-        hookJobStatus({ jobID: jobIDWithEULATrueAndGuestReadTrue, username: 'adam' });
-        it('is NOT shareable according to the shareable property', function () {
-          expect(JSON.parse(this.res.text).shareable).to.equal(false);
         });
       });
       describe('Accessing the STAC Catalog page', function () {
@@ -158,12 +146,6 @@ describe('Sharing job results with someone other than its owner', function () {
           expect(this.res.statusCode).to.equal(404);
         });
       });
-      describe('Accessing the job shareable property', function () {
-        hookJobStatus({ jobID: jobIDWithEULAFalseAndGuestReadFalse, username: 'adam' });
-        it('is NOT shareable according to the shareable property', function () {
-          expect(JSON.parse(this.res.text).shareable).to.equal(false);
-        });
-      });
       describe('Accessing the STAC Catalog page', function () {
         hookStacCatalog(jobIDWithEULAFalseAndGuestReadFalse, notJobOwner);
         it('returns a 200 response', function () {
@@ -183,12 +165,6 @@ describe('Sharing job results with someone other than its owner', function () {
         hookJobStatus({ jobID: jobIDWithEULANonexistent, username: notJobOwner });
         it('returns a 404 response', function () {
           expect(this.res.statusCode).to.equal(404);
-        });
-      });
-      describe('Accessing the job shareable property', function () {
-        hookJobStatus({ jobID: jobIDWithEULANonexistent, username: 'adam' });
-        it('is NOT shareable according to the shareable property', function () {
-          expect(JSON.parse(this.res.text).shareable).to.equal(false);
         });
       });
       describe('Accessing the STAC Catalog page', function () {
@@ -212,12 +188,6 @@ describe('Sharing job results with someone other than its owner', function () {
           expect(this.res.statusCode).to.equal(404);
         });
       });
-      describe('Accessing the job shareable property', function () {
-        hookJobStatus({ jobID: jobIDWithNoCollections, username: 'adam' });
-        it('is NOT shareable according to the shareable property', function () {
-          expect(JSON.parse(this.res.text).shareable).to.equal(false);
-        });
-      });
       describe('Accessing the STAC Catalog page', function () {
         hookStacCatalog(jobIDWithNoCollections, notJobOwner);
         it('returns a 200 response', function () {
@@ -239,12 +209,6 @@ describe('Sharing job results with someone other than its owner', function () {
         hookJobStatus({ jobID: jobIDWithMultipleCollections, username: notJobOwner });
         it('returns a 404 response', function () {
           expect(this.res.statusCode).to.equal(404);
-        });
-      });
-      describe('Accessing the job shareable property', function () {
-        hookJobStatus({ jobID: jobIDWithMultipleCollections, username: 'adam' });
-        it('is NOT shareable according to the shareable property', function () {
-          expect(JSON.parse(this.res.text).shareable).to.equal(false);
         });
       });
       describe('Accessing the STAC Catalog page', function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-900

## Description
After discussing with Chris, we realize that the field that I added for https://github.com/nasa/harmony/pull/423 will have little future value now that we have access to a new EULA acceptance validation endpoint (EDL `verify_user_eula`) which will change how we check for shareability.

Context:
The future plan is to allow sharing based on user EULA acceptance and user data permissions rather than what we do now which is based on EULA presence and whether or not the collections are public. This should increase access to job results and sharing once the new logic is implemented. This flag will be a lot less meaningful once we implement those changes, hence the desire to remove it now before it appears in prod.

## Local Test Steps
- submit a request with > 1 granule and view the job endpoint JSON
- the shareable field should no longer show up on the jobs endpoint

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)