### PR TITLE
HARMONY-1787: Force queryVars to an array before validating and

### DIFF
--- a/services/harmony/app/util/aggregation-batch.ts
+++ b/services/harmony/app/util/aggregation-batch.ts
@@ -113,7 +113,7 @@ Promise<number[]> {
       outputItemSizes = outputItemSizes.concat(sizes);
     }
   }
-  return outputItemSizes;
+  return outputItemSizes.map(Math.floor);
 }
 
 /**

--- a/services/harmony/app/util/parameter-parsing-helpers.ts
+++ b/services/harmony/app/util/parameter-parsing-helpers.ts
@@ -40,10 +40,14 @@ export function parseNumber(valueStr: string | number): number {
 
 /**
  * Returns the parameter as parsed as an array of comma-separated values if
- * it was a string, or just returns the array if it's already parsed
+ * it was a string, or just returns the array if it's already parsed. Returns
+ * an empty array if the parameter is null.
  * @param value - The parameter value to parse (either an array or a string)
  */
 export function parseMultiValueParameter(value: string[] | string): string[] {
+  if (value === null) {
+    return [];
+  }
   if (value instanceof Array) {
     return value;
   }

--- a/services/harmony/app/util/variables.ts
+++ b/services/harmony/app/util/variables.ts
@@ -105,22 +105,21 @@ export function getCoordinateVariables(variables: CmrUmmVariable[]): CmrUmmVaria
  * @param queryVars - The variables in query params
  */
 export function validateVariables(variableIds: string[], queryVars: string | string[]): void {
+  queryVars = parseMultiValueParameter(queryVars);
   if (variableIds.indexOf('all') !== -1 && variableIds.length !== 1) {
     throw new RequestValidationError('"all" cannot be specified alongside other variables');
   }
 
   if (variableIds.indexOf('parameter_vars') !== -1) {
-    if (!queryVars) {
+    if (!queryVars || queryVars.length < 1) {
       throw new RequestValidationError('"parameter_vars" specified, but no variables given');
     }
-    if (queryVars !== 'all' &&
-      queryVars.indexOf('all') !== -1 &&
-      queryVars.length !== 1) {
+    if (queryVars.indexOf('all') !== -1 && queryVars.length !== 1) {
       throw new RequestValidationError('"all" cannot be specified alongside other variables');
     }
   } else {
     // can't specify vars in the query AND in the path
-    if (queryVars) {
+    if (queryVars.length > 0) {
       throw new RequestValidationError('Value "parameter_vars" must be used in the url path when variables are passed in the query parameters or request body');
     }
   }
@@ -132,6 +131,8 @@ export function validateVariables(variableIds: string[], queryVars: string | str
  *
  * @param eosdisCollections - An array of collections
  * @param collectionIdParam - The OGC collectionId query parameter
+ * @param queryVars - A string of comma separated variable names or an array of variable names
+ * - taken from the request object via the `variable` parameter
  * @returns an array of objects with a collectionId and list
  *   of variables e.g. `[{ collectionId: C123-PROV1, variables: [<Variable object>] }]`
  * @throws RequestValidationError - if the requested OGC collection ID parameter is not valid

--- a/services/harmony/test/util/variables.ts
+++ b/services/harmony/test/util/variables.ts
@@ -50,4 +50,19 @@ describe('validateVariables', function () {
     expect(() => validateVariables(variableIds, null)).not.to.throw(RequestValidationError);
   });
 
+  describe('when variables have the word "all" in their names', function () {
+    describe('and the queryVars are passed as an array', function () {
+      const variableIds = ['parameter_vars'];
+      it('should not throw an error', function () {
+        expect(() => validateVariables(variableIds, ['var1', 'var_all_2'])).not.to.throw(RequestValidationError);
+      });
+    });
+    describe('and the queryVars are passed as a string', function () {
+      const variableIds = ['parameter_vars'];
+      it('should not throw an error', function () {
+        expect(() => validateVariables(variableIds, 'var_all_1,var2')).not.to.throw(RequestValidationError);
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
fix bug in parsing item size as an int

## Jira Issue ID
HARMONY-1787

## Description
Fixes a bug in the way we validate variables that was triggered when using a POST for the query with variables that have 'all' in their names.

## Local Test Steps
I don't know of a collection that has 'all' in the variable names outside of production, so it is hard to do a full end-to-end test for this. There is a new unit test that passes queryVars as a string containing a variable with `all` in the name. This test fails without the changes to the variable validation code, as expected.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)