### PR TITLE
HARMONY-1732: As a harmony user, I want to check my service self deployment status.

### DIFF
--- a/db/db.sql
+++ b/db/db.sql
@@ -131,6 +131,18 @@ CREATE TABLE `service_deployment` (
 
 INSERT INTO service_deployment (enabled, updatedAt) VALUES (true, CURRENT_TIMESTAMP);
 
+CREATE TABLE `service_deployments` (
+  `id` integer not null primary key autoincrement,
+  `deployment_id` char(36) not null,
+  `username` varchar(255) not null,
+  `service` varchar(255) not null,
+  `tag` varchar(255) not null,
+  `status` text check (`status` in ('running', 'successful', 'failed')) not null,
+  `message` varchar(4096),
+  `createdAt` datetime not null,
+  `updatedAt` datetime not null
+);
+
 -- Note this is not a full list of the indices, we rely on the database migrations to create
 -- all the indexes in Postgres
 CREATE INDEX jobs_jobID_idx ON jobs(jobID);
@@ -147,3 +159,4 @@ CREATE INDEX workflow_steps_jobID_StepIndex_idx ON workflow_steps(jobID, stepInd
 CREATE INDEX workflow_steps_serviceID_idx ON workflow_steps(serviceID);
 CREATE INDEX batch_jobID_service_ID_batchID ON batches(jobID, serviceID, batchID);
 CREATE INDEX batch_items_jobID_service_ID_batchID ON batch_items(jobID, serviceID, batchID);
+CREATE INDEX service_deployments_deployment_id_idx ON service_deployments(deployment_id);

--- a/db/migrations/20240321202226_add_service_deployments_table.js
+++ b/db/migrations/20240321202226_add_service_deployments_table.js
@@ -1,0 +1,39 @@
+const { onUpdateTrigger } = require('../knexfile');
+
+exports.up = function up(knex) {
+  return knex.schema.createTable('service_deployments', (t) => {
+    t.increments('id')
+      .primary();
+
+    t.uuid('deployment_id')
+      .notNullable();
+
+    t.string('username')
+      .notNullable();
+
+    t.string('service')
+      .notNullable();
+
+    t.string('tag')
+      .notNullable();
+
+    t.enu('status', ['running', 'successful', 'failed'])
+      .notNullable();
+
+    t.string('message', 4096);
+
+    t.timestamp('createdAt')
+      .notNullable();
+
+    t.timestamp('updatedAt')
+      .notNullable();
+
+    t.index(['deployment_id']);
+    t.index(['username']);
+  })
+  .then(() => knex.raw(onUpdateTrigger('service_deployments')));
+};
+
+exports.down = function down(knex) {
+  return knex.schema.dropTable('service_deployments');
+};

--- a/docs/guides/managing-existing-services.md
+++ b/docs/guides/managing-existing-services.md
@@ -77,12 +77,12 @@ example above:
 ```
 **Example 6** - Harmony `/service-image-tags` request body for updating a tag
 
-The returned JSON response has a tag field indicating the new tag value and a status_link field with the url for getting the status of the service image deployment.
+The returned JSON response has a tag field indicating the new tag value and a statusLink field with the url for getting the status of the service image deployment.
 
 ```JSON
 {
   "tag": "new-version",
-  "status_link": "https://harmony.uat.earthdat.nasa.gov/service-image-tag/deployment/<deployment-id>"
+  "statusLink": "https://harmony.uat.earthdat.nasa.gov/service-image-tag/deployment/<deployment-id>"
 }
 ```
 **Example 7** - Harmony `/service-image-tags` response for a updating a single service
@@ -96,7 +96,7 @@ Harmony validates that the image and tag are reachable - an error will be return
 
 ## Get backend service image tag update status
 
-You can get the status of backend service tag update by following the `status_link` returned in the backend service tag update response.
+You can get the status of backend service tag update by following the `statusLink` returned in the backend service tag update response.
 
 For example:
 
@@ -110,12 +110,12 @@ The returned JSON response has the fields indicating the current status of the s
 ```JSON
 {
   id: 1,
-  deployment_id: "befb50e0-e467-4776-86c8-e7218f1123cc",
+  deploymentId: "befb50e0-e467-4776-86c8-e7218f1123cc",
   username: "yliu10",
   service: "giovanni-adapter",
   tag: "new-version",
   status: "successful",
-  message: null,
+  message: "Deployment successful",
   createdAt: "2024-03-29T14:56:29.151Z",
   updatedAt: "2024-03-29T14:56:29.273Z"
 }

--- a/docs/guides/managing-existing-services.md
+++ b/docs/guides/managing-existing-services.md
@@ -77,11 +77,12 @@ example above:
 ```
 **Example 6** - Harmony `/service-image-tags` request body for updating a tag
 
-The returned JSON response is the same as the single service request above, indicating the new tag value
+The returned JSON response has a tag field indicating the new tag value and a status_link field with the url for getting the status of the service image deployment.
 
 ```JSON
 {
-  "tag": "new-version"
+  "tag": "new-version",
+  "status_link": "https://harmony.uat.earthdat.nasa.gov/service-image-tag/deployment/<deployment-id>"
 }
 ```
 **Example 7** - Harmony `/service-image-tags` response for a updating a single service
@@ -93,6 +94,34 @@ Harmony validates that the image and tag are reachable - an error will be return
 **Important** from the [Docker documentation](https://docs.docker.com/engine/reference/commandline/image_tag/):
 >A tag name may contain lowercase and uppercase characters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
 
+## Get backend service image tag update status
+
+You can get the status of backend service tag update by following the `status_link` returned in the backend service tag update response.
+
+For example:
+
+```
+curl -XGET -Ln -bj https://harmony.uat.earthdat.nasa.gov/service-image-tag/deployment/<deployment-id>
+```
+**Example 8** - Get service image tag update status
+
+The returned JSON response has the fields indicating the current status of the service image deployment.
+
+```JSON
+{
+  id: 1,
+  deployment_id: "befb50e0-e467-4776-86c8-e7218f1123cc",
+  username: "yliu10",
+  service: "giovanni-adapter",
+  tag: "new-version",
+  status: "successful",
+  message: null,
+  createdAt: "2024-03-29T14:56:29.151Z",
+  updatedAt: "2024-03-29T14:56:29.273Z"
+}
+```
+**Example 9** - Harmony get status of service image tag update response
+
 ## Get the current enable/disable state of the service deployment feature
 
 ```
@@ -100,7 +129,7 @@ Harmony validates that the image and tag are reachable - an error will be return
 GET https://harmony.uat.earthdat.nasa.gov/service-image-tag/state
 
 ```
-**Example 8** - Getting the current enable/disable state of the service deployment feature using the `service-image-tag` API
+**Example 10** - Getting the current enable/disable state of the service deployment feature using the `service-image-tag` API
 
 The returned JSON response shows if the service deployment is currently enabled (true) or disabled (false):
 
@@ -110,7 +139,7 @@ The returned JSON response shows if the service deployment is currently enabled 
 }
 ```
 ---
-**Example 9** - Harmony `service-image-tags` response for enable/disable state
+**Example 11** - Harmony `service-image-tags` response for enable/disable state
 
 ## Enable the service deployment feature
 The user must have admin permission in order to invoke this endpoint.
@@ -121,7 +150,7 @@ For example:
 curl -XPUT -H 'Authorization: bearer <your bearer token>' -H 'Content-type: application/json' https://harmony.uat.earthdat.nasa.gov/service-image-tag/state -d '{"enabled": true}'
 ```
 ---
-**Example 10** - Harmony `service-image-tags` request for enabling the service deployment
+**Example 12** - Harmony `service-image-tags` request for enabling the service deployment
 
 The returned JSON response is the same as the get current state of the service deployment feature request above, indicating the current state:
 
@@ -130,7 +159,7 @@ The returned JSON response is the same as the get current state of the service d
   "enabled": true
 }
 ```
-**Example 11** - Harmony `/service-image-tags` response for enabling the service deployment
+**Example 13** - Harmony `/service-image-tags` response for enabling the service deployment
 
 ## Disable the service deployment feature
 The user must have admin permission in order to invoke this endpoint.
@@ -141,7 +170,7 @@ For example:
 curl -XPUT -H 'Authorization: bearer <your bearer token>' -H 'Content-type: application/json' https://harmony.uat.earthdat.nasa.gov/service-image-tag/state -d '{"enabled": false}'
 ```
 ---
-**Example 12** - Harmony `service-image-tags` request for disabling the service deployment
+**Example 14** - Harmony `service-image-tags` request for disabling the service deployment
 
 The returned JSON response is the same as the get current state of the service deployment feature request above, indicating the current state:
 
@@ -150,4 +179,4 @@ The returned JSON response is the same as the get current state of the service d
   "enabled": false
 }
 ```
-**Example 13** - Harmony `/service-image-tags` response for disabling the service deployment
+**Example 15** - Harmony `/service-image-tags` response for disabling the service deployment

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -356,7 +356,7 @@ export async function execDeployScript(
         req.context.logger.info(`Script output: ${line}`);
       });
       await db.transaction(async (tx) => {
-        await setStatusMessage(tx, deploymentId, 'successful');
+        await setStatusMessage(tx, deploymentId, 'successful', 'Deployment successful');
       });
     }
   });
