### PR TITLE
HARMONY-1510: Work items update performance improvement

### DIFF
--- a/app/backends/workflow-orchestration/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration/workflow-orchestration.ts
@@ -70,7 +70,16 @@ export async function getWork(
  */
 export async function updateWorkItem(req: HarmonyRequest, res: Response): Promise<void> {
   const { id } = req.params;
-  const { status, hits, results, scrollID, workflowStepIndex, errorMessage, duration, operation, outputItemSizes } = req.body;
+  const {
+    status,
+    hits,
+    results,
+    scrollID,
+    workflowStepIndex,
+    errorMessage,
+    duration,
+    operation,
+    outputItemSizes } = req.body;
   const totalItemsSize = req.body.totalItemsSize ? parseFloat(req.body.totalItemsSize) : 0;
 
   const update = {

--- a/app/backends/workflow-orchestration/workflow-orchestration.ts
+++ b/app/backends/workflow-orchestration/workflow-orchestration.ts
@@ -70,7 +70,7 @@ export async function getWork(
  */
 export async function updateWorkItem(req: HarmonyRequest, res: Response): Promise<void> {
   const { id } = req.params;
-  const { status, hits, results, scrollID, errorMessage, duration, operation, outputItemSizes } = req.body;
+  const { status, hits, results, scrollID, workflowStepIndex, errorMessage, duration, operation, outputItemSizes } = req.body;
   const totalItemsSize = req.body.totalItemsSize ? parseFloat(req.body.totalItemsSize) : 0;
 
   const update = {
@@ -79,6 +79,7 @@ export async function updateWorkItem(req: HarmonyRequest, res: Response): Promis
     hits,
     results,
     scrollID,
+    workflowStepIndex,
     errorMessage,
     totalItemsSize,
     outputItemSizes,

--- a/app/models/work-item-update.ts
+++ b/app/models/work-item-update.ts
@@ -17,6 +17,9 @@ export default interface WorkItemUpdate {
   // The ID of the scroll session (only used for the query cmr service)
   scrollID?: string;
 
+  // The workflowStepIndex of the work item
+  workflowStepIndex?: number;
+
   // The number of cmr hits (only used for the query cmr service)
   hits?: number;
 

--- a/kubernetes-services/work-updater/app/workers/updater.ts
+++ b/kubernetes-services/work-updater/app/workers/updater.ts
@@ -63,7 +63,7 @@ async function handleBatchWorkItemUpdatesWithJobId(jobID: string, updates: WorkI
           item.preprocessResult = result;
           return item;
         }));
-      await processWorkItems(jobID, preprocessedWorkItems, logger);
+      await processWorkItems(jobID, parseInt(workflowStepIndex), preprocessedWorkItems, logger);
     }
   }
   const durationMs = new Date().getTime() - startTime;

--- a/kubernetes-services/work-updater/app/workers/updater.ts
+++ b/kubernetes-services/work-updater/app/workers/updater.ts
@@ -14,7 +14,7 @@ import { Worker } from '../../../../app/workers/worker';
 import env from '../util/env';
 
 /**
- * Group work item updates by its workflow step and returned the grouped work item updates
+ * Group work item updates by its workflow step and return the grouped work item updates
  * as a map of workflow step to a list of work item updates on that workflow step.
  * @param updates - List of work item updates
  *
@@ -40,7 +40,7 @@ function groupByWorkflowStepIndex(
 /**
  * Updates the batch of work items.
  * It is assumed that all the work items belong to the same job.
- * It processes the work tiem updates in groups by the workflow step.
+ * It processes the work item updates in groups by the workflow step.
  * @param jobID - ID of the job that the work item updates belong to
  * @param updates - List of work item updates
  * @param logger - Logger to use

--- a/kubernetes-services/work-updater/test/updater.ts
+++ b/kubernetes-services/work-updater/test/updater.ts
@@ -152,8 +152,8 @@ describe('Updater Worker', async function () {
       it('should call getQueueForType', async function () {
         expect(getQueueForTypeStub.called).to.be.true;
       });
-      it('should call handleWorkItemUpdateWithJobId twice', async function () {
-        expect(handleWorkItemUpdateWithJobIdStub.callCount).to.equal(2);
+      it('should not call handleWorkItemUpdateWithJobId', async function () {
+        expect(handleWorkItemUpdateWithJobIdStub.callCount).to.equal(0);
       });
       it('should call handleBatchWorkItemUpdates once', async function () {
         expect(handleBatchWorkItemUpdatesSpy.callCount).to.equal(1);


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1510

## Description
As promised, I made the work items update even more complicated :). But hopefully more readable.

In this PR, I made the following changes to improve the work items update performance:
1. Lowered the number of db transactions from one per granule to one per batch of granules (default to 10 granules a batch).
2. Lowered the number of workflow step completion checks from one per granule to one per batch.
3. Lowered the number of workflow step retrievals from two per granule to two per batch.

Based on test in Sandbox of 110K l2-subsetter requests with 400 max pods and 40 max nodes configuration, Harmony runs ~43% faster with these changes.

![Screenshot 2023-09-11 at 9 06 37 AM](https://github.com/nasa/harmony/assets/1275975/24915ac5-8f25-4b75-9563-bddc560af238)

![baseline_notes](https://github.com/nasa/harmony/assets/1275975/a8046253-445d-466b-a356-8ed9099da80e)

![harmony-1510-branch_notes](https://github.com/nasa/harmony/assets/1275975/c042b0eb-61cf-4b58-90b9-60c406af10a0)

## Local Test Steps
Tested in Sandbox (http://internal-harmony-yliu10-frontend-1539904139.us-west-2.elb.amazonaws.com). 

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)