### PR TITLE
Harmony 1469 - Add concatenation to UMM-S / services.yml comparison script

### DIFF
--- a/scripts/service-comparison.ts
+++ b/scripts/service-comparison.ts
@@ -71,18 +71,18 @@ function validateVariableSubsetting(
  * @returns validation failure message or '' if validation succeeds
  */
 function validateConcatenation(
-  _ummRecord: CmrUmmService, harmonyConfig: ServiceConfig<unknown>,
+  ummRecord: CmrUmmService, harmonyConfig: ServiceConfig<unknown>,
 ): string {
   const errors = [];
-  const _harmonyConcatenation = harmonyConfig.capabilities.concatenation || false;
-  const _harmonyConcatenateByDefault = harmonyConfig.capabilities.concatenate_by_default || false;
-  const ummConcatenation = _ummRecord.umm?.ServiceOptions?.Aggregation?.Concatenate !== undefined;
-  if (_harmonyConcatenation !== ummConcatenation) {
-    errors.push(`Concatenation mismatch: harmony is ${_harmonyConcatenation} and UMM-S is ${ummConcatenation}.`);
+  const harmonyConcatenation = harmonyConfig.capabilities.concatenation || false;
+  const ummConcatenation = ummRecord.umm?.ServiceOptions?.Aggregation?.Concatenate !== undefined;
+  if (harmonyConcatenation !== ummConcatenation) {
+    errors.push(`Concatenation mismatch: harmony is ${harmonyConcatenation} and UMM-S is ${ummConcatenation}.`);
   }
-  const ummConcatenateDefault = _ummRecord.umm?.ServiceOptions?.Aggregation?.Concatenate?.ConcatenateDefault || false;
-  if (ummConcatenateDefault !== _harmonyConcatenateByDefault) {
-    errors.push(`Concatenation default mismatch: harmony is ${_harmonyConcatenateByDefault} and UMM-S is ${ummConcatenateDefault}.`);
+  const harmonyConcatenateByDefault = harmonyConfig.capabilities.concatenate_by_default || false;
+  const ummConcatenateDefault = ummRecord.umm?.ServiceOptions?.Aggregation?.Concatenate?.ConcatenateDefault || false;
+  if (ummConcatenateDefault !== harmonyConcatenateByDefault) {
+    errors.push(`Concatenation default mismatch: harmony is ${harmonyConcatenateByDefault} and UMM-S is ${ummConcatenateDefault}.`);
   }
   return errors.join(' ');
 }

--- a/scripts/service-comparison.ts
+++ b/scripts/service-comparison.ts
@@ -82,7 +82,7 @@ function validateConcatenation(
   const harmonyConcatenateByDefault = harmonyConfig.capabilities.concatenate_by_default || false;
   const ummConcatenateDefault = ummRecord.umm?.ServiceOptions?.Aggregation?.Concatenate?.ConcatenateDefault || false;
   if (ummConcatenateDefault !== harmonyConcatenateByDefault) {
-    errors.push(`Concatenation default mismatch: harmony is ${harmonyConcatenateByDefault} and UMM-S is ${ummConcatenateDefault}.`);
+    errors.push(`Concatenate by default mismatch: harmony is ${harmonyConcatenateByDefault} and UMM-S is ${ummConcatenateDefault}.`);
   }
   return errors.join(' ');
 }

--- a/scripts/service-comparison.ts
+++ b/scripts/service-comparison.ts
@@ -73,9 +73,18 @@ function validateVariableSubsetting(
 function validateConcatenation(
   _ummRecord: CmrUmmService, harmonyConfig: ServiceConfig<unknown>,
 ): string {
+  const errors = [];
   const _harmonyConcatenation = harmonyConfig.capabilities.concatenation || false;
   const _harmonyConcatenateByDefault = harmonyConfig.capabilities.concatenate_by_default || false;
-  return '';
+  const ummConcatenation = _ummRecord.umm?.ServiceOptions?.Aggregation?.Concatenate !== undefined;
+  if (_harmonyConcatenation !== ummConcatenation) {
+    errors.push(`Concatenation mismatch: harmony is ${_harmonyConcatenation} and UMM-S is ${ummConcatenation}.`);
+  }
+  const ummConcatenateDefault = _ummRecord.umm?.ServiceOptions?.Aggregation?.Concatenate?.ConcatenateDefault || false;
+  if (ummConcatenateDefault !== _harmonyConcatenateByDefault) {
+    errors.push(`Concatenation default mismatch: harmony is ${_harmonyConcatenateByDefault} and UMM-S is ${ummConcatenateDefault}.`);
+  }
+  return errors.join(' ');
 }
 
 /**

--- a/scripts/service-comparison.ts
+++ b/scripts/service-comparison.ts
@@ -105,7 +105,7 @@ function validateReprojection(
   return '';
 }
 
-const allValidations = [
+export const allValidations = [
   validateSpatialSubsetting,
   validateShapefileSubsetting,
   validateVariableSubsetting,

--- a/services/harmony/app/util/cmr.ts
+++ b/services/harmony/app/util/cmr.ts
@@ -144,6 +144,12 @@ export interface UmmServiceOptions {
     ProjectionName?: string;
     ProjectionOutputAuthority?: string;
   }[];
+
+  Aggregation?: {
+    Concatenate?: {
+      ConcatenateDefault?: boolean;
+    }
+  }
 }
 
 export interface CmrUmmService {

--- a/services/harmony/test/service-comparison.ts
+++ b/services/harmony/test/service-comparison.ts
@@ -1,0 +1,190 @@
+import { ServiceConfig } from '../app/models/services/base-service';
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { allValidations } from '../../../scripts/service-comparison';
+
+
+describe('service-comparison.ts', function () {
+  describe('validateConcatenation', async function () {
+    const validateConcatenationFn = allValidations[3];
+    describe('when concatenate by default is true for the Harmony config and false for the UMM-S record', async function () {
+      const ummRecord = {
+        meta: {
+          'concept-id': 'service-a',
+        },
+        umm: {
+          Name: 'harmony subsetter',
+          ServiceOptions: {
+            Aggregation: {
+              Concatenate: {
+                ConcatenateDefault: false,
+              },
+            },
+          },
+        },
+      };
+      const harmonyConfig: ServiceConfig<unknown> = {
+        capabilities: {
+          concatenation: true,
+          concatenate_by_default: true,
+        },
+      };
+      it('returns an error describing the condition', function () {
+        const error = validateConcatenationFn(ummRecord, harmonyConfig);
+        expect(error).to.eq('Concatenate by default mismatch: harmony is true and UMM-S is false.');
+      });
+    });
+    describe('when concatenate by default is false for the Harmony config and true for the UMM-S record', async function () {
+      const ummRecord = {
+        meta: {
+          'concept-id': 'service-a',
+        },
+        umm: {
+          Name: 'harmony subsetter',
+          ServiceOptions: {
+            Aggregation: {
+              Concatenate: {
+                ConcatenateDefault: true,
+              },
+            },
+          },
+        },
+      };
+      const harmonyConfig: ServiceConfig<unknown> = {
+        capabilities: {
+          concatenation: true,
+          concatenate_by_default: false,
+        },
+      };
+      it('returns an error describing the condition', function () {
+        const error = validateConcatenationFn(ummRecord, harmonyConfig);
+        expect(error).to.eq('Concatenate by default mismatch: harmony is false and UMM-S is true.');
+      });
+    });
+    describe('when the UMM-S record matches the Harmony config (both support concatenation and concatenate by default)', async function () {
+      const ummRecord = {
+        meta: {
+          'concept-id': 'service-a',
+        },
+        umm: {
+          Name: 'harmony subsetter',
+          ServiceOptions: {
+            Aggregation: {
+              Concatenate: {
+                ConcatenateDefault: true,
+              },
+            },
+          },
+        },
+      };
+      const harmonyConfig: ServiceConfig<unknown> = {
+        capabilities: {
+          concatenation: true,
+          concatenate_by_default: true,
+        },
+      };
+      it('returns an empty string', function () {
+        const error = validateConcatenationFn(ummRecord, harmonyConfig);
+        expect(error).to.eq('');
+      });
+    });
+    describe('when the UMM-S record matches the Harmony config (both do not support concatenation)', async function () {
+      const ummRecord = {
+        meta: {
+          'concept-id': 'service-a',
+        },
+        umm: {
+          Name: 'harmony subsetter',
+          ServiceOptions: {
+
+          },
+        },
+      };
+      const harmonyConfig: ServiceConfig<unknown> = {
+        capabilities: {
+          concatenation: false,
+          concatenate_by_default: false,
+        },
+      };
+      it('returns an empty string', function () {
+        const error = validateConcatenationFn(ummRecord, harmonyConfig);
+        expect(error).to.eq('');
+      });
+    });
+    describe('when the UMM-S record has no Concatenate property and the Harmony config has concatenation=true', async function () {
+      const ummRecord = {
+        meta: {
+          'concept-id': 'service-a',
+        },
+        umm: {
+          Name: 'harmony subsetter',
+          ServiceOptions: {
+            Aggregation: {
+              
+            },
+          },
+        },
+      };
+      const harmonyConfig: ServiceConfig<unknown> = {
+        capabilities: {
+          concatenation: true,
+          concatenate_by_default: true,
+        },
+      };
+      it('returns an error describing the condition', function () {
+        const error = validateConcatenationFn(ummRecord, harmonyConfig);
+        expect(error).to.eq('Concatenation mismatch: harmony is true and UMM-S is false. Concatenate by default mismatch: harmony is true and UMM-S is false.');
+      });
+    });
+    describe('when the UMM-S record has no Aggregation property and Harmony has concatenation=true', async function () {
+      const ummRecord = {
+        meta: {
+          'concept-id': 'service-a',
+        },
+        umm: {
+          Name: 'harmony subsetter',
+          ServiceOptions: {
+
+          },
+        },
+      };
+      const harmonyConfig: ServiceConfig<unknown> = {
+        capabilities: {
+          concatenation: true,
+          concatenate_by_default: true,
+        },
+      };
+      it('returns an error describing the condition', function () {
+        const error = validateConcatenationFn(ummRecord, harmonyConfig);
+        expect(error).to.eq('Concatenation mismatch: harmony is true and UMM-S is false. Concatenate by default mismatch: harmony is true and UMM-S is false.');
+      });
+    });
+    describe('when the UMM-S record has Concatenation and Harmony has concatenation=false', async function () {
+      const ummRecord = {
+        meta: {
+          'concept-id': 'service-a',
+        },
+        umm: {
+          Name: 'harmony subsetter',
+          ServiceOptions: {
+            Aggregation: {
+              Concatenate: {
+                ConcatenateDefault: false,
+              },
+            },
+          },
+        },
+      };
+      const harmonyConfig: ServiceConfig<unknown> = {
+        capabilities: {
+          concatenation: false,
+          concatenate_by_default: false,
+        },
+      };
+      it('returns an error describing the condition', function () {
+        const error = validateConcatenationFn(ummRecord, harmonyConfig);
+        expect(error).to.eq('Concatenation mismatch: harmony is false and UMM-S is true.');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1469

## Description
Adds concatenation to UMM-S / services.yml comparison script. Errors are returned from the script output when there is a mismatch between the concatenation property of the Harmony service config and the UMM-S record.

## Local Test Steps
`npm run compare-services`
In my case I also console.logged() the UMM-S record and service config when there is an error to see if the error reported is accurate.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)