### PR TITLE
HARMONY-1692: Fix internal server error for STAC item generation when no mime-type is available

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -9,19 +9,14 @@
     "notes": "Will fix in HARMONY-1688",
     "expiry": "2024-08-01"
   },
-  "1092972": {
-    "active": true,
-    "notes": "Ignored since there is no fix",
-    "expiry": "2024-08-01"
-  },
   "1096643": {
     "active": true,
     "notes": "Will fix in HARMONY-1650",
     "expiry": "2024-08-01"
   },
-  "1096692": {
+  "1096727": {
     "active": true,
-    "notes": "Will fix in HARMONY-1724",
+    "notes": "Will fix in HARMONY-1729",
     "expiry": "2024-08-01"
   }
 }

--- a/services/harmony/.nsprc
+++ b/services/harmony/.nsprc
@@ -1,9 +1,4 @@
 {
-  "1092972": {
-    "active": true,
-    "notes": "Ignored since there is no fix",
-    "expiry": "2024-05-01"
-  },
   "1096643": {
     "active": true,
     "notes": "Will fix in HARMONY-1650",
@@ -19,9 +14,9 @@
     "notes": "Will fix in HARMONY-1700",
     "expiry": "2024-08-01"
   },
-  "1096692": {
+  "1096727": {
     "active": true,
-    "notes": "Will fix in HARMONY-1724",
+    "notes": "Will fix in HARMONY-1729",
     "expiry": "2024-08-01"
   }
 }

--- a/services/harmony/app/frontends/stac-item.ts
+++ b/services/harmony/app/frontends/stac-item.ts
@@ -189,36 +189,42 @@ export class HarmonyItem {
   addAsset(href: string, title: string, mimetype: string): void {
     let role = 'data';
     // Determine the role based on mimetype
-    const [type, subtype] = mimetype.split('/');
-    if (type === 'application') {
-      if (subtype === 'json') {
-        // application/json
-        role = 'metadata';
-      } else {
-        // application/nc, application/octet-stream ...
-        role = 'data';
+    if (mimetype) {
+      const [type, subtype] = mimetype.split('/');
+      if (type === 'application') {
+        if (subtype === 'json') {
+          // application/json
+          role = 'metadata';
+        } else {
+          // application/nc, application/octet-stream ...
+          role = 'data';
+        }
+      } else if (type === 'image') {
+        // image/*
+        role = 'overview';
+      } else if (type === 'text') {
+        if (subtype === 'xml') {
+          // text/xml
+          role = 'metadata';
+        } else {
+          // text/plain, text/csv, ...
+          role = 'data';
+        }
       }
-    } else if (type === 'image') {
-      // image/*
-      role = 'overview';
-    } else if (type === 'text') {
-      if (subtype === 'xml') {
-        // text/xml
-        role = 'metadata';
-      } else {
-        // text/plain, text/csv, ...
-        role = 'data';
-      }
+      this.assets[href] = {
+        href,
+        title,
+        type: mimetype,
+        roles: [role],
+      };
+    } else {
+      // type is not required - if we do not have the mimetype do not include it
+      this.assets[href] = {
+        href,
+        title,
+        roles: [role],
+      };
     }
-
-    // Using href as the key for assets; STAC clients seem to attach special meaning
-    // to some keys (ex: thumbnail)
-    this.assets[href] = {
-      href,
-      title,
-      type: mimetype,
-      roles: [role],
-    };
   }
 
   /**

--- a/services/service-runner/.nsprc
+++ b/services/service-runner/.nsprc
@@ -1,17 +1,12 @@
 {
-  "1092972": {
-    "active": true,
-    "notes": "Ignored since there is no fix",
-    "expiry": "2024-05-01"
-  },
   "1096643": {
     "active": true,
     "notes": "Will fix in HARMONY-1650",
     "expiry": "2024-05-01"
   },
-  "1096692": {
+  "1096727": {
     "active": true,
-    "notes": "Will fix in HARMONY-1724",
+    "notes": "Will fix in HARMONY-1729",
     "expiry": "2024-08-01"
   }
 }

--- a/services/work-failer/.nsprc
+++ b/services/work-failer/.nsprc
@@ -1,7 +1,7 @@
 {
-  "1096692": {
+  "1096727": {
     "active": true,
-    "notes": "Will fix in HARMONY-1724",
+    "notes": "Will fix in HARMONY-1729",
     "expiry": "2024-08-01"
   }
 }

--- a/services/work-reaper/.nsprc
+++ b/services/work-reaper/.nsprc
@@ -1,7 +1,1 @@
-{
-  "1096692": {
-    "active": true,
-    "notes": "Will fix in HARMONY-1724",
-    "expiry": "2024-08-01"
-  }
-}
+{}

--- a/services/work-scheduler/.nsprc
+++ b/services/work-scheduler/.nsprc
@@ -1,17 +1,12 @@
 {
-  "1092972": {
-    "active": true,
-    "notes": "Ignored since there is no fix",
-    "expiry": "2024-05-01"
-  },
   "1096643": {
     "active": true,
     "notes": "Will fix in HARMONY-1650",
     "expiry": "2024-05-01"
   },
-  "1096692": {
+  "1096727": {
     "active": true,
-    "notes": "Will fix in HARMONY-1724",
+    "notes": "Will fix in HARMONY-1729",
     "expiry": "2024-08-01"
   }
 }

--- a/services/work-updater/.nsprc
+++ b/services/work-updater/.nsprc
@@ -1,7 +1,1 @@
-{
-  "1096692": {
-    "active": true,
-    "notes": "Will fix in HARMONY-1724",
-    "expiry": "2024-08-01"
-  }
-}
+{}


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1692

## Description
When there is no mime-type available for a job link the STAC item generation currently fails with an internal server error.
Note that the tests are not currently testing the response format for the STAC items. I've written HARMONY-1730 to fix that as well as overhaul all the STAC item tests.

NOTE: I verified type is not a required STAC item asset field: https://github.com/radiantearth/stac-spec/blob/master/item-spec/json-schema/item.json

## Local Test Steps
Submit http://localhost:3000/C1205428742-ASF/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=1
Navigate to the STAC catalog and then append /0 to the catalog to get the first item.
Verify a STAC item response is generated, and note that the 'type' field is not included in the assets.
Switch back to the main branch and navigate to the same URL and verify that you see an internal server error - or submit the same request in SIT/UAT and verify that you see the internal server error.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)