### PR TITLE
HARMONY-1508: Add missing env vars needed to support aggregated output

### DIFF
--- a/kubernetes-services/work-updater/app/util/env.ts
+++ b/kubernetes-services/work-updater/app/util/env.ts
@@ -68,6 +68,9 @@ interface HarmonyEnv {
   nodeEnv: string;
   serviceQueueBatchSizeCoefficient: number;
   useServiceQueues: boolean;
+  maxErrorsForJob: number;
+  cmrMaxPageSize: number;
+  aggregateStacCatalogMaxPageSize: number;
 }
 
 // special cases

--- a/kubernetes-services/work-updater/env-defaults
+++ b/kubernetes-services/work-updater/env-defaults
@@ -52,3 +52,15 @@ WORK_ITEM_RETRY_LIMIT=5
 
 # Whether or not to use queues for retrieving work-items when handling polling for work
 USE_SERVICE_QUEUES=true
+
+# The maximum number of errors to allow for a job before considering it failed
+MAX_ERRORS_FOR_JOB=2000
+
+# page size to use with CMR calls
+CMR_MAX_PAGE_SIZE=2000
+
+# TODO change this to a smaller number when aggregating services are updated to handle paged catalogs
+# See HARNONY-1178
+AGGREGATE_STAC_CATALOG_MAX_PAGE_SIZE=1000000
+
+


### PR DESCRIPTION
## Jira Issue ID
HARMONY-158

## Description
Adds env vars that support aggregation that were inadvertently left out from the work updater service.

## Local Test Steps
1. Check out this branch
2. Rebuild the work updater service in the kubernestes-services/work-updater dir using `npm run build`
3. Run bin/restart-services
4. Run this query and verify that it works
http://localhost:3000/C1234410736-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?format=application%2Fx-zarr&maxResults=2&concatenate=true

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~