### PR TITLE
Harmony 1731 - Add registry ID when describing ECR images

### DIFF
--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -44,6 +44,7 @@ export function getImageTagMap(): {} {
 }
 
 export interface EcrImageNameComponents {
+  registryId: string;
   host: string;
   region: string;
   repository: string;
@@ -61,8 +62,10 @@ export function ecrImageNameToComponents(name: string): EcrImageNameComponents {
   if (!match) return null;
 
   const [ _, host, region, repository, tag ] = match;
+  const registryId = host.split('.')[0]; // the AWS account ID
 
   return {
+    registryId,
     host,
     region,
     repository,
@@ -91,7 +94,7 @@ async function validateTaggedImageIsReachable(
 
   if (nameComponents) {
     // use the AWS CLI to check
-    const { region, repository } = nameComponents;
+    const { region, repository, registryId } = nameComponents;
     let endpoint = `https://ecr.${region}.amazonaws.com`;
     if (env.useLocalstack === true) {
       endpoint = `http://${env.localstackHost}:4566`;
@@ -100,7 +103,7 @@ async function validateTaggedImageIsReachable(
       region,
       endpoint,
     });
-    if (! await ecr.describeImage(repository, tag)) {
+    if (! await ecr.describeImage(repository, tag, registryId)) {
       isReachable = false;
     }
   } else {

--- a/services/harmony/app/util/container-registry.ts
+++ b/services/harmony/app/util/container-registry.ts
@@ -41,15 +41,17 @@ export class ECR {
    * Returns image information from ECR for the given image repository and tag.
    * @param repository - the image repository (e.g. harmonyservices/service-example)
    * @param tag - the image tag
+   * @param registryId - the registry ID/AWS account ID where the image lives (optional -- may
+   * not always be available)
    * @returns A Promise containing ImageDetails or null if the image/tag does not exist
    */
-  async describeImage(repository: string, tag: string): Promise<ImageDetails> {
+  async describeImage(repository: string, tag: string, registryId?: string): Promise<ImageDetails> {
     let cmd: DescribeImagesCommandInput = {
       repositoryName: repository,
       imageIds: [{ imageTag: tag }],
     };
-    if (repository.indexOf('ldds') > -1) {
-      cmd = { ...cmd, registryId: '***' }
+    if (registryId) {
+      cmd = { ...cmd, registryId }
     }
     const command = new DescribeImagesCommand(cmd);
     let response;

--- a/services/harmony/app/util/container-registry.ts
+++ b/services/harmony/app/util/container-registry.ts
@@ -1,4 +1,4 @@
-import { ECRClient, DescribeImagesCommand, ECRClientConfig } from '@aws-sdk/client-ecr';
+import { ECRClient, DescribeImagesCommand, ECRClientConfig, DescribeImagesCommandInput } from '@aws-sdk/client-ecr';
 import env from './env';
 
 export interface ImageDetails {
@@ -44,10 +44,14 @@ export class ECR {
    * @returns A Promise containing ImageDetails or null if the image/tag does not exist
    */
   async describeImage(repository: string, tag: string): Promise<ImageDetails> {
-    const command = new DescribeImagesCommand({
+    let cmd: DescribeImagesCommandInput = {
       repositoryName: repository,
       imageIds: [{ imageTag: tag }],
-    });
+    };
+    if (repository.indexOf('ldds') > -1) {
+      cmd = { ...cmd, registryId: '***' }
+    }
+    const command = new DescribeImagesCommand(cmd);
     let response;
     try {
       response = await this.ecr.send(command);

--- a/services/harmony/app/util/container-registry.ts
+++ b/services/harmony/app/util/container-registry.ts
@@ -51,7 +51,7 @@ export class ECR {
       imageIds: [{ imageTag: tag }],
     };
     if (registryId) {
-      cmd = { ...cmd, registryId }
+      cmd = { ...cmd, registryId };
     }
     const command = new DescribeImagesCommand(cmd);
     let response;

--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -155,6 +155,7 @@ describe('ecrImageNameToComponents', function () {
     const imageName = '123456789012.dkr.ecr.us-west-2.amazonaws.com/harmony/my-repository:my-tag';
 
     const expectedComponents = {
+      registryId: '123456789012',
       host: '123456789012.dkr.ecr.us-west-2.amazonaws.com',
       region: 'us-west-2',
       repository: 'harmony/my-repository',


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1731

## Description
Fixes the issue where we could't get the ECR describe image command to work even though we were given the appropriate permissions. We were not passing the argument that specifies the registry where the image is located.

## Local Test Steps
I tested this in sandbox and so did Chris, for geoloco, and query-cmr.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)