### PR TITLE
HARMONY-1538: start-dev typo fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "coverage": "lerna run coverage",
     "lint": "lerna run lint",
     "start": "cd services/harmony && NODE_OPTIONS=--max-old-space-size=3096 ts-node -r tsconfig-paths/register app/server.ts",
-    "start-dev": "cd servcies/harmony && strict-npm-engines && ts-node-dev --no-notify -r tsconfig-paths/register --watch app/views,public/js --respawn app/server",
+    "start-dev": "cd services/harmony && strict-npm-engines && ts-node-dev --no-notify -r tsconfig-paths/register --watch app/views,public/js --respawn app/server",
     "start-dev-fast": "cd services/harmony && TS_NODE_TRANSPILE_ONLY=true ts-node-dev --no-notify -r tsconfig-paths/register --respawn --inspect=127.0.0.1:${DEBUG_PORT:-9200} app/server",
     "update-dev": "npm install && lerna run build && bin/restart-services",
     "watch-debug": "cd servcies/harmony && TS_NODE_TRANSPILE_ONLY=true nodemon --inspect=5858 -e ts,tsx,html --exec node -r tsconfig-paths/register -r ts-node/register app/server.ts",


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1538

## Description
Fixes a typo in the start-dev script, changing `cd servcies` to `cd services`.

## Local Test Steps
Run `harmony % npm run start-dev`

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)