### PR TITLE
DAS-2000 - Increase HOSS container memory.

### DIFF
--- a/ENV_CHANGELOG.md
+++ b/ENV_CHANGELOG.md
@@ -4,6 +4,10 @@ order with the most recent changes first.
 
 ## 2024-01-03
 ### Changed
+- HOSS_LIMITS_MEMORY - Increased to 8Gi to accommodate filling for bounding boxes crossing grid edge for large granules.
+
+## 2024-01-03
+### Changed
 - MAX_DOWNLOAD_RETRIES - Decreased to 3.
 
 ## 2023-10-09

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -410,7 +410,7 @@ HOSS_IMAGE=ghcr.io/nasa/harmony-opendap-subsetter:latest
 HOSS_REQUESTS_CPU=128m
 HOSS_REQUESTS_MEMORY=128Mi
 HOSS_LIMITS_CPU=128m
-HOSS_LIMITS_MEMORY=512Mi
+HOSS_LIMITS_MEMORY=8Gi
 HOSS_INVOCATION_ARGS='python -m hoss'
 HOSS_SERVICE_QUEUE_URLS='["ghcr.io/nasa/harmony-opendap-subsetter:latest,http://localstack:4566/queue/hoss.fifo"]'
 


### PR DESCRIPTION
## Jira Issue ID

DAS-2000

## Description

This PR increases the container memory for HOSS. HOSS has recently been failing for GHRSST MUR bounding box spatial subset requests that cross the longitudinal edge of the grid. This memory increase will also potentially help support spatial subsetting of high resolution grids when determining the minimally encompassing bounding box (e.g., ATL14 granules over the Antarctic).

## Local Test Steps

* Pull this branch.
* Make sure your Docker Desktop has comfortably more than 8 GB of memory available (I had 10 GB to be safe).
* Rebuild Harmony to use this branch.
* Run the following request, it should complete successfully:

```
http://localhost:3000/C1243747494-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&subset=lat(-30.0%3A30.0)&subset=lon(-180.0%3A-120.0)&skipPreview=true&ignoreErrors=true&maxResults=1 
```

(Depending on your machine, it might take a little while. 2 minutes ish seems like a lower limit, but my slightly struggling Mac took 8 - 9 minutes)

## PR Acceptance Checklist
* [x] Acceptance criteria met
* ~~Tests added/updated (if needed) and passing~~
* ~~Documentation updated (if needed)~~