### PR TITLE
HARMONY-1508: Add env vars needed to support batching to the work updater

### DIFF
--- a/kubernetes-services/work-updater/app/util/env.ts
+++ b/kubernetes-services/work-updater/app/util/env.ts
@@ -71,6 +71,8 @@ interface HarmonyEnv {
   maxErrorsForJob: number;
   cmrMaxPageSize: number;
   aggregateStacCatalogMaxPageSize: number;
+  maxBatchInputs: number;
+  maxBatchSizeInBytes: number;
 }
 
 // special cases

--- a/kubernetes-services/work-updater/env-defaults
+++ b/kubernetes-services/work-updater/env-defaults
@@ -63,4 +63,10 @@ CMR_MAX_PAGE_SIZE=2000
 # See HARNONY-1178
 AGGREGATE_STAC_CATALOG_MAX_PAGE_SIZE=1000000
 
+# The maximum number of input granules in each invocation of a service
+MAX_BATCH_INPUTS=1000000000000
+
+# The upper limit on the combined sizes of all the files in a batch
+MAX_BATCH_SIZE_IN_BYTES=5000000000
+
 


### PR DESCRIPTION


## Jira Issue ID
HARMONY-1508

## Description
Fix broken batching by adding missing env vars to work updater

## Local Test Steps
Run this query "http://localhost:3000/C1234208438-POCLOUD/ogc-api-coverages/1.0.0/collections/bathymetry/coverage/rangeset?concatenate=true&subset=lon(-160%3A160)&subset=lat(-80%3A80)&skipPreview=true&maxResults=2&subset=time(%221981-01-02T00%3A00%3A00.000Z%22%3A%222020-01-02T01%3A00%3A00.000Z%22)"

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~