### PR TITLE
HARMONY-1647: Add initial health and admin/health check endpoints.

### DIFF
--- a/services/harmony/app/frontends/health.ts
+++ b/services/harmony/app/frontends/health.ts
@@ -1,0 +1,102 @@
+import { Response, NextFunction } from 'express';
+import HarmonyRequest from '../models/harmony-request';
+import { Job } from '../models/job';
+import logger from '../util/log';
+import db, { Transaction } from '../util/db';
+
+const UP = 'up';
+const DOWN = 'down';
+const _DEGRADED = 'degraded';
+
+const HEALTHY_MESSAGE = 'Harmony is operating normally.';
+const DOWN_MESSAGE = 'Harmony is currently down.';
+const _DEGRADED_MESSAGE = 'Harmony is currently degraded.';
+
+interface ComponentStatus {
+  name: String;
+  status: String;
+  message?: String;
+}
+
+interface HealthStatus {
+  status: String;
+  message?: String;
+  components: ComponentStatus[];
+
+}
+
+/**
+ * Returns the health information
+ *
+ * @param tx - the database transaction
+ * @returns a promise resolving to the health check response
+ */
+async function getGeneralHealth(tx: Transaction): Promise<HealthStatus> {
+  let dbHealthy = true;
+  try {
+    await Job.getTimeOfMostRecentlyUpdatedJob(tx);
+  } catch (e) {
+    logger.error(e);
+    dbHealthy = false;
+  }
+
+  let health;
+  if (dbHealthy) {
+    health = {
+      status: UP,
+      message: HEALTHY_MESSAGE,
+      components: [{
+        name: 'db',
+        status: UP,
+      },
+      ],
+    };
+  } else {
+    health = {
+      status: DOWN,
+      message: DOWN_MESSAGE,
+      components: [{
+        name: 'db',
+        status: DOWN,
+        message: 'Unable to query the database',
+      },
+      ],
+    };
+  }
+  return health;
+}
+
+/**
+ * Express.js handler that returns the admin view of the health of the harmony system
+ *
+ * @param req - The request sent by the client
+ * @param res - The response to send to the client
+ * @param next - The next function in the call chain
+ * @returns Resolves when the request is complete
+ */
+export async function getAdminHealth(
+  _req: HarmonyRequest, res: Response, _next: NextFunction,
+): Promise<void> {
+  const health = await getGeneralHealth(db);
+  if (health.status === DOWN) {
+    res.statusCode = 503;
+  }
+  res.send(health);
+}
+
+/**
+ * Express.js handler that returns the public health of the harmony system
+ *
+ * @param req - The request sent by the client
+ * @param res - The response to send to the client
+ * @returns Resolves when the request is complete
+ */
+export async function getHealth(
+  _req: HarmonyRequest, res: Response, _next: NextFunction,
+): Promise<void> {
+  const health = await getGeneralHealth(db);
+  if (health.status === DOWN) {
+    res.statusCode = 503;
+  }
+  res.send(health);
+}

