### PR TITLE
DAS-2088 - Update the production Trajectory Subsetter UMM-S record reference.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -176,7 +176,7 @@ https://cmr.earthdata.nasa.gov:
         env:
           <<: *default-turbo-env
           STAGING_PATH: public/sds/trajectory-subsetter
-    umm_s: S2232210365-ORNL_CLOUD
+    umm_s: S2836723123-XYZ_PROV
     capabilities:
       subsetting:
         temporal: true


### PR DESCRIPTION
## Jira Issue ID

DAS-2088

## Description

This PR updates the UMM-S record used to identify the Trajectory Subsetter in production so that it is one maintained by the Data Services team, who develop the Trajectory Subsetter.

## Local Test Steps

Compare the UMM-S records for the ORNL_CLOUD and XYZ_PROV providers using the following CMR endpoint:

```
https://cmr.earthdata.nasa.gov/search/services.umm_json?concept_id=<UMM-S concept ID>
```

The important thing is that the service options (e.g., variable/temporal/spatial subsetting) and the Harmony endpoint are consistent. I added some contact information for David and I that were not in the original record.

I will only merge this once all UMM-S to UMM-C associations that exist with the ORNL_CLOUD record are replicated for the XYZ_PROV record. I do not have permission to make those associations, as it requires someone with permissions in the collection providers (ORNL_CLOUD and LARC_ASDC) to do so. I'll solicit help with that, though.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* ~~Tests added/updated (if needed) and passing~~
* ~~Documentation updated (if needed)~~