### PR TITLE
HARMONY-1660: Decrease MAX_DOWNLOAD_RETRIES

### DIFF
--- a/ENV_CHANGELOG.md
+++ b/ENV_CHANGELOG.md
@@ -2,6 +2,10 @@
 Any changes to the environment variables will be documented in this file in chronological
 order with the most recent changes first.
 
+## 2024-01-03
+### Changed
+- MAX_DOWNLOAD_RETRIES - Decreased to 3.
+
 ## 2023-10-09
 ### Changed
 - VAR_SUBSETTER_IMAGE to HOSS_IMAGE

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -227,7 +227,7 @@ KUBE_CONTEXT=docker-desktop
 # [0, 4, 8, 16, 32, 64, 120, 120, 120, 120] (~10 minutes)
 # 120 seconds is the maximum backoff and there is always 0 seconds before the
 # first retry regardless of the parameters.
-MAX_DOWNLOAD_RETRIES=10
+MAX_DOWNLOAD_RETRIES=3
 
 # The number of seconds to allow a pod to continue processing an active request before terminating a pod
 DEFAULT_POD_GRACE_PERIOD_SECS=14400


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1660

## Description
Decreases the default MAX_DOWNLOAD_RETRIES from 10 to 3. There is another ticket, HARMONY-1621 ("Retrying of download failures internally in service library is wasting resources and slowing down system throughput") that is related but likely involves a lot more work.

## Local Test Steps
n/a

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)