### PR TITLE
HARMONY-1617: Updates to work-failer to process database updates instead of using the message queue

### DIFF
--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -1,25 +1,25 @@
-import env from '../../harmony/app/util/env';
-import { logAsyncExecutionTime } from '../../harmony/app/util/log-execution';
+import env from '../../util/env';
+import { logAsyncExecutionTime } from '../../util/log-execution';
 import { v4 as uuid } from 'uuid';
-import WorkItemUpdate from '../../harmony/app/models/work-item-update';
-import WorkflowStep, { decrementFutureWorkItemCount, getWorkflowStepByJobIdStepIndex, getWorkflowStepsByJobId } from '../../harmony/app/models/workflow-steps';
+import WorkItemUpdate from '../../models/work-item-update';
+import WorkflowStep, { decrementFutureWorkItemCount, getWorkflowStepByJobIdStepIndex, getWorkflowStepsByJobId } from '../../models/workflow-steps';
 import { Logger } from 'winston';
 import _, { ceil, range, sum } from 'lodash';
-import { JobStatus, Job } from '../../harmony/app/models/job';
-import JobError, { getErrorCountForJob, getErrorsForJob } from '../../harmony/app/models/job-error';
-import JobLink, { getJobDataLinkCount } from '../../harmony/app/models/job-link';
-import { incrementReadyCount, deleteUserWorkForJob, incrementReadyAndDecrementRunningCounts, decrementRunningCount } from '../../harmony/app/models/user-work';
-import WorkItem, { maxSortIndexForJobService, workItemCountForStep, getWorkItemsByJobIdAndStepIndex, getWorkItemById, updateWorkItemStatus, getJobIdForWorkItem } from '../../harmony/app/models/work-item';
-import { WorkItemStatus, COMPLETED_WORK_ITEM_STATUSES } from '../../harmony/app/models/work-item-interface';
-import { outputStacItemUrls, handleBatching, resultItemSizes } from '../../harmony/app/util/aggregation-batch';
-import db, { Transaction, batchSize } from '../../harmony/app/util/db';
-import { ServiceError } from '../../harmony/app/util/errors';
-import { completeJob } from '../../harmony/app/util/job';
-import { objectStoreForProtocol } from '../../harmony/app/util/object-store';
-import { StacItem, readCatalogItems, StacItemLink, StacCatalog } from '../../harmony/app/util/stac';
-import { resolve } from '../../harmony/app/util/url';
-import { QUERY_CMR_SERVICE_REGEX, calculateQueryCmrLimit } from '../../harmony/app/backends/workflow-orchestration/util';
-import { makeWorkScheduleRequest } from '../../harmony/app/backends/workflow-orchestration/work-item-polling';
+import { JobStatus, Job } from '../../models/job';
+import JobError, { getErrorCountForJob, getErrorsForJob } from '../../models/job-error';
+import JobLink, { getJobDataLinkCount } from '../../models/job-link';
+import { incrementReadyCount, deleteUserWorkForJob, incrementReadyAndDecrementRunningCounts, decrementRunningCount } from '../../models/user-work';
+import WorkItem, { maxSortIndexForJobService, workItemCountForStep, getWorkItemsByJobIdAndStepIndex, getWorkItemById, updateWorkItemStatus, getJobIdForWorkItem } from '../../models/work-item';
+import { WorkItemStatus, COMPLETED_WORK_ITEM_STATUSES } from '../../models/work-item-interface';
+import { outputStacItemUrls, handleBatching, resultItemSizes } from '../../util/aggregation-batch';
+import db, { Transaction, batchSize } from '../../util/db';
+import { ServiceError } from '../../util/errors';
+import { completeJob } from '../../util/job';
+import { objectStoreForProtocol } from '../../util/object-store';
+import { StacItem, readCatalogItems, StacItemLink, StacCatalog } from '../../util/stac';
+import { resolve } from '../../util/url';
+import { QUERY_CMR_SERVICE_REGEX, calculateQueryCmrLimit } from '../../backends/workflow-orchestration/util';
+import { makeWorkScheduleRequest } from '../../backends/workflow-orchestration/work-item-polling';
 
 /**
  * A structure holding the preprocess info of a work item

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -18,9 +18,8 @@ import { objectStoreForProtocol } from '../util/object-store';
 import { Logger } from 'winston';
 import { serviceNames } from '../models/services';
 import { getEdlGroupInformation, isAdminUser } from '../util/edl-api';
-import { queueWorkItemUpdate } from '../backends/workflow-orchestration/workflow-orchestration';
-import { WorkItemQueueType } from '../util/queue/queue';
 import { ILengthAwarePagination } from 'knex-paginate';
+import { handleWorkItemUpdateWithJobId } from '../backends/workflow-orchestration/work-item-updates';
 
 // Default to retrieving this number of work items per page
 const defaultWorkItemPageSize = 100;
@@ -722,7 +721,7 @@ export async function retry(
       workflowStepIndex: item.workflowStepIndex,
     };
 
-    await queueWorkItemUpdate(jobID, workItemUpdate, null, WorkItemQueueType.SMALL_ITEM_UPDATE, workItemLogger);
+    await handleWorkItemUpdateWithJobId(jobID, workItemUpdate, null, workItemLogger);
 
     res.status(200).send({ message: 'The item was successfully requeued.' });
   } catch (e) {

--- a/services/work-failer/app/workers/failer.ts
+++ b/services/work-failer/app/workers/failer.ts
@@ -7,8 +7,7 @@ import sleep from '../../../harmony/app/util/sleep';
 import { Worker } from '../../../harmony/app/workers/worker';
 import { WorkItemStatus } from '../../../harmony/app/models/work-item-interface';
 import env from '../util/env';
-import { WorkItemQueueType } from '../../../harmony/app/util/queue/queue';
-import { queueWorkItemUpdate } from '../../../harmony/app/backends/workflow-orchestration/workflow-orchestration';
+import { handleWorkItemUpdateWithJobId } from '../../../harmony/app/backends/workflow-orchestration/work-item-updates';
 
 /**
  * Construct a message indicating that the given work item has exceeded the given duration
@@ -107,7 +106,7 @@ export default class Failer implements Worker {
                   hits: null, results: [], totalItemsSize: item.totalItemsSize, errorMessage: message,
                   workflowStepIndex: item.workflowStepIndex,
                 };
-                await queueWorkItemUpdate(jobID, workItemUpdate, null, WorkItemQueueType.SMALL_ITEM_UPDATE, workItemlog);
+                await handleWorkItemUpdateWithJobId(jobID, workItemUpdate, null, workItemlog);
               }));
             } catch (e) {
               log.error(`Error attempting to process work item updates for job ${jobID}.`);

--- a/services/work-failer/env-defaults
+++ b/services/work-failer/env-defaults
@@ -2,11 +2,11 @@
 PORT=5000
 
 # The time (in seconds) between invocations of the work failer service
-WORK_FAILER_PERIOD_SEC=120
+WORK_FAILER_PERIOD_SEC=300
 
 # WorkItems that have not been updated for more than this many minutes are
 # updated by the work failer (resulting either in job and work item failure or a retry)
-FAILABLE_WORK_AGE_MINUTES=1
+FAILABLE_WORK_AGE_MINUTES=5
 
 # The batch size used by work-failer. Set it to 0 will effectively disable work-failer.
 WORK_FAILER_BATCH_SIZE=1000

--- a/services/work-updater/app/workers/updater.ts
+++ b/services/work-updater/app/workers/updater.ts
@@ -4,7 +4,7 @@ import {
   handleWorkItemUpdate,
   handleWorkItemUpdateWithJobId,
   preprocessWorkItem,
-  processWorkItems } from '../work-item-updates';
+  processWorkItems } from '../../../harmony/app/backends/workflow-orchestration/work-item-updates';
 import { getJobIdForWorkItem } from '../../../harmony/app/models/work-item';
 import { default as defaultLogger } from '../../../harmony/app/util/log';
 import { WorkItemQueueType } from '../../../harmony/app/util/queue/queue';

--- a/services/work-updater/test/updater.ts
+++ b/services/work-updater/test/updater.ts
@@ -7,7 +7,7 @@ import * as updater from '../app/workers/updater';
 import * as queueFactory from '../../harmony/app/util/queue/queue-factory';
 import { MemoryQueue } from '../../harmony/test/helpers/memory-queue';
 import * as wi from '../../harmony/app/models/work-item';
-import * as wiu from '../app/work-item-updates';
+import * as wiu from '../../harmony/app/backends/workflow-orchestration/work-item-updates';
 import { WorkItemQueueType } from '../../harmony/app/util/queue/queue';
 import WorkItemUpdate from '../../harmony/app/models/work-item-update';
 import DataOperation from '../../harmony/app/models/data-operation';


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1617

## Description
This changes the work-failer and the workflow-ui to no longer put messages on the work item update queue for the work-item-updater to process retries. Instead the database updates will be directly performed by the components. This is to address an issue we were seeing in production with the message queue getting overwhelmed by retry messages.

## Local Test Steps

Build the work-failer image.

Set FAILABLE_WORK_AGE_MINUTES to 0 and WORK_FAILER_PERIOD_SEC to 2 so that it constantly tries to fail work items. Verify that the retries are processed in the work-failer by looking at the logs.

Also test retry from the workflow-ui and make sure the work item is moved back to the READY state and retry count incremented.

I tested this in the sandbox and found that when submitting a large request it identified 160 items to be retried less than 5 minutes into the request. I figured out this is because things get queued based on the number of expected pods, but the pods are in the pending state for a little while before they get to running. The items are then marked as needing retry within one minute of being queued even though they haven't been worked on.

To account for this I changed our defaults from 1 minute being considered a failure to 5 minutes. I also changed the work failer to run every 5 minutes instead of 2 minutes with the end result being we may retry something every 5-10 minutes instead of 1-3 minutes.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)