### PR TITLE
Harmony 1552 - Update EDL API requests to use Harmony client token instead of user-supplied bearer token

### DIFF
--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -449,7 +449,7 @@ export async function getWorkItemsTable(
   const { checkJobStatus } = req.query;
   try {
     const { isAdmin, isLogViewer } = await getEdlGroupInformation(
-      req.user, req.accessToken, req.context.logger,
+      req.user, req.context.logger,
     );
     const isAdminOrLogViewer = isAdmin || isLogViewer;
     const job = await getJobIfAllowed(jobID, req.user, isAdmin, req.accessToken, true);
@@ -514,7 +514,7 @@ export async function getWorkItemTableRow(
   const { jobID, id } = req.params;
   try {
     const { isAdmin, isLogViewer } = await getEdlGroupInformation(
-      req.user, req.accessToken, req.context.logger,
+      req.user, req.context.logger,
     );
     const isAdminOrLogViewer = isAdmin || isLogViewer;
     const job = await getJobIfAllowed(jobID, req.user, isAdmin, req.accessToken, true);
@@ -553,7 +553,7 @@ export async function getWorkItemLogs(
   const { id, jobID } = req.params;
   try {
     const { isAdmin, isLogViewer } = await getEdlGroupInformation(
-      req.user, req.accessToken, req.context.logger,
+      req.user, req.context.logger,
     );
     const isAdminOrLogViewer = isAdmin || isLogViewer;
     if (!isAdminOrLogViewer) {

--- a/app/middleware/admin.ts
+++ b/app/middleware/admin.ts
@@ -17,7 +17,7 @@ export default async function admin(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
   try {
-    const { isAdmin } = await getEdlGroupInformation(req.user, req.accessToken, req.context.logger);
+    const { isAdmin } = await getEdlGroupInformation(req.user, req.context.logger);
     if (isAdmin) {
       req.context.isAdminAccess = true;
       next();

--- a/app/middleware/cmr-collection-reader.ts
+++ b/app/middleware/cmr-collection-reader.ts
@@ -38,7 +38,7 @@ async function verifyEulaAcceptance(collections: CmrCollection[], req: HarmonyRe
   for (const collection of collections) {
     if (collection.eula_identifiers) {
       for (const eulaId of collection.eula_identifiers) {
-        const eulaInfo: EdlUserEulaInfo = await verifyUserEula(req.user, eulaId, req.accessToken);
+        const eulaInfo: EdlUserEulaInfo = await verifyUserEula(req.user, eulaId, req.context.logger);
         if (eulaInfo.statusCode == 404 && eulaInfo.acceptEulaUrl) { // EULA wasn't accepted
           acceptEulaUrls.push(eulaInfo.acceptEulaUrl);  
         } else if (eulaInfo.statusCode == 404) {

--- a/app/middleware/earthdata-login-oauth-authorizer.ts
+++ b/app/middleware/earthdata-login-oauth-authorizer.ts
@@ -14,7 +14,7 @@ if (missingVars.length > 0) {
   throw new Error(`Earthdata Login configuration error: You must set ${listToText(missingVars)} in the environment`);
 }
 
-const oauthOptions = {
+export const oauthOptions = {
   client: {
     id: process.env.OAUTH_CLIENT_ID,
     secret: process.env.OAUTH_PASSWORD,

--- a/app/middleware/earthdata-login-token-authorizer.ts
+++ b/app/middleware/earthdata-login-token-authorizer.ts
@@ -1,6 +1,6 @@
 import { RequestHandler } from 'express';
 import HarmonyRequest from '../models/harmony-request';
-import { getClientCredentialsToken, getUserIdRequest } from '../util/edl-api';
+import { getUserIdRequest } from '../util/edl-api';
 
 const BEARER_TOKEN_REGEX = new RegExp('^Bearer ([-a-zA-Z0-9._~+/]+)$', 'i');
 
@@ -26,9 +26,8 @@ export default function buildEdlAuthorizer(paths: Array<string | RegExp> = []): 
         // Generates a new client credentials token for each user request passing in a token
         // We should reuse client credentials if possible (seems like simple-oauth2 lib might)
         try {
-          const clientToken = await getClientCredentialsToken(logger);
           // Get the username for the provided token from EDL
-          const username = await getUserIdRequest(clientToken, userToken, logger);
+          const username = await getUserIdRequest(userToken, logger);
           req.user = username;
           req.accessToken = userToken;
           req.authorized = true;

--- a/app/middleware/earthdata-login-token-authorizer.ts
+++ b/app/middleware/earthdata-login-token-authorizer.ts
@@ -23,8 +23,6 @@ export default function buildEdlAuthorizer(paths: Array<string | RegExp> = []): 
       if (match) {
         const { logger } = req.context;
         const userToken = match[1];
-        // Generates a new client credentials token for each user request passing in a token
-        // We should reuse client credentials if possible (seems like simple-oauth2 lib might)
         try {
           // Get the username for the provided token from EDL
           const username = await getUserIdRequest(userToken, logger);

--- a/app/util/edl-api.ts
+++ b/app/util/edl-api.ts
@@ -17,6 +17,7 @@ let harmonyClientToken: AccessToken; // valid for 30 days
 /**
  * Returns the bearer token to use in all EDL requests from Harmony
  * @param logger - The logger associated with the request
+ * @returns The client bearer token
  */
 export async function getClientCredentialsToken(logger: Logger): Promise<string> {
   try {

--- a/app/util/edl-api.ts
+++ b/app/util/edl-api.ts
@@ -3,34 +3,48 @@ import { ForbiddenError } from './errors';
 import { Logger } from 'winston';
 import env from './env';
 import HarmonyRequest from '../models/harmony-request';
+import { oauthOptions } from '../middleware/earthdata-login-oauth-authorizer';
+import simpleOAuth2, { AccessToken } from 'simple-oauth2';
 
 const edlUserRequestUrl = `${env.oauthHost}/oauth/tokens/user`;
-const edlClientCredentialsUrl = `${env.oauthHost}/oauth/token`;
 const edlUserGroupsBaseUrl = `${env.oauthHost}/api/user_groups/groups_for_user`;
 const edlVerifyUserEulaUrl = (username: string, eulaId: string): string =>
   `${env.oauthHost}/api/users/${username}/verify_user_eula?eula_id=${eulaId}`;
 
-const clientCredentialsData = {
-  params: { grant_type: 'client_credentials' },
-  auth: {
-    username: env.oauthClientId,
-    password: env.oauthPassword,
-  },
-};
+const oauth2 = simpleOAuth2.create(oauthOptions);
+let clientToken: AccessToken; // valid for 30 days
+
+/**
+ * Returns the bearer token to use in all EDL requests from Harmony
+ * @param logger - The logger associated with the request
+ */
+async function getClientCredentialsToken(logger: Logger): Promise<string> {
+  try {
+    if (!clientToken || clientToken.expired()) {
+      const oauthToken = await oauth2.clientCredentials.getToken({});
+      clientToken = oauth2.accessToken.create(oauthToken);
+    }
+    return clientToken.token.access_token;
+  } catch (e) {
+    logger.error('Failed to get client credentials for harmony user.');
+    logger.error(e);
+    throw new ForbiddenError();
+  }
+}
 
 /**
  * Makes a request to the EDL users endpoint to validate a token and return the user ID
  * associated with that token.
  *
- * @param clientToken - The harmony client token
  * @param userToken - The user's token
  * @param logger - The logger associated with the request
  * @returns the username associated with the token
  * @throws ForbiddenError if the token is invalid
  */
-export async function getUserIdRequest(clientToken: string, userToken: string, logger: Logger)
+export async function getUserIdRequest(userToken: string, logger: Logger)
   : Promise<string> {
   try {
+    const token = await getClientCredentialsToken(logger);
     const response = await axios.default.post(
       edlUserRequestUrl,
       null,
@@ -39,7 +53,7 @@ export async function getUserIdRequest(clientToken: string, userToken: string, l
           client_id: env.oauthClientId,
           token: userToken,
         },
-        headers: { authorization: `Bearer ${clientToken}` },
+        headers: { authorization: `Bearer ${token}` },
       },
     );
     return response.data.uid;
@@ -51,33 +65,18 @@ export async function getUserIdRequest(clientToken: string, userToken: string, l
 }
 
 /**
- * Returns the bearer token to use in all EDL requests from Harmony
- * @param logger - The logger associated with the request
- */
-export async function getClientCredentialsToken(logger: Logger): Promise<string> {
-  try {
-    const response = await axios.default.post(edlClientCredentialsUrl, null, clientCredentialsData);
-    return response.data.access_token;
-  } catch (e) {
-    logger.error('Failed to get client credentials for harmony user.');
-    logger.error(e);
-    throw new ForbiddenError();
-  }
-}
-
-/**
  * Returns the groups to which a user belongs
  *
  * @param username - The EDL username
- * @param userToken - The user's token
  * @param logger - The logger associated with the request
  * @returns the groups to which the user belongs
  */
-async function getUserGroups(username: string, userToken: string, logger: Logger)
+async function getUserGroups(username: string, logger: Logger)
   : Promise<string[]> {
   try {
+    const token = await getClientCredentialsToken(logger);
     const response = await axios.default.get(
-      `${edlUserGroupsBaseUrl}/${username}`, { headers: { Authorization: `Bearer ${userToken}` } },
+      `${edlUserGroupsBaseUrl}/${username}`, { headers: { Authorization: `Bearer ${token}` } },
     );
     const groups = response.data?.user_groups.map((group) => group.group_id) || [];
     return groups;
@@ -97,13 +96,12 @@ export interface EdlGroupMembership {
  * Returns the harmony relevant group information for a user with two keys isAdmin and isLogViewer.
  *
  * @param username - The EDL username
- * @param userToken - The user's token
  * @param logger - The logger associated with the request
  * @returns A promise which resolves to info about whether the user is an admin or log viewer
  */
-export async function getEdlGroupInformation(username: string, userToken: string, logger: Logger)
+export async function getEdlGroupInformation(username: string, logger: Logger)
   : Promise<EdlGroupMembership> {
-  const groups = await getUserGroups(username, userToken, logger);
+  const groups = await getUserGroups(username, logger);
   let isAdmin = false;
   if (groups.includes(env.adminGroupId)) {
     isAdmin = true;
@@ -123,7 +121,7 @@ export async function getEdlGroupInformation(username: string, userToken: string
  */
 export async function isAdminUser(req: HarmonyRequest): Promise<boolean> {
   const isAdmin = req.context.isAdminAccess ||
-    (await getEdlGroupInformation(req.user, req.accessToken, req.context.logger)).isAdmin;
+    (await getEdlGroupInformation(req.user, req.context.logger)).isAdmin;
   return isAdmin;
 }
 
@@ -138,17 +136,18 @@ export interface EdlUserEulaInfo {
  *
  * @param username - The EDL username
  * @param eulaId - The id of the EULA (from the collection metadata)
- * @param userToken - The user's token
+ * @param logger - The logger associated with the request
  * @returns A promise which resolves to info about whether the user has accepted a EULA,
  * and if not, where they can go to accept it
  */
-export async function verifyUserEula(username: string, eulaId: string, userToken: string)
+export async function verifyUserEula(username: string, eulaId: string, logger: Logger)
   : Promise<EdlUserEulaInfo> {
   let statusCode: number;
   let eulaResponse: { msg: string, error: string, accept_eula_url: string };
   try {
+    const token = await getClientCredentialsToken(logger);
     const response = await axios.default.get(
-      edlVerifyUserEulaUrl(username, eulaId), { headers: { Authorization: `Bearer ${userToken}` } },
+      edlVerifyUserEulaUrl(username, eulaId), { headers: { Authorization: `Bearer ${token}` } },
     );
     eulaResponse = response.data;
     statusCode = response.status;

--- a/app/util/edl-api.ts
+++ b/app/util/edl-api.ts
@@ -18,7 +18,7 @@ let clientToken: AccessToken; // valid for 30 days
  * Returns the bearer token to use in all EDL requests from Harmony
  * @param logger - The logger associated with the request
  */
-async function getClientCredentialsToken(logger: Logger): Promise<string> {
+export async function getClientCredentialsToken(logger: Logger): Promise<string> {
   try {
     if (!clientToken || clientToken.expired()) {
       const oauthToken = await oauth2.clientCredentials.getToken({});

--- a/fixtures/uat.urs.earthdata.nasa.gov-443/undefined-user-groups
+++ b/fixtures/uat.urs.earthdata.nasa.gov-443/undefined-user-groups
@@ -1,0 +1,26 @@
+GET /api/user_groups/groups_for_user/undefined
+accept: application/json, text/plain, */*
+authorization: Bearer fake_access
+
+HTTP/1.1 200 OK
+Server: nginx/1.20.1
+Date: Wed, 19 Apr 2023 20:07:41 GMT
+Content-Type: application/json; charset=utf-8
+Connection: keep-alive
+X-Frame-Options: SAMEORIGIN
+X-XSS-Protection: 1; mode=block
+X-Content-Type-Options: nosniff
+X-Download-Options: noopen
+X-Permitted-Cross-Domain-Policies: none
+Referrer-Policy: strict-origin-when-cross-origin
+Cache-Control: no-store
+Pragma: no-cache
+Expires: Fri, 01 Jan 1990 00:00:00 GMT
+Vary: Accept
+ETag: W/"95d47ed009d4ca4a238f2b3bbcd1d4a3"
+X-Request-Id: 96d4861c-072b-4d69-9d39-2b83d2852899
+X-Runtime: 0.011620
+Strict-Transport-Security: max-age=31536000
+Transfer-Encoding: chunked
+
+{"user_groups":[]}

--- a/test/concatenation.ts
+++ b/test/concatenation.ts
@@ -12,7 +12,7 @@ describe('testing concatenation', function () {
     const serviceTag = 'ghcr.io/podaac/concise:sit';
 
     describe('When passing the concatenate parameter', function () {
-      hookServersStartStop( { skipEarthdataLogin: false });
+      hookServersStartStop({ skipEarthdataLogin: false });
 
       describe('calling the backend service', function () {
         const query = {

--- a/test/earthdata-login.ts
+++ b/test/earthdata-login.ts
@@ -18,7 +18,7 @@ const fakeUsername = 'testy_mctestface';
 
 describe('Earthdata Login', function () {
   StubService.hookEach();
-  hookServersStartStop({ skipEarthdataLogin: false });
+  hookServersStartStop({ skipEarthdataLogin: false }, false);
 
   describe('Calls to authenticated resources', function () {
     describe('When a request provides no token', function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1552

## Description
When the user supplies their own bearer token to authenticate with Harmony (rather than going through the OAuth flow using their EDL credentials) it can't be used to make API calls to Earthdata Login. We need to use a token that is associated with the Harmony app instead, like the Harmony client token.

This was causing some Harmony requests to fail when the EULA verification logic was executed.

## Local Test Steps
- submit some requests from a browser (using EDL credentials), and from another client using a bearer token (insomnia, harmony-py, etc.)
- make sure that they function as expected
- if you have a test user that hasn't accepted any EULAs, you can also test that EULA verification still works with these collections:
```
  twoEulasCollection = 'C1258836670-EEDTEST';
  oneEulaCollection = 'C1258839703-EEDTEST';
  badEulaIdCollection = 'C1258840703-EEDTEST';
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)