### PR TITLE
HARMONY-1732: Drop id from service deployment status result.

### DIFF
--- a/bin/update-harmony
+++ b/bin/update-harmony
@@ -18,7 +18,7 @@ function usage
   echo "  -s|--services     Upate service images in addition to harmony images."
   echo "  -h|--help         Print this message."
   echo -e "\033[1mDESCRIPTION\033[0m"
-  echo "This script updates the Docker images used internally by Harmony then restars Harmony."
+  echo "This script updates the Docker images used internally by Harmony then restarts Harmony."
   echo "Optionally it can also update the service images."
 }
 

--- a/docs/guides/managing-existing-services.md
+++ b/docs/guides/managing-existing-services.md
@@ -109,7 +109,6 @@ The returned JSON response has the fields indicating the current status of the s
 
 ```JSON
 {
-  id: 1,
   deploymentId: "befb50e0-e467-4776-86c8-e7218f1123cc",
   username: "yliu10",
   service: "giovanni-adapter",

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -477,7 +477,6 @@ export async function getServiceDeployment(
     });
     const { deployment_id, username, service, tag, status, message, createdAt, updatedAt } = deployment;
     deployment = {
-      id: id,
       deploymentId: deployment_id,
       username: username,
       service: service,


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1732

## Description
This PR drops the `id` field from service deployment status result. It is just noise (internal implementation detail) that we should not expose to the end user.

## Local Test Steps
Attempt to update service image tag and then follow the status link to see everything is fine.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)