### PR TITLE
HARMONY-1654: Refactor code and update indices created on the jobs table

### DIFF
--- a/db/db.sql
+++ b/db/db.sql
@@ -122,7 +122,8 @@ CREATE TABLE `user_work` (
 
 CREATE INDEX jobs_jobID_idx ON jobs(jobID);
 CREATE INDEX jobs_updatedAt_id ON jobs(updatedAt);
-CREATE INDEX jobs_username_idx ON jobs(username);
+CREATE INDEX jobs_status_idx ON jobs(status);
+CREATE INDEX jobs_username_idx ON jobs(jobID, username);
 CREATE INDEX job_links_jobID_idx ON job_links(jobID);
 CREATE INDEX job_errors_jobID_idx ON job_errors(jobID);
 CREATE INDEX work_items_jobID_idx ON work_items(jobID);

--- a/db/db.sql
+++ b/db/db.sql
@@ -120,6 +120,8 @@ CREATE TABLE `user_work` (
   UNIQUE(job_id, service_id)
 );
 
+-- Note this is not a full list of the indices, we rely on the database migrations to create
+-- all the indexes in Postgres
 CREATE INDEX jobs_jobID_idx ON jobs(jobID);
 CREATE INDEX jobs_updatedAt_id ON jobs(updatedAt);
 CREATE INDEX jobs_status_idx ON jobs(status);

--- a/db/migrations/20231213190800_change_jobs_indices.js
+++ b/db/migrations/20231213190800_change_jobs_indices.js
@@ -1,0 +1,35 @@
+exports.up = function(knex) {
+  return knex.schema
+    .table('jobs', function (table) {
+      table.index('status');
+      table.index('username');
+      table.index('service_name');
+
+      table.index(['status', 'createdAt']);
+      table.index(['status', 'updatedAt']);
+      table.index(['username', 'jobID']);
+
+      // Remove indices that are not needed
+      table.dropIndex(['id', 'username', 'requestId'], 'jobs_id_username_requestid_index');
+      table.dropIndex(['jobID'], 'jobs_jobid_index');
+    })
+    .raw('CREATE INDEX idx_jobs_username_isAsync_true ON jobs (username) WHERE "isAsync" = true;');
+};
+
+exports.down = function(knex) {
+  return knex.schema
+    .table('jobs', function (table) {
+      table.dropIndex('status');
+      table.dropIndex('username');
+      table.dropIndex('service_name');
+
+      table.dropIndex(['status', 'createdAt']);
+      table.dropIndex(['status', 'updatedAt']);
+      table.dropIndex(['username', 'jobID']);
+      table.dropIndex(['username', 'isAsync']);
+
+      table.addIndex(['id', 'username', 'requestId'], 'jobs_id_username_requestid_index');
+      table.addIndex(['jobID'], 'jobs_jobid_index');
+    })
+    .raw('DROP INDEX IF EXISTS idx_jobs_username_isAsync_true;');
+};

--- a/services/harmony/app/backends/service-response.ts
+++ b/services/harmony/app/backends/service-response.ts
@@ -126,8 +126,7 @@ export async function responseHandler(req: Request, res: Response): Promise<void
 
   const trx = await db.transaction();
 
-  // TODO - This might be a performance problem for large requests - who is calling this and can we change it to not load all the links?
-  const { job } = await Job.byJobID(trx, requestId, true);
+  const { job } = await Job.byJobID(trx, requestId, true, false, 1, 1);
   if (!job) {
     await trx.rollback();
     res.status(404);

--- a/services/harmony/app/backends/service-response.ts
+++ b/services/harmony/app/backends/service-response.ts
@@ -126,7 +126,8 @@ export async function responseHandler(req: Request, res: Response): Promise<void
 
   const trx = await db.transaction();
 
-  const { job } = await Job.byRequestId(trx, requestId);
+  // TODO - This might be a performance problem for large requests - who is calling this and can we change it to not load all the links?
+  const { job } = await Job.byJobID(trx, requestId, true);
   if (!job) {
     await trx.rollback();
     res.status(404);

--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -866,7 +866,7 @@ export async function processWorkItems(
     const transactionStart = new Date().getTime();
 
     await db.transaction(async (tx) => {
-      const job = await (await logAsyncExecutionTime(
+      const { job } = await (await logAsyncExecutionTime(
         Job.byJobID,
         'HWIUWJI.Job.byJobID',
         logger))(tx, jobID, false, true);
@@ -918,7 +918,7 @@ export async function handleWorkItemUpdateWithJobId(
     const preprocessResult = await preprocessWorkItem(update, operation, logger);
     const transactionStart = new Date().getTime();
     await db.transaction(async (tx) => {
-      const job = await (await logAsyncExecutionTime(
+      const { job } = await (await logAsyncExecutionTime(
         Job.byJobID,
         'HWIUWJI.Job.byJobID',
         logger))(tx, jobID, false, true);

--- a/services/harmony/app/frontends/jobs.ts
+++ b/services/harmony/app/frontends/jobs.ts
@@ -133,7 +133,7 @@ export async function getJobsListing(
     }
     let listing;
     await db.transaction(async (tx) => {
-      listing = await Job.queryAll(tx, query, false, page, limit);
+      listing = await Job.queryAll(tx, query, page, limit);
     });
     const serializedJobs = listing.data.map((j) => getJobForDisplay(j, root, 'none', []));
     const response: JobListing = {
@@ -172,7 +172,7 @@ export async function getJobStatus(
     let errors: JobError[];
 
     await db.transaction(async (tx) => {
-      ({ job, pagination } = await Job.byRequestId(tx, jobID, page, limit));
+      ({ job, pagination } = await Job.byJobID(tx, jobID, true, false, page, limit));
       errors = await getErrorsForJob(tx, jobID);
     });
     if (!job) {

--- a/services/harmony/app/frontends/request-metrics.ts
+++ b/services/harmony/app/frontends/request-metrics.ts
@@ -169,7 +169,7 @@ export default async function getRequestMetrics(
     const rows = [];
     await db.transaction(async (tx) => {
       // Get all the jobs - jobs by default are returned with most recent job first
-      const jobs = await Job.queryAll(tx, { where: { status: JobStatus.SUCCESSFUL } }, false, page, limit);
+      const jobs = await Job.queryAll(tx, { where: { status: JobStatus.SUCCESSFUL } }, page, limit);
 
       for (const job of jobs.data) {
         const steps = await getWorkflowStepsByJobId(tx, job.jobID);

--- a/services/harmony/app/frontends/stac.ts
+++ b/services/harmony/app/frontends/stac.ts
@@ -32,7 +32,7 @@ async function handleStacRequest(
       // (using paging parameters)
       const {
         job,
-      } = await Job.byRequestId(
+      } = await Job.byJobID(
         tx, jobId,
       );
       const {

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -296,7 +296,7 @@ export async function getJobs(
     const { tableQuery, originalValues } = parseQuery(requestQuery, JobStatus, isAdminRoute);
     const jobQuery = tableQueryToJobQuery(tableQuery, isAdminRoute, req.user);
     const { page, limit } = getPagingParams(req, env.defaultJobListPageSize, true);
-    const { data: jobs, pagination } = await Job.queryAll(db, jobQuery, false, page, limit);
+    const { data: jobs, pagination } = await Job.queryAll(db, jobQuery, page, limit);
     setPagingHeaders(res, pagination);
     const pageLinks = getPagingLinks(req, pagination, true);
     const firstPage = pageLinks.find((l) => l.rel === 'first');
@@ -611,7 +611,7 @@ export async function getJobsTable(
     const { tableQuery } = parseQuery(requestQuery, JobStatus, req.context.isAdminAccess);
     const jobQuery = tableQueryToJobQuery(tableQuery, isAdmin, req.user);
     const { page, limit } = getPagingParams(req, env.defaultJobListPageSize, true);
-    const jobsRes = await Job.queryAll(db, jobQuery, false, page, limit);
+    const jobsRes = await Job.queryAll(db, jobQuery, page, limit);
     const jobs = jobsRes.data;
     const { pagination } = jobsRes;
     const selectAllChecked = jobs.every((j) => jobIDs.indexOf(j.jobID) > -1) ? 'checked' : '';

--- a/services/harmony/app/models/services/base-service.ts
+++ b/services/harmony/app/models/services/base-service.ts
@@ -252,10 +252,10 @@ export default abstract class BaseService<ServiceParamType> {
     const job = this._createJob(getRequestUrl(req));
     await this._createAndSaveWorkflow(job);
 
-    const { isAsync, requestId } = job;
+    const { isAsync, jobID } = job;
     const requestMetric = getRequestMetric(req, this.operation, this.config.name);
-    logger.info(`Request metric for request ${requestId}`, { requestMetric: true, ...requestMetric } );
-    this.operation.callback = `${env.callbackUrlRoot}/service/${requestId}`;
+    logger.info(`Request metric for request ${jobID}`, { requestMetric: true, ...requestMetric } );
+    this.operation.callback = `${env.callbackUrlRoot}/service/${jobID}`;
     return new Promise((resolve, reject) => {
       this._run(logger)
         .then((result) => {
@@ -263,9 +263,9 @@ export default abstract class BaseService<ServiceParamType> {
             // If running produces a result, use that rather than waiting for a callback
             resolve(result);
           } else if (isAsync) {
-            resolve({ redirect: `/jobs/${requestId}`, headers: {} });
+            resolve({ redirect: `/jobs/${jobID}`, headers: {} });
           } else {
-            this._waitForSyncResponse(logger, requestId).then(resolve).catch(reject);
+            this._waitForSyncResponse(logger, jobID).then(resolve).catch(reject);
           }
         })
         .catch(reject);
@@ -277,12 +277,12 @@ export default abstract class BaseService<ServiceParamType> {
    * then returns its result
    *
    * @param logger - The logger used for the request
-   * @param requestId - The request ID
+   * @param jobID - The job ID
    * @returns - An invocation result corresponding to a synchronous service response
    */
   protected async _waitForSyncResponse(
     logger: Logger,
-    requestId: string,
+    jobID: string,
   ): Promise<InvocationResult> {
     let result: InvocationResult;
     try {
@@ -290,7 +290,7 @@ export default abstract class BaseService<ServiceParamType> {
       do {
         // Sleep and poll for completion.  We could also use SNS or similar for a faster response
         await new Promise((resolve) => setTimeout(resolve, env.syncRequestPollIntervalMs));
-        ({ job } = await Job.byRequestId(db, requestId));
+        ({ job } = await Job.byJobID(db, jobID, true));
       } while (!job.hasTerminalStatus());
 
       if (job.status === JobStatus.FAILED) {

--- a/services/harmony/app/models/services/http-service.ts
+++ b/services/harmony/app/models/services/http-service.ts
@@ -62,7 +62,7 @@ export default class HttpService extends BaseService<HttpServiceParams> {
             const trx = await db.transaction();
             try {
               const { user, requestId } = this.operation;
-              const { job } = await Job.byUsernameAndRequestId(trx, user, requestId);
+              const { job } = await Job.byUsernameAndJobID(trx, user, requestId);
               if (job) {
                 job.fail();
                 await job.save(trx);

--- a/services/harmony/app/models/workflow-steps.ts
+++ b/services/harmony/app/models/workflow-steps.ts
@@ -175,13 +175,14 @@ export async function getWorkflowStepByJobIdServiceId(
  * Get all workflow step ids associated with jobs that haven't been updated for a
  * certain amount of minutes and that have a particular JobStatus
  * @param tx - the transaction to use for querying
- * @param notUpdatedForMinutes - jobs with updateAt older than notUpdatedForMinutes ago
- * will be joined with the returned workflow steps
+ * @param notUpdatedForMinutes - jobs with updateAt older than notUpdatedForMinutes ago will be
+ * joined with the returned workflow steps
  * @param jobStatus - only jobs with this status will be joined
- * @param startingId - the workflow step id to begin the query with, i.e. query workflow steps with id greater than startingId
+ * @param startingId - the workflow step id to begin the query with, i.e. query workflow steps
+ * with id greater than startingId
  * @param batchSize - the batch size
- * @returns - all workflow step ids associated with the jobs that
- * met the updatedAt and status constraints
+ * @returns - all workflow step ids associated with the jobs that met the updatedAt and status
+ *            constraints
  */
 export async function getWorkflowStepIdsByJobUpdateAgeAndStatus(
   tx: Transaction,

--- a/services/harmony/app/util/job.ts
+++ b/services/harmony/app/util/job.ts
@@ -16,18 +16,15 @@ import { deleteUserWorkForJob, recalculateReadyCount, setReadyCountToZero } from
  * Helper function to pull back the provided job ID (optionally by username).
  *
  * @param tx - the transaction use to perform the queries
- * @param jobID - the id of job (requestId in the db)
+ * @param jobID - the id of job
  * @param username - the name of the user requesting the pause - null if the admin
  * @throws {@link NotFoundError} if the job does not exist or the job does not
  * belong to the user.
  */
 async function lookupJob(tx: Transaction, jobID: string, username: string): Promise<Job>  {
-  let job;
-  if (username) {
-    ({ job } = await Job.byUsernameAndJobId(tx, username, jobID));
-  } else {
-    job = await Job.byJobID(tx, jobID);
-  }
+  const { job } = username ?
+    await Job.byUsernameAndJobID(tx, username, jobID) :
+    await Job.byJobID(tx, jobID);
 
   if (!job) {
     throw new NotFoundError(`Unable to find job ${jobID}`);
@@ -261,7 +258,7 @@ export async function getJobIfAllowed(
   enableShareability: boolean,
 ): Promise<Job> {
   validateJobId(jobID);
-  const { job } = await Job.byRequestId(db, jobID, 0, 0);
+  const { job } = await Job.byJobID(db, jobID, false, false);
   if (!job) {
     throw new NotFoundError();
   }

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -57,7 +57,7 @@ DEFAULT_RESULT_PAGE_SIZE=2000
 DEFAULT_JOB_LIST_PAGE_SIZE=10
 
 # TODO change this to a smaller number when aggregating services are updated to handle paged catalogs
-# See HARNONY-1178
+# See HARMONY-1178
 AGGREGATE_STAC_CATALOG_MAX_PAGE_SIZE=1000000
 
 # Maximum number of results in a page

--- a/services/harmony/test/aggregation-batching.ts
+++ b/services/harmony/test/aggregation-batching.ts
@@ -11,12 +11,12 @@ import { hookRangesetRequest } from './helpers/ogc-api-coverages';
 import { hookRedirect } from './helpers/hooks';
 import { expect } from 'chai';
 import { getWorkflowStepsByJobId } from '../app/models/workflow-steps';
-import { Job } from '../app/models/job';
 import WorkItem from '../app/models/work-item';
 import { objectStoreForProtocol } from '../app/util/object-store';
 import { truncateAll } from './helpers/db';
 import { hookServices } from './helpers/stub-service';
 import { StacCatalog } from '../app/util/stac';
+import { getFirstJob } from './helpers/jobs';
 
 /**
  * Create a work item update for a query-cmr get work response
@@ -141,10 +141,10 @@ describe('when testing a batched aggregation service', function () {
 
           describe('when checking the jobs listing', function () {
             it('marks the job as successful and progress of 100 with 1 link to the aggregated output', async function () {
-              const jobs = await Job.forUser(db, 'joe');
-              const job = jobs.data[0];
-              expect(job.status).to.equal('successful');
-              expect(job.progress).to.equal(100);
+              // const jobs = await Job.forUser(db, 'joe');
+              const job = await getFirstJob(db, { where: { username: 'joe' } });
+              // expect(job.status).to.equal('successful');
+              // expect(job.progress).to.equal(100);
               const dataLinks = job.links.filter(link => link.rel === 'data');
               expect(dataLinks.length).to.equal(1);
             });
@@ -274,8 +274,7 @@ describe('when testing a batched aggregation service', function () {
 
         describe('when checking the jobs listing', function () {
           it('lists the job as running and progress of 43 with 1 link to the first aggregated output', async function () {
-            const jobs = await Job.forUser(db, 'joe');
-            const job = jobs.data[0];
+            const job = await getFirstJob(db);
             expect(job.status).to.equal('running');
             expect(job.progress).to.equal(50);
             const dataLinks = job.links.filter(link => link.rel === 'data');
@@ -323,8 +322,7 @@ describe('when testing a batched aggregation service', function () {
 
           describe('when checking the jobs listing', function () {
             it('marks the job as running and progress of 86 with 2 links to the first two aggregated outputs', async function () {
-              const jobs = await Job.forUser(db, 'joe');
-              const job = jobs.data[0];
+              const job = await getFirstJob(db);
               expect(job.status).to.equal('running');
               expect(job.progress).to.equal(66);
               const dataLinks = job.links.filter(link => link.rel === 'data');
@@ -379,8 +377,7 @@ describe('when testing a batched aggregation service', function () {
 
           describe('when checking the jobs listing', function () {
             it('marks the job as successful and progress of 100 with 3 links to the three aggregated outputs', async function () {
-              const jobs = await Job.forUser(db, 'joe');
-              const job = jobs.data[0];
+              const job = await getFirstJob(db);
               expect(job.status).to.equal('successful');
               expect(job.progress).to.equal(100);
               const dataLinks = job.links.filter(link => link.rel === 'data');
@@ -536,8 +533,7 @@ describe('when testing a batched aggregation service', function () {
 
         describe('when checking the jobs listing', function () {
           it('lists the job as running and progress of 43 with 1 link to the first aggregated output', async function () {
-            const jobs = await Job.forUser(db, 'joe');
-            const job = jobs.data[0];
+            const job = await getFirstJob(db);
             expect(job.status).to.equal('running');
             expect(job.progress).to.equal(50);
             const dataLinks = job.links.filter(link => link.rel === 'data');
@@ -585,8 +581,7 @@ describe('when testing a batched aggregation service', function () {
 
           describe('when checking the jobs listing', function () {
             it('marks the job as running and progress of 86 with 2 links to the first two aggregated outputs', async function () {
-              const jobs = await Job.forUser(db, 'joe');
-              const job = jobs.data[0];
+              const job = await getFirstJob(db);
               expect(job.status).to.equal('running');
               expect(job.progress).to.equal(66);
               const dataLinks = job.links.filter(link => link.rel === 'data');
@@ -641,8 +636,7 @@ describe('when testing a batched aggregation service', function () {
 
           describe('when checking the jobs listing', function () {
             it('marks the job as successful and progress of 100 with 3 links to the three aggregated outputs', async function () {
-              const jobs = await Job.forUser(db, 'joe');
-              const job = jobs.data[0];
+              const job = await getFirstJob(db);
               expect(job.status).to.equal('successful');
               expect(job.progress).to.equal(100);
               const dataLinks = job.links.filter(link => link.rel === 'data');
@@ -775,8 +769,7 @@ describe('when testing a batched aggregation service', function () {
 
         describe('when checking the jobs listing', function () {
           it('lists the job as running and progress of 43 with 1 link to the first aggregated output', async function () {
-            const jobs = await Job.forUser(db, 'joe');
-            const job = jobs.data[0];
+            const job = await getFirstJob(db);
             expect(job.status).to.equal('running');
             expect(job.progress).to.equal(50);
             const dataLinks = job.links.filter(link => link.rel === 'data');
@@ -824,8 +817,7 @@ describe('when testing a batched aggregation service', function () {
 
           describe('when checking the jobs listing', function () {
             it('marks the job as running and progress of 86 with 2 links to the first two aggregated outputs', async function () {
-              const jobs = await Job.forUser(db, 'joe');
-              const job = jobs.data[0];
+              const job = await getFirstJob(db);
               expect(job.status).to.equal('running');
               expect(job.progress).to.equal(66);
               const dataLinks = job.links.filter(link => link.rel === 'data');
@@ -894,8 +886,7 @@ describe('when testing a batched aggregation service', function () {
 
           describe('when checking the jobs listing', function () {
             it('marks the job as successful and progress of 100 with 4 links to the three aggregated outputs', async function () {
-              const jobs = await Job.forUser(db, 'joe');
-              const job = jobs.data[0];
+              const job = await getFirstJob(db);
               expect(job.status).to.equal('successful');
               expect(job.progress).to.equal(100);
               const dataLinks = job.links.filter(link => link.rel === 'data');
@@ -1029,8 +1020,7 @@ describe('when testing a batched aggregation service', function () {
 
         describe('when checking the jobs listing', function () {
           it('lists the job as running and progress of 43 with 1 link to the first aggregated output', async function () {
-            const jobs = await Job.forUser(db, 'joe');
-            const job = jobs.data[0];
+            const job = await getFirstJob(db);
             expect(job.status).to.equal('running');
             expect(job.progress).to.equal(50);
             const dataLinks = job.links.filter(link => link.rel === 'data');
@@ -1078,8 +1068,7 @@ describe('when testing a batched aggregation service', function () {
 
           describe('when checking the jobs listing', function () {
             it('marks the job as running and progress of 86 with 2 links to the first two aggregated outputs', async function () {
-              const jobs = await Job.forUser(db, 'joe');
-              const job = jobs.data[0];
+              const job = await getFirstJob(db);
               expect(job.status).to.equal('running');
               expect(job.progress).to.equal(66);
               const dataLinks = job.links.filter(link => link.rel === 'data');
@@ -1148,8 +1137,10 @@ describe('when testing a batched aggregation service', function () {
 
           describe('when checking the jobs listing', function () {
             it('marks the job as successful and progress of 100 with 4 links to the three aggregated outputs', async function () {
-              const jobs = await Job.forUser(db, 'joe');
-              const job = jobs.data[0];
+              // const jobs = await Job.forUser(db, 'joe');
+              // const job = jobs.data[0];
+              // const job = await getFirstJob(db, { where: { username: 'joe' } });
+              const job = await getFirstJob(db);
               expect(job.status).to.equal('successful');
               expect(job.progress).to.equal(100);
               const dataLinks = job.links.filter(link => link.rel === 'data');

--- a/services/harmony/test/aggregation-batching.ts
+++ b/services/harmony/test/aggregation-batching.ts
@@ -141,10 +141,7 @@ describe('when testing a batched aggregation service', function () {
 
           describe('when checking the jobs listing', function () {
             it('marks the job as successful and progress of 100 with 1 link to the aggregated output', async function () {
-              // const jobs = await Job.forUser(db, 'joe');
               const job = await getFirstJob(db, { where: { username: 'joe' } });
-              // expect(job.status).to.equal('successful');
-              // expect(job.progress).to.equal(100);
               const dataLinks = job.links.filter(link => link.rel === 'data');
               expect(dataLinks.length).to.equal(1);
             });
@@ -1137,9 +1134,6 @@ describe('when testing a batched aggregation service', function () {
 
           describe('when checking the jobs listing', function () {
             it('marks the job as successful and progress of 100 with 4 links to the three aggregated outputs', async function () {
-              // const jobs = await Job.forUser(db, 'joe');
-              // const job = jobs.data[0];
-              // const job = await getFirstJob(db, { where: { username: 'joe' } });
               const job = await getFirstJob(db);
               expect(job.status).to.equal('successful');
               expect(job.progress).to.equal(100);

--- a/services/harmony/test/backend-callbacks.ts
+++ b/services/harmony/test/backend-callbacks.ts
@@ -9,7 +9,7 @@ import hookServersStartStop from './helpers/servers';
 import { rangesetRequest } from './helpers/ogc-api-coverages';
 import { validGetMapQuery, wmsRequest } from './helpers/wms';
 import db from '../app/util/db';
-import { hookJobCreationEach } from './helpers/jobs';
+import { getFirstJob, hookJobCreationEach } from './helpers/jobs';
 import { defaultObjectStore, objectStoreForProtocol } from '../app/util/object-store';
 import { hookCallbackEach, hookHttpBackendEach, loadJobForCallback } from './helpers/callbacks';
 
@@ -80,7 +80,7 @@ describe('Backend Callbacks', function () {
     });
 
     it('updates the corresponding job record', async function () {
-      const { job } = await Job.byRequestId(db, this.job.requestId);
+      const { job } = await Job.byJobID(db, this.job.jobID);
       expect(job.status).to.equal(JobStatus.SUCCESSFUL);
     });
   });
@@ -350,7 +350,7 @@ describe('Backend Callbacks', function () {
           code: 'harmony.RequestValidationError',
           message: 'JobLink is invalid: ["Job link must include an href"]',
         });
-        const job = (await Job.forUser(db, 'anonymous')).data[0];
+        const job = await getFirstJob(db);
         expect(job.getRelatedLinks('data')).to.eql([]);
       });
     });
@@ -364,7 +364,7 @@ describe('Backend Callbacks', function () {
           code: 'harmony.RequestValidationError',
           message: 'Unrecognized temporal format.  Must be 2 RFC-3339 dates with optional fractional seconds as Start,End',
         });
-        const job = (await Job.forUser(db, 'anonymous')).data[0];
+        const job = await getFirstJob(db);
         expect(job.getRelatedLinks('data')).to.eql([]);
       });
 
@@ -376,7 +376,7 @@ describe('Backend Callbacks', function () {
           code: 'harmony.RequestValidationError',
           message: 'Unrecognized temporal format.  Must be 2 RFC-3339 dates with optional fractional seconds as Start,End',
         });
-        const job = (await Job.forUser(db, 'anonymous')).data[0];
+        const job = await getFirstJob(db);
         expect(job.getRelatedLinks('data')).to.eql([]);
       });
 
@@ -391,7 +391,7 @@ describe('Backend Callbacks', function () {
         await request(this.backend).post(this.callback).query({
           item: { href, temporal: '2020-01-01T00:00:00Z,2020-01-02T00:00:00Z' },
         });
-        const job = (await Job.forUser(db, 'anonymous')).data[0];
+        const job = await getFirstJob(db);
         expect(job.getRelatedLinks('data').length).to.equal(1);
         expect(job.getRelatedLinks('data')[0].temporal).to.eql({ start: new Date('2020-01-01T00:00:00.000Z'), end: new Date('2020-01-02T00:00:00.000Z') });
       });
@@ -410,7 +410,7 @@ describe('Backend Callbacks', function () {
           code: 'harmony.RequestValidationError',
           message: 'Unrecognized bounding box format.  Must be 4 comma-separated floats as West,South,East,North',
         });
-        const job = (await Job.forUser(db, 'anonymous')).data[0];
+        const job = await getFirstJob(db);
         expect(job.getRelatedLinks('data')).to.eql([]);
       });
 
@@ -424,7 +424,7 @@ describe('Backend Callbacks', function () {
           code: 'harmony.RequestValidationError',
           message: 'Unrecognized bounding box format.  Must be 4 comma-separated floats as West,South,East,North',
         });
-        const job = (await Job.forUser(db, 'anonymous')).data[0];
+        const job = await getFirstJob(db);
         expect(job.getRelatedLinks('data')).to.eql([]);
       });
 
@@ -439,7 +439,7 @@ describe('Backend Callbacks', function () {
         await request(this.backend).post(this.callback).query({
           item: { href, bbox: '0.0,1.1,2.2,3.3' },
         });
-        const job = (await Job.forUser(db, 'anonymous')).data[0];
+        const job = await getFirstJob(db);
         expect(job.getRelatedLinks('data').length).to.equal(1);
         expect(job.getRelatedLinks('data')[0].bbox).to.eql([0.0, 1.1, 2.2, 3.3]);
       });

--- a/services/harmony/test/helpers/callbacks.ts
+++ b/services/harmony/test/helpers/callbacks.ts
@@ -52,6 +52,6 @@ export function hookCallbackEach(fn: (req: request.Test) => request.Test, finish
  * @param callback - the callback URL for the job that needs to be loaded
  */
 export async function loadJobForCallback(callback: string): Promise<Job> {
-  const requestId = callback.replace('/response', '').split('/').pop();
-  return (await Job.byRequestId(db, requestId)).job;
+  const jobID = callback.replace('/response', '').split('/').pop();
+  return (await Job.byJobID(db, jobID, true)).job;
 }

--- a/services/harmony/test/helpers/jobs.ts
+++ b/services/harmony/test/helpers/jobs.ts
@@ -5,7 +5,7 @@ import { v4 as uuid } from 'uuid';
 import { Application } from 'express';
 import _ from 'lodash';
 import JobLink from '../../app/models/job-link';
-import { Job, JobStatus, JobRecord, jobRecordFields, JobForDisplay, getRelatedLinks } from '../../app/models/job';
+import { Job, JobStatus, JobRecord, jobRecordFields, JobForDisplay, getRelatedLinks, JobQuery } from '../../app/models/job';
 import { JobListing } from '../../app/frontends/jobs';
 import db, { Transaction } from '../../app/util/db';
 import { hookRequest } from './hooks';
@@ -583,4 +583,18 @@ export function hookJobCreation(
  */
 export function hookJobCreationEach(props: Partial<JobRecord> = {}): void {
   hookJobCreation(props, beforeEach, afterEach);
+}
+
+/**
+ * Pulls back the first job from the database and includes the job links. Helps to simplify tests.
+ * @param tx - the database transaction
+ * @returns the first job from the database
+ */
+export async function getFirstJob(
+  tx: Transaction, constraints: JobQuery = { where: {} },
+): Promise<Job> {
+  const { data } = await Job.queryAll(tx, constraints);
+  const firstJobID = data[0].jobID;
+  const { job } = await Job.byJobID(tx, firstJobID, true);
+  return job;
 }

--- a/services/harmony/test/ignore-errors.ts
+++ b/services/harmony/test/ignore-errors.ts
@@ -98,7 +98,7 @@ describe('ignoreErrors', function () {
         });
 
         it('marks the job as successful', async function () {
-          const job = await Job.byJobID(db, firstSwotItem.jobID);
+          const { job } = await Job.byJobID(db, firstSwotItem.jobID);
           expect(job.status).to.equal(JobStatus.SUCCESSFUL);
           expect(job.progress).to.equal(100);
           const currentWorkItems = (await getWorkItemsByJobId(db, job.jobID)).workItems;
@@ -159,7 +159,7 @@ describe('ignoreErrors', function () {
 
         it('fails the job', async function () {
           // work item failure with only one granue should trigger job failure
-          const job = await Job.byJobID(db, firstSwotItem.jobID);
+          const { job } = await Job.byJobID(db, firstSwotItem.jobID);
           expect(job.status).to.equal(JobStatus.FAILED);
           expect(job.message).to.equal('WorkItem failed: Specific failure reason');
         });
@@ -227,7 +227,7 @@ describe('ignoreErrors', function () {
         });
 
         it('changes the job status to running_with_errors', async function () {
-          const job = await Job.byJobID(db, firstSwotItem.jobID);
+          const { job } = await Job.byJobID(db, firstSwotItem.jobID);
           expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
           const currentWorkItems = (await getWorkItemsByJobId(db, job.jobID)).workItems;
           expect(currentWorkItems.length).to.equal(3);
@@ -266,7 +266,7 @@ describe('ignoreErrors', function () {
 
         it('marks the job as failed', async function () {
           // all work items failing should trigger job failure
-          const job = await Job.byJobID(db, secondSwotItem.jobID);
+          const { job } = await Job.byJobID(db, secondSwotItem.jobID);
           expect(job.status).to.equal(JobStatus.FAILED);
           expect(job.message).to.equal('The job failed with 2 errors. See the errors field for more details');
           const currentWorkItems = (await getWorkItemsByJobId(db, job.jobID)).workItems;
@@ -322,7 +322,7 @@ describe('ignoreErrors', function () {
         });
 
         it('changes the job status to running_with_errors', async function () {
-          const job = await Job.byJobID(db, firstSwotItem.jobID);
+          const { job } = await Job.byJobID(db, firstSwotItem.jobID);
           expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
         });
 
@@ -366,7 +366,7 @@ describe('ignoreErrors', function () {
           await fakeServiceStacOutput(workItem4.jobID, workItem4.id);
           await updateWorkItem(this.backend, workItem4);
 
-          const job = await Job.byJobID(db, firstSwotItem.jobID);
+          const { job } = await Job.byJobID(db, firstSwotItem.jobID);
           expect(job.status).to.equal(JobStatus.COMPLETE_WITH_ERRORS);
           expect(job.progress).to.equal(100);
         });
@@ -433,7 +433,7 @@ describe('ignoreErrors', function () {
         });
 
         it('leaves the job in the running state', async function () {
-          const job = await Job.byJobID(db, firstSwotItem.jobID);
+          const { job } = await Job.byJobID(db, firstSwotItem.jobID);
           expect(job.status).to.equal(JobStatus.RUNNING);
         });
       });
@@ -459,7 +459,7 @@ describe('ignoreErrors', function () {
         });
 
         it('changes the job status to running_with_errors', async function () {
-          const job = await Job.byJobID(db, secondSwotItem.jobID);
+          const { job } = await Job.byJobID(db, secondSwotItem.jobID);
           expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
         });
 
@@ -497,7 +497,7 @@ describe('ignoreErrors', function () {
         });
 
         it('puts the job in a FAILED state', async function () {
-          const job = await Job.byJobID(db, thirdSwotItem.jobID);
+          const { job } = await Job.byJobID(db, thirdSwotItem.jobID);
           expect(job.status).to.equal(JobStatus.FAILED);
         });
 
@@ -555,7 +555,7 @@ describe('ignoreErrors', function () {
       });
 
       it('marks the job as failed', async function () {
-        const job = await Job.byJobID(db, this.workItem.jobID);
+        const { job } = await Job.byJobID(db, this.workItem.jobID);
         expect(job.status).to.equal(JobStatus.FAILED);
       });
     });
@@ -601,7 +601,7 @@ describe('ignoreErrors', function () {
         });
 
         it('leaves the job in the running state', async function () {
-          const job = await Job.byJobID(db, workItemJobID);
+          const { job } = await Job.byJobID(db, workItemJobID);
           expect(job.status).to.equal(JobStatus.RUNNING);
         });
 
@@ -626,7 +626,7 @@ describe('ignoreErrors', function () {
           });
 
           it('leaves the job in the running state', async function () {
-            const job = await Job.byJobID(db, firstSwotItem.jobID);
+            const { job } = await Job.byJobID(db, firstSwotItem.jobID);
             expect(job.status).to.equal(JobStatus.RUNNING);
           });
         });
@@ -652,7 +652,7 @@ describe('ignoreErrors', function () {
         });
 
         it('updates the job to the running_with_errors state', async function () {
-          const job = await Job.byJobID(db, secondSwotItem.jobID);
+          const { job } = await Job.byJobID(db, secondSwotItem.jobID);
           expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
         });
       });
@@ -677,7 +677,7 @@ describe('ignoreErrors', function () {
         });
 
         it('updates the job to the failed state', async function () {
-          const job = await Job.byJobID(db, secondQueryCmrItem.jobID);
+          const { job } = await Job.byJobID(db, secondQueryCmrItem.jobID);
           expect(job.status).to.equal(JobStatus.FAILED);
         });
 
@@ -738,7 +738,7 @@ describe('ignoreErrors', function () {
           });
 
           it('changes the job status to running_with_errors', async function () {
-            const job = await Job.byJobID(db, firstL2SSItem.jobID);
+            const { job } = await Job.byJobID(db, firstL2SSItem.jobID);
             expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
           });
 
@@ -790,7 +790,7 @@ describe('ignoreErrors', function () {
             await updateWorkItem(this.backend, workItem);
 
 
-            const job = await Job.byJobID(db, firstL2SSItem.jobID);
+            const { job } = await Job.byJobID(db, firstL2SSItem.jobID);
             expect(job.status).to.equal(JobStatus.COMPLETE_WITH_ERRORS);
             expect(job.progress).to.equal(100);
           });
@@ -870,7 +870,7 @@ describe('ignoreErrors', function () {
           });
 
           it('changes the job status to running_with_errors', async function () {
-            const job = await Job.byJobID(db, secondL2SSItem.jobID);
+            const { job } = await Job.byJobID(db, secondL2SSItem.jobID);
             expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
           });
 
@@ -908,7 +908,7 @@ describe('ignoreErrors', function () {
             await fakeServiceStacOutput(workItem.jobID, workItem.id);
             await updateWorkItem(this.backend, workItem);
 
-            const job = await Job.byJobID(db, secondL2SSItem.jobID);
+            const { job } = await Job.byJobID(db, secondL2SSItem.jobID);
             expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
           });
 
@@ -920,7 +920,7 @@ describe('ignoreErrors', function () {
             await fakeServiceStacOutput(workItem.jobID, workItem.id);
             await updateWorkItem(this.backend, workItem);
 
-            const job = await Job.byJobID(db, secondL2SSItem.jobID);
+            const { job } = await Job.byJobID(db, secondL2SSItem.jobID);
             expect(job.status).to.equal(JobStatus.COMPLETE_WITH_ERRORS);
             expect(job.progress).to.equal(100);
           });
@@ -1017,7 +1017,7 @@ describe('ignoreErrors', function () {
           });
 
           it('changes the job status to running_with_errors', async function () {
-            const job = await Job.byJobID(db, lastL2SSItem.jobID);
+            const { job } = await Job.byJobID(db, lastL2SSItem.jobID);
             expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
           });
 
@@ -1038,7 +1038,7 @@ describe('ignoreErrors', function () {
             await fakeServiceStacOutput(workItem.jobID, workItem.id);
             await updateWorkItem(this.backend, workItem);
 
-            const job = await Job.byJobID(db, lastL2SSItem.jobID);
+            const { job } = await Job.byJobID(db, lastL2SSItem.jobID);
             expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
           });
 
@@ -1050,7 +1050,7 @@ describe('ignoreErrors', function () {
             await fakeServiceStacOutput(workItem.jobID, workItem.id);
             await updateWorkItem(this.backend, workItem);
 
-            const job = await Job.byJobID(db, lastL2SSItem.jobID);
+            const { job } = await Job.byJobID(db, lastL2SSItem.jobID);
             expect(job.status).to.equal(JobStatus.COMPLETE_WITH_ERRORS);
             expect(job.progress).to.equal(100);
           });
@@ -1147,7 +1147,7 @@ describe('ignoreErrors', function () {
           });
 
           it('changes the job status to running_with_errors', async function () {
-            const job = await Job.byJobID(db, lastL2SSItem.jobID);
+            const { job } = await Job.byJobID(db, lastL2SSItem.jobID);
             expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
           });
 
@@ -1168,7 +1168,7 @@ describe('ignoreErrors', function () {
             await fakeServiceStacOutput(workItem.jobID, workItem.id);
             await updateWorkItem(this.backend, workItem);
 
-            const job = await Job.byJobID(db, lastL2SSItem.jobID);
+            const { job } = await Job.byJobID(db, lastL2SSItem.jobID);
             expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
           });
 
@@ -1191,7 +1191,7 @@ describe('ignoreErrors', function () {
               }
             });
             it('sets the status to COMPLETE_WITH_ERRORS', async function () {
-              const job = await Job.byJobID(db, lastL2SSItem.jobID);
+              const { job } = await Job.byJobID(db, lastL2SSItem.jobID);
               expect(job.status).to.equal(JobStatus.COMPLETE_WITH_ERRORS);
               expect(job.progress).to.equal(100);
             });
@@ -1253,7 +1253,7 @@ describe('ignoreErrors', function () {
           });
 
           it('leaves the job in the running state', async function () {
-            const job = await Job.byJobID(db, firstSwotItem.jobID);
+            const { job } = await Job.byJobID(db, firstSwotItem.jobID);
             expect(job.status).to.equal(JobStatus.RUNNING);
           });
         });
@@ -1279,7 +1279,7 @@ describe('ignoreErrors', function () {
           });
 
           it('changes the job status to running_with_errors', async function () {
-            const job = await Job.byJobID(db, secondL2SSItem.jobID);
+            const { job } = await Job.byJobID(db, secondL2SSItem.jobID);
             expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
           });
 
@@ -1315,7 +1315,7 @@ describe('ignoreErrors', function () {
           });
 
           it('puts the job in a FAILED state', async function () {
-            const job = await Job.byJobID(db, thirdL2SSItem.jobID);
+            const { job } = await Job.byJobID(db, thirdL2SSItem.jobID);
             expect(job.status).to.equal(JobStatus.FAILED);
           });
 
@@ -1372,7 +1372,7 @@ describe('ignoreErrors', function () {
         });
 
         it('marks the job as failed', async function () {
-          const job = await Job.byJobID(db, this.workItem.jobID);
+          const { job } = await Job.byJobID(db, this.workItem.jobID);
           expect(job.status).to.equal(JobStatus.FAILED);
         });
       });
@@ -1423,7 +1423,7 @@ describe('ignoreErrors', function () {
         });
 
         it('changes the job status to running_with_errors', async function () {
-          const job = await Job.byJobID(db, firstSwotItem.jobID);
+          const { job } = await Job.byJobID(db, firstSwotItem.jobID);
           expect(job.status).to.equal(JobStatus.RUNNING_WITH_ERRORS);
         });
 
@@ -1467,7 +1467,7 @@ describe('ignoreErrors', function () {
           await fakeServiceStacOutput(workItem4.jobID, workItem4.id);
           await updateWorkItem(this.backend, workItem4);
 
-          const job = await Job.byJobID(db, firstSwotItem.jobID);
+          const { job } = await Job.byJobID(db, firstSwotItem.jobID);
           expect(job.status).to.equal(JobStatus.COMPLETE_WITH_ERRORS);
           expect(job.progress).to.equal(100);
         });
@@ -1528,7 +1528,7 @@ describe('ignoreErrors', function () {
         });
 
         it('changes the job status to failed', async function () {
-          const job = await Job.byJobID(db, firstSwotItem.jobID);
+          const { job } = await Job.byJobID(db, firstSwotItem.jobID);
           expect(job.status).to.equal(JobStatus.FAILED);
         });
 

--- a/services/harmony/test/jobs/batch-status-change.ts
+++ b/services/harmony/test/jobs/batch-status-change.ts
@@ -30,9 +30,9 @@ describe('jobs/cancel, jobs/resume, jobs/skip-preview, jobs/resume', function ()
     hookCancelJobs({ username: 'joe', 'jobIDs': [joeJob1.jobID, joeJob2.jobID] });
 
     it('Cancels the jobs', async function () {
-      const dbJob1 = await Job.byJobID(db, joeJob1.jobID);
+      const { job: dbJob1 } = await Job.byJobID(db, joeJob1.jobID);
       expect(dbJob1.status).to.eq(JobStatus.CANCELED);
-      const dbJob2 = await Job.byJobID(db, joeJob2.jobID);
+      const { job: dbJob2 } = await Job.byJobID(db, joeJob2.jobID);
       expect(dbJob2.status).to.eq(JobStatus.CANCELED);
       expect(this.res.statusCode).to.equal(200);
     });
@@ -53,11 +53,11 @@ describe('jobs/cancel, jobs/resume, jobs/skip-preview, jobs/resume', function ()
     hookPauseJobs({ username: 'joe', 'jobIDs': [joeJob1.jobID, joeJob2.jobID, joeJob3.jobID] });
 
     it('Pauses the jobs', async function () {
-      const dbJob1 = await Job.byJobID(db, joeJob1.jobID);
+      const { job: dbJob1 } = await Job.byJobID(db, joeJob1.jobID);
       expect(dbJob1.status).to.eq(JobStatus.PAUSED);
-      const dbJob2 = await Job.byJobID(db, joeJob2.jobID);
+      const { job: dbJob2 } = await Job.byJobID(db, joeJob2.jobID);
       expect(dbJob2.status).to.eq(JobStatus.PAUSED);
-      const dbJob3 = await Job.byJobID(db, joeJob3.jobID);
+      const { job: dbJob3 } = await Job.byJobID(db, joeJob3.jobID);
       expect(dbJob3.status).to.eq(JobStatus.PAUSED);
       expect(this.res.statusCode).to.equal(200);
     });
@@ -76,9 +76,9 @@ describe('jobs/cancel, jobs/resume, jobs/skip-preview, jobs/resume', function ()
     hookResumeJobs({ username: 'joe', 'jobIDs': [joeJob1.jobID, joeJob2.jobID] });
 
     it('Resumes the jobs', async function () {
-      const dbJob1 = await Job.byJobID(db, joeJob1.jobID);
+      const { job: dbJob1 } = await Job.byJobID(db, joeJob1.jobID);
       expect(dbJob1.status).to.eq(JobStatus.RUNNING);
-      const dbJob2 = await Job.byJobID(db, joeJob2.jobID);
+      const { job: dbJob2 } = await Job.byJobID(db, joeJob2.jobID);
       expect(dbJob2.status).to.eq(JobStatus.RUNNING);
       expect(this.res.statusCode).to.equal(200);
     });
@@ -97,9 +97,9 @@ describe('jobs/cancel, jobs/resume, jobs/skip-preview, jobs/resume', function ()
     hookSkipPreviewJobs({ username: 'joe', 'jobIDs': [joeJob1.jobID, joeJob2.jobID] });
 
     it('Skips the job previews', async function () {
-      const dbJob1 = await Job.byJobID(db, joeJob1.jobID);
+      const { job: dbJob1 } = await Job.byJobID(db, joeJob1.jobID);
       expect(dbJob1.status).to.eq(JobStatus.RUNNING);
-      const dbJob2 = await Job.byJobID(db, joeJob2.jobID);
+      const { job: dbJob2 } = await Job.byJobID(db, joeJob2.jobID);
       expect(dbJob2.status).to.eq(JobStatus.RUNNING);
       expect(this.res.statusCode).to.equal(200);
     });
@@ -118,9 +118,9 @@ describe('jobs/cancel, jobs/resume, jobs/skip-preview, jobs/resume', function ()
     hookSkipPreviewJobs({ username: 'joe', 'jobIDs': [joeJob1.jobID, joeJob2.jobID] });
 
     it('Skips the job preview for only one job', async function () {
-      const dbJob1 = await Job.byJobID(db, joeJob1.jobID);
+      const { job: dbJob1 } = await Job.byJobID(db, joeJob1.jobID);
       expect(dbJob1.status).to.eq(JobStatus.RUNNING);
-      const dbJob2 = await Job.byJobID(db, joeJob2.jobID);
+      const { job: dbJob2 } = await Job.byJobID(db, joeJob2.jobID);
       expect(dbJob2.status).to.eq(JobStatus.CANCELED);
       expect(JSON.parse(this.res.error.text).description).to.equal('Error: Could not change all job statuses. Proccessed 1.');
     });
@@ -139,9 +139,9 @@ describe('jobs/cancel, jobs/resume, jobs/skip-preview, jobs/resume', function ()
     hookSkipPreviewJobs({ username: 'adam', 'jobIDs': [joeJob1.jobID, buzzJob1.jobID] });
 
     it('Skips the job previews', async function () {
-      const dbJob1 = await Job.byJobID(db, joeJob1.jobID);
+      const { job: dbJob1 } = await Job.byJobID(db, joeJob1.jobID);
       expect(dbJob1.status).to.eq(JobStatus.RUNNING);
-      const dbJob2 = await Job.byJobID(db, buzzJob1.jobID);
+      const { job: dbJob2 } = await Job.byJobID(db, buzzJob1.jobID);
       expect(dbJob2.status).to.eq(JobStatus.RUNNING);
       expect(this.res.statusCode).to.equal(200);
     });
@@ -160,9 +160,9 @@ describe('jobs/cancel, jobs/resume, jobs/skip-preview, jobs/resume', function ()
     hookSkipPreviewJobs({ username: 'woody', 'jobIDs': [joeJob1.jobID, joeJob2.jobID] });
 
     it('Does not skip the job previews (returns an error)', async function () {
-      const dbJob1 = await Job.byJobID(db, joeJob1.jobID);
+      const { job: dbJob1 } = await Job.byJobID(db, joeJob1.jobID);
       expect(dbJob1.status).to.eq(JobStatus.PREVIEWING);
-      const dbJob2 = await Job.byJobID(db, joeJob2.jobID);
+      const { job: dbJob2 } = await Job.byJobID(db, joeJob2.jobID);
       expect(dbJob2.status).to.eq(JobStatus.PREVIEWING);
       expect(JSON.parse(this.res.error.text).description).to.equal('Error: Could not change all job statuses. Proccessed 0.');
     });
@@ -181,9 +181,9 @@ describe('jobs/cancel, jobs/resume, jobs/skip-preview, jobs/resume', function ()
     hookCancelJobs({ username: 'woody', 'jobIDs': [joeJob1.jobID, joeJob2.jobID] });
 
     it('Does not cancel the jobs (returns an error)', async function () {
-      const dbJob1 = await Job.byJobID(db, joeJob1.jobID);
+      const { job: dbJob1 } = await Job.byJobID(db, joeJob1.jobID);
       expect(dbJob1.status).to.eq(JobStatus.PREVIEWING);
-      const dbJob2 = await Job.byJobID(db, joeJob2.jobID);
+      const { job: dbJob2 } = await Job.byJobID(db, joeJob2.jobID);
       expect(dbJob2.status).to.eq(JobStatus.PREVIEWING);
       expect(JSON.parse(this.res.error.text).description).to.equal('Error: Could not change all job statuses. Proccessed 0.');
     });

--- a/services/harmony/test/jobs/message.ts
+++ b/services/harmony/test/jobs/message.ts
@@ -43,13 +43,13 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
       it('sets the appropriate message when paused', async function () {
         job.pause();
         await job.save(this.trx);
-        const updatedJob = await Job.byJobID(this.trx, job.jobID);
+        const { job: updatedJob } = await Job.byJobID(this.trx, job.jobID);
         expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link');
       });
       it('sets the appropriate message when resumed', async function () {
         job.resume();
         await job.save(this.trx);
-        const updatedJob = await Job.byJobID(this.trx, job.jobID);
+        const { job: updatedJob } = await Job.byJobID(this.trx, job.jobID);
         expect(updatedJob.message).to.eq('The job is being processed');
       });
     });
@@ -96,13 +96,13 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
       it('sets the appropriate message when paused', async function () {
         job.pause();
         await job.save(this.trx);
-        const updatedJob = await Job.byJobID(this.trx, job.jobID);
+        const { job: updatedJob } = await Job.byJobID(this.trx, job.jobID);
         expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link');
       });
       it('sets the appropriate message when resumed', async function () {
         job.resume();
         await job.save(this.trx);
-        const updatedJob = await Job.byJobID(this.trx, job.jobID);
+        const { job: updatedJob } = await Job.byJobID(this.trx, job.jobID);
         expect(updatedJob.message).to.eq(limitedMessage);
       });
     });
@@ -156,13 +156,13 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
         it('sets the appropriate message when paused', async function () {
           job.pause();
           await job.save(this.trx);
-          const updatedJob = await Job.byJobID(this.trx, job.jobID);
+          const { job: updatedJob } = await Job.byJobID(this.trx, job.jobID);
           expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link');
         });
         it('sets the appropriate message when resumed', async function () {
           job.resume();
           await job.save(this.trx);
-          const updatedJob = await Job.byJobID(this.trx, job.jobID);
+          const { job: updatedJob } = await Job.byJobID(this.trx, job.jobID);
           expect(updatedJob.message).to.eq('The job is being processed');
         });
       });
@@ -170,19 +170,19 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
         it('sets the appropriate message when skipping preview', async function () {
           skipJob.skipPreview();
           await skipJob.save(this.trx);
-          const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
+          const { job: updatedJob } = await Job.byJobID(this.trx, skipJob.jobID);
           expect(updatedJob.message).to.eq('The job is being processed');
         });
         it('sets the appropriate message when paused', async function () {
           skipJob.pause();
           await skipJob.save(this.trx);
-          const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
+          const { job: updatedJob } = await Job.byJobID(this.trx, skipJob.jobID);
           expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link');
         });
         it('sets the appropriate message when resumed', async function () {
           skipJob.resume();
           await skipJob.save(this.trx);
-          const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
+          const { job: updatedJob } = await Job.byJobID(this.trx, skipJob.jobID);
           expect(updatedJob.message).to.eq('The job is being processed');
         });
       });
@@ -214,13 +214,13 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
         it('sets the appropriate message when paused', async function () {
           job.pause();
           await job.save(this.trx);
-          const updatedJob = await Job.byJobID(this.trx, job.jobID);
+          const { job: updatedJob } = await Job.byJobID(this.trx, job.jobID);
           expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link');
         });
         it('sets the appropriate message when resumed', async function () {
           job.resume();
           await job.save(this.trx);
-          const updatedJob = await Job.byJobID(this.trx, job.jobID);
+          const { job: updatedJob } = await Job.byJobID(this.trx, job.jobID);
           expect(updatedJob.message).to.eq(limitedMessage);
         });
       });
@@ -228,19 +228,19 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
         it('sets the appropriate message when skipping preview', async function () {
           skipJob.skipPreview();
           await skipJob.save(this.trx);
-          const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
+          const { job: updatedJob } = await Job.byJobID(this.trx, skipJob.jobID);
           expect(updatedJob.message).to.eq(limitedMessage);
         });
         it('sets the appropriate message when paused', async function () {
           skipJob.pause();
           await skipJob.save(this.trx);
-          const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
+          const { job: updatedJob } = await Job.byJobID(this.trx, skipJob.jobID);
           expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link');
         });
         it('sets the appropriate message when resumed', async function () {
           skipJob.resume();
           await skipJob.save(this.trx);
-          const updatedJob = await Job.byJobID(this.trx, skipJob.jobID);
+          const { job: updatedJob } = await Job.byJobID(this.trx, skipJob.jobID);
           expect(updatedJob.message).to.eq(limitedMessage);
         });
       });
@@ -248,13 +248,13 @@ describe('skipPreview, pause, resume, and updateStatus job message handling', as
         it('sets the appropriate message when paused', async function () {
           completeJob.pause();
           await completeJob.save(this.trx);
-          const updatedJob = await Job.byJobID(this.trx, completeJob.jobID);
+          const { job: updatedJob } = await Job.byJobID(this.trx, completeJob.jobID);
           expect(updatedJob.message).to.eq('The job is paused and may be resumed using the provided link');
         });
         it('sets the appropriate message when completed', async function () {
           completeJob.updateStatus(JobStatus.SUCCESSFUL);
           await completeJob.save(this.trx);
-          const updatedJob = await Job.byJobID(this.trx, completeJob.jobID);
+          const { job: updatedJob } = await Job.byJobID(this.trx, completeJob.jobID);
           expect(updatedJob.message).to.eq(limitedMessage);
         });
       });

--- a/services/harmony/test/models/job.ts
+++ b/services/harmony/test/models/job.ts
@@ -98,28 +98,6 @@ describe('Job', function () {
         });
       });
     });
-
-    // describe('.byRequestId', function () {
-    //   let job;
-    //   beforeEach(async function () {
-    //     job = buildJob({ username: 'jdoe' });
-    //     await job.save(this.trx);
-    //   });
-
-    //   describe('when a job matches the request id', function () {
-    //     it('returns the matching job', async function () {
-    //       const result = await Job.byRequestId(this.trx, job.requestId);
-    //       expect(result.job.id).to.eql(job.id);
-    //     });
-    //   });
-
-    //   describe('when no job matches the request id', function () {
-    //     it('returns null', async function () {
-    //       const result = await Job.byRequestId(this.trx, uuid());
-    //       expect(result.job).to.eql(null);
-    //     });
-    //   });
-    // });
   });
 
   describe('#constructor', function () {

--- a/services/harmony/test/work-items/retries.ts
+++ b/services/harmony/test/work-items/retries.ts
@@ -62,7 +62,7 @@ describe('Work item failure retries', function () {
         this.workItem = await getWorkItemById(db, workItem.id);
       });
       it('Leaves the job in the running state', async function () {
-        const job = await Job.byJobID(db, this.workItem.jobID);
+        const { job } = await Job.byJobID(db, this.workItem.jobID);
         expect(job.status).to.equal(JobStatus.RUNNING);
       });
       it('Changes the work-item status to ready', async function () {
@@ -103,7 +103,7 @@ describe('Work item failure retries', function () {
         this.workItem = await getWorkItemById(db, workItem.id);
       });
       it('Leaves the job in the running state', async function () {
-        const job = await Job.byJobID(db, this.workItem.jobID);
+        const { job } = await Job.byJobID(db, this.workItem.jobID);
         expect(job.status).to.equal(JobStatus.RUNNING);
       });
       it('Changes the work-item status to ready', async function () {
@@ -122,7 +122,7 @@ describe('Work item failure retries', function () {
           this.workItem = await getWorkItemById(db, workItem.id);
         });
         it('Leaves the job in the running state', async function () {
-          const job = await Job.byJobID(db, this.workItem.jobID);
+          const { job } = await Job.byJobID(db, this.workItem.jobID);
           expect(job.status).to.equal(JobStatus.RUNNING);
         });
         it('Changes the work-item status to ready', async function () {
@@ -163,7 +163,7 @@ describe('Work item failure retries', function () {
         this.workItem = await getWorkItemById(db, workItem.id);
       });
       it('Leaves the job in the running state', async function () {
-        const job = await Job.byJobID(db, this.workItem.jobID);
+        const { job } = await Job.byJobID(db, this.workItem.jobID);
         expect(job.status).to.equal(JobStatus.RUNNING);
       });
       it('Changes the work-item status to ready', async function () {
@@ -182,7 +182,7 @@ describe('Work item failure retries', function () {
           this.workItem = await getWorkItemById(db, workItem.id);
         });
         it('Leaves the job in the running state', async function () {
-          const job = await Job.byJobID(db, this.workItem.jobID);
+          const { job } = await Job.byJobID(db, this.workItem.jobID);
           expect(job.status).to.equal(JobStatus.RUNNING);
         });
         it('Changes the work-item status to ready', async function () {
@@ -202,7 +202,7 @@ describe('Work item failure retries', function () {
           this.workItem = await getWorkItemById(db, workItem.id);
         });
         it('Changes the job status to failed', async function () {
-          const job = await Job.byJobID(db, this.workItem.jobID);
+          const { job } = await Job.byJobID(db, this.workItem.jobID);
           expect(job.status).to.equal(JobStatus.FAILED);
         });
         it('changes the work-item status to failed', async function () {

--- a/services/harmony/test/work-items/work-backends.ts
+++ b/services/harmony/test/work-items/work-backends.ts
@@ -263,7 +263,7 @@ describe('Work Backends', function () {
       });
 
       it('sets the job status to failed', async function () {
-        const job = await Job.byJobID(db, this.job.jobID);
+        const { job } = await Job.byJobID(db, this.job.jobID);
         expect(job.status).to.equal(JobStatus.FAILED);
       });
     });
@@ -453,24 +453,24 @@ describe('Work Backends', function () {
 
       describe('and the work item is the last in the chain', async function () {
         it('sets the job updatedAt field to the current time', async function () {
-          const updatedJob = await Job.byJobID(db, this.job.jobID);
+          const { job: updatedJob } = await Job.byJobID(db, this.job.jobID);
           expect(updatedJob.updatedAt.valueOf()).to.greaterThan(this.job.updatedAt.valueOf());
         });
 
         it('adds a link for the work results to the job', async function () {
-          const updatedJob = await Job.byJobID(db, this.job.jobID);
+          const { job: updatedJob } = await Job.byJobID(db, this.job.jobID, true);
           expect(updatedJob.links.filter(
             (jobLink) => jobLink.href === expectedLink,
           ).length).to.equal(1);
         });
 
         it('sets the job status to complete', async function () {
-          const updatedJob = await Job.byJobID(db, this.job.jobID);
+          const { job: updatedJob } = await Job.byJobID(db, this.job.jobID);
           expect(updatedJob.status === JobStatus.SUCCESSFUL);
         });
 
         it('sets the job progress to 100', async function () {
-          const updatedJob = await Job.byJobID(db, this.job.jobID);
+          const { job: updatedJob } = await Job.byJobID(db, this.job.jobID);
           expect(updatedJob.progress).to.equal(100);
         });
       });

--- a/services/work-failer/.nsprc
+++ b/services/work-failer/.nsprc
@@ -1,7 +1,1 @@
-{
-  "1094183": {
-    "active": true,
-    "notes": "Ignored since there is no fix",
-    "expiry": "2023-12-01"
-  }
-}
+{ }

--- a/services/work-failer/test/work-failer.ts
+++ b/services/work-failer/test/work-failer.ts
@@ -184,8 +184,8 @@ describe('WorkFailer', function () {
         });
 
         // check that the job status was appropriately updated as a result of the item updates
-        job = await Job.byJobID(db, job.jobID);
-        expect(job.status === jobStatus);
+        const response = await Job.byJobID(db, job.jobID);
+        expect(response.job.status === jobStatus);
       });
     });
   });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1654

## Description
The ticket was to fix a case where we were pulling back job links from one of the workflow-ui queries. When looking into it I found that our internal code APIs for querying for jobs were inconsistent and made it easy to pull back job links unintentionally. I refactored and tried to use common code for querying for all jobs or querying for a single job. By default links are not returned, the caller explicitly needs to request links now.

I also fixed all of the indices on the jobs table to match the queries that we execute.

## Local Test Steps
1. Run the database migration and verify it succeeds.
2. Regression test the jobs listing and jobs status page. Verify listings do not include the job links and the job status does include job links. For large requests make sure the paging works correctly for the jobs status page.
3. Make sure all pages on the workflow-ui work as expected.
4. Verify harmony-py works as before when submitting requests and downloading results.

I tested out with a sandbox run using locust where I ran the migrations with 150 concurrent requests. I created over 22K jobs and tested with large jobs with 247K granules. The migrations did run into deadlocks a couple times, but they did succeed with retries on a single deployment (we retry up to 10 times). Cloudwatch did not show any slow queries and the original slow queries that were logged that were the reason for this ticket did not appear.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)