### PR TITLE
HARMONY-1623: Fix LOCALSTACK_HOST value for config map

### DIFF
--- a/bin/create-k8s-config-maps-and-secrets
+++ b/bin/create-k8s-config-maps-and-secrets
@@ -41,7 +41,6 @@ kind: ConfigMap
 metadata:
   name: harmony-env
 data:
-  LOCALSTACK_HOST: "${LOCALSTACK_K8S_HOST}"
   STAGING_PATH: "${STAGING_PATH}"
   SERVICES_YML: $(echo -n "${SERVICES_YML}" | base64 | tr -d "\n")
 EOF
@@ -63,6 +62,7 @@ for file in "${env_files[@]}"; do
   fi
 done
 
+echo "  LOCALSTACK_HOST: \"${LOCALSTACK_K8S_HOST}\"" >> /tmp/config_map.yml
 
 kubectl -n harmony apply -f /tmp/config_map.yml
 rm /tmp/config_map.yml


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1623

## Description
Fixes an issue with creating the k8s configmap that resulted in LOCALSTACK_HOST being overwritten

## Local Test Steps
1. check out this branch
2. Set your .env for harmony-in-a-box
3. Run bin/bootstrap-harmony
4. Make sure everything works
5. Run bin/stop-harmony-and-services
6. Set your .env for local development
7. Run bin/bootstrap-harmony
8. Run bin/start-dev-services
9. Make sure everything works

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)