### PR TITLE
Harmony 1505/6 - Add extendDimensions parameter to DataOperation

### DIFF
--- a/app/frontends/ogc-coverages/get-coverage-rangeset.ts
+++ b/app/frontends/ogc-coverages/get-coverage-rangeset.ts
@@ -2,7 +2,7 @@ import { NextFunction, Response } from 'express';
 import DataOperation from '../../models/data-operation';
 import HarmonyRequest from '../../models/harmony-request';
 import wrap from '../../util/array';
-import { handleCrs, handleFormat, handleGranuleIds, handleGranuleNames, handleScaleExtent, handleScaleSize } from '../../util/parameter-parsers';
+import { handleCrs, handleExtend, handleFormat, handleGranuleIds, handleGranuleNames, handleScaleExtent, handleScaleSize } from '../../util/parameter-parsers';
 import { createDecrypter, createEncrypter } from '../../util/crypto';
 import env from '../../util/env';
 import { RequestValidationError } from '../../util/errors';
@@ -33,6 +33,7 @@ export default function getCoverageRangeset(
   const operation = new DataOperation(null, encrypter, decrypter);
 
   handleFormat(operation, query, req);
+  handleExtend(operation, query);
   handleGranuleIds(operation, query);
   handleGranuleNames(operation, query);
   handleCrs(operation, query);

--- a/app/models/data-operation.ts
+++ b/app/models/data-operation.ts
@@ -8,7 +8,7 @@ import { CmrUmmCollection, CmrUmmVariable } from '../util/cmr';
 import { Encrypter, Decrypter } from '../util/crypto';
 import { cmrVarToHarmonyVar, HarmonyVariable } from '../util/variables';
 
-export const CURRENT_SCHEMA_VERSION = '0.17.0';
+export const CURRENT_SCHEMA_VERSION = '0.18.0';
 
 /**
  * Synchronously reads and parses the JSON Schema at the given path
@@ -40,6 +40,15 @@ let _schemaVersions: SchemaVersion[];
 function schemaVersions(): SchemaVersion[] {
   if (_schemaVersions) return _schemaVersions;
   _schemaVersions = [
+    {
+      version: '0.18.0',
+      schema: readSchema('0.18.0'),
+      down: (model): unknown => {
+        const revertedModel = _.cloneDeep(model);
+        delete revertedModel.extendDimensions;
+        return revertedModel;
+      },
+    },
     {
       version: '0.17.0',
       schema: readSchema('0.17.0'),
@@ -636,9 +645,27 @@ export default class DataOperation {
   }
 
   /**
+   * Gets the dimensions used for dimension extension
+   *
+   * @returns The dimensions that will be extended
+   */
+  get extendDimensions(): string[] {
+    return this.model.extendDimensions;
+  }
+
+  /**
+   * Sets dimensions used for dimension extension
+   *
+   * @param dimensions - The dimensions that will be extended
+   */
+  set extendDimensions(dimensions: string[]) {
+    this.model.extendDimensions = dimensions;
+  }
+
+  /**
    * Gets the dimensions used for dimension subsetting
    *
-   * @returns A URI to the geojson shape
+   * @returns The dimensions against which to subset
    */
   get dimensions(): Dimension[] {
     return this.model.subset.dimensions;

--- a/app/schemas/data-operation/0.18.0/data-operation-v0.18.0.json
+++ b/app/schemas/data-operation/0.18.0/data-operation-v0.18.0.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://harmony.earthdata.nasa.gov/schemas/data-operation-v0.17.0.json",
+    "$id": "https://harmony.earthdata.nasa.gov/schemas/data-operation-v0.18.0.json",
     "$ref": "#/definitions/DataOperation",
     "definitions": {
       "DataOperation": {

--- a/app/schemas/data-operation/0.18.0/data-operation-v0.18.0.json
+++ b/app/schemas/data-operation/0.18.0/data-operation-v0.18.0.json
@@ -27,8 +27,13 @@
           },
           "extendDimensions": {
             "type": "array",
+            "title": "Extend Dimensions",
+            "description": "The names or concept IDs of the dimensions that should be extended.",
+            "examples": [
+              ["lat", "lon"]
+            ],
             "items": {
-              "$ref": "#/definitions/ExtendDimensions"
+              "type": "string"
             }
           },
           "temporal": {
@@ -383,17 +388,6 @@
           }
         },
         "required": []
-      },
-      "ExtendDimensions": {
-        "type": "array",
-        "title": "Extend Dimensions",
-        "description": "The names or concept IDs of the dimensions that should be extended.",
-        "examples": [
-          ["lat", "lon"]
-        ],
-        "items": {
-          "type": "string"
-        }
       },
       "SpatialPoint": {
         "type": "array",

--- a/app/schemas/data-operation/0.18.0/data-operation-v0.18.0.json
+++ b/app/schemas/data-operation/0.18.0/data-operation-v0.18.0.json
@@ -1,0 +1,555 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://harmony.earthdata.nasa.gov/schemas/data-operation-v0.17.0.json",
+    "$ref": "#/definitions/DataOperation",
+    "definitions": {
+      "DataOperation": {
+        "type": "object",
+        "title": "DataOperation",
+        "description": "Describes an operation to be performed by backend services",
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "JSON schema location",
+            "type": "string"
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Source"
+            }
+          },
+          "format": {
+            "$ref": "#/definitions/Format"
+          },
+          "subset": {
+            "$ref": "#/definitions/Subset"
+          },
+          "extendDimensions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/ExtendDimensions"
+            }
+          },
+          "temporal": {
+            "description": "The time which should be used as the range for temporal subsetting",
+            "$ref": "#/definitions/Temporal"
+          },
+          "callback": {
+            "name": "Callback URL",
+            "description": "The URL that non-HTTP services must POST to when their execution is complete (HTTP services simply return a response).  Set query param \"redirect=\" with a URL to redirect the user to a service result (preferred).  Set the Content-Type header and POST bytes in order to send a file directly to the user.  Set query param \"error=\" with a message to provide a service error.",
+            "type": "string",
+            "format": "uri",
+            "qt-uri-protocols": [
+              "http",
+              "https"
+            ]
+          },
+          "stagingLocation": {
+            "name": "Result staging prefix",
+            "description": "An object store (S3) URL prefix under which services may elect to put their output.  Services must have write access to the Harmony staging bucket for the deployed environment to use this value.  The location will be unique per Harmony request but services are responsible for ensuring no name clashes occur within a single request.  The prefix will end in a \"/\" character",
+            "type": "string",
+            "examples": [
+              "s3://example-bucket/public/organization-name/service-name/1234567/"
+            ]
+          },
+          "user": {
+            "name": "Earthdata Login Username",
+            "description": "The name of the user on behalf of whom Harmony is acting",
+            "type": "string"
+          },
+          "accessToken": {
+            "name": "Earthdata Login Token",
+            "description": "The encrypted EDL token of the user on behalf of whom Harmony is acting",
+            "type": "string"
+          },
+          "client": {
+            "name": "Client ID",
+            "description": "An identifier indicating the client submitting the request",
+            "type": "string"
+          },
+          "version": {
+            "name": "Version number",
+            "description": "Identifies which schema version and Harmony callback protocol is being used",
+            "type": "string"
+          },
+          "isSynchronous": {
+            "name": "Synchronous request mode",
+            "description": "True if the request is going to be returned synchronously back to the end user. Note a backend service can still use a callback URL to indicate completion.",
+            "type": "boolean"
+          },
+          "requestId": {
+            "name": "Request identifier",
+            "description": "UUID to uniquely identify a request.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "concatenate": {
+            "name": "Concatenate outputs",
+            "description": "True if the service should concatenate multiple input files into a single output file.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "format",
+          "sources",
+          "subset",
+          "user",
+          "accessToken",
+          "client",
+          "version",
+          "requestId",
+          "stagingLocation"
+        ]
+      },
+      "Format": {
+        "type": "object",
+        "title": "Format",
+        "description": "Service parameters pertaining to the output file's format",
+        "additionalProperties": false,
+        "properties": {
+          "crs": {
+            "type": "string",
+            "description": "The requested output projection in Proj4",
+            "examples": [
+              "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"
+            ]
+          },
+          "srs": {
+            "type": ["object", "null"],
+            "description": "SRS / CRS information for requested output projection",
+            "additionalProperties": false,
+            "properties": {
+              "proj4": {
+                "type": "string",
+                "description": "The requested output projection in Proj4",
+                "examples": [
+                  "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"
+                ]
+              },
+              "wkt": {
+                "type": "string",
+                "description": "The requested output projection in WKT",
+                "examples": [
+                  "PROJCS[ ... ]"
+                ]
+              },
+              "epsg": {
+                "type": "string",
+                "description": "The requested output projection in EPSG. Optional; empty string when absent.",
+                "examples": [
+                  "EPSG:7030"
+                ]
+              }
+            },
+            "required": []
+          },
+          "isTransparent": {
+            "type": "boolean",
+            "description": "If set to true, no data areas should be set to transparent in the output"
+          },
+          "mime": {
+            "type": "string",
+            "description": "The requested mime type of the output file",
+            "examples": [
+              "image/tiff",
+              "application/x-netcdf4"
+            ]
+          },
+          "width": {
+            "type": "number",
+            "description": "For image output, the requested image width in pixels"
+          },
+          "height": {
+            "type": "number",
+            "description": "For image output, the requested image height in pixels"
+          },
+          "dpi": {
+            "type": "integer",
+            "description": "For image output, the dots-per-inch resolution of the output image"
+          },
+          "interpolation": {
+            "type": "string",
+            "description": "The interpolation method to be used during reprojection and scaling",
+            "examples": [
+              "near",
+              "bilinear"
+            ]
+          },
+          "scaleExtent": {
+            "$ref": "#/definitions/ScaleExtent"
+          },
+          "scaleSize": {
+            "$ref": "#/definitions/ScaleSize"
+          }
+        },
+        "required": []
+      },
+      "Source": {
+        "type": "object",
+        "title": "Source",
+        "description": "A group of files which come from a common collection and will have a common set of variables operated on",
+        "additionalProperties": false,
+        "properties": {
+          "collection": {
+            "type": "string",
+            "description": "The CMR Collection ID that has the variables and granules in this data source",
+            "examples": ["C1233800302-EEDTEST"]
+          },
+          "shortName": {
+            "type": "string",
+            "description": "The CMR short-name for this data source",
+            "examples": ["harmony_example"]
+          },
+          "versionId": {
+            "type": "string",
+            "description": "The CMR version-id for this data source",
+            "examples": ["1"]
+          },
+          "variables": {
+            "type": "array",
+            "description": "A list of variables the caller would like provided in the output.  If this attribute is null or absent, the service should provide all available variables in the output.",
+            "default": "all",
+            "items": {
+              "$ref": "#/definitions/Variable"
+            }
+          },
+          "coordinateVariables": {
+            "type": "array",
+            "description": "A list of coordinate variables for the source collection. A service may want to include the coordinate variables in the output.",
+            "default": "all",
+            "items": {
+              "$ref": "#/definitions/Variable"
+            }
+          },
+          "granules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Granule"
+            }
+          }
+        },
+        "required": [
+          "collection"
+        ]
+      },
+      "Granule": {
+        "type": "object",
+        "title": "Granule",
+        "description": "A granule file the caller would like included in the output.",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The CMR granule identifier",
+            "examples": [
+              "G1233800343-EEDTEST"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the granule (GranuleID, GranuleUR), typically corresponding to the data file name",
+            "examples": [
+              "001_00_7f00ff_global.nc"
+            ]
+          },
+          "url": {
+            "type": "string",
+            "description": "The URL or relative file path where the granule data file can be accessed.  This may be behind Earthdata Login."
+          },
+          "bbox": {
+            "description": "The bounding box for the granule.  Coordinates are [West, South, East, North].",
+            "examples": [
+              [-100.5, 30.4, -99.5, 31.4]
+            ],
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 4,
+            "maxItems": 4
+          },
+          "temporal": {
+            "description": "Time range for the granule",
+            "$ref": "#/definitions/Temporal"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "url"
+        ]
+      },
+      "Variable": {
+        "type": "object",
+        "title": "Variable",
+        "description": "A variable which the caller would like provided in the output",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The CMR ID of the variable",
+            "examples": [ "V1233801695-EEDTEST" ]
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the variable in the data file",
+            "examples": [ "red_var" ]
+          },
+          "fullPath": {
+            "type": "string",
+            "description": "The variable's absolute path within the file, including hierarchy.  Derived from UMM-Var group path combined with name.  If the group path is not set, this is the name",
+            "examples": [ "data/colors/red_var", "red_var" ]
+          },
+          "relatedUrls": {
+            "type": "array",
+            "description": "A list of the variable's related URL objects.",
+            "items": {
+              "$ref": "#/definitions/RelatedUrl"
+            }
+          },
+          "type": {
+            "type": "string",
+            "description": "The UMM Variable VariableType",
+            "examples": ["SCIENCE_VARIABLE", "QUALITY_VARIABLE", "ANCILLARY_VARIABLE", "COORDINATE", "OTHER"]
+          },
+          "subtype": {
+            "type": "string",
+            "description": "The UMM Variable VariableSubType",
+            "examples": ["SCIENCE_SCALAR", "SCIENCE_VECTOR", "SCIENCE_ARRAY", "SCIENCE_EVENTFLAG", "LATITUDE", "LONGITUDE", "TIME", "OTHER"]
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "fullPath"
+        ]
+      },
+      "Subset": {
+        "type": "object",
+        "title": "Subset",
+        "description": "Subsetting request parameters",
+        "additionalProperties": false,
+        "properties": {
+          "bbox": {
+            "name": "Bounding Box",
+            "description": "The bounding box which should be used for spatial subsetting.  Coordinates are [West, South, East, North].",
+            "examples": [
+              [-100.5, 30.4, -99.5, 31.4]
+            ],
+            "default": [-180, -90, 180, 90],
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 4,
+            "maxItems": 4
+          },
+          "point": {
+            "description": "Spatial point query parameter. Coordinates are [Longitude, Latitude].",
+            "$ref": "#/definitions/SpatialPoint"
+          },
+          "shape": {
+            "description": "Reference to a location containing a shape within which the service should spatially subset.  If present, the resource will always be GeoJSON (application/geo+json) in an object store (S3)",
+            "$ref": "#/definitions/RemoteResource"
+          },
+          "dimensions": {
+            "description": "Dimensions to subset against.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Dimension"
+            }
+          }
+        },
+        "required": []
+      },
+      "Temporal": {
+        "type": "object",
+        "title": "Temporal",
+        "description": "Temporal parameters for a date/time range",
+        "additionalProperties": false,
+        "properties": {
+          "start": {
+            "name": "Start time",
+            "description": "The start date/time. The format is an RFC-3339 datetime.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "end": {
+            "name": "End time",
+            "description": "The end date/time. The format is an RFC-3339 datetime.",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": []
+      },
+      "ExtendDimensions": {
+        "type": "array",
+        "title": "Extend Dimensions",
+        "description": "The names or concept IDs of the dimensions that should be extended.",
+        "examples": [
+          ["lat", "lon"]
+        ],
+        "items": {
+          "type": "string"
+        }
+      },
+      "SpatialPoint": {
+        "type": "array",
+        "title": "Point",
+        "description": "Spatial point query parameter. Coordinates are [Longitude, Latitude].",
+        "examples": [
+          [-100.5, 31.4]
+        ],
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 2
+      },
+      "ScaleExtent": {
+        "type": "object",
+        "title": "ScaleExtent",
+        "description": "Target grid extent",
+        "additionalProperties": false,
+        "properties": {
+          "x": {
+            "type": "object",
+            "description": "X dimension scale extent.",
+            "additionalProperties": false,
+            "properties": {
+              "min": {
+                "type": "number",
+                "description": "Minimum x of the scale extent."
+              },
+              "max": {
+                "type": "number",
+                "description": "Maximum x of the scale extent."
+              }
+            },
+            "required": []
+          },
+          "y": {
+            "type": "object",
+            "description": "Y dimension scale extent.",
+            "additionalProperties": false,
+            "properties": {
+              "min": {
+                "type": "number",
+                "description": "Minimum y of the scale extent."
+              },
+              "max": {
+                "type": "number",
+                "description": "Maximum y of the scale extent."
+              }
+            },
+            "required": []
+          }
+        },
+        "required": []
+      },
+      "ScaleSize": {
+        "type": "object",
+        "title": "ScaleSize",
+        "description": "Target grid scale size",
+        "additionalProperties": false,
+        "properties": {
+          "x": {
+            "type": "number",
+            "description": "Row scale size"
+          },
+          "y": {
+            "type": "number",
+            "description": "Column scale size."
+          }
+        },
+        "required": []
+      },
+      "RemoteResource": {
+        "type": "object",
+        "description": "A remote resource which needs to be downloaded before use",
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "The URI of the remote resource",
+            "examples": [ "s3://example-bucket/some/path/resource.ext" ]
+          },
+          "type": {
+            "type": "string",
+            "description": "The content type of the resource",
+            "examples": [ "application/geo+json" ]
+          }
+        },
+        "required": [
+          "href",
+          "type"
+        ]
+      },
+      "RelatedUrl": {
+        "type": "object",
+        "title": "RelatedUrl",
+        "description": "A related URL from the CMR",
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Points to an external resource or location on the web (data access location, project home page, relevant software packages, etc.)"
+          },
+          "urlContentType": {
+            "type": "string",
+            "description": "A keyword which describes the content of a link at a high level.",
+            "examples": ["CollectionURL", "PublicationURL", "DataCenterURL", "DistributionURL", "DataContactURL", "VisualizationURL"]
+          },
+          "type": {
+            "type": "string",
+            "description": "A keyword which specifies the content of a link.",
+            "examples": ["GET DATA", "HOME PAGE", "Color Map"]
+          },
+          "subtype": {
+            "type": "string",
+            "description": "A keyword which further specifies the content of a link.",
+            "examples": ["Harmony GDAL", "GITC", "Giovanni"]
+          },
+          "description": {
+            "type": "string",
+            "description": "Explains where the link navigates and the type of information it contains."
+          },
+          "format": {
+            "type": "string",
+            "description": "The format of the data.",
+            "examples": ["ASCII", "GIF", "JPEG"]
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "The mime type of the data.",
+            "examples": ["application/json", "application/x-hdf", "image/png"]
+          }
+        },
+        "required": []
+      },
+      "Dimension": {
+        "type": "object",
+        "title": "Dimension",
+        "description": "Information on how to subset the data file for a dimension.",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the dimension of the variable represented in the data field.",
+            "examples": ["XDim"]
+          },
+          "min": {
+            "type": "number",
+            "description": "The minimum value for the dimension."
+          },
+          "max": {
+            "type": "number",
+            "description": "The maximum value for the dimension."
+          }
+        },
+        "required": ["name"]
+      }
+    }
+  }

