### PR TITLE
HARMONY-1763: Lock macos version to 12 for github action

### DIFF
--- a/.github/workflows/harmony-in-a-box.yml
+++ b/.github/workflows/harmony-in-a-box.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   harmony-in-a-box:
 
-    runs-on: macos-latest
+    runs-on: macos-12
 
     strategy:
       matrix:

--- a/.github/workflows/harmony-in-a-box.yml
+++ b/.github/workflows/harmony-in-a-box.yml
@@ -4,7 +4,8 @@ on: [push]
 
 jobs:
   harmony-in-a-box:
-
+    # TODO this is locked to macos-12 to fix an issue with the gdal dependency
+    # We will go back to macos-latest in HARMONY-1765
     runs-on: macos-12
 
     strategy:


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1763

## Description
Fix for Harmony in a box test run in GitHub action

## Local Test Steps
Look at the status of the Harmony in a box test at the bottom of this page

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)