### PR TITLE
HARMONY-1526: Fix for port-forwarding with harmony in a box

### DIFF
--- a/bin/port-forward
+++ b/bin/port-forward
@@ -19,7 +19,7 @@ function start_port_forwarding() {
   local iteration=0
 
   while [ "$iteration" -lt "$max_iterations" ]; do
-    # Check if there is exactly 1 pod in the "Running" state
+    # Wait until there is exactly 1 pod running for the service
     local running_count
     running_count=$(kubectl get pods -n harmony -l app="$service_name" --no-headers | wc -l)
 

--- a/bin/port-forward
+++ b/bin/port-forward
@@ -14,8 +14,31 @@ function start_port_forwarding() {
   done
 
   stop_port_forwarding "$service_name"
-  kubectl wait -n harmony --for=condition=ready pod --selector=app="$service_name" --timeout=60s
 
+  local max_iterations=60
+  local iteration=0
+
+  while [ "$iteration" -lt "$max_iterations" ]; do
+    # Check if there is exactly 1 pod in the "Running" state
+    local running_count
+    running_count=$(kubectl get pods -n harmony -l app="$service_name" --no-headers | wc -l)
+
+    if [ "$running_count" -eq 1 ]; then
+      echo "Exactly 1 ${service_name} pod found. Setting up port forward when pod is ready."
+      break
+    fi
+
+    ((iteration++))
+
+    sleep 1
+  done
+
+  if [ "$iteration" -eq "$max_iterations" ]; then
+    echo "WARNING: Timeout reached. There are ${running_count} pods running. Port forwarding may not work."
+    exit 1
+  fi
+
+  kubectl wait -n harmony --for=condition=ready pod -l app="$service_name" --timeout=60s
   nohup kubectl -n harmony port-forward "service/${service_name}" "${args[@]}" > "logs/port-forward-${service_name}.log" 2>&1 &
   echo "Port forwarding started for service: ${service_name}, port pairs: ${port_pairs[*]}"
 }

--- a/bin/start-postgres-localstack
+++ b/bin/start-postgres-localstack
@@ -109,9 +109,10 @@ kubectl -n harmony create configmap localstack-config --from-literal=startup.py=
 kubectl apply -n harmony -f ./config/local-postgres-localstack-deployment.yml
 
 [[ $USE_LOCALSTACK = 'true' ]] && s3_endpoint="localstack:4572" || s3_endpoint="s3.amazonaws.com"
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
 
 bin/port-forward start localstack 4566:4566 4572:4566 4592:4566
-bin/port-forward start postgres 5432:5432
+bin/port-forward start postgres ${POSTGRES_PORT}:5432
 
 echo ''
 echo 'Localstack has started at http://localhost:4566/'


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1526

## Description
Fixes issue with port forwarding when running `bin/restart-services` sometimes being set up against the pod that is being terminated. Also allows overriding the local port used for connecting to Postgres.

## Local Test Steps
Configure your environment to run harmony in a box. Run bin/restart-services and verify that when it completes harmony is available on localhost:3000.

Delete your postgres and localstack deployments (or delete the harmony namespace altogether). Then run `POSTGRES_PORT=15432 bin/bootstrap-harmony` and verify that postgres is available at port localhost:15432.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)