### PR TITLE
HARMONY-1651: Queue fewer items to ensure faster processing of new requests and better fair queueing

### DIFF
--- a/services/work-scheduler/Dockerfile
+++ b/services/work-scheduler/Dockerfile
@@ -4,11 +4,12 @@ RUN apt-get update && apt-get -y install postgresql
 RUN git config --global url."https://".insteadOf ssh://
 
 RUN mkdir -p /work-scheduler/services/work-scheduler
-
-COPY env-defaults package.json package-lock.json /work-scheduler/services/work-scheduler/
-COPY built /work-scheduler/
+COPY package.json package-lock.json /work-scheduler/services/work-scheduler/
 WORKDIR /work-scheduler/services/work-scheduler
 RUN npm ci
+
+COPY env-defaults /work-scheduler/services/work-scheduler/
+COPY built /work-scheduler/
 WORKDIR /work-scheduler
 # This symlink is needed to make module loading work correctly
 RUN ln -s services/work-scheduler/node_modules .

--- a/services/work-scheduler/Dockerfile.mac
+++ b/services/work-scheduler/Dockerfile.mac
@@ -5,11 +5,12 @@ RUN apk add bash vim curl git python3 postgresql-client make gcc g++ libc-dev li
 RUN git config --global url."https://".insteadOf ssh://
 
 RUN mkdir -p /work-scheduler/services/work-scheduler
-
-COPY env-defaults package.json package-lock.json /work-scheduler/services/work-scheduler/
-COPY built /work-scheduler/
+COPY package.json package-lock.json /work-scheduler/services/work-scheduler/
 WORKDIR /work-scheduler/services/work-scheduler
 RUN npm ci
+
+COPY env-defaults /work-scheduler/services/work-scheduler/
+COPY built /work-scheduler/
 WORKDIR /work-scheduler
 # This symlink is needed to make module loading work correctly
 RUN ln -s services/work-scheduler/node_modules .

--- a/services/work-scheduler/app/util/env.ts
+++ b/services/work-scheduler/app/util/env.ts
@@ -25,7 +25,7 @@ interface IHarmonyWorkSchedulerEnv extends IHarmonyEnv {
 class HarmonyWorkSchedulerEnv extends HarmonyEnv implements IHarmonyWorkSchedulerEnv {
 
   @IsNumber()
-  @Min(1)
+  @Min(0)
   serviceQueueBatchSizeCoefficient: number;
 
   @IsNotEmpty()

--- a/services/work-scheduler/app/util/k8s.ts
+++ b/services/work-scheduler/app/util/k8s.ts
@@ -21,5 +21,28 @@ export async function getPodsCountForService(serviceId: string, namespace = 'har
     });
   });
 
-  return pods.length;
+  const runningPods = pods.filter((pod) => pod.status.phase === 'Running');
+  return runningPods.length;
+}
+
+/**
+ * Get the number of pods running for a given pod name
+ * @param podName - The pod name for which to get the number of pods
+ * @param namespace - The namespace in which to look for pods
+ * @returns The number of pods running for the service
+ **/
+export async function getPodsCountForPodName(podName: string, namespace = 'harmony'): Promise<number> {
+  try {
+    const labelSelector = `name=${podName}`;
+
+    const res = await k8sApi.listNamespacedPod(namespace, undefined, undefined, undefined, undefined, labelSelector);
+    const pods = res.body.items;
+    const runningPods = pods.filter(pod => pod.status.phase === 'Running');
+
+    return runningPods.length;
+  } catch (e) {
+    logger.error(`Error getting the number of running ${podName} pods`);
+    logger.error(e);
+    return 1;
+  }
 }

