### PR TITLE
HARMONY-1708: Update frontend and backend to be able to use TLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ docs/outputs
 
 .netrc
 .ignore
+certs/

--- a/.nsprc
+++ b/.nsprc
@@ -14,9 +14,9 @@
     "notes": "Ignored since there is no fix",
     "expiry": "2024-08-01"
   },
-  "1095019": {
+  "1096610": {
     "active": true,
-    "notes": "Will fix in HARMONY-1648",
+    "notes": "Will fix in HARMONY-TBD",
     "expiry": "2024-08-01"
   },
   "1095102": {

--- a/.nsprc
+++ b/.nsprc
@@ -14,11 +14,6 @@
     "notes": "Ignored since there is no fix",
     "expiry": "2024-08-01"
   },
-  "1096610": {
-    "active": true,
-    "notes": "Will fix in HARMONY-TBD",
-    "expiry": "2024-08-01"
-  },
   "1095102": {
     "active": true,
     "notes": "Will fix in HARMONY-1650",

--- a/services/harmony/.nsprc
+++ b/services/harmony/.nsprc
@@ -4,9 +4,9 @@
     "notes": "Ignored since there is no fix",
     "expiry": "2024-05-01"
   },
-  "1095019": {
+  "1096610": {
     "active": true,
-    "notes": "Will fix in HARMONY-1648",
+    "notes": "Will fix in HARMONY-TBD",
     "expiry": "2024-05-01"
   },
   "1095102": {

--- a/services/harmony/.nsprc
+++ b/services/harmony/.nsprc
@@ -4,11 +4,6 @@
     "notes": "Ignored since there is no fix",
     "expiry": "2024-05-01"
   },
-  "1096610": {
-    "active": true,
-    "notes": "Will fix in HARMONY-TBD",
-    "expiry": "2024-05-01"
-  },
   "1095102": {
     "active": true,
     "notes": "Will fix in HARMONY-1650",

--- a/services/harmony/app/routers/router.ts
+++ b/services/harmony/app/routers/router.ts
@@ -48,6 +48,7 @@ export interface RouterConfig {
   // in production.  Defaults to true until we have real HTTP services.
   EXAMPLE_SERVICES?: string;
   skipEarthdataLogin?: string; // True if we should skip using EDL
+  USE_HTTPS?: string; // True if the server should use https
 }
 
 /**

--- a/services/harmony/app/util/url.ts
+++ b/services/harmony/app/util/url.ts
@@ -7,6 +7,9 @@ import * as url from 'url';
  * @returns The protocol (http or https) to use for public Harmony URLs
  */
 function _getProtocol(req): string {
+  if (process.env.USE_HTTPS === 'true') {
+    return 'https';
+  }
   const host = req.get('host');
   return (host.startsWith('localhost') || host.startsWith('127.0.0.1')) ? 'http' : 'https';
 }

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -40,7 +40,7 @@ METRICS_ENDPOINT=
 # The Metrics index to query (via the METRICS_ENDPOINT)
 METRICS_INDEX=
 
-# If set to true, only include EDL cookies if the request is made via https.
+# If set to true the listener for the harmony application will use HTTPS
 USE_HTTPS=false
 
 # Whether to run example service endpoints under /example.  Useful for


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1708

## Description
With the USE_HTTPS variable set to true both the harmony frontend and backend listeners will use TLS. We will set this to true in the deployed environments. See the ci-cd repo for instructions on how to test there.

## Local Test Steps
Verify that locally everything continues to work as expected by default (and does not use TLS). Verify in the sandbox that setting USE_HTTPS to true works correctly.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)