### PR TITLE
HARMONY-1717: As a harmony operator, I want to be able to disable and enable service provider self deployments

### DIFF
--- a/bin/port-forward
+++ b/bin/port-forward
@@ -48,7 +48,7 @@ function start_port_forwarding() {
     exit 1
   fi
 
-  kubectl wait -n harmony --for=condition=ready pod -l app="$service_name" --timeout=60s
+  kubectl wait -n harmony --for=condition=ready pod -l app="$service_name" --timeout=120s
   nohup kubectl -n harmony port-forward "service/${service_name}" "${args[@]}" > "logs/port-forward-${service_name}.log" 2>&1 &
   echo "Port forwarding started for service: ${service_name}, port pairs: ${port_pairs[*]}"
 }

--- a/db/db.sql
+++ b/db/db.sql
@@ -124,6 +124,13 @@ CREATE TABLE `user_work` (
   UNIQUE(job_id, service_id)
 );
 
+CREATE TABLE `service_deployment` (
+  `enabled` boolean,
+  `updated_at` datetime not null
+);
+
+INSERT INTO service_deployment (enabled, updated_at) VALUES (true, CURRENT_TIMESTAMP);
+
 -- Note this is not a full list of the indices, we rely on the database migrations to create
 -- all the indexes in Postgres
 CREATE INDEX jobs_jobID_idx ON jobs(jobID);

--- a/db/migrations/20240312181125_add_service_deployment_table.js
+++ b/db/migrations/20240312181125_add_service_deployment_table.js
@@ -1,0 +1,18 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema.createTable('service_deployment', (t) => {
+    t.boolean('enabled').notNullable();
+    t.timestamp('updated_at').notNullable();
+  }).raw('INSERT INTO service_deployment (enabled, updated_at) VALUES (true, now())');
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.dropTable('service_deployment');
+};

--- a/docs/guides/managing-existing-services.md
+++ b/docs/guides/managing-existing-services.md
@@ -92,3 +92,62 @@ Harmony validates that the image and tag are reachable - an error will be return
 
 **Important** from the [Docker documentation](https://docs.docker.com/engine/reference/commandline/image_tag/):
 >A tag name may contain lowercase and uppercase characters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
+
+#### Get the current enable/disable state of the service deployment feature
+
+```
+
+GET {{root}}/service-image-tag/state
+
+```
+**Example {{exampleCounter}}** - Getting the current enable/disable state of the service deployment feature using the `service-image-tag` API
+
+The returned JSON response shows if the service deployment is currently enabled (true) or disabled (false):
+
+```JSON
+{
+  "enabled": true
+}
+```
+---
+**Example {{exampleCounter}}** - Harmony `service-image-tags` response for enable/disable state
+
+#### Enable the service deployment feature
+The user must have admin permission in order to invoke this endpoint.
+
+```
+
+PUT {{root}}/service-image-tag/enable
+
+```
+**Example {{exampleCounter}}** - Enable the service deployment feature using the `service-image-tag` API
+
+The returned JSON response shows if the service deployment is currently enabled:
+
+```JSON
+{
+  "enabled": true
+}
+```
+---
+**Example {{exampleCounter}}** - Harmony `service-image-tags` response for enabling the service deployment
+
+#### Disable the service deployment feature
+The user must have admin permission in order to invoke this endpoint.
+
+```
+
+PUT {{root}}/service-image-tag/disable
+
+```
+**Example {{exampleCounter}}** - Disable the service deployment feature using the `service-image-tag` API
+
+The returned JSON response shows the service deployment is currently disabled:
+
+```JSON
+{
+  "enabled": false
+}
+```
+---
+**Example {{exampleCounter}}** - Harmony `service-image-tags` response for disabling the service deployment

--- a/services/harmony/app/routers/router.ts
+++ b/services/harmony/app/routers/router.ts
@@ -28,7 +28,7 @@ import { setLogLevel } from '../frontends/configuration';
 import getVersions from '../frontends/versions';
 import serviceInvoker from '../backends/service-invoker';
 import HarmonyRequest, { addRequestContextToOperation } from '../models/harmony-request';
-import { getServiceImageTag, getServiceImageTags, updateServiceImageTag } from '../frontends/service-image-tags';
+import { getServiceImageTag, getServiceImageTags, updateServiceImageTag, getServiceImageTagState, enableServiceImageTag, disableServiceImageTag } from '../frontends/service-image-tags';
 import cmrCollectionReader = require('../middleware/cmr-collection-reader');
 import cmrUmmCollectionReader = require('../middleware/cmr-umm-collection-reader');
 import env from '../util/env';
@@ -287,6 +287,9 @@ export default function router({ skipEarthdataLogin = 'false' }: RouterConfig): 
 
   // service images
   result.get('/service-image-tag', asyncHandler(getServiceImageTags));
+  result.get('/service-image-tag/state', jsonParser, asyncHandler(getServiceImageTagState));
+  result.put('/service-image-tag/enable', jsonParser, asyncHandler(enableServiceImageTag));
+  result.put('/service-image-tag/disable', jsonParser, asyncHandler(disableServiceImageTag));
   result.get('/service-image-tag/:service', asyncHandler(getServiceImageTag));
   result.put('/service-image-tag/:service', jsonParser, asyncHandler(updateServiceImageTag));
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1717

## Description
This PR added three endpoints:
GET <harmony_root>/service-image-tag/state
PUT <harmony_root>/service-image-tag/enable
PUT <harmony_root>/service-image-tag/disable

and add check in service deployment endpoint to verify the deployment is only allowed when the service deployment feature is enabled. See api doc for details.

## Local Test Steps
### check service deployment enable/disable state
http://localhost:3000/service-image-tag/state

### test enable service deployment
curl -XPUT -H "Authorization: Bearer token" -H 'Content-type: application/json' http://localhost:3000/service-image-tag/enable -d ''

### test disable service deployment
curl -XPUT -H "Authorization: Bearer token" -H 'Content-type: application/json' http://localhost:3000/service-image-tag/disable -d ''

mocha -g "Enable and disable service image tag update"

### test error message when service deployment is disabled
curl -XPUT -H "Authorization: Bearer token" -H 'Content-type: application/json' http://localhost:3000/service-image-tag/giovanni-adapter -d '{"tag": "yliu10"}'

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)