--- a/app/schemas/data-operation/CHANGELOG.md
+++ b/app/schemas/data-operation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.18.0] - 2022-08-24
+### Added
+- sources.extendDimensions - The dimensions to extend (added inititally for TEMPO users)
+
 ## [0.17.0] - 2022-07-12
 ### Added
 - sources.shortName - The CMR short name for a source

--- a/app/schemas/data-operation/CHANGELOG.md
+++ b/app/schemas/data-operation/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.18.0] - 2022-08-24
+## [0.18.0] - 2023-08-28
 ### Added
 - sources.extendDimensions - The dimensions to extend (added inititally for TEMPO users)
 

--- a/app/schemas/data-operation/README.md
+++ b/app/schemas/data-operation/README.md
@@ -20,7 +20,7 @@
 - [ ] Update [harmony-service-lib-py/example/example_message.json](../../../../harmony-service-lib-py/example/example_message.json) to use the new schema
 - [ ] Update [harmony-service-example/example/harmony-operation.json](../../../../harmony-service-example/example/harmony-operation.json) to use the new schema
 - [ ] Update [config/services.yml](../../../config/services.yml) to supply the new library version for any services that will be automatically or manually upgraded with the change
-- [ ] Update [docs/adapting-new-services.md](../../../docs/adapting-new-services.md) to specify the updated version
+- [ ] Update [docs/adapting-new-services.md](../../../docs/guides/adapting-new-services.md) to specify the updated version
 - [ ] Update any Harmony-owned services that need to use the new features or may be incompatible with the change
 - [ ] Notify service authors that the schema was updated
 - [ ] Swear that next time around you'll make the process a little easier

