### PR TITLE
HARMONY-1755: As a harmony deployer, I want only one harmony deployment or service deployment running at a given time

### DIFF
--- a/docs/guides/managing-existing-services.md
+++ b/docs/guides/managing-existing-services.md
@@ -90,6 +90,8 @@ The returned JSON response has a tag field indicating the new tag value and a st
 
 >**Note** this is an asynchronous request, so the status code for the response will be `202 Accepted` - it may take several minutes for the entire update to complete.
 
+Only one service deployment can be run at any given time. If your request is rejectd with error message: `Service deployment is disabled.`, it might be because either a Harmony deployment or another service deployment is running. Please wait for a few minutes, then retry your request. If the problem persists, contact Harmony support.
+
 Harmony validates that the image and tag are reachable - an error will be returned if not.
 
 **Important** from the [Docker documentation](https://docs.docker.com/engine/reference/commandline/image_tag/):

--- a/docs/guides/managing-existing-services.md
+++ b/docs/guides/managing-existing-services.md
@@ -90,7 +90,7 @@ The returned JSON response has a tag field indicating the new tag value and a st
 
 >**Note** this is an asynchronous request, so the status code for the response will be `202 Accepted` - it may take several minutes for the entire update to complete.
 
-Only one service deployment can be run at any given time. If your request is rejectd with error message: `Service deployment is disabled.`, it might be because either a Harmony deployment or another service deployment is running. Please wait for a few minutes, then retry your request. If the problem persists, contact Harmony support.
+Only one service deployment can be run at any given time. If your request is rejected with error message: `Service deployment is disabled.`, it might be because either a Harmony deployment or another service deployment is running. Please wait for a few minutes, then retry your request. If the problem persists, contact Harmony support.
 
 Harmony validates that the image and tag are reachable - an error will be returned if not.
 

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -189,7 +189,7 @@ async function validateServiceDeploymentIsEnabled(
 ): Promise<boolean> {
   const enabled = await getEnabled();
   if (!enabled) {
-    res.statusCode = 503;
+    res.statusCode = 423;
     res.send('Service deployment is disabled.');
     return false;
   }

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -466,6 +466,8 @@ export async function updateServiceImageTag(
 export async function getServiceImageTagState(
   req: HarmonyRequest, res: Response, _next: NextFunction,
 ): Promise<void> {
+  if (! await validateUserIsInDeployerOrAdminGroup(req, res)) return;
+
   const enabled = await getEnabled();
   res.statusCode = 200;
   res.send({ 'enabled': enabled });
@@ -503,6 +505,8 @@ export async function setServiceImageTagState(
 export async function getServiceDeployment(
   req: HarmonyRequest, res: Response, _next: NextFunction,
 ): Promise<void> {
+  if (! await validateUserIsInDeployerOrAdminGroup(req, res)) return;
+
   const { id } = req.params;
   let deployment;
   try {

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -491,8 +491,7 @@ export async function setServiceImageTagState(
 
   const { enabled } = req.body;
 
-  const statusCode = await setEnabled(enabled);
-  res.statusCode = statusCode;
+  res.statusCode = await setEnabled(enabled);
   res.send({ 'enabled': enabled });
 }
 

--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -784,7 +784,7 @@ describe('Service image endpoint', async function () {
   });
 
   describe('Enable and disable service image tag update', async function () {
-    describe('when a user is a regular user, not in the EDL service admin groups', async function () {
+    describe('when a user is a regular user, not in the EDL service deployers or admin groups', async function () {
 
       describe('when get the service image tag update state', async function () {
         before(async function () {

--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -256,7 +256,7 @@ describe('Service image endpoint', async function () {
         delete this.res;
       });
 
-      it('rejects the user', async function () {
+      it('rejects the request', async function () {
         expect(this.res.status).to.equal(403);
       });
 
@@ -311,7 +311,7 @@ describe('Service image endpoint', async function () {
           delete this.res;
         });
 
-        it('rejects the user', async function () {
+        it('rejects the request', async function () {
           expect(this.res.status).to.equal(403);
         });
 
@@ -331,7 +331,7 @@ describe('Service image endpoint', async function () {
           delete this.res;
         });
 
-        it('rejects the user', async function () {
+        it('rejects the request', async function () {
           expect(this.res.status).to.equal(403);
         });
 
@@ -454,7 +454,7 @@ describe('Service image endpoint', async function () {
         delete this.res;
       });
 
-      it('rejects the user', async function () {
+      it('rejects the request', async function () {
         expect(this.res.status).to.equal(403);
       });
 
@@ -741,7 +741,7 @@ describe('Service image endpoint', async function () {
         delete this.res;
       });
 
-      it('rejects the user', async function () {
+      it('rejects the request', async function () {
         expect(this.res.status).to.equal(403);
       });
 
@@ -795,7 +795,7 @@ describe('Service image endpoint', async function () {
           delete this.res;
         });
 
-        it('rejects the user', async function () {
+        it('rejects the request', async function () {
           expect(this.res.status).to.equal(400);
         });
 
@@ -814,7 +814,7 @@ describe('Service image endpoint', async function () {
           delete this.res;
         });
 
-        it('rejects the user', async function () {
+        it('rejects the request', async function () {
           expect(this.res.status).to.equal(400);
         });
 
@@ -828,22 +828,20 @@ describe('Service image endpoint', async function () {
 
       describe('when get the service image tag update state', async function () {
         before(async function () {
-          hookRedirect('buzz');
-          this.res = await request(this.frontend).get('/service-image-tag/state').use(auth({ username: 'buzz' }));
+          hookRedirect('joe');
+          this.res = await request(this.frontend).get('/service-image-tag/state').use(auth({ username: 'joe' }));
         });
 
         after(function () {
           delete this.res;
         });
 
-        it('returns a status 200', async function () {
-          expect(this.res.status).to.equal(200);
+        it('rejects the request', async function () {
+          expect(this.res.status).to.equal(403);
         });
 
-        it('returns enabled true', async function () {
-          expect(this.res.body).to.eql({
-            'enabled': true,
-          });
+        it('returns a meaningful error message', async function () {
+          expect(this.res.text).to.equal('User joe is not in the service deployers or admin EDL groups');
         });
       });
 
@@ -857,7 +855,7 @@ describe('Service image endpoint', async function () {
           delete this.res;
         });
 
-        it('rejects the user', async function () {
+        it('rejects the request', async function () {
           expect(this.res.status).to.equal(403);
         });
 
@@ -876,7 +874,7 @@ describe('Service image endpoint', async function () {
           delete this.res;
         });
 
-        it('rejects the user', async function () {
+        it('rejects the request', async function () {
           expect(this.res.status).to.equal(403);
         });
 
@@ -920,7 +918,7 @@ describe('Service image endpoint', async function () {
           delete this.res;
         });
 
-        it('rejects the user', async function () {
+        it('rejects the request', async function () {
           expect(this.res.status).to.equal(403);
         });
 
@@ -939,7 +937,7 @@ describe('Service image endpoint', async function () {
           delete this.res;
         });
 
-        it('rejects the user', async function () {
+        it('rejects the request', async function () {
           expect(this.res.status).to.equal(403);
         });
 
@@ -1117,7 +1115,7 @@ describe('Service image endpoint', async function () {
                 delete this.res;
               });
 
-              it('rejects the user', async function () {
+              it('rejects the request', async function () {
                 expect(this.res.status).to.equal(403);
               });
 

--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -649,7 +649,7 @@ describe('Service image endpoint', async function () {
           expect(this.res.status).to.equal(200);
         });
 
-        it('returns the service image information', async function () {
+        it('returns enabled true', async function () {
           expect(this.res.body).to.eql({
             'enabled': true,
           });
@@ -747,7 +747,7 @@ describe('Service image endpoint', async function () {
           expect(this.res.status).to.equal(200);
         });
 
-        it('returns the service image information', async function () {
+        it('returns enabled true', async function () {
           expect(this.res.body).to.eql({
             'enabled': true,
           });
@@ -810,7 +810,7 @@ describe('Service image endpoint', async function () {
           expect(this.res.status).to.equal(200);
         });
 
-        it('returns the service image information', async function () {
+        it('returns enabled true', async function () {
           expect(this.res.body).to.eql({
             'enabled': true,
           });
@@ -1012,27 +1012,6 @@ describe('Service image endpoint', async function () {
             const noTimeout = await waitUntilStatusChange(deploymentId);
             expect(noTimeout).to.be.true;
           });
-
-          describe('when get the service image tag update state after a successful service deployment', async function () {
-            before(async function () {
-              hookRedirect('adam');
-              this.res = await request(this.frontend).get('/service-image-tag/state').use(auth({ username: 'adam' }));
-            });
-
-            after(function () {
-              delete this.res;
-            });
-
-            it('returns a status 200', async function () {
-              expect(this.res.status).to.equal(200);
-            });
-
-            it('returns the service image information', async function () {
-              expect(this.res.body).to.eql({
-                'enabled': true,
-              });
-            });
-          });
         });
       });
     });
@@ -1116,6 +1095,27 @@ describe('Service self-deployment successful', async function () {
         expect(tag).to.eql('foo');
         expect(status).to.eql('successful');
         expect(message).to.eql('Deployment successful');
+      });
+    });
+
+    describe('when get the service image tag update state after a successful service deployment', async function () {
+      before(async function () {
+        hookRedirect('joe');
+        this.res = await request(this.frontend).get('/service-image-tag/state').use(auth({ username: 'joe' }));
+      });
+
+      after(function () {
+        delete this.res;
+      });
+
+      it('returns a status 200', async function () {
+        expect(this.res.status).to.equal(200);
+      });
+
+      it('returns enabled true', async function () {
+        expect(this.res.body).to.eql({
+          'enabled': true,
+        });
       });
     });
 
@@ -1219,6 +1219,27 @@ describe('Service self-deployment failure', async function () {
         expect(tag).to.eql('foo');
         expect(status).to.eql('failed');
         expect(message).to.eql(`Failed service deployment for deploymentId: ${deploymentId}. Error: ${errorMessage}`);
+      });
+    });
+
+    describe('when get the service image tag update state after a failed service deployment', async function () {
+      before(async function () {
+        hookRedirect('adam');
+        this.res = await request(this.frontend).get('/service-image-tag/state').use(auth({ username: 'adam' }));
+      });
+
+      after(function () {
+        delete this.res;
+      });
+
+      it('returns a status 200', async function () {
+        expect(this.res.status).to.equal(200);
+      });
+
+      it('returns enabled false', async function () {
+        expect(this.res.body).to.eql({
+          'enabled': false,
+        });
       });
     });
   });

--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -913,8 +913,8 @@ describe('Service image endpoint', async function () {
             delete this.res;
           });
 
-          it('returns a status 503', async function () {
-            expect(this.res.status).to.equal(503);
+          it('returns a status 423', async function () {
+            expect(this.res.status).to.equal(423);
           });
 
           it('returns service deployment is disbabled error message', async function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1755

## Description
This PR is the harmony project portion of the ticket. It adds disabling of service deployment at the beginning of a service deployment and re-enable the service deployment when the service deployment is successful. 

## Local Test Steps
Run harmony locally, change the `command` in `execDeployScript` function to sleep 100 seconds.

```
// const command = `./bin/exec-deploy-service ${service} ${tag}`;
const command = 'sleep 100';
```
Then kick off a service deployment, the service deployment will run for 100 seconds and succeed.
Verify within the 100 seconds while the service deployment is running, any deployment of any service will fail with http status code `423` and message `Service deployment is disabled.`. 
Verify after 100 seconds, the first service deployment status changes from `running` to `successful` and service deployment of a service will be accepted with status code `202` and run successfully.

Note: 
1) More intensive contention on the service_deployment table is covered in unit tests and will not be attempted in integration test.
2) CI changes will be added to CI directly once this PR is merged.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)