### PR TITLE
HARMONY-1639: Fix for harmony in a box to be able to create SQS queues after NodeJS 18 update

### DIFF
--- a/services/harmony/Dockerfile
+++ b/services/harmony/Dockerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE=node:18-buster
 FROM $BASE_IMAGE
 RUN apt update && apt-get -y install sqlite3 python3 python3-pip python3-setuptools
 RUN pip3 install --upgrade pip awscli awscli-local
+# Need to downgrade boto3 because there is a bug breaking creating SQS queues
+RUN pip3 install boto3==1.25.5
 RUN mkdir -p /harmony/services/harmony
 COPY built /harmony
 RUN chown node -R /harmony


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1639 (sort of - JIRA has two tickets marked as 1639 right now)

## Description
Harmony in a box is failing to create SQS queues due to a bug in the default versions available on the node18-buster image. This downgrades boto3 to allow the version of the aws cli and boto3 to successfully create SQS queues.

## Local Test Steps

1. Build the harmony image.
2. Run harmony in a box.
3. Verify queues get created and you can complete a request successfully.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)