### PR TITLE
HARMONY-1751: Add browse stac assets based on UMM JSON RelatedURL subtype.

### DIFF
--- a/services/query-cmr/test/cmr-to-stac.ts
+++ b/services/query-cmr/test/cmr-to-stac.ts
@@ -92,6 +92,12 @@ describe('addCmrUmmGranules to catalog', function () {
             Description: 'OPeNDAP request URL (GET DATA : OPENDAP DATA)',
             MimeType: 'application/x-hdf',
           },
+          {
+            URL: 'https://archive.gesdisc.nasa.gov/Aqua_AIRS_Level3/AIR222P5.006/browse_source.zip',
+            Type: 'GET DATA',
+            Description: 'Download browse_source.zip',
+            Subtype: 'BROWSE IMAGE SOURCE',
+          },
           ],
         },
       },
@@ -175,6 +181,13 @@ describe('addCmrUmmGranules to catalog', function () {
         description: 'OPeNDAP request URL (GET DATA : OPENDAP DATA)',
         type: 'application/x-hdf',
         roles: ['data', 'opendap'],
+      });
+      expect(assets.browse).to.eql({
+        href: 'https://archive.gesdisc.nasa.gov/Aqua_AIRS_Level3/AIR222P5.006/browse_source.zip',
+        title: 'browse_source.zip',
+        description: 'Download browse_source.zip',
+        type: undefined,
+        roles: ['visual'],
       });
       expect(assets.data2).to.be.undefined;
     });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1751

## Description
Add browse stac assets based on UMM JSON RelatedURL subtype.

## Local Test Steps
Since there is no service provider test data in UAT right now, I created a testing collection in UAT for manual testing. Submit the following harmony request:
`http://localhost:3000/C1265140586-MMT_2/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-45%3A45)&subset=lon(0%3A180)&maxResults=1&skipPreview=true&ignoreErrors=true`

Then in the granule stac catalog which is created as output of the query-cmr step in `s3://local-artifact-bucket/<harmony-request-id>/<work-item-id>/outputs/`, verify there is a browse asset with the following content:

```
"browse": {
      "href": "https://archive.swot.podaac.earthdata.nasa.gov/podaac-swot-ops-cumulus-protected/SWOT_L2_HR_LakeSP_1.0/SWOT_L2_HR_LakeSP_Unassigned_407_008_SI_20230121T143155_20230121T143229_PIA0_01.zip",
      "title": "SWOT_L2_HR_LakeSP_Unassigned_407_008_SI_20230121T143155_20230121T143229_PIA0_01.zip",
      "description": "Download SWOT_L2_HR_LakeSP_Unassigned_407_008_SI_20230121T143155_20230121T143229_PIA0_01.zip",
      "roles": [
        "visual"
      ]
    }
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)