### PR TITLE
HARMONY-1572: Remove dependencies on NodeJS and AWS CLI from harmony in a box

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE=node:16-buster
 FROM $BASE_IMAGE
-RUN apt update && apt-get -y install sqlite3
+RUN apt update && apt-get -y install sqlite3 python3 python3-pip python3-setuptools
+RUN pip3 install --upgrade pip awscli awscli-local
 RUN mkdir -p /harmony
 COPY package.json package-lock.json lerna.json /harmony/
 RUN chown node -R /harmony

--- a/bin/deploy-services
+++ b/bin/deploy-services
@@ -53,9 +53,17 @@ if [ ! -f "$file" ]; then
 fi
 envsubst < $file | kubectl apply -f - -n harmony
 
+harmony_pod=$(kubectl get pods -n harmony -l app=harmony | grep -v NAME | awk '{print $1;}')
 # create the service queue
 if [ "$USE_SERVICE_QUEUES" == "true" ]; then
-  awslocal sqs create-queue --queue-name "query-cmr.fifo" --attributes FifoQueue=true,ContentBasedDeduplication=true --region us-west-2
+  if [ "$harmony_pod" == "" ]; then
+    # Not running harmony in a box
+    awslocal sqs create-queue --queue-name "query-cmr.fifo" --attributes FifoQueue=true,ContentBasedDeduplication=true --region us-west-2
+  else
+    # Running harmony in a box
+    echo "Creating query-cmr queue using harmony container"
+    kubectl -n harmony exec -it $harmony_pod -- awslocal sqs create-queue --queue-name "query-cmr.fifo" --attributes FifoQueue=true,ContentBasedDeduplication=true --region us-west-2
+  fi
 fi
 
 # create the other services
@@ -91,6 +99,13 @@ do
 
   # create the service queue
   if [ "$USE_SERVICE_QUEUES" == "true" ]; then
-    awslocal sqs create-queue --queue-name "${SERVICE_NAME}.fifo" --attributes FifoQueue=true,ContentBasedDeduplication=true --region us-west-2
+    if [ "$harmony_pod" == "" ]; then
+      # Not running harmony in a box
+      awslocal sqs create-queue --queue-name "${SERVICE_NAME}.fifo" --attributes FifoQueue=true,ContentBasedDeduplication=true --region us-west-2
+    else
+      # Running harmony in a box
+      echo "Creating ${SERVICE_NAME} queue using harmony container"
+      kubectl -n harmony exec -it $harmony_pod -- awslocal sqs create-queue --queue-name "${SERVICE_NAME}.fifo" --attributes FifoQueue=true,ContentBasedDeduplication=true --region us-west-2
+    fi
   fi
 done

--- a/bin/start-harmony
+++ b/bin/start-harmony
@@ -12,4 +12,8 @@ eval "$env_save"
 
 envsubst < ./config/harmony-k8s.yaml | kubectl apply -f - -n harmony > /dev/null
 bin/port-forward start harmony 3000:3000
+
+harmony_pod=$(kubectl get pods -n harmony -l app=harmony | grep -v NAME | awk '{print $1;}')
+echo 'Running database migrations using harmony container'
+kubectl -n harmony exec -it $harmony_pod -- npx knex --cwd db migrate:latest
 echo 'Harmony has started at http://localhost:3000/'

--- a/bin/start-postgres-localstack
+++ b/bin/start-postgres-localstack
@@ -114,8 +114,9 @@ POSTGRES_PORT="${POSTGRES_PORT:-5432}"
 bin/port-forward start localstack 4566:4566 4572:4566 4592:4566
 bin/port-forward start postgres ${POSTGRES_PORT}:5432
 
-# run migrations
-DATABASE_TYPE=postgres DATABASE_URL="postgresql://postgres:password@localhost:${POSTGRES_PORT}/postgres" npx knex --cwd db migrate:latest
+# Try to run migrations when not using harmony in a box. If using harmony in a box and this fails,
+# the migrations will run during the bin/start-harmony script.
+DATABASE_TYPE=postgres DATABASE_URL="postgresql://postgres:password@localhost:${POSTGRES_PORT}/postgres" npx knex --cwd db migrate:latest || true
 
 echo ''
 echo 'Localstack has started at http://localhost:4566/'


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1572

## Description
Currently harmony in a box requires NodeJS, a successful npm install within harmony, the AWS and awslocal CLIs. This ticket makes it so that none of those are required. Instead any calls that need to be made from our scripts that use those dependencies are performed through the harmony container.

## Local Test Steps
`npm run bulid` - this will take 10 minutes
`bin/stop-harmony-and-services`
Switch your .env file to one for harmony in a box.
`bin/bootstrap-harmony`
Verify from the screen that the database migrations were successfully run and the queues were created using the harmony container. You should see messages like:
"Creating harmony-service-example queue using harmony container".
Verify you can submit a successful request.

Run `bin/stop-harmony-and-services` to destroy everything and copy back your .env file for local development.
Run `bin/start-postgres-localstack && bin/restart-services` and verify migrations are run and queues are created. This time you should not see a log message for creating the queues using the harmony container.
Verify you can submit a successful request.

If someone wants to try without NodeJS or the AWS cli installed to verify harmony in a box definitely works without them that would be good, but not sure how to do that.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)