### PR TITLE
HARMONY-1531: Cancel queued work items on job cancelation

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,8 +1,8 @@
 {
-  "1092779": {
+  "1092826": {
     "active": true,
-    "notes": "Ignored since we don't expose the vulnerability and there is no fix",
-    "expiry": "2023-09-01"
+    "notes": "Ignored since there is no fix",
+    "expiry": "2023-10-01"
   },
   "1092429": {
     "active": true,

--- a/app/util/job.ts
+++ b/app/util/job.ts
@@ -75,7 +75,7 @@ export async function completeJob(
     await job.save(tx);
     if (failed) {
       const numUpdated = await updateWorkItemStatusesByJobId(
-        tx, job.jobID, [WorkItemStatus.READY, WorkItemStatus.RUNNING], WorkItemStatus.CANCELED,
+        tx, job.jobID, [WorkItemStatus.READY, WorkItemStatus.RUNNING, WorkItemStatus.QUEUED], WorkItemStatus.CANCELED,
       );
       const itemMeta: WorkItemMeta = { workItemStatus: WorkItemStatus.CANCELED, workItemAmount: numUpdated, workItemEvent: 'statusUpdate' };
       logger.info(`Updated work items to ${WorkItemStatus.CANCELED} for completed job.`, itemMeta);

--- a/kubernetes-services/work-scheduler/.nsprc
+++ b/kubernetes-services/work-scheduler/.nsprc
@@ -1,8 +1,8 @@
 {
-  "1092779": {
+  "1092826": {
     "active": true,
-    "notes": "Ignored since we don't expose the vunlerability and there is no fix",
-    "expiry": "2023-09-01"
+    "notes": "Ignored since there is no fix",
+    "expiry": "2023-10-01"
   },
   "1092470": {
     "active": true,

--- a/tasks/service-runner/.nsprc
+++ b/tasks/service-runner/.nsprc
@@ -1,8 +1,8 @@
 {
-  "1092779": {
+  "1092826": {
     "active": true,
-    "notes": "Ignored since we don't expose the vunlerability and there is no fix",
-    "expiry": "2023-09-01"
+    "notes": "Ignored since there is no fix",
+    "expiry": "2023-10-01"
   },
   "1092470": {
     "active": true,

--- a/test/util/job.ts
+++ b/test/util/job.ts
@@ -29,6 +29,10 @@ const readyTurboWorkItem = buildWorkItem({
   jobID: acceptedTurboJob.jobID,
   status: WorkItemStatus.READY,
 });
+const queuedTurboWorkItem = buildWorkItem({
+  jobID: acceptedTurboJob.jobID,
+  status: WorkItemStatus.QUEUED,
+});
 
 const finishedTurboJob = buildJob({ username: 'doe', status: JobStatus.SUCCESSFUL });
 const finishedTurboWorkItem = buildWorkItem({
@@ -55,6 +59,7 @@ describe('Canceling a job', async function () {
     await thirdTurboWorkItem.save(this.trx);
     await anotherTurboWorkItem.save(this.trx);
     await readyTurboWorkItem.save(this.trx);
+    await queuedTurboWorkItem.save(this.trx);
     await finishedTurboWorkItem.save(this.trx);
     await failedTurboWorkItem.save(this.trx);
     this.trx.commit();
@@ -67,6 +72,7 @@ describe('Canceling a job', async function () {
         await cancelAndSaveJob(acceptedTurboJob.requestId, log, 'doe');
         const { workItems } = await getWorkItemsByJobId(db, readyTurboWorkItem.jobID);
         expect(workItems[0].status).to.equal(WorkItemStatus.CANCELED);
+        expect(workItems[1].status).to.equal(WorkItemStatus.CANCELED);
       });
 
       it('is able to cancel the job in running state', async function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1531

## Description
Cancels queued work items on job cancelation. Prior to this modification, it was possible for a job to be canceled and have work items left in the queued state. These items could then be picked up and set to the running state, which was undesirable.

## Local Test Steps
To test this out, I issued a request, then paused it after it generated all of the work items. Then executed `UPDATE work_items SET status = 'queued' WHERE "jobID" = 'my-job-id';`, unpaused the job, then canceled it.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)