### PR TITLE
HARMONY-1766 - Handle numerical parameters in POST requests.

### DIFF
--- a/services/harmony/app/frontends/ogc-coverages/get-coverage-rangeset.ts
+++ b/services/harmony/app/frontends/ogc-coverages/get-coverage-rangeset.ts
@@ -2,7 +2,7 @@ import { NextFunction, Response } from 'express';
 import DataOperation from '../../models/data-operation';
 import HarmonyRequest from '../../models/harmony-request';
 import wrap from '../../util/array';
-import { handleCrs, handleExtend, handleFormat, handleGranuleIds, handleGranuleNames, handleScaleExtent, handleScaleSize } from '../../util/parameter-parsers';
+import { handleCrs, handleExtend, handleFormat, handleGranuleIds, handleGranuleNames, handleHeight, handleScaleExtent, handleScaleSize, handleWidth } from '../../util/parameter-parsers';
 import { createDecrypter, createEncrypter } from '../../util/crypto';
 import env from '../../util/env';
 import { RequestValidationError } from '../../util/errors';
@@ -39,10 +39,10 @@ export default function getCoverageRangeset(
   handleCrs(operation, query);
   handleScaleExtent(operation, query);
   handleScaleSize(operation, query);
+  handleHeight(operation, query);
+  handleWidth(operation, query);
 
   operation.interpolationMethod = query.interpolation;
-  operation.outputWidth = query.width;
-  operation.outputHeight = query.height;
   if (query.forceasync) {
     operation.isSynchronous = false;
   }

--- a/services/harmony/app/frontends/ogc-coverages/util/subset-parameter-parsing.ts
+++ b/services/harmony/app/frontends/ogc-coverages/util/subset-parameter-parsing.ts
@@ -166,7 +166,7 @@ export function parsePointParam(
   if (values !== undefined) {
     coordinates = values;
     if ( coordinates.length !== 2 )
-      throw new ParameterParseError(`should point 2 values in "point" but got "${values}" instead.`);
+      throw new ParameterParseError(`should have 2 values in "point" but received "${values}" instead.`);
 
     results = ['lon', 'lat'].map( (dimName, idx): number => {
       const dim = dimConfig[dimName];

--- a/services/harmony/app/util/parameter-parsers.ts
+++ b/services/harmony/app/util/parameter-parsers.ts
@@ -4,9 +4,30 @@
 
 import DataOperation from '../models/data-operation';
 import parseCRS from './crs';
-import { parseMultiValueParameter, parseNumber } from './parameter-parsing-helpers';
+import { ParameterParseError, parseMultiValueParameter, parseNumber } from './parameter-parsing-helpers';
 import HarmonyRequest from '../models/harmony-request';
 import { parseAcceptHeader } from './content-negotiation';
+import { RequestValidationError } from './errors';
+
+/**
+ * Helper function to convert parameter parsing errors into 400 errors for an end
+ * user that identifies the query parameter that was a problem and the message
+ * when failing to parse the parameter. If any other type of exception was thrown
+ * that exception is passed through unchanged.
+ *
+ * @param e - the exception that was thrown
+ * @param parameterName - the name of the query parameter that was being parsed
+ *
+ * @throws RequestValidationError if there was a specific parsing error message otherwise
+ * the original exception is thrown.
+ */
+function convertParameterParsingError(e: Error, parameterName: string): void {
+  if (e instanceof ParameterParseError) {
+    throw new RequestValidationError(`parsing query parameter '${parameterName}', value ${e.message}`);
+  } else {
+    throw (e);
+  }
+}
 
 /**
  * Handle the granuleName parameter in a Harmony query, adding it to the DataOperation
@@ -79,24 +100,22 @@ export function handleCrs(
  */
 export function handleScaleExtent(
   operation: DataOperation,
-  query: Record<string, number[]>): void;
-export function handleScaleExtent(
-  operation: DataOperation,
-  query: Record<string, string>): void;
-export function handleScaleExtent(
-  operation: DataOperation,
   query: Record<string, number[] | string>): void {
   if (query.scaleextent) {
-    if (typeof query.scaleextent === 'string') {
-      const scaleExtentString = query.scaleextent.replace('(', '').replace(')', '');
-      const [xMinString, yMinString, xMaxString, yMaxString] = scaleExtentString.split(/,\s*/);
-      operation.scaleExtent = {
-        x: { min: parseNumber(xMinString), max: parseNumber(xMaxString) },
-        y: { min: parseNumber(yMinString), max: parseNumber(yMaxString) },
-      };
-    } else {
-      const [xMin, yMin, xMax, yMax] = query.scaleextent;
-      operation.scaleExtent = { x: { min: xMin, max: xMax }, y: { min: yMin, max: yMax } };
+    try {
+      if (typeof query.scaleextent === 'string') {
+        const scaleExtentString = query.scaleextent.replace('(', '').replace(')', '');
+        const [xMinString, yMinString, xMaxString, yMaxString] = scaleExtentString.split(/,\s*/);
+        operation.scaleExtent = {
+          x: { min: parseNumber(xMinString), max: parseNumber(xMaxString) },
+          y: { min: parseNumber(yMinString), max: parseNumber(yMaxString) },
+        };
+      } else {
+        const [xMin, yMin, xMax, yMax] = query.scaleextent;
+        operation.scaleExtent = { x: { min: xMin, max: xMax }, y: { min: yMin, max: yMax } };
+      }
+    } catch (e) {
+      convertParameterParsingError(e, 'scaleExtent');
     }
   }
 }
@@ -110,21 +129,19 @@ export function handleScaleExtent(
  */
 export function handleScaleSize(
   operation: DataOperation,
-  query: Record<string, number[]>): void;
-export function handleScaleSize(
-  operation: DataOperation,
-  query: Record<string, string>): void;
-export function handleScaleSize(
-  operation: DataOperation,
   query: Record<string, number[] | string>): void {
   if (query.scalesize) {
-    if (typeof query.scalesize === 'string') {
-      const scaleSizeString: string = query.scalesize.replace('(', '').replace(')', '');
-      const [xString, yString] = scaleSizeString.split(/,\s*/);
-      operation.scaleSize = { x: parseNumber(xString), y: parseNumber(yString) };
-    } else {
-      const [x, y] = query.scalesize;
-      operation.scaleSize = { x, y };
+    try {
+      if (typeof query.scalesize === 'string') {
+        const scaleSizeString: string = query.scalesize.replace('(', '').replace(')', '');
+        const [xString, yString] = scaleSizeString.split(/,\s*/);
+        operation.scaleSize = { x: parseNumber(xString), y: parseNumber(yString) };
+      } else {
+        const [x, y] = query.scalesize;
+        operation.scaleSize = { x, y };
+      }
+    } catch (e) {
+      convertParameterParsingError(e, 'scaleSize');
     }
   }
 }
@@ -162,7 +179,11 @@ export function handleHeight(
   operation: DataOperation,
   query: Record<string, string>): void {
   if (query.height) {
-    operation.outputHeight = parseNumber(query.height);
+    try {
+      operation.outputHeight = parseNumber(query.height);
+    } catch (e) {
+      convertParameterParsingError(e, 'height');
+    }
   }
 }
 
@@ -178,6 +199,10 @@ export function handleWidth(
   operation: DataOperation,
   query: Record<string, string>): void {
   if (query.width) {
-    operation.outputWidth = parseNumber(query.width);
+    try {
+      operation.outputWidth = parseNumber(query.width);
+    } catch (e) {
+      convertParameterParsingError(e, 'width');
+    }
   }
 }

--- a/services/harmony/app/util/parameter-parsers.ts
+++ b/services/harmony/app/util/parameter-parsers.ts
@@ -105,11 +105,8 @@ export function handleScaleExtent(
     try {
       if (typeof query.scaleextent === 'string') {
         const scaleExtentString = query.scaleextent.replace('(', '').replace(')', '');
-        const [xMinString, yMinString, xMaxString, yMaxString] = scaleExtentString.split(/,\s*/);
-        operation.scaleExtent = {
-          x: { min: parseNumber(xMinString), max: parseNumber(xMaxString) },
-          y: { min: parseNumber(yMinString), max: parseNumber(yMaxString) },
-        };
+        const [xMin, yMin, xMax, yMax] = scaleExtentString.split(/,\s*/).map(parseNumber);
+        operation.scaleExtent = { x: { min: xMin, max: xMax }, y: { min: yMin, max: yMax } };
       } else {
         const [xMin, yMin, xMax, yMax] = query.scaleextent;
         operation.scaleExtent = { x: { min: xMin, max: xMax }, y: { min: yMin, max: yMax } };
@@ -134,8 +131,8 @@ export function handleScaleSize(
     try {
       if (typeof query.scalesize === 'string') {
         const scaleSizeString: string = query.scalesize.replace('(', '').replace(')', '');
-        const [xString, yString] = scaleSizeString.split(/,\s*/);
-        operation.scaleSize = { x: parseNumber(xString), y: parseNumber(yString) };
+        const [x, y] = scaleSizeString.split(/,\s*/).map(parseNumber);
+        operation.scaleSize = { x, y };
       } else {
         const [x, y] = query.scalesize;
         operation.scaleSize = { x, y };
@@ -173,7 +170,6 @@ export function handleFormat(
  *
  * @param operation - the DataOperation for the request
  * @param query - the query for the request
- * @param req - the request
  */
 export function handleHeight(
   operation: DataOperation,
@@ -193,7 +189,6 @@ export function handleHeight(
  *
  * @param operation - the DataOperation for the request
  * @param query - the query for the request
- * @param req - the request
  */
 export function handleWidth(
   operation: DataOperation,

--- a/services/harmony/app/util/parameter-parsers.ts
+++ b/services/harmony/app/util/parameter-parsers.ts
@@ -103,14 +103,14 @@ export function handleScaleExtent(
   query: Record<string, number[] | string>): void {
   if (query.scaleextent) {
     try {
+      let xMin, xMax, yMin, yMax;
       if (typeof query.scaleextent === 'string') {
         const scaleExtentString = query.scaleextent.replace('(', '').replace(')', '');
-        const [xMin, yMin, xMax, yMax] = scaleExtentString.split(/,\s*/).map(parseNumber);
-        operation.scaleExtent = { x: { min: xMin, max: xMax }, y: { min: yMin, max: yMax } };
+        [xMin, yMin, xMax, yMax] = scaleExtentString.split(/,\s*/).map(parseNumber);
       } else {
-        const [xMin, yMin, xMax, yMax] = query.scaleextent;
-        operation.scaleExtent = { x: { min: xMin, max: xMax }, y: { min: yMin, max: yMax } };
+        [xMin, yMin, xMax, yMax] = query.scaleextent;
       }
+      operation.scaleExtent = { x: { min: xMin, max: xMax }, y: { min: yMin, max: yMax } };
     } catch (e) {
       convertParameterParsingError(e, 'scaleExtent');
     }
@@ -129,14 +129,14 @@ export function handleScaleSize(
   query: Record<string, number[] | string>): void {
   if (query.scalesize) {
     try {
+      let x, y;
       if (typeof query.scalesize === 'string') {
         const scaleSizeString: string = query.scalesize.replace('(', '').replace(')', '');
-        const [x, y] = scaleSizeString.split(/,\s*/).map(parseNumber);
-        operation.scaleSize = { x, y };
+        [x, y] = scaleSizeString.split(/,\s*/).map(parseNumber);
       } else {
-        const [x, y] = query.scalesize;
-        operation.scaleSize = { x, y };
+        [x, y] = query.scalesize;
       }
+      operation.scaleSize = { x, y };
     } catch (e) {
       convertParameterParsingError(e, 'scaleSize');
     }

--- a/services/harmony/app/util/parameter-parsing-helpers.ts
+++ b/services/harmony/app/util/parameter-parsing-helpers.ts
@@ -23,6 +23,22 @@ export function parseBoolean(valueStr: string): boolean {
 }
 
 /**
+ * Helper function for parameters that parses and validates numerical values.
+ * If the input string is not numerical, a ParameterParseError is thrown.
+ *
+ * @param valueStr - the unparsed number as it appears in the input
+ * @returns the parsed result
+ * @throws ParameterParseError - if there are errors while parsing (e.g., a NaN)
+ */
+export function parseNumber(valueStr: string | number): number {
+  const parsedNumber = Number(valueStr);
+  if (isNaN(parsedNumber)) {
+    throw new ParameterParseError(`'${valueStr}' must be a number.`);
+  }
+  return parsedNumber;
+}
+
+/**
  * Returns the parameter as parsed as an array of comma-separated values if
  * it was a string, or just returns the array if it's already parsed
  * @param value - The parameter value to parse (either an array or a string)

--- a/services/harmony/test/ogc-api-coverages/subset-parameter-parsing.ts
+++ b/services/harmony/test/ogc-api-coverages/subset-parameter-parsing.ts
@@ -129,7 +129,7 @@ describe('OGC API Coverages - Utilities', function () {
       });
 
       it('throws a parse error when wrong number of point values are provided', function () {
-        expect(parsePointParamFn([-160.2, 80.2, 36.8])).to.throw(ParameterParseError, 'should point 2 values in "point" but got "-160.2,80.2,36.8" instead.');
+        expect(parsePointParamFn([-160.2, 80.2, 36.8])).to.throw(ParameterParseError, 'should have 2 values in "point" but received "-160.2,80.2,36.8" instead.');
       });
 
     });

--- a/services/harmony/test/util/parameter-parsing.ts
+++ b/services/harmony/test/util/parameter-parsing.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import { ParameterParseError, parseBoolean, parseMultiValueParameter } from '../../app/util/parameter-parsing-helpers';
+import { ParameterParseError, parseBoolean, parseMultiValueParameter, parseNumber } from '../../app/util/parameter-parsing-helpers';
 
 describe('util/parameter-parsing', function () {
   describe('#parseMultiValueParameter', function () {
@@ -61,6 +61,34 @@ describe('util/parameter-parsing', function () {
 
     it('throws a parse error for "truthy"', function () {
       expect(parseBooleanFn('truthy')).to.throw(ParameterParseError, '\'truthy\' must be \'false\' or \'true\'');
+    });
+  });
+
+  describe('#parseNumber', function () {
+
+    // Function that returns a function that calls parseNumber with the given value,
+    // necesssary for setting mocha expectations about exceptions.
+    // Copied from parseBolean tests.
+    const parseNumberFn = (value) => (): number => parseNumber(value);
+
+    it('returns 123 for "123"', function () {
+      expect(parseNumber('123')).to.equal(123);
+    });
+
+    it('returns 123 for 123', function () {
+      expect(parseNumber(123)).to.equal(123);
+    });
+
+    it('returns 123.45 for "123.45"', function () {
+      expect(parseNumber('123.45')).to.equal(123.45);
+    });
+
+    it('returns 123.45 for 123.45', function () {
+      expect(parseNumber(123.45)).to.equal(123.45);
+    });
+
+    it('throws a parse error for "abc"', function () {
+      expect(parseNumberFn('abc')).to.throw(ParameterParseError, '\'abc\' must be a number.');
     });
   });
 });


### PR DESCRIPTION
## Jira Issue ID

HARMONY-1766

## Description

Running `harmony-py~=0.4.12` I noticed that requests with `height`, `width`, `scale_size` or `scale_extent` were causing 500 errors. It looks like this is due to the new use of the POST method for requests in this version of the package onwards. Looking at Harmony itself, these parameters are either numbers or lists of numbers, but are being passed around as strings, which has cause schema validation errors within Harmony.

This PR might not be the best way to fix it (I'm kind of just wading in trying to make a fix), but maybe it's okay? Totally happy if there's a better way to fix the issue, and this PR gets throw away, though.

## Local Test Steps

* Build a local Docker image of the Harmony Regridding service (it's _almost_ in open-source land, but for now, [use this script](https://git.earthdata.nasa.gov/projects/SITC/repos/harmony-regridding-service/browse/bin/build-image)).
* Pull this branch.
* Add `harmony-regridder` to your `.env` under `LOCALLY_DEPLOYED_SERVICES`.
* Build and run a local Harmony instance from this branch.
* Create a new Python environment and run `pip install harmony-py` (you'll probably get v0.4.13, which is the latest, and affected by this issue).
* Run the following command:

```
from harmony import Collection, Environment, Client, Request


harmony_client = Client(env=Environment.LOCAL)

merra_request = Request(
    Collection(id='C1245662776-EEDTEST'),
    granule_id='G1245662793-EEDTEST',
    interpolation='Elliptical Weighted Averaging',
    scale_size=(2.5, 2.5),
    scale_extent=(-180, -90, 180, 90),
    crs='+proj=latlong +datum=WGS84 +no_defs',
    height=72,
    width=144
)                       
merra_job_id = harmony_client.submit(merra_request)
harmony_client.wait_for_processing(merra_job_id, show_progress=True) 
```

This request should successfully trigger a job.

To see the issue, you can run the same snippet of code, but against UAT:

```
harmony_client = Client(env=Environment.UAT)
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* ~~Documentation updated (if needed)~~