### PR TITLE
HARMONY-1543: Call revokeAll for EDL tokens on logout

### DIFF
--- a/services/harmony/app/middleware/earthdata-login-oauth-authorizer.ts
+++ b/services/harmony/app/middleware/earthdata-login-oauth-authorizer.ts
@@ -75,17 +75,8 @@ function handleLogout(oauth2: OAuthClient, req, res, _next): void {
 
   const { token } = req.signedCookies;
   if (token) {
-    // Revocation does not currently work due to non-standard OAuth Impl.
-    // Bug: https://bugs.earthdata.nasa.gov/browse/URSFOUR-1042
-    //
-    // If we need to revoke in the mean time, we can
-    // DELETE /oauth2/token/{token}
-    //
-    // See https://developer.earthdata.nasa.gov/urs/urs-integration/working-with-the-earthdata-login-api/api-documentation
-    //
-    // const oauthToken = oauth2.accessToken.create(token);
-    // oauthToken.revokeAll();
-
+    const oauthToken = oauth2.accessToken.create(token);
+    oauthToken.revokeAll();
     res.clearCookie('token', cookieOptions);
   }
   res.redirect(307, redirect || '/');

--- a/services/harmony/fixtures/uat.urs.earthdata.nasa.gov-443/171043516925921933
+++ b/services/harmony/fixtures/uat.urs.earthdata.nasa.gov-443/171043516925921933
@@ -1,0 +1,28 @@
+POST /oauth/revoke
+accept: application/json
+authorization: Basic Zm9vOmZvbw==
+content-type: application/x-www-form-urlencoded
+host: uat.urs.earthdata.nasa.gov
+body: token=fake_access&token_type_hint=access_token
+
+HTTP/1.1 200 OK
+server: nginx/1.22.1
+date: Thu, 14 Mar 2024 16:52:49 GMT
+content-type: text/html; charset=utf-8
+transfer-encoding: chunked
+connection: close
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+x-download-options: noopen
+x-permitted-cross-domain-policies: none
+referrer-policy: strict-origin-when-cross-origin
+cache-control: no-store
+pragma: no-cache
+expires: Fri, 01 Jan 1990 00:00:00 GMT
+www-authenticate: Basic realm="Application"
+x-request-id: 02f39558-1c73-44ad-97a9-0539820bb3d2
+x-runtime: 0.003169
+strict-transport-security: max-age=31536000
+
+HTTP Basic:

--- a/services/harmony/fixtures/uat.urs.earthdata.nasa.gov-443/171043516925999154
+++ b/services/harmony/fixtures/uat.urs.earthdata.nasa.gov-443/171043516925999154
@@ -1,0 +1,28 @@
+POST /oauth/revoke
+accept: application/json
+authorization: Basic Zm9vOmZvbw==
+content-type: application/x-www-form-urlencoded
+host: uat.urs.earthdata.nasa.gov
+body: token=fake_access&token_type_hint=access_token
+
+HTTP/1.1 200 OK
+server: nginx/1.22.1
+date: Thu, 14 Mar 2024 16:52:49 GMT
+content-type: text/html; charset=utf-8
+transfer-encoding: chunked
+connection: close
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+x-download-options: noopen
+x-permitted-cross-domain-policies: none
+referrer-policy: strict-origin-when-cross-origin
+cache-control: no-store
+pragma: no-cache
+expires: Fri, 01 Jan 1990 00:00:00 GMT
+www-authenticate: Basic realm="Application"
+x-request-id: c9494405-51a8-4491-a1ae-1bbc2757b7f3
+x-runtime: 0.006218
+strict-transport-security: max-age=31536000
+
+HTTP Basic:

--- a/services/harmony/fixtures/uat.urs.earthdata.nasa.gov-443/171043516926013045
+++ b/services/harmony/fixtures/uat.urs.earthdata.nasa.gov-443/171043516926013045
@@ -1,0 +1,28 @@
+POST /oauth/revoke
+accept: application/json
+authorization: Basic Zm9vOmZvbw==
+content-type: application/x-www-form-urlencoded
+host: uat.urs.earthdata.nasa.gov
+body: token=fake_access&token_type_hint=access_token
+
+HTTP/1.1 200 OK
+server: nginx/1.22.1
+date: Thu, 14 Mar 2024 16:52:49 GMT
+content-type: text/html; charset=utf-8
+transfer-encoding: chunked
+connection: close
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+x-download-options: noopen
+x-permitted-cross-domain-policies: none
+referrer-policy: strict-origin-when-cross-origin
+cache-control: no-store
+pragma: no-cache
+expires: Fri, 01 Jan 1990 00:00:00 GMT
+www-authenticate: Basic realm="Application"
+x-request-id: aaf7a1b8-01cf-4378-bcdc-1b26b742bf69
+x-runtime: 0.008507
+strict-transport-security: max-age=31536000
+
+HTTP Basic:

--- a/services/harmony/fixtures/uat.urs.earthdata.nasa.gov-443/171043516926073536
+++ b/services/harmony/fixtures/uat.urs.earthdata.nasa.gov-443/171043516926073536
@@ -1,0 +1,28 @@
+POST /oauth/revoke
+accept: application/json
+authorization: Basic Zm9vOmZvbw==
+content-type: application/x-www-form-urlencoded
+host: uat.urs.earthdata.nasa.gov
+body: token=fake_access&token_type_hint=access_token
+
+HTTP/1.1 200 OK
+server: nginx/1.22.1
+date: Thu, 14 Mar 2024 16:52:49 GMT
+content-type: text/html; charset=utf-8
+transfer-encoding: chunked
+connection: close
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+x-content-type-options: nosniff
+x-download-options: noopen
+x-permitted-cross-domain-policies: none
+referrer-policy: strict-origin-when-cross-origin
+cache-control: no-store
+pragma: no-cache
+expires: Fri, 01 Jan 1990 00:00:00 GMT
+www-authenticate: Basic realm="Application"
+x-request-id: 14b608ff-087f-4f70-9647-91d48a9c2d01
+x-runtime: 0.006892
+strict-transport-security: max-age=31536000
+
+HTTP Basic:


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1543

## Description
Our /oauth2/logout method now calls the EDL API method `/oauth/revoke` on logout.

## Local Test Steps


## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)