### PR TITLE
HARMONY-1733: Update /service-image-tag to only show deployed services in an environment

### DIFF
--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -11,25 +11,19 @@ import env from '../util/env';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 export const asyncExec = util.promisify(require('child_process').exec);
 
-
-export const harmonyTaskServices = [
-  'work-item-scheduler',
-  'work-item-updater',
-  'work-reaper',
-  'work-failer',
-];
-
 /**
  * Compute the map of services to tags. Harmony core services are excluded.
  * @returns The map of canonical service names to image tags.
  */
 export function getImageTagMap(): {} {
   const unsortedImageMap = {};
+  const deployedServices = env.locallyDeployedServices.split(',');
+  deployedServices.push('query-cmr');
   for (const v of Object.keys(process.env)) {
-    if (v.endsWith('_IMAGE') && v !== 'SERVICE_RUNNER_IMAGE') {
+    if (v.endsWith('_IMAGE')) {
       const serviceName = v.slice(0, -6).toLowerCase().replaceAll('_', '-');
-      // add in any services that are not Harmony core task services
-      if (!harmonyTaskServices.includes(serviceName)) {
+      // add in any services that are deployed in the environment
+      if (deployedServices.includes(serviceName)) {
         const image = process.env[v];
         const match = image.match(/.*:(.*)/);
         if (match) {

--- a/services/harmony/app/util/env.ts
+++ b/services/harmony/app/util/env.ts
@@ -98,6 +98,7 @@ class HarmonyServerEnv extends HarmonyEnv {
   @Min(1)
   maxPostFileSize: number;
 
+  locallyDeployedServices: string;
 }
 
 const localPath = path.resolve(__dirname, '../../env-defaults');

--- a/services/harmony/test/helpers/servers.ts
+++ b/services/harmony/test/helpers/servers.ts
@@ -44,7 +44,13 @@ export default function hookServersStartStop(opts = { skipEarthdataLogin: true }
     });
     this.frontend = servers.frontend;
     this.backend = servers.backend;
+
     stub(env, 'callbackUrlRoot').get(() => `http://localhost:${servers.backend.address().port}`);
+    const locallyDeployedServices = 'giovanni-adapter,harmony-service-example,' +
+      'harmony-netcdf-to-zarr,var-subsetter,swath-projector,harmony-gdal-adapter,' +
+      'podaac-concise,sds-maskfill,trajectory-subsetter,podaac-l2-subsetter,harmony-regridder,' +
+      'hybig,geoloco,stitchee,batchee,hoss';
+    stub(env, 'locallyDeployedServices').get(() => locallyDeployedServices);
     process.env.OAUTH_REDIRECT_URI = `http://localhost:${servers.frontend.address().port}/oauth2/redirect`;
 
     if (stubOAuthClientCredentialsReq) {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1733

## Description
Update /service-image-tag to only show deployed services in an environment. Before it was showing services that were not deployed such as podaac/ps3 and in production several services like hybig, geoloco, stitchee, and batchee are not deployed.

## Local Test Steps
Bring up http://localhost:3000/service-image-tag. Verify that only the services which are defined in your LOCALLY_DEPLOYED_SERVICES are reported. Verify that it matches your k8s deployments of backend services.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)