--- a/services/work-scheduler/app/workers/scheduler.ts
+++ b/services/work-scheduler/app/workers/scheduler.ts
@@ -73,6 +73,30 @@ function sizeToBatches(
 }
 
 /**
+ * Calculates the number of work items to request to queue
+ *
+ * @param servicePodCount - number of service pods running
+ * @param schedulerPodCount - number of work scheduler pods running
+ * @param queuedCount - current number of messages on the service queue
+ * @param scaleFactor - percent of the number of messages we want
+ * @returns the number of work items to request to queue
+ */
+export function calculateNumItemsToQueue(
+  servicePodCount: number, schedulerPodCount: number, queuedCount: number, scaleFactor: number,
+): number {
+  const minOneSchedulerPodCount = Math.max(1, schedulerPodCount);
+  const numItemsToQueue = scaleFactor * (servicePodCount / minOneSchedulerPodCount) - queuedCount;
+  let numItemsToQueueInt = Math.max(0, Math.floor(numItemsToQueue));
+
+  // With some configurations it's possible to request zero items in all cases. Make sure we avoid
+  // the situation where we never queue anything
+  if (numItemsToQueueInt <= 0 && queuedCount <= 0) {
+    numItemsToQueueInt = 1;
+  }
+  return numItemsToQueueInt;
+}
+
+/**
  * Read the scheduler queue and process any items in it
  *
  * @param reqLogger - a logger instance
@@ -85,7 +109,6 @@ export async function processSchedulerQueue(reqLogger: Logger): Promise<void> {
   const startTime = new Date().getTime();
   let durationMs;
   const schedulerQueue = getWorkSchedulerQueue();
-  // const queueItems = await schedulerQueue.getMessages(env.workItemSchedulerQueueMaxBatchSize);
   const queueItems = await (await logAsyncExecutionTime(
     drainQueue,
     'PSQ.drainQueue',
@@ -118,21 +141,18 @@ export async function processSchedulerQueue(reqLogger: Logger): Promise<void> {
         'PSQ.getPodsCountForService',
         reqLogger))(serviceID);
 
-      let schedulerPodCount = await (await logAsyncExecutionTime(
+      const schedulerPodCount = await (await logAsyncExecutionTime(
         getPodsCountForPodName,
         'PSQ.getSchedulerPodsCount',
         reqLogger))(SCHEDULER_POD_NAME);
 
-      schedulerPodCount = Math.max(1, schedulerPodCount);
       const podCountEnd = new Date();
       const messageCountTime = messageCountEnd.getTime() - messageCountStart.getTime();
       const podCountTime = podCountEnd.getTime() - messageCountEnd.getTime();
       reqLogger.debug(`Message count took ${messageCountTime}ms`, { durationMs: messageCountTime });
       reqLogger.debug(`Pod count took ${podCountTime}ms`, { durationMs: podCountTime });
 
-      // If there are more pods than messages, we need to send more work. Allow more work
-      // than pods to avoid queue starvation (env.serviceQueueBatchSizeCoefficient)
-      const workSize = Math.ceil(env.serviceQueueBatchSizeCoefficient * (servicePodCount / schedulerPodCount) - messageCount);
+      const workSize = calculateNumItemsToQueue(servicePodCount, schedulerPodCount, messageCount, env.serviceQueueBatchSizeCoefficient);
       reqLogger.debug(`Attempting to retrieve ${workSize} work items for queue ${queueUrl}`);
       reqLogger.debug(`Work size count is ${workSize} based on service pod count of ${servicePodCount}, message count ${messageCount}, and scheduler pod count ${schedulerPodCount} for queue ${queueUrl}`);
 

--- a/services/work-scheduler/env-defaults
+++ b/services/work-scheduler/env-defaults
@@ -11,6 +11,6 @@ WORK_ITEM_SCHEDULER_QUEUE_MAX_GET_MESSAGE_REQUESTS=20
 # Used to allow slightly more work items to be queued than the number of available workers
 # to avoid queue starvation. 1.1 for example means to queue 10% more work items than there
 # are running pods for the service.
-SERVICE_QUEUE_BATCH_SIZE_COEFFICIENT=1.1
+SERVICE_QUEUE_BATCH_SIZE_COEFFICIENT=0.25
 # Maximum number of work items to retrieve from database at once
 WORK_ITEM_SCHEDULER_BATCH_SIZE=50

--- a/services/work-scheduler/test/scheduler.ts
+++ b/services/work-scheduler/test/scheduler.ts
@@ -190,17 +190,24 @@ describe('Scheduler Worker', async function () {
       });
     });
 
-    describe('when there are no workers running and no messages queued', function () {
+    describe('when there are no service workers running and no messages queued', function () {
       it('will queue exactly one message', function () {
-        const actual = calculateNumItemsToQueue(0, 0, 0, 1.1);
+        const actual = calculateNumItemsToQueue(0, 1, 0, 1.1);
         expect(actual).to.equal(1);
       });
     });
 
-    describe('when there are no workers running and 1 message queued', function () {
+    describe('when there are no service workers running and 1 message queued', function () {
       it('queues zero items', function () {
         const actual = calculateNumItemsToQueue(0, 0, 1, 1.1);
         expect(actual).to.equal(0);
+      });
+    });
+
+    describe('when there are no schedulers running and no messages queued', function () {
+      it('treats it as if there is 1 scheduler running', function () {
+        const actual = calculateNumItemsToQueue(100, 0, 0, 1);
+        expect(actual).to.equal(100);
       });
     });
   });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1651

## Description
Queues fewer items to resolve an issue where synchronous requests were timing out when there were other requests in the system for many granules for the same service and the processing of those granules was extremely slow.

I also sped up the docker build for the work-scheduler (we need to do this for all the images) by reordering the npm ci command so that it happens before installing the code. So when there are only code changes the build and pushing the image to sandbox take seconds due to the layer caching.

## Local Test Steps
This is best tested in a sandbox environment since you'll have more than one worker pod and multiple schedulers. I tested in sandbox and saw that with 125 workers anywhere from 109 to 161 items were in the queued or running state at any point in time. That means we were fairly balanced. We were not allowing too many workers to be idle due to queue starvation (lowering overall system throughput) and we were not overqueueing (hindering the response time of synchronous requests while processing the large request). I submitted single granule requests throughout the run and they all completed in under 30 seconds.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)