### PR TITLE
HARMONY-1696: Ensure that STAC catalogs are returned in proper order

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -25,7 +25,7 @@
     "expiry": "2024-08-01"
   },
   "1096460": {
-    "active": true,,
+    "active": true,
     "notes": "Ignored since there is no fix",
     "expiry": "2024-08-01"
   },
@@ -34,5 +34,4 @@
     "notes": "Will fix in HARMONY-",
     "expiry": "2024-08-1"
   }
-
 }

--- a/.nsprc
+++ b/.nsprc
@@ -23,5 +23,16 @@
     "active": true,
     "notes": "Will fix in HARMONY-1650",
     "expiry": "2024-08-01"
+  },
+  "1096460": {
+    "active": true,,
+    "notes": "Ignored since there is no fix",
+    "expiry": "2024-08-01"
+  },
+  "1095019": {
+    "active": true,
+    "notes": "Will fix in HARMONY-",
+    "expiry": "2024-08-1"
   }
+
 }

--- a/.nsprc
+++ b/.nsprc
@@ -23,15 +23,5 @@
     "active": true,
     "notes": "Will fix in HARMONY-1650",
     "expiry": "2024-08-01"
-  },
-  "1096460": {
-    "active": true,
-    "notes": "Ignored since there is no fix",
-    "expiry": "2024-08-01"
-  },
-  "1095019": {
-    "active": true,
-    "notes": "Will fix in HARMONY-",
-    "expiry": "2024-08-1"
   }
 }

--- a/services/harmony/.nsprc
+++ b/services/harmony/.nsprc
@@ -26,7 +26,17 @@
   },
   "1096460": {
     "active": true,
-    "notes": "Will fix in HARMONY-",
+    "notes": "Will fix in HARMONY-1698",
+    "expiry": "2024-08-01"
+  },
+  "1096482": {
+    "active": true,
+    "notes": "Will fix in HARMONY-1700",
+    "expiry": "2024-08-01"
+  },
+  "1096484": {
+    "active": true,
+    "notes": "Will fix in HARMONY-1700",
     "expiry": "2024-08-01"
   }
 }

--- a/services/harmony/.nsprc
+++ b/services/harmony/.nsprc
@@ -23,5 +23,10 @@
     "active": true,
     "notes": "Will fix in HARMONY-1650",
     "expiry": "2024-05-01"
+  },
+  " 1096460": {
+    "active": true,,
+    "notes": "Will fix in HARMONY-",
+    "expiry": "2024-08-01"
   }
 }

--- a/services/harmony/.nsprc
+++ b/services/harmony/.nsprc
@@ -24,8 +24,8 @@
     "notes": "Will fix in HARMONY-1650",
     "expiry": "2024-05-01"
   },
