### PR TITLE
HARMONY-1591: Refactor work-item updates to always use the work item update queue

### DIFF
--- a/app/backends/workflow-orchestration/util.ts
+++ b/app/backends/workflow-orchestration/util.ts
@@ -1,9 +1,9 @@
 import { Logger } from 'winston';
-import { Job } from '../../models/job';
-import WorkItem, { workItemCountForStep } from '../../models/work-item';
-import env from '../../util/env';
 import { Transaction } from '../../util/db';
+import WorkItem, { workItemCountForStep } from '../../models/work-item';
 import { WorkItemStatus } from '../../models/work-item-interface';
+import { Job } from '../../models/job';
+import env from '../../util/env';
 
 export const QUERY_CMR_SERVICE_REGEX = /harmonyservices\/query-cmr:.*/;
 
@@ -25,6 +25,7 @@ export async function calculateQueryCmrLimit(tx: Transaction, workItem: WorkItem
   return queryCmrLimit;
 }
 
+// TODO - can we get rid of this and just handle it in the test framework
 /**
  * Empty function that will be overridden in tests. Not needed for runtime environments since
  * the scheduler pod will be running

--- a/app/frontends/workflow-ui.ts
+++ b/app/frontends/workflow-ui.ts
@@ -15,10 +15,11 @@ import { getItemLogsLocation, WorkItemQuery, WorkItemStatus } from '../models/wo
 import { getRequestRoot } from '../util/url';
 import { getAllStateChangeLinks, getJobStateChangeLinks } from '../util/links';
 import { objectStoreForProtocol } from '../util/object-store';
-import { handleWorkItemUpdate } from '../backends/workflow-orchestration/work-item-updates';
 import { Logger } from 'winston';
 import { serviceNames } from '../models/services';
 import { getEdlGroupInformation, isAdminUser } from '../util/edl-api';
+import { queueWorkItemUpdate } from '../backends/workflow-orchestration/workflow-orchestration';
+import { WorkItemQueueType } from '../util/queue/queue';
 
 // Default to retrieving this number of work items per page
 const defaultWorkItemPageSize = 100;
@@ -609,12 +610,13 @@ export async function retry(
       res.status(200).send({ message: 'The item does not have any retries left.' });
     }
     const workItemLogger = req.context.logger.child({ workItemId: item.id });
-    await handleWorkItemUpdate(
-      { workItemID: item.id, status: WorkItemStatus.FAILED,
-        scrollID: item.scrollID, hits: null, results: [], totalItemsSize: item.totalItemsSize,
-        errorMessage: 'A user attempted to trigger a retry via the Workflow UI.' },
-      null,
-      workItemLogger);
+    const workItemUpdate = {
+      workItemID: item.id, status: WorkItemStatus.FAILED, scrollID: item.scrollID, hits: null, results: [],
+      totalItemsSize: item.totalItemsSize, errorMessage: 'A user attempted to trigger a retry via the Workflow UI.',
+    };
+
+    await queueWorkItemUpdate(jobID, workItemUpdate, null, WorkItemQueueType.SMALL_ITEM_UPDATE, workItemLogger);
+
     res.status(200).send({ message: 'The item was successfully requeued.' });
   } catch (e) {
     req.context.logger.error(e);

--- a/app/models/work-item.ts
+++ b/app/models/work-item.ts
@@ -402,7 +402,7 @@ export async function getJobIdForWorkItem(id: number): Promise<string> {
       .select('jobID')
       .where({ id })
       .first()
-  ).jobID;
+  )?.jobID;
 }
 
 /**

--- a/kubernetes-services/work-failer/test/work-failer.ts
+++ b/kubernetes-services/work-failer/test/work-failer.ts
@@ -11,6 +11,7 @@ import WorkFailer from '../app/workers/failer';
 import { WorkItemStatus } from '../../../app/models/work-item-interface';
 import env from '../../../app/util/env';
 import { buildWorkflowStep } from './helpers/workflow-steps';
+import { hookGetQueueForType } from '../../../test/helpers/queue';
 
 const workFailer = new WorkFailer();
 
@@ -36,6 +37,7 @@ describe('WorkFailer', function () {
   let readyItemJobItem2: WorkItem;
 
   hookTransaction();
+  hookGetQueueForType();
 
   before(async function () {
     // Set the limit to something small for these tests

--- a/kubernetes-services/work-failer/test/work-failer.ts
+++ b/kubernetes-services/work-failer/test/work-failer.ts
@@ -12,7 +12,6 @@ import { WorkItemStatus } from '../../../app/models/work-item-interface';
 import env from '../../../app/util/env';
 import { buildWorkflowStep } from './helpers/workflow-steps';
 
-
 const workFailer = new WorkFailer();
 
 // 11 hours -- any RUNNING items that haven't been updatedAt for this long should get picked up

--- a/kubernetes-services/work-updater/app/work-item-updates.ts
+++ b/kubernetes-services/work-updater/app/work-item-updates.ts
@@ -1,25 +1,25 @@
-import env from '../../util/env';
-import { logAsyncExecutionTime } from '../../util/log-execution';
+import env from '../../../app/util/env';
+import { logAsyncExecutionTime } from '../../../app/util/log-execution';
 import { v4 as uuid } from 'uuid';
-import WorkItemUpdate from '../../models/work-item-update';
-import WorkflowStep, { decrementFutureWorkItemCount, getWorkflowStepByJobIdStepIndex, getWorkflowStepsByJobId } from '../../models/workflow-steps';
+import WorkItemUpdate from '../../../app/models/work-item-update';
+import WorkflowStep, { decrementFutureWorkItemCount, getWorkflowStepByJobIdStepIndex, getWorkflowStepsByJobId } from '../../../app/models/workflow-steps';
 import { Logger } from 'winston';
 import _, { ceil, range, sum } from 'lodash';
-import { JobStatus, Job } from '../../models/job';
-import JobError, { getErrorCountForJob, getErrorsForJob } from '../../models/job-error';
-import JobLink, { getJobDataLinkCount } from '../../models/job-link';
-import { incrementReadyCount, deleteUserWorkForJob, incrementReadyAndDecrementRunningCounts, decrementRunningCount } from '../../models/user-work';
-import WorkItem, { maxSortIndexForJobService, workItemCountForStep, getWorkItemsByJobIdAndStepIndex, getWorkItemById, updateWorkItemStatus, getJobIdForWorkItem } from '../../models/work-item';
-import { WorkItemStatus, COMPLETED_WORK_ITEM_STATUSES } from '../../models/work-item-interface';
-import { outputStacItemUrls, handleBatching, resultItemSizes } from '../../util/aggregation-batch';
-import db, { Transaction, batchSize } from '../../util/db';
-import { ServiceError } from '../../util/errors';
-import { completeJob } from '../../util/job';
-import { objectStoreForProtocol } from '../../util/object-store';
-import { StacItem, readCatalogItems, StacItemLink, StacCatalog } from '../../util/stac';
-import { resolve } from '../../util/url';
-import { QUERY_CMR_SERVICE_REGEX, calculateQueryCmrLimit } from './util';
-import { makeWorkScheduleRequest } from './work-item-polling';
+import { JobStatus, Job } from '../../../app/models/job';
+import JobError, { getErrorCountForJob, getErrorsForJob } from '../../../app/models/job-error';
+import JobLink, { getJobDataLinkCount } from '../../../app/models/job-link';
+import { incrementReadyCount, deleteUserWorkForJob, incrementReadyAndDecrementRunningCounts, decrementRunningCount } from '../../../app/models/user-work';
+import WorkItem, { maxSortIndexForJobService, workItemCountForStep, getWorkItemsByJobIdAndStepIndex, getWorkItemById, updateWorkItemStatus, getJobIdForWorkItem } from '../../../app/models/work-item';
+import { WorkItemStatus, COMPLETED_WORK_ITEM_STATUSES } from '../../../app/models/work-item-interface';
+import { outputStacItemUrls, handleBatching, resultItemSizes } from '../../../app/util/aggregation-batch';
+import db, { Transaction, batchSize } from '../../../app/util/db';
+import { ServiceError } from '../../../app/util/errors';
+import { completeJob } from '../../../app/util/job';
+import { objectStoreForProtocol } from '../../../app/util/object-store';
+import { StacItem, readCatalogItems, StacItemLink, StacCatalog } from '../../../app/util/stac';
+import { resolve } from '../../../app/util/url';
+import { QUERY_CMR_SERVICE_REGEX, calculateQueryCmrLimit } from '../../../app/backends/workflow-orchestration/util';
+import { makeWorkScheduleRequest } from '../../../app/backends/workflow-orchestration/work-item-polling';
 
 /**
  * A structure holding the preprocess info of a work item

--- a/kubernetes-services/work-updater/app/workers/updater.ts
+++ b/kubernetes-services/work-updater/app/workers/updater.ts
@@ -88,14 +88,18 @@ export async function handleBatchWorkItemUpdates(
     await updates.reduce(async (acc, item) => {
       const { workItemID } = item.update;
       const jobID = await getJobIdForWorkItem(workItemID);
-      logger.debug(`Processing work item update for job ${jobID}`);
-      const accValue = await acc;
-      if (accValue[jobID]) {
-        accValue[jobID].push(item);
+      if (!jobID) {
+        logger.error(`Received a message to process a work item that could not be found in the jobs table ${workItemID}.`, item);
       } else {
-        accValue[jobID] = [item];
+        logger.debug(`Processing work item update for job ${jobID}`);
+        const accValue = await acc;
+        if (accValue[jobID]) {
+          accValue[jobID].push(item);
+        } else {
+          accValue[jobID] = [item];
+        }
+        return accValue;
       }
-      return accValue;
     }, {});
   // process each job's updates
   for (const jobID in jobUpdates) {

--- a/kubernetes-services/work-updater/app/workers/updater.ts
+++ b/kubernetes-services/work-updater/app/workers/updater.ts
@@ -4,7 +4,7 @@ import {
   handleWorkItemUpdate,
   handleWorkItemUpdateWithJobId,
   preprocessWorkItem,
-  processWorkItems } from '../../../../app/backends/workflow-orchestration/work-item-updates';
+  processWorkItems } from '../work-item-updates';
 import { getJobIdForWorkItem } from '../../../../app/models/work-item';
 import { default as defaultLogger } from '../../../../app/util/log';
 import { WorkItemQueueType } from '../../../../app/util/queue/queue';

--- a/kubernetes-services/work-updater/test/updater.ts
+++ b/kubernetes-services/work-updater/test/updater.ts
@@ -7,7 +7,7 @@ import * as updater from '../app/workers/updater';
 import * as queueFactory from '../../../app/util/queue/queue-factory';
 import { MemoryQueue } from '../../../test/helpers/memory-queue';
 import * as wi from '../../../app/models/work-item';
-import * as wiu from '../../../app/backends/workflow-orchestration/work-item-updates';
+import * as wiu from '../app/work-item-updates';
 import { WorkItemQueueType } from '../../../app/util/queue/queue';
 import WorkItemUpdate from '../../../app/models/work-item-update';
 import DataOperation from '../../../app/models/data-operation';


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1591

## Description
Moved the work item update code into the work-updater service. Updated the places where it was being used directly in the workflow-ui and work-failer to instead send a message to the queue.

## Local Test Steps
Submit a request for a service that is not deployed in your local environment (so that it will not be processed).
Manually update the database to cause the work failer to attempt to re-queue it:
```update work_items set status = 'running', "startedAt" = CURRENT_DATE - INTERVAL '1 day', "updatedAt" = CURRENT_DATE - INTERVAL '1 day' where id = <the ID>```
Verify the work-failer successfully causes the work to get requeued - looking at work-failer logs and work-updater logs and verifying the retry count is incremented by 1.

For the workflow-ui manually update the database to set the status to running and then click 'Retry' on the workflow-ui. Verify a message is received in the work-updater logs and the retry count is incremented by 1 and status set back to 'ready'.


## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)