### PR TITLE
Adds sds/HyBIG service to PROD

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -18,5 +18,10 @@
     "active": true,
     "notes": "Will fix in HARMONY-1729",
     "expiry": "2024-08-01"
+  },
+  "1096915": {
+    "active": true,
+    "notes": "Will not fix. Only moderate vulnerability for functionality we don't use. Upgrade would break gdal-async dependency which is fixed to a specific version.",
+    "expiry": "2024-08-01"
   }
 }

--- a/config/services.yml
+++ b/config/services.yml
@@ -328,6 +328,37 @@ https://cmr.earthdata.nasa.gov:
         is_sequential: true
       - image: !Env ${HARMONY_GDAL_ADAPTER_IMAGE}
 
+  - name: sds/HyBIG
+    description: |
+      The Harmony Browse Image Generator (HyBIG) supports the conversion of
+      GeoTIFF inputs to Global Imagery Browse Services (GIBS) compatible PNG or
+      JPEG outputs. This includes, where necessary, conversion to a GIBS
+      supported Coordinate Reference System (CRS). Other projections can be
+      requested, but will not be compatible with GIBS.
+    data_operation_version: '0.17.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/sds/hybig
+    collections: []
+    umm_s:
+      - S2697183066-XYZ_PROV
+    capabilities:
+      subsetting:
+        bbox: false
+        shape: false
+        temporal: false
+      output_formats:
+        - image/png
+        - image/jpeg
+      reprojection: true
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+      - image: !Env ${HYBIG_IMAGE}
+
   - name: harmony/netcdf-to-zarr
     description: |
       Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.

--- a/config/services.yml
+++ b/config/services.yml
@@ -335,7 +335,7 @@ https://cmr.earthdata.nasa.gov:
       JPEG outputs. This includes, where necessary, conversion to a GIBS
       supported Coordinate Reference System (CRS). Other projections can be
       requested, but will not be compatible with GIBS.
-    data_operation_version: '0.17.0'
+    data_operation_version: '0.18.0'
     type:
       <<: *default-turbo-config
       params:
@@ -343,7 +343,6 @@ https://cmr.earthdata.nasa.gov:
         env:
           <<: *default-turbo-env
           STAGING_PATH: public/sds/hybig
-    collections: []
     umm_s:
       - S2697183066-XYZ_PROV
     capabilities:
@@ -1093,4 +1092,3 @@ https://cmr.uat.earthdata.nasa.gov:
         operations: ['concatenate']
         conditional:
           exists: ['concatenate']
-

--- a/config/services.yml
+++ b/config/services.yml
@@ -343,8 +343,7 @@ https://cmr.earthdata.nasa.gov:
         env:
           <<: *default-turbo-env
           STAGING_PATH: public/sds/hybig
-    umm_s:
-      - S2697183066-XYZ_PROV
+    umm_s: S2697183066-XYZ_PROV
     capabilities:
       subsetting:
         bbox: false

--- a/services/harmony/.nsprc
+++ b/services/harmony/.nsprc
@@ -18,5 +18,10 @@
     "active": true,
     "notes": "Will fix in HARMONY-1729",
     "expiry": "2024-08-01"
+  },
+  "1096915": {
+    "active": true,
+    "notes": "Will not fix. Only moderate vulnerability for functionality we don't use. Upgrade would break gdal-async dependency which is fixed to a specific version.",
+    "expiry": "2024-08-01"
   }
 }

--- a/services/service-runner/.nsprc
+++ b/services/service-runner/.nsprc
@@ -8,5 +8,10 @@
     "active": true,
     "notes": "Will fix in HARMONY-1729",
     "expiry": "2024-08-01"
+  },
+  "1096915": {
+    "active": true,
+    "notes": "Will not fix. Only moderate vulnerability for functionality we don't use. Upgrade would break gdal-async dependency which is fixed to a specific version.",
+    "expiry": "2024-08-01"
   }
 }

--- a/services/work-scheduler/.nsprc
+++ b/services/work-scheduler/.nsprc
@@ -8,5 +8,10 @@
     "active": true,
     "notes": "Will fix in HARMONY-1729",
     "expiry": "2024-08-01"
+  },
+  "1096915": {
+    "active": true,
+    "notes": "Will not fix. Only moderate vulnerability for functionality we don't use. Upgrade would break gdal-async dependency which is fixed to a specific version.",
+    "expiry": "2024-08-01"
   }
 }


### PR DESCRIPTION
## Jira Issue ID
DAS-2131

## Description

This PR updates the Harmony services.yml with the information for harmony prod. It mimics the initial Harmony record for [HyBIG in UAT](https://github.com/nasa/harmony/pull/397).

It points to the correct UMM-S service record. [HyBIG UMM-S Service record in production](https://mmt.earthdata.nasa.gov/services/S2697183066-XYZ_PROV)

I'm not sure what else needs to be done to enable HyBIG in Production.

## Local Test Steps
¯\_(ツ)_/¯


## PR Acceptance Checklist
* [X] Acceptance criteria met
* [N/A] Tests added/updated (if needed) and passing
* [N/A] Documentation updated (if needed)