### PR TITLE
DAS-1975 - Fix respository for work-scheduler image.

### DIFF
--- a/bin/update-harmony
+++ b/bin/update-harmony
@@ -78,7 +78,7 @@ while read -r line; do
 done < <(sort <(echo "${referenced_images[*]}") <(echo "${pulled_images[*]}") | uniq -d)
 
 # always reload the harmony image, query-cmr, work-updater, work-scheudler, and service-runner images
-all_images+=( "harmonyservices/harmony:latest" "harmonyservices/query-cmr:latest" "harmonyservices/service-runner:latest" "harmonyservices/work-updater:latest" "harmony-services/work-scheduler:latest" )
+all_images+=( "harmonyservices/harmony:latest" "harmonyservices/query-cmr:latest" "harmonyservices/service-runner:latest" "harmonyservices/work-updater:latest" "harmonyservices/work-scheduler:latest" )
 
 for image in ${all_images[@]}; do
   echo "${image}"


### PR DESCRIPTION
## Jira Issue ID

DAS-1975 (not directly part of ticket, discovered while testing)

## Description

This PR makes a quick change to fix the name of the `harmonyservices` Docker repository when pulling the `work-scheduler` image as part of the `bin/update-harmony` script.

## Local Test Steps

* Pull branch.
* Run the `bin/update-harmony` script.
* All images should be pulled successfully (particularly `harmonyservices/work-scheduler`).

## PR Acceptance Checklist
* ~~Acceptance criteria met~~
* ~~Tests added/updated (if needed) and passing~~
* ~~Documentation updated (if needed)~~