--- a/services/harmony/app/middleware/error-handler.ts
+++ b/services/harmony/app/middleware/error-handler.ts
@@ -9,7 +9,7 @@ import {
 import HarmonyRequest from '../models/harmony-request';
 
 const errorTemplate = fs.readFileSync(path.join(__dirname, '../views/server-error.mustache.html'), { encoding: 'utf8' });
-const jsonErrorRoutesRegex = /jobs|capabilities|ogc-api-coverages|stac|metrics|configuration|workflow-ui\/.*\/(?:links|logs|retry)/;
+const jsonErrorRoutesRegex = /jobs|capabilities|ogc-api-coverages|stac|metrics|health|configuration|workflow-ui\/.*\/(?:links|logs|retry)/;
 
 /**
  * Returns true if the provided error should be returned as JSON.

--- a/services/harmony/app/models/job.ts
+++ b/services/harmony/app/models/job.ts
@@ -650,6 +650,17 @@ export class Job extends DBRecord implements JobRecord {
   }
 
   /**
+   * Returns the time of the most recently updated job
+   *
+   * @param transaction - the transaction to use for querying
+   * @returns a promise resolving to the timestamp of the most recently updated job
+   */
+  static async getTimeOfMostRecentlyUpdatedJob(transaction: Transaction): Promise<Date> {
+    const response = await transaction('jobs').max('updatedAt as latest_update');
+    return new Date(response[0].latest_update);
+  }
+
+  /**
    * Creates a Job instance.
    *
    * @param fields - Object containing fields to set on the record

--- a/services/harmony/app/routers/router.ts
+++ b/services/harmony/app/routers/router.ts
@@ -39,6 +39,7 @@ import { parseGridMiddleware } from '../util/grids';
 import docsPage from '../frontends/docs/docs';
 import { getCollectionCapabilitiesJson } from '../frontends/capabilities';
 import extendDefault from '../middleware/extend';
+import { getAdminHealth, getHealth } from '../frontends/health';
 export interface RouterConfig {
   PORT?: string | number; // The port to run the frontend server on
   BACKEND_PORT?: string | number; // The port to run the backend server on
@@ -273,6 +274,9 @@ export default function router({ skipEarthdataLogin = 'false' }: RouterConfig): 
   result.get('/cloud-access.sh', asyncHandler(cloudAccessSh));
   result.get('/stac/:jobId', asyncHandler(getStacCatalog));
   result.get('/stac/:jobId/:itemIndex', asyncHandler(getStacItem));
+
+  result.get('/health', asyncHandler(getHealth));
+  result.get('/admin/health', asyncHandler(getAdminHealth));
 
   // Kubernetes readiness probe for Harmony in a Box
   result.get('/readiness', async (_req, res, _next: Function): Promise<void> => {

--- a/services/harmony/test/health.ts
+++ b/services/harmony/test/health.ts
@@ -1,0 +1,99 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import hookServersStartStop from './helpers/servers';
+import { hookGetHealth, hookGetAdminHealth } from './helpers/health';
+import { hookDatabaseFailure } from './helpers/db';
+
+const healthyResponse = {
+  status: 'up',
+  message: 'Harmony is operating normally.',
+  components: [{
+    name: 'db',
+    status: 'up',
+  }],
+};
+
+const databaseDownHealthResponse = {
+  status: 'down',
+  message: 'Harmony is currently down.',
+  components: [{
+    name: 'db',
+    status: 'down',
+    message: 'Unable to query the database',
+  }],
+};
+
+describe('Health endpoints', function () {
+  hookServersStartStop({ skipEarthdataLogin: false });
+
+  describe('When calling /health', function () {
+    describe('When not authenticated', function () {
+      describe('When the system is healthy', function () {
+        hookGetHealth();
+        it('returns a 200 status code', function () {
+          expect(this.res.statusCode).to.equal(200);
+        });
+        it('returns a healthy response', function () {
+          const body = JSON.parse(this.res.text);
+          expect(body).to.eql(healthyResponse);
+        });
+      });
+      describe('When the database catches fire', function () {
+        hookDatabaseFailure();
+        hookGetHealth();
+        it('returns a 503 status code', function () {
+          expect(this.res.statusCode).to.equal(503);
+        });
+        it('returns a healthy response', function () {
+          const body = JSON.parse(this.res.text);
+          expect(body).to.eql(databaseDownHealthResponse);
+        });
+      });
+    });
+  });
+
+  describe('When calling /admin/health', function () {
+    describe('When not authenticated', function () {
+      hookGetAdminHealth();
+      it('redirects to Earthdata Login', function () {
+        expect(this.res.statusCode).to.equal(303);
+        expect(this.res.headers.location).to.include(process.env.OAUTH_HOST);
+      });
+    });
+
+    describe('When authenticated as a regular user', function () {
+      hookGetAdminHealth({ username: 'joe' });
+      it('returns a 403', function () {
+        expect(this.res.statusCode).to.equal(403);
+      });
+      it('returns a JSON message indicating not authorized', function () {
+        const response = JSON.parse(this.res.text);
+        expect(response).to.eql({ code: 'harmony.ForbiddenError', description: 'Error: You are not permitted to access this resource' });
+      });
+    });
+  });
+
+  describe('When authenticated as an admin user', function () {
+    describe('When the system is healthy', function () {
+      hookGetAdminHealth({ username: 'adam' });
+      it('returns a 200 status code', function () {
+        expect(this.res.statusCode).to.equal(200);
+      });
+      it('returns a healthy response', function () {
+        const body = JSON.parse(this.res.text);
+        expect(body).to.eql(healthyResponse);
+      });
+    });
+    describe('When the database catches fire', function () {
+      hookDatabaseFailure();
+      hookGetAdminHealth({ username: 'adam' });
+      it('returns a 503 status code', function () {
+        expect(this.res.statusCode).to.equal(503);
+      });
+      it('returns a healthy response', function () {
+        const body = JSON.parse(this.res.text);
+        expect(body).to.eql(databaseDownHealthResponse);
+      });
+    });
+  });
+});

--- a/services/harmony/test/helpers/health.ts
+++ b/services/harmony/test/helpers/health.ts
@@ -1,0 +1,24 @@
+import request from 'supertest';
+import { hookRequest } from './hooks';
+
+/**
+ * Makes a /admin/health request
+ * @param app - The express application (typically this.frontend)
+ * @returns The response
+ */
+export function getAdminHealth(app: Express.Application): request.Test {
+  return request(app).get('/admin/health');
+}
+
+/**
+ * Makes a /health request
+ * @param app - The express application (typically this.frontend)
+ * @returns The response
+ */
+export function getHealth(app: Express.Application): request.Test {
+  return request(app).get('/health');
+}
+
+export const hookGetAdminHealth = hookRequest.bind(this, getAdminHealth);
+export const hookGetHealth = hookRequest.bind(this, getHealth);
+

--- a/services/harmony/test/jobs/jobs-listing.ts
+++ b/services/harmony/test/jobs/jobs-listing.ts
@@ -3,7 +3,7 @@ import { describe, it, before } from 'mocha';
 import { Job, JobStatus } from '../../app/models/job';
 import env from '../../app/util/env';
 import hookServersStartStop from '../helpers/servers';
-import { hookTransaction, hookTransactionFailure, truncateAll } from '../helpers/db';
+import { hookTransaction, hookDatabaseFailure, truncateAll } from '../helpers/db';
 import { containsJob, jobListing, hookJobListing, createIndexedJobs, itIncludesPagingRelations, hookAdminJobListing, buildJob } from '../helpers/jobs';
 
 // Example jobs to use in tests
@@ -131,7 +131,7 @@ describe('Jobs listing route', function () {
   });
 
   describe('When the database catches fire', function () {
-    hookTransactionFailure();
+    hookDatabaseFailure();
     hookJobListing({ username: 'woody' });
     describe('for a user that should have jobs', function () {
       it('returns an internal server error status code', function () {

--- a/services/harmony/test/jobs/jobs-status.ts
+++ b/services/harmony/test/jobs/jobs-status.ts
@@ -6,7 +6,7 @@ import { v4 as uuid } from 'uuid';
 import request from 'supertest';
 import { itReturnsUnchangedDataLinksForZarr, itProvidesAWorkingHttpUrl } from '../helpers/job-status';
 import hookServersStartStop from '../helpers/servers';
-import { hookTransaction, hookTransactionFailure } from '../helpers/db';
+import { hookTransaction, hookDatabaseFailure } from '../helpers/db';
 import { jobStatus, hookJobStatus, jobsEqual, itIncludesRequestUrl, buildJob } from '../helpers/jobs';
 import StubService from '../helpers/stub-service';
 import { hookRedirect, hookUrl } from '../helpers/hooks';
@@ -184,7 +184,7 @@ describe('Individual job status route', function () {
   });
 
   describe('When the database catches fire', function () {
-    hookTransactionFailure();
+    hookDatabaseFailure();
     describe('for a user that should have jobs', function () {
       hookJobStatus({ jobID, username: 'joe' });
       it('returns an internal server error status code', function () {

--- a/services/harmony/test/ogc-api-coverages/get-coverage-rangeset.ts
+++ b/services/harmony/test/ogc-api-coverages/get-coverage-rangeset.ts
@@ -10,7 +10,7 @@ import { ServiceConfig } from '../../app/models/services/base-service';
 import { hookRedirect } from '../helpers/hooks';
 import { stub } from 'sinon';
 import env from '../../app/util/env';
-import { hookTransactionFailure } from '../helpers/db';
+import { hookDatabaseFailure } from '../helpers/db';
 
 describe('OGC API Coverages - getCoverageRangeset', function () {
   const collection = 'C1233800302-EEDTEST';
@@ -863,7 +863,7 @@ describe('OGC API Coverages - getCoverageRangeset', function () {
   });
 
   describe('when the database catches fire during an asynchronous request', function () {
-    hookTransactionFailure();
+    hookDatabaseFailure();
     StubService.hook({ params: { redirect: 'http://example.com' } });
     hookRangesetRequest(version, collection, variableName, {});
 
@@ -1015,7 +1015,7 @@ describe('OGC API Coverages - getCoverageRangeset', function () {
 
 describe('OGC API Coverages - getCoverageRangeset with the extend query parameter', async function () {
   hookServersStartStop();
-  
+
   describe('when requesting all vars and extending dimension_var', function () {
     StubService.hook({ params: { redirect: 'http://example.com' } });
     hookRangesetRequest('1.0.0', 'C1233800302-EEDTEST', 'all', { query: { extend: 'dimension_var', skipPreview: 'true', maxResults: 2 }, username: 'joe' });

--- a/services/work-failer/test/helpers/db.ts
+++ b/services/work-failer/test/helpers/db.ts
@@ -81,7 +81,7 @@ export function hookTransactionEach(): void {
  * just that test.
  *
  */
-export function hookTransactionFailure(): void {
+export function hookDatabaseFailure(): void {
   let txStub;
   before(function () {
     txStub = stub(db, 'transaction').throws();

--- a/services/work-reaper/test/helpers/db.ts
+++ b/services/work-reaper/test/helpers/db.ts
@@ -81,7 +81,7 @@ export function hookTransactionEach(): void {
  * just that test.
  *
  */
-export function hookTransactionFailure(): void {
+export function hookDatabaseFailure(): void {
   let txStub;
   before(function () {
     txStub = stub(db, 'transaction').throws();


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1647

## Description
Adds a couple of endpoints /health and /admin/health that we can use in the future for health checks and uptrends. This is just the initial ticket to create the endpoints. We'll have future tickets to address adding more components to check and determining when things are degraded and eventually have uptrends use these endpoints for tracking status. We'll also write tickets to add documentation once we've nailed down the response format a little more.

## Local Test Steps
Start harmony and verify that http://localhost:3000/health returns that harmony is up and the return code is 200. Also as an admin user verify the same for http://localhost:3000/admin/health. The responses are identical at the moment. In the future we will add more operations only detailed information to the admin/health endpoint.

To test a down status change line 660 of app/models/jobs to use an invalid index e.g. 
`return new Date(response[1].latest_update);` since only one item is returned. Verify the health says down with a message about a database issue and the status code is 503.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)