@@ -396,6 +396,7 @@ export async function updateServiceImageTag(
     service: service,
     tag: tag,
     status: 'running',
+    message: 'Deployment in progress',
   });
 
   await db.transaction(async (tx) => {
@@ -407,7 +408,7 @@ export async function updateServiceImageTag(
   res.statusCode = 202;
   res.send({
     'tag': tag,
-    'status_link': `${urlRoot}/service-image-tag/deployment/${deploymentId}`,
+    'statusLink': `${urlRoot}/service-image-tag/deployment/${deploymentId}`,
   });
 }
 
@@ -474,6 +475,18 @@ export async function getServiceDeployment(
     await db.transaction(async (tx) => {
       deployment = await getDeploymentById(tx, id);
     });
+    const { deployment_id, username, service, tag, status, message, createdAt, updatedAt } = deployment;
+    deployment = {
+      id: id,
+      deploymentId: deployment_id,
+      username: username,
+      service: service,
+      tag: tag,
+      status: status,
+      message: message,
+      createdAt: createdAt,
+      updatedAt: updatedAt,
+    };
   } catch (e) {
     req.context.logger.error(`Caught exception: ${e}`);
     deployment = undefined;

--- a/services/harmony/app/models/service-deployment.ts
+++ b/services/harmony/app/models/service-deployment.ts
@@ -22,6 +22,9 @@ export default class ServiceDeployment extends Record {
   // The service tag associated with the deployment
   tag: string;
 
+  // The status of the deployment
+  status: string;
+
   // The error message of the deployment if applicable
   message: string;
 }

--- a/services/harmony/app/models/service-deployment.ts
+++ b/services/harmony/app/models/service-deployment.ts
@@ -1,0 +1,60 @@
+import { Transaction } from './../util/db';
+import Record from './record';
+import { truncateString } from '@harmony/util/string';
+
+/**
+ *
+ * Wrapper object for service deployment
+ *
+ */
+export default class ServiceDeployment extends Record {
+  static table = 'service_deployments';
+
+  // The ID of the deployment
+  deployment_id: string;
+
+  // The username associated with the deployment
+  username: string;
+
+  // The service name associated with the deployment
+  service: string;
+
+  // The service tag associated with the deployment
+  tag: string;
+
+  // The error message of the deployment if applicable
+  message: string;
+}
+
+/**
+ * Sets the status and message for the given deployment id.
+ * @param tx - The database transaction
+ * @param deploymentId - The deployment id
+ * @param status - The deployment status
+ * @param message - The deployment error message
+ */
+export async function setStatusMessage(tx: Transaction, deploymentId: string, status: string, message = ''): Promise<void> {
+  if (message === '') {
+    await tx(ServiceDeployment.table)
+      .where({ deployment_id: deploymentId })
+      .update('status', status);
+  } else {
+    await tx(ServiceDeployment.table)
+      .where({ deployment_id: deploymentId })
+      .update('status', status)
+      .update('message', truncateString(message, 4096));
+  }
+}
+
+/**
+ * Gets deployment for the given deployment id.
+ * @param tx - The database transaction
+ * @param deploymentId - The deployment id
+ * Retruns deployment object
+ */
+export async function getDeploymentById(tx: Transaction, deploymentId: string): Promise<ServiceDeployment> {
+  const result = await tx(ServiceDeployment.table)
+    .select()
+    .where({ deployment_id: deploymentId });
+  return result[0];
+}

--- a/services/harmony/app/routers/router.ts
+++ b/services/harmony/app/routers/router.ts
@@ -28,7 +28,7 @@ import { setLogLevel } from '../frontends/configuration';
 import getVersions from '../frontends/versions';
 import serviceInvoker from '../backends/service-invoker';
 import HarmonyRequest, { addRequestContextToOperation } from '../models/harmony-request';
-import { getServiceImageTag, getServiceImageTags, updateServiceImageTag, getServiceImageTagState, setServiceImageTagState } from '../frontends/service-image-tags';
+import { getServiceImageTag, getServiceImageTags, updateServiceImageTag, getServiceImageTagState, setServiceImageTagState, getServiceDeployment } from '../frontends/service-image-tags';
 import cmrCollectionReader = require('../middleware/cmr-collection-reader');
 import cmrUmmCollectionReader = require('../middleware/cmr-umm-collection-reader');
 import env from '../util/env';
@@ -289,6 +289,7 @@ export default function router({ skipEarthdataLogin = 'false' }: RouterConfig): 
   result.get('/service-image-tag', asyncHandler(getServiceImageTags));
   result.get('/service-image-tag/state', asyncHandler(getServiceImageTagState));
   result.put('/service-image-tag/state', jsonParser, asyncHandler(setServiceImageTagState));
+  result.get('/service-image-tag/deployment/:id', asyncHandler(getServiceDeployment));
   result.get('/service-image-tag/:service', asyncHandler(getServiceImageTag));
   result.put('/service-image-tag/:service', jsonParser, asyncHandler(updateServiceImageTag));
 

--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -71,7 +71,6 @@ async function waitUntilStatusChange(deploymentId: string): Promise<boolean | nu
   return new Promise<boolean | null>((resolve) => {
     let elapsedTime = 0;
     const interval = setInterval(async () => {
-      // Call your function to check the result
       await db.transaction(async (tx) => {
         const { status } = await getDeploymentById(tx, deploymentId);
         deploymentStatus = status;
@@ -969,12 +968,13 @@ describe('Service self-deployment successful', async function () {
       });
 
       it('returns the deployment status successful', async function () {
-        const { deploymentId, username, service, tag, status } = this.res.body;
+        const { deploymentId, username, service, tag, status, message } = this.res.body;
         expect(deploymentId).to.eql(linkDeploymentId);
         expect(username).to.eql('buzz');
         expect(service).to.eql('harmony-service-example');
         expect(tag).to.eql('foo');
         expect(status).to.eql('successful');
+        expect(message).to.eql('Deployment successful');
       });
     });
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1732

## Description
This PR has the following changes:
- adds service_deployments table in harmony to track all service self-deployments. 
- adds `status_link` field in service image tag update endpoint response to list the url to track service self-deployment status
- adds new route `GET <harmony-root>/service-image-tag/deployment/<deployment-id>` and support to show the deployment details including status for the given `deployment-id`.

## Local Test Steps
Modify the command line in `execDeployScript` to simulate successful and failed service deployments. e.g. 
```
//const command = `./bin/exec-deploy-service ${service} ${tag}`;
const command = 'ls';
```
Verify:
1) when update a service tag, a `status_link` field is returned in the response. e.g.
curl -XPUT -H "Authorization: Bearer <token>" -H 'Content-type: application/json' http://localhost:3000/service-image-tag/harmony-service-example -d '{"tag": "latest"}'

2) verify following the `status_link`, user can see the deployment detail of the service tag update. It shows the service deployment status, service, tag, username who performed the service deployment, `createdAt` is the deployment start time, `updatedAt` is the deployment end time.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)