-  " 1096460": {
-    "active": true,,
+  "1096460": {
+    "active": true,
     "notes": "Will fix in HARMONY-",
     "expiry": "2024-08-01"
   }

--- a/services/harmony/app/util/object-store/file-store.ts
+++ b/services/harmony/app/util/object-store/file-store.ts
@@ -59,8 +59,12 @@ export class FileStore implements ObjectStore {
 
   listObjectKeys(paramsOrUrl: string | object): Promise<string[]> {
     try {
+      let prefix = '';
+      if (typeof paramsOrUrl === 'string') {
+        prefix = paramsOrUrl.match(/s3:\/\/.*?\/(.*)\//)[1];
+      }
       const files = fs.readdirSync(this._getFilename(paramsOrUrl));
-      return Promise.resolve(files);
+      return Promise.resolve(files.map((file) => `${prefix}/${file}`));
     } catch (e) {
       return Promise.resolve([]);
     }
@@ -143,5 +147,3 @@ export class FileStore implements ObjectStore {
     return Promise.resolve();
   }
 }
-
-

--- a/services/service-runner/app/service/service-runner.ts
+++ b/services/service-runner/app/service/service-runner.ts
@@ -96,17 +96,16 @@ async function _getStacCatalogs(dir: string): Promise<string[]> {
   const batchCatalogsJsonUrl = `${dir}batch-catalogs.json`;
   if (await s3.objectExists(batchCatalogsJsonUrl)) {
     const batchCatalogs = await s3.getObjectJson(batchCatalogsJsonUrl) as string[];
-    const result =  batchCatalogs.map(filename => `${dir}${filename}`);
-    return result;
+    return batchCatalogs.map(filename => `${dir}${filename}`);
   }
 
   // otherwise retrieve the keys from the bucket that are of the form catalog*.json,
   // and sort them by index number
   const urls = (await s3.listObjectKeys(dir))
     .filter((fileKey) => fileKey.match(/catalog\d*.json$/))
-    .map((fileKey) => `${dir}${fileKey}`);
+    .map((fileKey) => `s3://${env.artifactBucket}/${fileKey}`);
   const fileNumRegex = /.*catalog(\d+)\.json$/;
-  return urls.sort((a, b) =>{
+  return urls.sort((a, b) => {
     const aMatches = a.match(fileNumRegex);
     const aNum = aMatches.length > 1 ? Number(aMatches[1]) : 0;
     const bMatches = b.match(fileNumRegex);

--- a/services/service-runner/app/service/service-runner.ts
+++ b/services/service-runner/app/service/service-runner.ts
@@ -112,7 +112,7 @@ async function _getStacCatalogs(dir: string): Promise<string[]> {
     const bMatches = b.match(fileNumRegex);
     const bNum = bMatches.length > 1 ? Number(bMatches[1]) : 0;
     return aNum - bNum;
-  })
+  });
 }
 
 /**

--- a/services/service-runner/test/service-runner.ts
+++ b/services/service-runner/test/service-runner.ts
@@ -55,44 +55,44 @@ const dummyCatalog = {
 
 };
 
-describe('Service Runner', function () {
-  describe('_getErrorMessage()', function () {
-    before(async function () {
+describe('Service Runner', function() {
+  describe('_getErrorMessage()', function() {
+    before(async function() {
       const s3 = objectStoreForProtocol('s3');
       const errorJson = JSON.stringify({ 'error': 'Service error message', 'category': 'Service' });
       const errorJsonUrl = resolve(workItemWithErrorJson, 'error.json');
       await s3.upload(errorJson, errorJsonUrl, null, 'application/json');
     });
-    describe('when there is an error.json file associated with the WorkItem', async function () {
-      it('returns the error message from error.json', async function () {
+    describe('when there is an error.json file associated with the WorkItem', async function() {
+      it('returns the error message from error.json', async function() {
         const errorMessage = await _getErrorMessage(exampleStatus, workItemWithErrorJson);
         expect(errorMessage).equal('Service error message');
       });
     });
-    describe('when the error status code is 137', async function () {
-      it('returns "OOM error"', async function () {
+    describe('when the error status code is 137', async function() {
+      it('returns "OOM error"', async function() {
         const errorMessage = await _getErrorMessage(oomStatus, workItemWithoutErrorJson);
         expect(errorMessage).equal('Service failed due to running out of memory');
       });
     });
   });
 
-  describe('_getStacCatalogs()', function () {
+  describe('_getStacCatalogs()', function() {
 
     const workItemWithOneCatalog = 's3://stac-catalogs/abc/789/outputs/';
     const workItemWithMultipleCatalogs = 's3://stac-catalogs/abc/321/outputs/';
     const workItemWithMultipleCatalogsNoBatchFile = 's3://stac-catalogs/abc/987/outputs/';
     const emptyCatalogUrl = 's3://stac-catalogs/empty/';
 
-    describe('when the directory has no catalogs', async function () {
-      it('returns any empty list', async function () {
+    describe('when the directory has no catalogs', async function() {
+      it('returns any empty list', async function() {
         const files = await _getStacCatalogs(emptyCatalogUrl);
         expect(files).to.eql([]);
       });
     });
 
-    describe('when there is a batch-catalogs.json file associated with the WorkItem', async function () {
-      before(async function () {
+    describe('when there is a batch-catalogs.json file associated with the WorkItem', async function() {
+      before(async function() {
         const s3 = objectStoreForProtocol('s3');
         const batchFileContent = JSON.stringify([
           'catalog0.json',
@@ -111,7 +111,7 @@ describe('Service Runner', function () {
         await s3.upload(batchFileContent, stacCatalogsUrl, null, 'application/json');
       });
 
-      it('returns the stac catalogs from batch-catalogs.json in the order they are in the file', async function () {
+      it('returns the stac catalogs from batch-catalogs.json in the order they are in the file', async function() {
         const stacCatalogs = await _getStacCatalogs(workItemWithMultipleCatalogs);
         expect(stacCatalogs).to.deep.equal([
           's3://stac-catalogs/abc/321/outputs/catalog0.json',
@@ -129,24 +129,24 @@ describe('Service Runner', function () {
       });
     });
 
-    describe('when there is no batch-catalogs.json file associated with the WorkItem', async function () {
-      describe('when there is just one catalog', async function () {
-        before(async function () {
+    describe('when there is no batch-catalogs.json file associated with the WorkItem', async function() {
+      describe('when there is just one catalog', async function() {
+        before(async function() {
           const s3 = objectStoreForProtocol('s3');
           const catalogContent = JSON.stringify(dummyCatalog);
           const stacCatalogUrl = resolve(workItemWithOneCatalog, 'catalog.json');
           await s3.upload(catalogContent, stacCatalogUrl, null, 'application/json');
         });
 
-        it('returns the url of the catalog.json file', async function () {
+        it('returns the url of the catalog.json file', async function() {
           const stacCatalogs = await _getStacCatalogs(workItemWithOneCatalog);
           expect(stacCatalogs).to.deep.equal(['s3://stac-catalogs/abc/789/outputs/catalog.json']);
         });
       });
 
       // This should never happen, but it's good to test the behavior
-      describe('when there is more than one catalog', async function () {
-        before(async function () {
+      describe('when there is more than one catalog', async function() {
+        before(async function() {
           const s3 = objectStoreForProtocol('s3');
           const catalogContent = JSON.stringify(dummyCatalog);
           for (let i = 0; i < 11; i++) {
@@ -155,7 +155,7 @@ describe('Service Runner', function () {
           }
         });
 
-        it('returns an array sorted by catalog index', async function () {
+        it('returns an array sorted by catalog index', async function() {
           const stacCatalogs = await _getStacCatalogs(workItemWithMultipleCatalogsNoBatchFile);
           expect(stacCatalogs).to.deep.equal([
             's3://stac-catalogs/abc/987/outputs/catalog0.json',
@@ -175,8 +175,8 @@ describe('Service Runner', function () {
     });
   });
 
-  describe('uploadLogs', function () {
-    describe('with text logs', function () {
+  describe('uploadLogs', function() {
+    describe('with text logs', function() {
       const itemRecord0: WorkItemRecord = {
         id: 0, jobID: '123', serviceID: '', sortIndex: 0,
         workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(),
@@ -185,15 +185,15 @@ describe('Service Runner', function () {
         id: 1, jobID: '123', serviceID: '', sortIndex: 0,
         workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(),
       };
-      before(async function () {
+      before(async function() {
         // One of the items will have its log file written to twice
         await uploadLogs(itemRecord0, ['the old logs']);
         itemRecord0.retryCount = 1; // simulate a retry
         await uploadLogs(itemRecord0, ['the new logs']);
         await uploadLogs(itemRecord1, ['the only logs']);
       });
-      describe('when there is a logs file already associated with the WorkItem', async function () {
-        it('appends the new logs to the old ones', async function () {
+      describe('when there is a logs file already associated with the WorkItem', async function() {
+        it('appends the new logs to the old ones', async function() {
           const logsLocation0 = getItemLogsLocation(itemRecord0);
           const s3 = objectStoreForProtocol('s3');
           const logs = await s3.getObjectJson(logsLocation0);
@@ -205,8 +205,8 @@ describe('Service Runner', function () {
           ]);
         });
       });
-      describe('when there is no logs file associated with the WorkItem', async function () {
-        it('writes the logs to a new file', async function () {
+      describe('when there is no logs file associated with the WorkItem', async function() {
+        it('writes the logs to a new file', async function() {
           const logsLocation1 = getItemLogsLocation(itemRecord1);
           const s3 = objectStoreForProtocol('s3');
           const logs = await s3.getObjectJson(logsLocation1);
@@ -217,7 +217,7 @@ describe('Service Runner', function () {
         });
       });
     });
-    describe('with JSON logs', function () {
+    describe('with JSON logs', function() {
       const itemRecord0: WorkItemRecord = {
         id: 2, jobID: '123', serviceID: '', sortIndex: 0,
         workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(),
@@ -226,7 +226,7 @@ describe('Service Runner', function () {
         id: 3, jobID: '123', serviceID: '', sortIndex: 0,
         workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(),
       };
-      before(async function () {
+      before(async function() {
         // One of the items will have its log file written to twice
         await uploadLogs(itemRecord0, [{ message: 'the old logs' }]);
         itemRecord0.retryCount = 1; // simulate a retry
@@ -234,8 +234,8 @@ describe('Service Runner', function () {
 
         await uploadLogs(itemRecord1, [{ message: 'the only logs' }]);
       });
-      describe('when there is a logs file already associated with the WorkItem', async function () {
-        it('appends the new logs to the old ones', async function () {
+      describe('when there is a logs file already associated with the WorkItem', async function() {
+        it('appends the new logs to the old ones', async function() {
           const logsLocation0 = getItemLogsLocation(itemRecord0);
           const s3 = objectStoreForProtocol('s3');
           const logs = await s3.getObjectJson(logsLocation0);
@@ -247,8 +247,8 @@ describe('Service Runner', function () {
           ]);
         });
       });
-      describe('when there is no logs file associated with the WorkItem', async function () {
-        it('writes the logs to a new file', async function () {
+      describe('when there is no logs file associated with the WorkItem', async function() {
+        it('writes the logs to a new file', async function() {
           const logsLocation1 = getItemLogsLocation(itemRecord1);
           const s3 = objectStoreForProtocol('s3');
           const logs = await s3.getObjectJson(logsLocation1);
@@ -261,7 +261,7 @@ describe('Service Runner', function () {
     });
   });
 
-  describe('runQueryCmrFromPull', async function () {
+  describe('runQueryCmrFromPull', async function() {
     const workItem = new WorkItem({
       jobID: '123',
       serviceID: 'abc',
@@ -270,41 +270,41 @@ describe('Service Runner', function () {
       operation: { requestID: 'foo' },
       id: 1,
     });
-    describe('when an error occurs', async function () {
+    describe('when an error occurs', async function() {
       // https://axios-http.com/docs/res_schema
       let axiosStub;
-      afterEach(function () {
+      afterEach(function() {
         axiosStub.restore();
       });
-      describe('and the server provides data', async function () {
+      describe('and the server provides data', async function() {
         const description = 'Query CMR server failed unexpectedly';
-        before(async function () {
+        before(async function() {
           axiosStub = sinon.stub(axios, 'post').callsFake(
-            async function () { throw { 'response': { 'data': { description } } }; });
+            async function() { throw { 'response': { 'data': { description } } }; });
         });
-        it('returns an error message matching the description', async function () {
+        it('returns an error message matching the description', async function() {
           const result = await serviceRunner.runQueryCmrFromPull(workItem);
           expect(result.error).to.equal(description);
         });
       });
-      describe('and there is a status code', async function () {
+      describe('and there is a status code', async function() {
         const status = 500;
-        before(async function () {
+        before(async function() {
           axiosStub = sinon.stub(axios, 'post').callsFake(
-            async function () { throw { 'response': { status } }; });
+            async function() { throw { 'response': { status } }; });
         });
-        it('returns an error message that includes the status code', async function () {
+        it('returns an error message that includes the status code', async function() {
           const result = await serviceRunner.runQueryCmrFromPull(workItem);
           expect(result.error).to.equal(`The Query CMR service responded with status ${status}.`);
         });
       });
-      describe('and there is status text', async function () {
+      describe('and there is status text', async function() {
         const statusText = 'Not Found';
-        before(async function () {
+        before(async function() {
           axiosStub = sinon.stub(axios, 'post').callsFake(
-            async function () { throw { 'response': { statusText } }; });
+            async function() { throw { 'response': { statusText } }; });
         });
-        it('returns an error message that includes the status text', async function () {
+        it('returns an error message that includes the status text', async function() {
           const result = await serviceRunner.runQueryCmrFromPull(workItem);
           expect(result.error).to.equal(`The Query CMR service responded with status ${statusText}.`);
         });
@@ -312,8 +312,8 @@ describe('Service Runner', function () {
     });
   });
 
-  describe('runServiceFromPull', async function () {
-    describe('when an error occurs', async function () {
+  describe('runServiceFromPull', async function() {
+    describe('when an error occurs', async function() {
       const invocArgs = env.invocationArgs;
       const workItem = new WorkItem({
         jobID: '123',
@@ -322,22 +322,22 @@ describe('Service Runner', function () {
         operation: { requestID: 'foo' },
         id: 1,
       });
-      beforeEach(function () {
+      beforeEach(function() {
         env.invocationArgs = 'abc\n123';
       });
 
-      afterEach(function () {
+      afterEach(function() {
         env.invocationArgs = invocArgs;
       });
 
-      it('returns an error message', async function () {
+      it('returns an error message', async function() {
         const result = await serviceRunner.runServiceFromPull(workItem);
         expect(result.error).to.equal('The harmonyservices/query-cmr:latest service failed.');
       });
     });
   });
 
-  describe('LogStream', function () {
+  describe('LogStream', function() {
 
     const message = 'mv \'/tmp/tmpkwxpifmr/tmp-result.tif\' \'/tmp/tmpkwxpifmr/result.tif\'';
     const user = 'bo';
@@ -348,9 +348,9 @@ describe('Service Runner', function () {
     const textLog = `${timestamp} [${level}] [harmony-service.cmd:199] ${message}`;
     const jsonLog = `{ "level":"${level}", "message":"${message}", "user":"${user}", "requestId":"${requestId}", "timestamp":"${timestamp}"}`;
 
-    describe('_handleLogString with a JSON logger', function () {
+    describe('_handleLogString with a JSON logger', function() {
 
-      before(function () {
+      before(function() {
         const { getTestLogs, testLogger } = createLoggerForTest(true);
         this.testLogger = testLogger;
         this.logStream = new serviceRunner.LogStream(testLogger);
@@ -363,29 +363,29 @@ describe('Service Runner', function () {
         this.jsonLogOutput = JSON.parse(this.testLogsArr[1]);
       });
 
-      after(function () {
+      after(function() {
         for (const transport of this.testLogger.transports) {
           transport.close;
         }
         this.testLogger.close();
       });
 
-      it('saves each log to an array in the original format, as a string or JSON', function () {
+      it('saves each log to an array in the original format, as a string or JSON', function() {
         expect(this.logStream.logStrArr.length == 2);
         expect(this.logStream.logStrArr[0] === JSON.parse(jsonLog));
         expect(this.logStream.logStrArr[1] === textLog);
       });
 
-      it('outputs the proper quantity of logs to the log stream', function () {
+      it('outputs the proper quantity of logs to the log stream', function() {
         expect(this.testLogsArr.length == 2);
       });
 
-      it('sets the appropriate message for each log', function () {
+      it('sets the appropriate message for each log', function() {
         expect(this.textLogOutput.message).to.equal(textLog);
         expect(this.jsonLogOutput.message).to.equal(message);
       });
 
-      it('sets custom attributes appropriately for each log', function () {
+      it('sets custom attributes appropriately for each log', function() {
         expect(this.jsonLogOutput.user).to.equal(user);
         expect(this.jsonLogOutput.requestId).to.equal(requestId);
 
@@ -393,7 +393,7 @@ describe('Service Runner', function () {
         expect(this.jsonLogOutput.worker).to.equal(true);
       });
 
-      it('does not override manager container log attributes with those from the worker container', function () {
+      it('does not override manager container log attributes with those from the worker container', function() {
         expect(this.textLogOutput.timestamp).to.not.equal(timestamp);
         expect(this.jsonLogOutput.timestamp).to.not.equal(timestamp);
         expect(this.jsonLogOutput.workerTimestamp).to.equal(timestamp);
@@ -404,9 +404,9 @@ describe('Service Runner', function () {
       });
     });
 
-    describe('_handleLogString with a text logger', function () {
+    describe('_handleLogString with a text logger', function() {
 
-      before(function () {
+      before(function() {
         const { getTestLogs, testLogger } = createLoggerForTest(false);
         this.testLogger = testLogger;
         this.logStream = new serviceRunner.LogStream(testLogger);
@@ -415,24 +415,24 @@ describe('Service Runner', function () {
         this.testLogs = getTestLogs();
       });
 
-      after(function () {
+      after(function() {
         for (const transport of this.testLogger.transports) {
           transport.close;
         }
         this.testLogger.close();
       });
 
-      it('saves each log to an array in the original format, as a string or JSON', function () {
+      it('saves each log to an array in the original format, as a string or JSON', function() {
         expect(this.logStream.logStrArr.length == 2);
         expect(this.logStream.logStrArr[0] === JSON.parse(jsonLog));
         expect(this.logStream.logStrArr[1] === textLog);
       });
 
-      it('outputs the proper quantity of logs to the log stream', function () {
+      it('outputs the proper quantity of logs to the log stream', function() {
         expect(this.testLogs.split('\n').length == 2);
       });
 
-      it('outputs the appropriate text to the log stream', function () {
+      it('outputs the appropriate text to the log stream', function() {
         const jsonLogOutput = `[${requestId}]: ${message}`;
         expect(this.testLogs.includes(textLog));
         expect(this.testLogs.includes(jsonLogOutput));

--- a/services/service-runner/test/service-runner.ts
+++ b/services/service-runner/test/service-runner.ts
@@ -36,22 +36,22 @@ const workItemWithErrorJson = 's3://stac-catalogs/abc/123/outputs/';
 const workItemWithoutErrorJson = 's3://stac-catalogs/abc/456/outputs/';
 
 const dummyCatalog = {
-  "stac_version": "1.0.0-beta.2",
-  "stac_extensions": [],
-  "id": "e8c152dd-112f-499d-9307-65a21ecb0ae6",
-  "links": [
+  'stac_version': '1.0.0-beta.2',
+  'stac_extensions': [],
+  'id': 'e8c152dd-112f-499d-9307-65a21ecb0ae6',
+  'links': [
     {
-      "rel": "harmony_source",
-      "href": "https://cmr.uat.earthdata.nasa.gov/search/concepts/C1234208438-POCLOUD"
+      'rel': 'harmony_source',
+      'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/C1234208438-POCLOUD',
     },
     {
-      "rel": "item",
-      "href": "./granule_G1234495188-POCLOUD_0000000.json",
-      "type": "application/json",
-      "title": "JA1_GPS_2PeP220_111_20071231_005214_20071231_014826"
-    }
+      'rel': 'item',
+      'href': './granule_G1234495188-POCLOUD_0000000.json',
+      'type': 'application/json',
+      'title': 'JA1_GPS_2PeP220_111_20071231_005214_20071231_014826',
+    },
   ],
-  "description": "CMR collection C1234208438-POCLOUD, granule G1234495188-POCLOUD"
+  'description': 'CMR collection C1234208438-POCLOUD, granule G1234495188-POCLOUD',
 
 };
 
@@ -179,11 +179,11 @@ describe('Service Runner', function () {
     describe('with text logs', function () {
       const itemRecord0: WorkItemRecord = {
         id: 0, jobID: '123', serviceID: '', sortIndex: 0,
-        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date()
+        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(),
       };
       const itemRecord1: WorkItemRecord = {
         id: 1, jobID: '123', serviceID: '', sortIndex: 0,
-        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date()
+        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(),
       };
       before(async function () {
         // One of the items will have its log file written to twice
@@ -220,11 +220,11 @@ describe('Service Runner', function () {
     describe('with JSON logs', function () {
       const itemRecord0: WorkItemRecord = {
         id: 2, jobID: '123', serviceID: '', sortIndex: 0,
-        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date()
+        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(),
       };
       const itemRecord1: WorkItemRecord = {
         id: 3, jobID: '123', serviceID: '', sortIndex: 0,
-        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date()
+        workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(),
       };
       before(async function () {
         // One of the items will have its log file written to twice

--- a/services/service-runner/test/service-runner.ts
+++ b/services/service-runner/test/service-runner.ts
@@ -55,44 +55,44 @@ const dummyCatalog = {
 
 };
 
-describe('Service Runner', function() {
-  describe('_getErrorMessage()', function() {
-    before(async function() {
+describe('Service Runner', function () {
+  describe('_getErrorMessage()', function () {
+    before(async function () {
       const s3 = objectStoreForProtocol('s3');
       const errorJson = JSON.stringify({ 'error': 'Service error message', 'category': 'Service' });
       const errorJsonUrl = resolve(workItemWithErrorJson, 'error.json');
       await s3.upload(errorJson, errorJsonUrl, null, 'application/json');
     });
-    describe('when there is an error.json file associated with the WorkItem', async function() {
-      it('returns the error message from error.json', async function() {
+    describe('when there is an error.json file associated with the WorkItem', async function () {
+      it('returns the error message from error.json', async function () {
         const errorMessage = await _getErrorMessage(exampleStatus, workItemWithErrorJson);
         expect(errorMessage).equal('Service error message');
       });
     });
-    describe('when the error status code is 137', async function() {
-      it('returns "OOM error"', async function() {
+    describe('when the error status code is 137', async function () {
+      it('returns "OOM error"', async function () {
         const errorMessage = await _getErrorMessage(oomStatus, workItemWithoutErrorJson);
         expect(errorMessage).equal('Service failed due to running out of memory');
       });
     });
   });
 
-  describe('_getStacCatalogs()', function() {
+  describe('_getStacCatalogs()', function () {
 
     const workItemWithOneCatalog = 's3://stac-catalogs/abc/789/outputs/';
     const workItemWithMultipleCatalogs = 's3://stac-catalogs/abc/321/outputs/';
     const workItemWithMultipleCatalogsNoBatchFile = 's3://stac-catalogs/abc/987/outputs/';
     const emptyCatalogUrl = 's3://stac-catalogs/empty/';
 
-    describe('when the directory has no catalogs', async function() {
-      it('returns any empty list', async function() {
+    describe('when the directory has no catalogs', async function () {
+      it('returns any empty list', async function () {
         const files = await _getStacCatalogs(emptyCatalogUrl);
         expect(files).to.eql([]);
       });
     });
 
-    describe('when there is a batch-catalogs.json file associated with the WorkItem', async function() {
-      before(async function() {
+    describe('when there is a batch-catalogs.json file associated with the WorkItem', async function () {
+      before(async function () {
         const s3 = objectStoreForProtocol('s3');
         const batchFileContent = JSON.stringify([
           'catalog0.json',
@@ -111,7 +111,7 @@ describe('Service Runner', function() {
         await s3.upload(batchFileContent, stacCatalogsUrl, null, 'application/json');
       });
 
-      it('returns the stac catalogs from batch-catalogs.json in the order they are in the file', async function() {
+      it('returns the stac catalogs from batch-catalogs.json in the order they are in the file', async function () {
         const stacCatalogs = await _getStacCatalogs(workItemWithMultipleCatalogs);
         expect(stacCatalogs).to.deep.equal([
           's3://stac-catalogs/abc/321/outputs/catalog0.json',
@@ -129,24 +129,24 @@ describe('Service Runner', function() {
       });
     });
 
-    describe('when there is no batch-catalogs.json file associated with the WorkItem', async function() {
-      describe('when there is just one catalog', async function() {
-        before(async function() {
+    describe('when there is no batch-catalogs.json file associated with the WorkItem', async function () {
+      describe('when there is just one catalog', async function () {
+        before(async function () {
           const s3 = objectStoreForProtocol('s3');
           const catalogContent = JSON.stringify(dummyCatalog);
           const stacCatalogUrl = resolve(workItemWithOneCatalog, 'catalog.json');
           await s3.upload(catalogContent, stacCatalogUrl, null, 'application/json');
         });
 
-        it('returns the url of the catalog.json file', async function() {
+        it('returns the url of the catalog.json file', async function () {
           const stacCatalogs = await _getStacCatalogs(workItemWithOneCatalog);
           expect(stacCatalogs).to.deep.equal(['s3://stac-catalogs/abc/789/outputs/catalog.json']);
         });
       });
 
       // This should never happen, but it's good to test the behavior
-      describe('when there is more than one catalog', async function() {
-        before(async function() {
+      describe('when there is more than one catalog', async function () {
+        before(async function () {
           const s3 = objectStoreForProtocol('s3');
           const catalogContent = JSON.stringify(dummyCatalog);
           for (let i = 0; i < 11; i++) {
@@ -155,7 +155,7 @@ describe('Service Runner', function() {
           }
         });
 
-        it('returns an array sorted by catalog index', async function() {
+        it('returns an array sorted by catalog index', async function () {
           const stacCatalogs = await _getStacCatalogs(workItemWithMultipleCatalogsNoBatchFile);
           expect(stacCatalogs).to.deep.equal([
             's3://stac-catalogs/abc/987/outputs/catalog0.json',
@@ -175,8 +175,8 @@ describe('Service Runner', function() {
     });
   });
 
-  describe('uploadLogs', function() {
-    describe('with text logs', function() {
+  describe('uploadLogs', function () {
+    describe('with text logs', function () {
       const itemRecord0: WorkItemRecord = {
         id: 0, jobID: '123', serviceID: '', sortIndex: 0,
         workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(),
@@ -185,15 +185,15 @@ describe('Service Runner', function() {
         id: 1, jobID: '123', serviceID: '', sortIndex: 0,
         workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(),
       };
-      before(async function() {
+      before(async function () {
         // One of the items will have its log file written to twice
         await uploadLogs(itemRecord0, ['the old logs']);
         itemRecord0.retryCount = 1; // simulate a retry
         await uploadLogs(itemRecord0, ['the new logs']);
         await uploadLogs(itemRecord1, ['the only logs']);
       });
-      describe('when there is a logs file already associated with the WorkItem', async function() {
-        it('appends the new logs to the old ones', async function() {
+      describe('when there is a logs file already associated with the WorkItem', async function () {
+        it('appends the new logs to the old ones', async function () {
           const logsLocation0 = getItemLogsLocation(itemRecord0);
           const s3 = objectStoreForProtocol('s3');
           const logs = await s3.getObjectJson(logsLocation0);
@@ -205,8 +205,8 @@ describe('Service Runner', function() {
           ]);
         });
       });
-      describe('when there is no logs file associated with the WorkItem', async function() {
-        it('writes the logs to a new file', async function() {
+      describe('when there is no logs file associated with the WorkItem', async function () {
+        it('writes the logs to a new file', async function () {
           const logsLocation1 = getItemLogsLocation(itemRecord1);
           const s3 = objectStoreForProtocol('s3');
           const logs = await s3.getObjectJson(logsLocation1);
@@ -217,7 +217,7 @@ describe('Service Runner', function() {
         });
       });
     });
-    describe('with JSON logs', function() {
+    describe('with JSON logs', function () {
       const itemRecord0: WorkItemRecord = {
         id: 2, jobID: '123', serviceID: '', sortIndex: 0,
         workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(),
@@ -226,7 +226,7 @@ describe('Service Runner', function() {
         id: 3, jobID: '123', serviceID: '', sortIndex: 0,
         workflowStepIndex: 0, retryCount: 0, duration: 0, updatedAt: new Date(), createdAt: new Date(),
       };
-      before(async function() {
+      before(async function () {
         // One of the items will have its log file written to twice
         await uploadLogs(itemRecord0, [{ message: 'the old logs' }]);
         itemRecord0.retryCount = 1; // simulate a retry
@@ -234,8 +234,8 @@ describe('Service Runner', function() {
 
         await uploadLogs(itemRecord1, [{ message: 'the only logs' }]);
       });
-      describe('when there is a logs file already associated with the WorkItem', async function() {
-        it('appends the new logs to the old ones', async function() {
+      describe('when there is a logs file already associated with the WorkItem', async function () {
+        it('appends the new logs to the old ones', async function () {
           const logsLocation0 = getItemLogsLocation(itemRecord0);
           const s3 = objectStoreForProtocol('s3');
           const logs = await s3.getObjectJson(logsLocation0);
@@ -247,8 +247,8 @@ describe('Service Runner', function() {
           ]);
         });
       });
-      describe('when there is no logs file associated with the WorkItem', async function() {
-        it('writes the logs to a new file', async function() {
+      describe('when there is no logs file associated with the WorkItem', async function () {
+        it('writes the logs to a new file', async function () {
           const logsLocation1 = getItemLogsLocation(itemRecord1);
           const s3 = objectStoreForProtocol('s3');
           const logs = await s3.getObjectJson(logsLocation1);
@@ -261,7 +261,7 @@ describe('Service Runner', function() {
     });
   });
 
-  describe('runQueryCmrFromPull', async function() {
+  describe('runQueryCmrFromPull', async function () {
     const workItem = new WorkItem({
       jobID: '123',
       serviceID: 'abc',
@@ -270,41 +270,41 @@ describe('Service Runner', function() {
       operation: { requestID: 'foo' },
       id: 1,
     });
-    describe('when an error occurs', async function() {
+    describe('when an error occurs', async function () {
       // https://axios-http.com/docs/res_schema
       let axiosStub;
-      afterEach(function() {
+      afterEach(function () {
         axiosStub.restore();
       });
-      describe('and the server provides data', async function() {
+      describe('and the server provides data', async function () {
         const description = 'Query CMR server failed unexpectedly';
-        before(async function() {
+        before(async function () {
           axiosStub = sinon.stub(axios, 'post').callsFake(
-            async function() { throw { 'response': { 'data': { description } } }; });
+            async function () { throw { 'response': { 'data': { description } } }; });
         });
-        it('returns an error message matching the description', async function() {
+        it('returns an error message matching the description', async function () {
           const result = await serviceRunner.runQueryCmrFromPull(workItem);
           expect(result.error).to.equal(description);
         });
       });
-      describe('and there is a status code', async function() {
+      describe('and there is a status code', async function () {
         const status = 500;
-        before(async function() {
+        before(async function () {
           axiosStub = sinon.stub(axios, 'post').callsFake(
-            async function() { throw { 'response': { status } }; });
+            async function () { throw { 'response': { status } }; });
         });
-        it('returns an error message that includes the status code', async function() {
+        it('returns an error message that includes the status code', async function () {
           const result = await serviceRunner.runQueryCmrFromPull(workItem);
           expect(result.error).to.equal(`The Query CMR service responded with status ${status}.`);
         });
       });
-      describe('and there is status text', async function() {
+      describe('and there is status text', async function () {
         const statusText = 'Not Found';
-        before(async function() {
+        before(async function () {
           axiosStub = sinon.stub(axios, 'post').callsFake(
-            async function() { throw { 'response': { statusText } }; });
+            async function () { throw { 'response': { statusText } }; });
         });
-        it('returns an error message that includes the status text', async function() {
+        it('returns an error message that includes the status text', async function () {
           const result = await serviceRunner.runQueryCmrFromPull(workItem);
           expect(result.error).to.equal(`The Query CMR service responded with status ${statusText}.`);
         });
@@ -312,8 +312,8 @@ describe('Service Runner', function() {
     });
   });
 
-  describe('runServiceFromPull', async function() {
-    describe('when an error occurs', async function() {
+  describe('runServiceFromPull', async function () {
+    describe('when an error occurs', async function () {
       const invocArgs = env.invocationArgs;
       const workItem = new WorkItem({
         jobID: '123',
@@ -322,22 +322,22 @@ describe('Service Runner', function() {
         operation: { requestID: 'foo' },
         id: 1,
       });
-      beforeEach(function() {
+      beforeEach(function () {
         env.invocationArgs = 'abc\n123';
       });
 
-      afterEach(function() {
+      afterEach(function () {
         env.invocationArgs = invocArgs;
       });
 
-      it('returns an error message', async function() {
+      it('returns an error message', async function () {
         const result = await serviceRunner.runServiceFromPull(workItem);
         expect(result.error).to.equal('The harmonyservices/query-cmr:latest service failed.');
       });
     });
   });
 
-  describe('LogStream', function() {
+  describe('LogStream', function () {
 
     const message = 'mv \'/tmp/tmpkwxpifmr/tmp-result.tif\' \'/tmp/tmpkwxpifmr/result.tif\'';
     const user = 'bo';
@@ -348,9 +348,9 @@ describe('Service Runner', function() {
     const textLog = `${timestamp} [${level}] [harmony-service.cmd:199] ${message}`;
     const jsonLog = `{ "level":"${level}", "message":"${message}", "user":"${user}", "requestId":"${requestId}", "timestamp":"${timestamp}"}`;
 
-    describe('_handleLogString with a JSON logger', function() {
+    describe('_handleLogString with a JSON logger', function () {
 
-      before(function() {
+      before(function () {
         const { getTestLogs, testLogger } = createLoggerForTest(true);
         this.testLogger = testLogger;
         this.logStream = new serviceRunner.LogStream(testLogger);
@@ -363,29 +363,29 @@ describe('Service Runner', function() {
         this.jsonLogOutput = JSON.parse(this.testLogsArr[1]);
       });
 
-      after(function() {
+      after(function () {
         for (const transport of this.testLogger.transports) {
           transport.close;
         }
         this.testLogger.close();
       });
 
-      it('saves each log to an array in the original format, as a string or JSON', function() {
+      it('saves each log to an array in the original format, as a string or JSON', function () {
         expect(this.logStream.logStrArr.length == 2);
         expect(this.logStream.logStrArr[0] === JSON.parse(jsonLog));
         expect(this.logStream.logStrArr[1] === textLog);
       });
 
-      it('outputs the proper quantity of logs to the log stream', function() {
+      it('outputs the proper quantity of logs to the log stream', function () {
         expect(this.testLogsArr.length == 2);
       });
 
-      it('sets the appropriate message for each log', function() {
+      it('sets the appropriate message for each log', function () {
         expect(this.textLogOutput.message).to.equal(textLog);
         expect(this.jsonLogOutput.message).to.equal(message);
       });
 
-      it('sets custom attributes appropriately for each log', function() {
+      it('sets custom attributes appropriately for each log', function () {
         expect(this.jsonLogOutput.user).to.equal(user);
         expect(this.jsonLogOutput.requestId).to.equal(requestId);
 
@@ -393,7 +393,7 @@ describe('Service Runner', function() {
         expect(this.jsonLogOutput.worker).to.equal(true);
       });
 
-      it('does not override manager container log attributes with those from the worker container', function() {
+      it('does not override manager container log attributes with those from the worker container', function () {
         expect(this.textLogOutput.timestamp).to.not.equal(timestamp);
         expect(this.jsonLogOutput.timestamp).to.not.equal(timestamp);
         expect(this.jsonLogOutput.workerTimestamp).to.equal(timestamp);
@@ -404,9 +404,9 @@ describe('Service Runner', function() {
       });
     });
 
-    describe('_handleLogString with a text logger', function() {
+    describe('_handleLogString with a text logger', function () {
 
-      before(function() {
+      before(function () {
         const { getTestLogs, testLogger } = createLoggerForTest(false);
         this.testLogger = testLogger;
         this.logStream = new serviceRunner.LogStream(testLogger);
@@ -415,24 +415,24 @@ describe('Service Runner', function() {
         this.testLogs = getTestLogs();
       });
 
-      after(function() {
+      after(function () {
         for (const transport of this.testLogger.transports) {
           transport.close;
         }
         this.testLogger.close();
       });
 
-      it('saves each log to an array in the original format, as a string or JSON', function() {
+      it('saves each log to an array in the original format, as a string or JSON', function () {
         expect(this.logStream.logStrArr.length == 2);
         expect(this.logStream.logStrArr[0] === JSON.parse(jsonLog));
         expect(this.logStream.logStrArr[1] === textLog);
       });
 
-      it('outputs the proper quantity of logs to the log stream', function() {
+      it('outputs the proper quantity of logs to the log stream', function () {
         expect(this.testLogs.split('\n').length == 2);
       });
 
-      it('outputs the appropriate text to the log stream', function() {
+      it('outputs the appropriate text to the log stream', function () {
         const jsonLogOutput = `[${requestId}]: ${message}`;
         expect(this.testLogs.includes(textLog));
         expect(this.testLogs.includes(jsonLogOutput));


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1696

## Description
This PR returns the STAC catalogs in proper numerical order rather than in string order. In other words catalog2.json
comes before catalog10.json. This is needed by Batchee to preserve the order it creates when it batches granules.

## Local Test Steps
Not easy to test locally. You will need to add Batchee and Stitchee to config.yml  as well as env vars for their queue URLS to lib/util/env-defaults. OR you can look at the following screen shots. The first one is our current code and shows that the Stitchee work-items were created in order of the "string sorted" STAC catalog file names. The Second one is from this branch and shows the Stichee work items were created in the order of the STAC catalogs created by Batchee, which is what we want. Note the rows from the dB are sorted by work-item ID in both cases.

<img width="1368" alt="Screenshot 2024-02-13 at 3 46 09 PM" src="https://github.com/nasa/harmony/assets/308058/f47d8fee-669c-46f1-8150-abd220bbab57">
<img width="1362" alt="Screenshot 2024-02-13 at 3 24 49 PM" src="https://github.com/nasa/harmony/assets/308058/e4f61038-2eff-43c4-a152-e318bb4ac3d2">


## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~