--- a/app/util/parameter-parsers.ts
+++ b/app/util/parameter-parsers.ts
@@ -39,6 +39,21 @@ export function handleGranuleIds(
 }
 
 /**
+ * Handle the extend parameter in a Harmony query, adding it to extendDimensions in
+ * the DataOperation if necessary.
+ *
+ * @param operation - the DataOperation for the request
+ * @param query - the query for the request
+ */
+export function handleExtend(
+  operation: DataOperation,
+  query: Record<string, string>): void {
+  if (query.granuleid) {
+    operation.extendDimensions = parseMultiValueParameter(query.extend);
+  }
+}
+
+/**
  * Handle the ouptputCrs parameter in a Harmony query, adding it to the DataOperation
  * if necessary.
  *

--- a/app/util/parameter-parsers.ts
+++ b/app/util/parameter-parsers.ts
@@ -48,7 +48,7 @@ export function handleGranuleIds(
 export function handleExtend(
   operation: DataOperation,
   query: Record<string, string>): void {
-  if (query.granuleid) {
+  if (query.extend) {
     operation.extendDimensions = parseMultiValueParameter(query.extend);
   }
 }

--- a/config/services.yml
+++ b/config/services.yml
@@ -27,7 +27,7 @@ https://cmr.earthdata.nasa.gov:
     description: |
       A service to compose the Giovanni URL and invoke Giovanni service to produce output file to visualize, analyze,
       and access vast amounts of Earth science remote sensing data without having to download the data.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     enabled: !Env ${EXAMPLE_SERVICES}
     has_granule_limit: false
     default_sync: true
@@ -74,7 +74,7 @@ https://cmr.earthdata.nasa.gov:
       * Variable subsetting supported
       * works with hierarchical groups
       Outputs netcdf4.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -100,7 +100,7 @@ https://cmr.earthdata.nasa.gov:
     description: |
       Service capabale of "concatenating" multiple netCDF files into a single netCDF files.
       The resulting file has an extra dimension with size equal to the number of input files where each slice in that dimension corresponds to the data from one of the inputs.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -137,7 +137,7 @@ https://cmr.earthdata.nasa.gov:
       #### PODAAC concise services
       Service capabale of "concatenating" multiple netCDF files into a single netCDF files.
       The resulting file has an extra dimension with size equal to the number of input files where each slice in that dimension corresponds to the data from one of the inputs.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -172,7 +172,7 @@ https://cmr.earthdata.nasa.gov:
       A service that supports L2 segmented trajectory (**not swath**) data.
       Currently uses the same C++ binary as is on-premises in SDPS, to offer variable, temporal, bounding box spatial and polygon spatial subsetting.
       **This subsetter also ensures valid segment indices and sizes following transformation.**
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -202,7 +202,7 @@ https://cmr.earthdata.nasa.gov:
       plus all those that are required to support meaningful downstream operations upon those data (e.g. associated coordinate variables).
 
       This service is currently operated from the same Docker image as the sds/variable-subsetter service.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -238,7 +238,7 @@ https://cmr.earthdata.nasa.gov:
       plus all those that are required to support meaningful downstream operations upon those data (e.g. associated coordinate variables).
 
       This service is currently operated from the same Docker image as the sds/variable-subsetter service.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -274,7 +274,7 @@ https://cmr.earthdata.nasa.gov:
       and output to NetCDF4, COG, PNG, and GIF.
       Operates on input file types supported by GDAL (most EOSDIS data).
       Most operations assume L3 data, though it is likely that some work on L2.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -304,7 +304,7 @@ https://cmr.earthdata.nasa.gov:
     description: |
       Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
       The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -331,7 +331,7 @@ https://cmr.earthdata.nasa.gov:
     description: |
       Reference service that can be used to perform most operations supported by Harmony.
       Useful for testing new API features end-to-end on example data but not meant for production use.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -360,7 +360,7 @@ https://cmr.uat.earthdata.nasa.gov:
     description: |
       A service to compose the Giovanni URL and invoke Giovanni service to produce output file to visualize, analyze,
       and access vast amounts of Earth science remote sensing data without having to download the data.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     has_granule_limit: false
     default_sync: true
     type:
@@ -406,7 +406,7 @@ https://cmr.uat.earthdata.nasa.gov:
       * Variable subsetting supported
       * works with hierarchical groups
       Outputs netcdf4.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -432,7 +432,7 @@ https://cmr.uat.earthdata.nasa.gov:
     description: |
       Service capabale of "concatenating" multiple netCDF files into a single netCDF files.
       The resulting file has an extra dimension with size equal to the number of input files where each slice in that dimension corresponds to the data from one of the inputs.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -469,7 +469,7 @@ https://cmr.uat.earthdata.nasa.gov:
       #### PODAAC concise service
       Service capabale of "concatenating" multiple netCDF files into a single netCDF files.
       The resulting file has an extra dimension with size equal to the number of input files where each slice in that dimension corresponds to the data from one of the inputs.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -503,7 +503,7 @@ https://cmr.uat.earthdata.nasa.gov:
     description: |
       Takes NetCDF-4 input files and projects input swath variables to an output grid.
       Target CRS, output grid dimensions, extents and/or resolutions can be specified in the Harmony request.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -527,7 +527,7 @@ https://cmr.uat.earthdata.nasa.gov:
   - name: sds/harmony-regridder
     description: |
       The Harmony Regridding Service for L3/L4 collections
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -554,7 +554,7 @@ https://cmr.uat.earthdata.nasa.gov:
       The Variable Subsetter provides _only_ variable subsetting.
       Accesses NetCDF-4 files hosted in Hyrax cloud service (OPeNDAP), and retrieves the requested list of variables,
       plus all those that are required to support meaningful downstream operations upon those data (e.g. associated coordinate variables).
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -580,7 +580,7 @@ https://cmr.uat.earthdata.nasa.gov:
     description: |
       The service takes input HDF-5 or GeoTIFF file and GeoJSON shape file,
       masks science (non-coordinate) variables such that pixel values outside of the GeoJSON shape are set to a fill value.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -601,7 +601,7 @@ https://cmr.uat.earthdata.nasa.gov:
       A service that supports L2 segmented trajectory (**not swath**) data.
       Currently uses the same C++ binary as is on-premises in SDPS, to offer variable, temporal, bounding box spatial and polygon spatial subsetting.
       **This subsetter also ensures valid segment indices and sizes following transformation.**
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -629,7 +629,7 @@ https://cmr.uat.earthdata.nasa.gov:
   - name: harmony/example
     description: |
       An example service for testing harmony http service integration. This service isn't docker-based or make GDAL calls - it does not actually do anything with the data files.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     enabled: !Env ${EXAMPLE_SERVICES}
     type:
       name: http
@@ -652,7 +652,7 @@ https://cmr.uat.earthdata.nasa.gov:
       and output to NetCDF4, COG, PNG, and GIF.
       Operates on input file types supported by GDAL (most EOSDIS data).
       Most operations assume L3 data, though it is likely that some work on L2.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -685,7 +685,7 @@ https://cmr.uat.earthdata.nasa.gov:
       JPEG outputs. This includes, where necessary, conversion to a GIBS
       supported Coordinate Reference System (CRS). Other projections can be
       requested, but will not be compatible with GIBS.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -716,7 +716,7 @@ https://cmr.uat.earthdata.nasa.gov:
       plus all those that are required to support meaningful downstream operations upon those data (e.g. associated coordinate variables).
 
       This service is currently operated from the same Docker image as the sds/variable-subsetter service.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -752,7 +752,7 @@ https://cmr.uat.earthdata.nasa.gov:
       plus all those that are required to support meaningful downstream operations upon those data (e.g. associated coordinate variables).
 
       This service is currently operated from the same Docker image as the sds/variable-subsetter service.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -784,7 +784,7 @@ https://cmr.uat.earthdata.nasa.gov:
     description: |
       Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
       The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -821,7 +821,7 @@ https://cmr.uat.earthdata.nasa.gov:
       #### Harmony netcdf-to-zarr service
       Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
       The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -864,7 +864,7 @@ https://cmr.uat.earthdata.nasa.gov:
       Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
       The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
 
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -901,7 +901,7 @@ https://cmr.uat.earthdata.nasa.gov:
     description: |
       Reference service that can be used to perform most operations supported by Harmony.
       Useful for testing new API features end-to-end on example data but not meant for production use.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:

--- a/docs/guides/adapting-new-services.md
+++ b/docs/guides/adapting-new-services.md
@@ -86,7 +86,7 @@ The structure of an entry in the [services.yml](../../config/services.yml) file 
 
 ```yaml
 - name: harmony/service-example    # A unique identifier string for the service, conventionally <team>/<service>
-  data_operation_version: '0.17.0' # The version of the data-operation messaging schema to use
+  data_operation_version: '0.18.0' # The version of the data-operation messaging schema to use
   has_granule_limit: true          # Optional flag indicating whether we will impose granule limts for the request. Default to true.
   default_sync: false              # Optional flag indicating whether we will force the request to run synchrously. Default to false.
   type:                            # Configuration for service invocation

--- a/example/service-operation.json
+++ b/example/service-operation.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "../app/schemas/data-operation/0.17.0/data-operation-v0.17.0.json",
-  "version": "0.17.0",
+  "$schema": "../app/schemas/data-operation/0.18.0/data-operation-v0.18.0.json",
+  "version": "0.18.0",
   "callback": "http://localhost/some-path",
   "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
   "user": "jdoe",
@@ -93,6 +93,7 @@
       "max": 12.0
     }]
   },
+  "extendDimensions": ["lat", "lon"],
   "isSynchronous": false,
   "requestId": "c045c793-19f1-43b5-9547-c87a5c7dfadb",
   "client": "harmony-sit",

--- a/fixtures/cmr.uat.earthdata.nasa.gov-443/169290180525797114
+++ b/fixtures/cmr.uat.earthdata.nasa.gov-443/169290180525797114
@@ -1,0 +1,29 @@
+POST /search/granules.json
+accept: application/json
+content-type: multipart/form-data; boundary=----------------------------012345678901234567890123
+accept-encoding: gzip,deflate
+body: ------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"collection_concept_id\"\r\n\r\nC1233800302-EEDTEST\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"page_size\"\r\n\r\n100\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"temporal\"\r\n\r\n2020-01-02T00:00:00.000Z,2020-01-02T01:00:00.000Z\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"concept_id\"\r\n\r\nG1233800352-EEDTEST\r\n------------------------------012345678901234567890123--\r\n
+
+HTTP/1.1 200 OK
+content-type: application/json;charset=utf-8
+transfer-encoding: chunked
+connection: close
+date: Thu, 24 Aug 2023 18:30:04 GMT
+x-frame-options: SAMEORIGIN
+access-control-allow-origin: *
+x-xss-protection: 1; mode=block
+cmr-request-id: aa68143c-229b-4dce-8431-534b96fdbd1d
+strict-transport-security: max-age=31536000
+cmr-search-after: ["eedtest",1577923200000,1233800352]
+cmr-hits: 1
+access-control-expose-headers: CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out, CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+x-content-type-options: nosniff
+cmr-took: 68
+x-request-id: d-Hw6so_sPKat106p6iE9v7Tlu2uEPvV46MdPitHmTD2MjdQqmUMgA==
+server: ServerTokens ProductOnly
+x-cache: Miss from cloudfront
+via: 1.1 5fa120f79d5713714191c32768eca58c.cloudfront.net (CloudFront)
+x-amz-cf-pop: SFO5-C1
+x-amz-cf-id: d-Hw6so_sPKat106p6iE9v7Tlu2uEPvV46MdPitHmTD2MjdQqmUMgA==
+
+{"feed":{"updated":"2023-08-24T18:30:04.932Z","id":"https://cmr.uat.earthdata.nasa.gov:443/search/granules.json","title":"ECHO granule metadata","entry":[{"producer_granule_id":"002_00_3200ff_global","boxes":["-90 -180 90 180"],"time_start":"2020-01-02T00:00:00.000Z","updated":"2020-02-25T21:43:11.000Z","dataset_id":"Harmony Example Data","data_center":"EEDTEST","title":"002_00_3200ff_global","coordinate_system":"CARTESIAN","day_night_flag":"BOTH","time_end":"2020-01-02T01:59:59.000Z","id":"G1233800352-EEDTEST","original_format":"UMM_JSON","granule_size":"1.3663883209228516","browse_flag":false,"collection_concept_id":"C1233800302-EEDTEST","online_access_flag":true,"links":[{"rel":"http://esipfed.org/ns/fedsearch/1.1/data#","type":"application/x-netcdf","hreflang":"en-US","href":"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/nc/002_00_3200ff_global.nc"},{"rel":"http://esipfed.org/ns/fedsearch/1.1/data#","type":"image/tiff","hreflang":"en-US","href":"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/tiff/002_00_3200ff_global.tif"}]}]}}

--- a/fixtures/cmr.uat.earthdata.nasa.gov-443/169290180675467658
+++ b/fixtures/cmr.uat.earthdata.nasa.gov-443/169290180675467658
@@ -1,0 +1,29 @@
+POST /search/granules.json
+accept: application/json
+content-type: multipart/form-data; boundary=----------------------------012345678901234567890123
+accept-encoding: gzip,deflate
+body: ------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"collection_concept_id\"\r\n\r\nC1233800302-EEDTEST\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"page_size\"\r\n\r\n100\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"temporal\"\r\n\r\n2020-01-02T00:00:00.000Z,2020-01-02T01:00:00.000Z\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"concept_id\"\r\n\r\nG1233800352-EEDTEST\r\n------------------------------012345678901234567890123--\r\n
+
+HTTP/1.1 200 OK
+content-type: application/json;charset=utf-8
+transfer-encoding: chunked
+connection: close
+date: Thu, 24 Aug 2023 18:30:06 GMT
+x-frame-options: SAMEORIGIN
+access-control-allow-origin: *
+x-xss-protection: 1; mode=block
+cmr-request-id: 6e4fc9a6-1f12-4ab9-9576-22b0235940bb
+strict-transport-security: max-age=31536000
+cmr-search-after: ["eedtest",1577923200000,1233800352]
+cmr-hits: 1
+access-control-expose-headers: CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out, CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+x-content-type-options: nosniff
+cmr-took: 66
+x-request-id: e41cd20LUc4ghmt6Qsutzpvg83djy9w7ER5aRG1CVn8MQmPHrMqoaQ==
+server: ServerTokens ProductOnly
+x-cache: Miss from cloudfront
+via: 1.1 b5546ff55405d525045e7263ba6db012.cloudfront.net (CloudFront)
+x-amz-cf-pop: SFO5-C1
+x-amz-cf-id: e41cd20LUc4ghmt6Qsutzpvg83djy9w7ER5aRG1CVn8MQmPHrMqoaQ==
+
+{"feed":{"updated":"2023-08-24T18:30:06.714Z","id":"https://cmr.uat.earthdata.nasa.gov:443/search/granules.json","title":"ECHO granule metadata","entry":[{"producer_granule_id":"002_00_3200ff_global","boxes":["-90 -180 90 180"],"time_start":"2020-01-02T00:00:00.000Z","updated":"2020-02-25T21:43:11.000Z","dataset_id":"Harmony Example Data","data_center":"EEDTEST","title":"002_00_3200ff_global","coordinate_system":"CARTESIAN","day_night_flag":"BOTH","time_end":"2020-01-02T01:59:59.000Z","id":"G1233800352-EEDTEST","original_format":"UMM_JSON","granule_size":"1.3663883209228516","browse_flag":false,"collection_concept_id":"C1233800302-EEDTEST","online_access_flag":true,"links":[{"rel":"http://esipfed.org/ns/fedsearch/1.1/data#","type":"application/x-netcdf","hreflang":"en-US","href":"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/nc/002_00_3200ff_global.nc"},{"rel":"http://esipfed.org/ns/fedsearch/1.1/data#","type":"image/tiff","hreflang":"en-US","href":"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/tiff/002_00_3200ff_global.tif"}]}]}}

--- a/test/helpers/data-operation.ts
+++ b/test/helpers/data-operation.ts
@@ -6,6 +6,7 @@ import { v4 as uuid } from 'uuid';
 export const samplesDir = './test/resources/data-operation-samples';
 
 export const versions = [
+  '0.18.0',
   '0.17.0',
   '0.16.0',
   '0.15.0',

--- a/test/models/data-operation.ts
+++ b/test/models/data-operation.ts
@@ -11,7 +11,7 @@ const expectedOutput = parseSchemaFile(`valid-operation-v${versions[0]}.json`);
 // The fields that all operations should contain
 const baseFields = new Set([
   'client', 'callback', 'stagingLocation', 'sources', 'format', 'user', 'accessToken',
-  'subset', 'isSynchronous', 'requestId', 'version', 'concatenate', 'extend',
+  'subset', 'isSynchronous', 'requestId', 'version', 'concatenate', 'extendDimensions',
 ]);
 
 describe('DataOperation', () => {

--- a/test/models/data-operation.ts
+++ b/test/models/data-operation.ts
@@ -11,7 +11,7 @@ const expectedOutput = parseSchemaFile(`valid-operation-v${versions[0]}.json`);
 // The fields that all operations should contain
 const baseFields = new Set([
   'client', 'callback', 'stagingLocation', 'sources', 'format', 'user', 'accessToken',
-  'subset', 'isSynchronous', 'requestId', 'version', 'concatenate',
+  'subset', 'isSynchronous', 'requestId', 'version', 'concatenate', 'extend',
 ]);
 
 describe('DataOperation', () => {

--- a/test/models/services.ts
+++ b/test/models/services.ts
@@ -94,6 +94,19 @@ describe('services.chooseServiceConfig and services.buildService', function () {
             },
           },
         },
+        {
+          name: 'extend-service',
+          type: { name: 'turbo' },
+          collections: [{ id: collectionId }],
+          capabilities: {
+            extend: true,
+            output_formats: ['application/x-netcdf4'],
+            concatenation: true,
+            subsetting: {
+              temporal: false,
+            },
+          },
+        },
       ];
     });
 
@@ -155,6 +168,17 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       it('chooses the service that supports spatial subsetting', function () {
         const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
         expect(serviceConfig.name).to.equal('tiff-png-bbox-service');
+      });
+    });
+
+    describe('and the request needs dimension extension', function () {
+      beforeEach(function () {
+        this.operation.extendDimensions = ['lat', 'lon'];
+      });
+
+      it('chooses the service that supports dimension extension', function () {
+        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        expect(serviceConfig.name).to.equal('extend-service');
       });
     });
 

--- a/test/ogc-api-coverages/get-coverage-rangeset.ts
+++ b/test/ogc-api-coverages/get-coverage-rangeset.ts
@@ -46,6 +46,7 @@ describe('OGC API Coverages - getCoverageRangeset', function () {
           width: 1000,
           format: 'image/png',
           skipPreview: 'true',
+          extend: 'lat,lon',
         };
 
         describe('calling the backend service', function () {
@@ -130,6 +131,10 @@ describe('OGC API Coverages - getCoverageRangeset', function () {
 
           it('passes the format parameter to the backend', function () {
             expect(this.service.operation.outputFormat).to.equal('image/png');
+          });
+
+          it('passes the extend parameter to the backend', function () {
+            expect(this.service.operation.extendDimensions).to.have.members(['lat', 'lon']);
           });
         });
 

--- a/test/resources/data-operation-samples/batch1-operation.json
+++ b/test/resources/data-operation-samples/batch1-operation.json
@@ -122,6 +122,7 @@
       10
     ]
   },
+  "extendDimensions": ["lat", "lon"],
   "requestId": "5fab13b7-cff1-4fb3-83ac-e4fe95775701",
   "user": "jnorton1",
   "client": "harmony-local",

--- a/test/resources/data-operation-samples/batch2-operation.json
+++ b/test/resources/data-operation-samples/batch2-operation.json
@@ -122,6 +122,7 @@
       10
     ]
   },
+  "extendDimensions": ["lat", "lon"],
   "requestId": "5fab13b7-cff1-4fb3-83ac-e4fe95775701",
   "user": "jnorton1",
   "client": "harmony-local",

--- a/test/resources/data-operation-samples/batch3-operation.json
+++ b/test/resources/data-operation-samples/batch3-operation.json
@@ -61,6 +61,7 @@
       10
     ]
   },
+  "extendDimensions": ["lat", "lon"],
   "requestId": "5fab13b7-cff1-4fb3-83ac-e4fe95775701",
   "user": "jnorton1",
   "client": "harmony-local",

--- a/test/resources/data-operation-samples/batch4-operation.json
+++ b/test/resources/data-operation-samples/batch4-operation.json
@@ -122,6 +122,7 @@
       10
     ]
   },
+  "extendDimensions": ["lat", "lon"],
   "requestId": "5fab13b7-cff1-4fb3-83ac-e4fe95775701",
   "user": "jnorton1",
   "client": "harmony-local",

--- a/test/resources/data-operation-samples/batch5-operation.json
+++ b/test/resources/data-operation-samples/batch5-operation.json
@@ -107,6 +107,7 @@
       10
     ]
   },
+  "extendDimensions": ["lat", "lon"],
   "requestId": "5fab13b7-cff1-4fb3-83ac-e4fe95775701",
   "user": "jnorton1",
   "client": "harmony-local",

--- a/test/resources/data-operation-samples/multiple-collections-operation.json
+++ b/test/resources/data-operation-samples/multiple-collections-operation.json
@@ -368,6 +368,7 @@
       10
     ]
   },
+  "extendDimensions": ["lat", "lon"],
   "requestId": "5fab13b7-cff1-4fb3-83ac-e4fe95775701",
   "user": "jnorton1",
   "client": "harmony-local",

--- a/test/resources/data-operation-samples/valid-operation-input.json
+++ b/test/resources/data-operation-samples/valid-operation-input.json
@@ -97,6 +97,7 @@
       "max": 12.0
     }]
   },
+  "extendDimensions": ["lat", "lon"],
   "isSynchronous": true,
   "requestId": "c045c793-19f1-43b5-9547-c87a5c7dfadb",
   "temporal": {
@@ -104,5 +105,5 @@
     "end": "2020-02-20T15:00:00.000Z"
   },
   "concatenate": false,
-  "version": "0.17.0"
+  "version": "0.18.0"
 }

--- a/test/resources/data-operation-samples/valid-operation-v0.18.0.json
+++ b/test/resources/data-operation-samples/valid-operation-v0.18.0.json
@@ -1,0 +1,110 @@
+{
+    "client": "harmony-test",
+    "callback": "http://example.com/callback",
+    "stagingLocation": "s3://some-bucket/public/some/prefix/",
+    "sources": [
+      {
+        "collection": "C1233800302-EEDTEST",
+        "shortName": "harmony_example",
+        "versionId": "1",
+        "variables": [{
+          "id": "V1233801717-EEDTEST",
+          "name": "alpha_var",
+          "fullPath": "data/colors/red_var",
+          "relatedUrls": [
+            {
+              "description" : "This URL points to some text data.",
+              "urlContentType" : "DistributionURL",
+              "type" : "GET DATA" ,
+              "url" : "http://example.com/file649.txt"
+            }
+          ],
+          "type": "SCIENCE_VARIABLE",
+          "subtype": "SCIENCE_ARRAY"
+        }],
+        "coordinateVariables": [{
+          "id": "V1233801718-EEDTEST",
+          "name": "lat",
+          "fullPath": "lat",
+          "type": "COORDINATE",
+          "subtype": "LATITUDE"
+        }],
+        "granules": [
+          {
+            "id": "G1233800343-EEDTEST",
+            "name": "001_00_7f00ff_global.nc",
+            "url": "http://opendap.two.example.com",
+            "bbox": [
+              -100.5,
+              30.4,
+              -99.5,
+              31.4
+            ],
+            "temporal": {
+              "start": "1999-01-01T10:00:00.000Z",
+              "end": "2020-02-20T15:00:00.000Z"
+            }
+          }
+        ]
+      }
+    ],
+    "format": {
+      "mime": "image/png",
+      "interpolation": "near",
+      "scaleExtent": {
+        "x": {
+          "min": 0.5,
+          "max": 125
+        },
+        "y": {
+          "min": 52,
+          "max": 75.22
+        }
+      },
+      "scaleSize": {
+        "x": 14.2,
+        "y": 35
+      },
+      "crs": "CRS84",
+      "srs": {
+        "proj4": "+proj=longlat +datum=WGS84 +no_defs",
+        "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]",
+        "epsg": "EPSG:4326"
+      },
+      "width": 120,
+      "height": 225
+    },
+    "user": "test-user",
+    "accessToken": "FxLhvhM8JsmdxJHk4Edsmyn7Z0s5tkXe:4M2RrCrhVbS0IKxicg+ix567em1W5UDV9dSdkn3m",
+    "subset": {
+      "bbox": [
+        -130,
+        -45,
+        130,
+        45
+      ],
+      "point": [
+        -130,
+        45
+      ],
+      "shape": {
+        "href": "s3://example-bucket/some/path/resource.ext",
+        "type": "application/geo+json"
+      },
+      "dimensions": [{
+        "name": "XDim",
+        "min": 0.5,
+        "max": 12.0
+      }]
+    },
+    "extendDimensions": ["lat", "lon"],
+    "isSynchronous": true,
+    "requestId": "c045c793-19f1-43b5-9547-c87a5c7dfadb",
+    "temporal": {
+      "start": "1999-01-01T10:00:00.000Z",
+      "end": "2020-02-20T15:00:00.000Z"
+    },
+    "concatenate": false,
+    "version": "0.18.0"
+  }
+  


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1505/6

## Description
Adds extendDimensions to the DataOperation. Holding off on API documentation until we are fully operational with the first extend-capable service.

## Local Test Steps
- Under `capabilities:` in services.yml, for harmony-service-example in UAT, add `extend: true`.
- Request: http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?granuleId=G1233800343-EEDTEST&format=image/tiff&extend=a,b
- Check the workflow_steps table, operation column to ensure the values `a,b` were passed via the extendDimensions property in the operation JSON

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)