### PR TITLE
HARMONY-1469: Update UMM-S version to 1.5.2

### DIFF
--- a/services/harmony/app/util/cmr.ts
+++ b/services/harmony/app/util/cmr.ts
@@ -588,7 +588,7 @@ export async function getAllVariables(
 export async function getAllServices(
   query: CmrQuery, token: string,
 ): Promise<Array<CmrUmmService>> {
-  const servicesResponse = await _cmrPost('/search/services.umm_json_v1_5_1', query, token) as CmrServicesResponse;
+  const servicesResponse = await _cmrPost('/search/services.umm_json_v1_5_2', query, token) as CmrServicesResponse;
   const { hits } = servicesResponse.data;
   let services = servicesResponse.data.items;
   let numServicesRetrieved = services.length;
@@ -598,7 +598,7 @@ export async function getAllServices(
     page_num += 1;
     logger.debug(`Paging through services = ${page_num}, numServicesRetrieved = ${numServicesRetrieved}, total hits ${hits}`);
     query.page_num = page_num;
-    const response = await _cmrPost('/search/services.umm_json_v1_5_1', query, token) as CmrServicesResponse;
+    const response = await _cmrPost('/search/services.umm_json_v1_5_2', query, token) as CmrServicesResponse;
     const pageOfServices = response.data.items;
     services = services.concat(pageOfServices);
     numServicesRetrieved += pageOfServices.length;


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1469

## Description
This is a follow-on pull request for this ticket which added concatenation to the service comparison script. Apparently we are on the wrong version of UMM-S currently (1.5.1 is not surfacing the concatenation information). I'm not sure how this worked before as I do remember checking things manually while developing this, so I'm pretty confused but I think we need this update nonetheless.

## Local Test Steps
Compare 
https://cmr.uat.earthdata.nasa.gov/search/services.umm_json_v1_5_1?concept_id=S1240999847-EEDTEST&pretty=true
with
https://cmr.uat.earthdata.nasa.gov/search/services.umm_json_v1_5_2?concept_id=S1240999847-EEDTEST&pretty=true

The newer version should have `Concatenate`.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)