### PR TITLE
HARMONY-1701: Add invocation of harmony-ci-cd script in service-image-tag endpoint.

### DIFF
--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -236,6 +236,15 @@ describe('Service image endpoint', async function () {
   });
 
   describe('Update service image', function () {
+    let execDeployScriptStub: sinon.SinonStub;
+    before(async function () {
+      execDeployScriptStub = sinon.stub(serviceImageTags, 'execDeployScript').callsFake(() => Promise.resolve('successful'));
+    });
+
+    after(function () {
+      execDeployScriptStub.restore();
+    });
+
     describe('when a user is not in the EDL service deployers or admin groups', async function () {
 
       before(async function () {
@@ -317,16 +326,13 @@ describe('Service image endpoint', async function () {
     });
 
     describe('when the user is in the deployers group and a valid tag is sent in the request', async function () {
-      let execDeployScriptStub: sinon.SinonStub;
       before(async function () {
         hookRedirect('buzz');
-        execDeployScriptStub = sinon.stub(serviceImageTags, 'execDeployScript').callsFake(() => Promise.resolve('successful'));
         this.res = await request(this.frontend).put('/service-image-tag/harmony-service-example').use(auth({ username: 'buzz' })).send({ tag: 'foo' });
       });
 
       after(function () {
         delete this.res;
-        execDeployScriptStub.restore();
       });
 
       it('returns a status 201', async function () {

--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -1,9 +1,11 @@
 import { expect } from 'chai';
+import * as sinon from 'sinon';
 import request from 'supertest';
 
 import hookServersStartStop from './helpers/servers';
 import { hookRedirect } from './helpers/hooks';
 import { auth } from './helpers/auth';
+import * as serviceImageTags from '../app/frontends/service-image-tags';
 
 //
 // Tests for the service-image endpoint
@@ -315,14 +317,16 @@ describe('Service image endpoint', async function () {
     });
 
     describe('when the user is in the deployers group and a valid tag is sent in the request', async function () {
-
+      let execDeployScriptStub: sinon.SinonStub;
       before(async function () {
         hookRedirect('buzz');
+        execDeployScriptStub = sinon.stub(serviceImageTags, 'execDeployScript').callsFake(() => Promise.resolve('successful'));
         this.res = await request(this.frontend).put('/service-image-tag/harmony-service-example').use(auth({ username: 'buzz' })).send({ tag: 'foo' });
       });
 
       after(function () {
         delete this.res;
+        execDeployScriptStub.restore();
       });
 
       it('returns a status 201', async function () {
@@ -332,28 +336,9 @@ describe('Service image endpoint', async function () {
       it('returns the tag we sent', async function () {
         expect(this.res.body).to.eql({ 'tag': 'foo' });
       });
-
-      // TODO HARMONY-1701 enable this test or remove it as you see fit
-      // describe('when the user checks the tag', async function () {
-      //   before(async function () {
-      //     hookRedirect('buzz');
-      //     this.res = await request(this.frontend).get('/service-image-tag/harmony-service-example').use(auth({ username: 'buzz' }));
-      //   });
-
-      //   after(function () {
-      //     delete this.res;
-      //   });
-
-      //   it('returns the updated tag', async function () {
-      //     expect(this.res.body).to.eql({
-      //       'tag': 'foo',
-      //     });
-      //   });
-      // });
     });
 
     describe('when the user is in the admin group and a valid tag is sent in the request', async function () {
-
       before(async function () {
         hookRedirect('adam');
         this.res = await request(this.frontend).put('/service-image-tag/harmony-service-example').use(auth({ username: 'adam' })).send({ tag: 'foo' });
@@ -370,24 +355,6 @@ describe('Service image endpoint', async function () {
       it('returns the tag we sent', async function () {
         expect(this.res.body).to.eql({ 'tag': 'foo' });
       });
-
-      // TODO HARMONY-1701 enable this test or remove it as you see fit
-      // describe('when the user checks the tag', async function () {
-      //   before(async function () {
-      //     hookRedirect('adam');
-      //     this.res = await request(this.frontend).get('/service-image-tag/harmony-service-example').use(auth({ username: 'adam' }));
-      //   });
-
-      //   after(function () {
-      //     delete this.res;
-      //   });
-
-      //   it('returns the updated tag', async function () {
-      //     expect(this.res.body).to.eql({
-      //       'tag': 'foo',
-      //     });
-      //   });
-      // });
     });
   });
 });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1701

## Description
This is the harmony part of the HARMONY-1701. It invokes the harmony-ci-cd script to deploy the specified service asynchronously on the EC2 instance and put an SNS message for harmony service to consume.

## Local Test Steps
Tested in Sandbox.
1) Set up an email subscription to the SNS topic, e.g. deploy-service-status-topic-yliu10
2) submit a service-image-tag PUT request via insomnia, e.g. `{{ _.root }}/service-image-tag/giovanni-adapter` with request body: `{"tag": "yliu10"}`
3) Verify a email is sent with a successful SNS message:
{"deploy_service":"giovanni-adapter","tag":"yliu10","status":"successful","image":"266xxx.dkr.ecr.us-west-2.amazonaws.com/harmonyservices/giovanni-adapter:yliu10","service_queue_urls":"[\"266xxx.dkr.ecr.us-west-2.amazonaws.com/harmonyservices/giovanni-adapter:latest,https://sqs.us-west-2.amazonaws.com/266xxx/giovanni-adapter-latest-0-yliu10.fifo\",\"266xxx.dkr.ecr.us-west-2.amazonaws.com/harmonyservices/giovanni-adapter:yliu10,https://sqs.us-west-2.amazonaws.com/266xxx/giovanni-adapter-yliu10-1-yliu10.fifo\",\"266xxx.dkr.ecr.us-west-2.amazonaws.com/harmonyservices/giovanni-adapter:yliu22,https://sqs.us-west-2.amazonaws.com/266xxx/giovanni-adapter-yliu22-2-yliu10.fifo\"]\n"}

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)