### PR TITLE
HARMONY-1787: Increase size of allowed JSON body on back-end

### DIFF
--- a/services/harmony/app/routers/backend-router.ts
+++ b/services/harmony/app/routers/backend-router.ts
@@ -1,5 +1,6 @@
 import { Router, json } from 'express';
 import asyncHandler from 'express-async-handler';
+import env from '../util/env';
 import handleCallbackMessage from '../backends/deployment-callback';
 import { getWork, updateWorkItem } from '../backends/workflow-orchestration/workflow-orchestration';
 import { responseHandler } from '../backends/service-response';
@@ -16,7 +17,7 @@ export default function router(): Router {
   const result = Router();
   result.use(json({
     type: 'application/json',
-    limit: '500kb',
+    limit: env.maxHarmonyBackEndJsonSize,
   }));
   result.post('/:requestId/response', asyncHandler(responseHandler));
   result.get('/work', asyncHandler(getWork));

--- a/services/harmony/app/util/env.ts
+++ b/services/harmony/app/util/env.ts
@@ -1,5 +1,5 @@
-import { IsInt, IsNotEmpty, Min } from 'class-validator';
-import { HarmonyEnv } from '@harmony/util/env';
+import { IsInt, IsNotEmpty, Matches, Min } from 'class-validator';
+import { HarmonyEnv, memorySizeRegex } from '@harmony/util/env';
 import _ from 'lodash';
 import * as path from 'path';
 
@@ -100,6 +100,9 @@ class HarmonyServerEnv extends HarmonyEnv {
   @IsInt()
   @Min(1)
   maxPostFileSize: number;
+
+  @Matches(memorySizeRegex)
+  maxHarmonyBackEndJsonSize: string;
 
   @IsInt()
   @Min(1)

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -74,6 +74,9 @@ PREVIEW_THRESHOLD=100
 # The maximum number of errors to allow for a job before considering it failed
 MAX_ERRORS_FOR_JOB=2000
 
+# max JSON payload that can be sent to the harmony back end via express. Should take the form of '100mb', etc.
+MAX_HARMONY_BACK_END_JSON_SIZE=400mb
+
 # A bucket with brief lifecycle where temporary uploads (shapefiles) are stored while
 # requests are in flight
 UPLOAD_BUCKET=local-upload-bucket


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1787

## Description
This is a fix for a problem we are having with work-item updates being too large for the express server on the back-end.

## Local Test Steps
Run a many (4000+) variable query and observe that the query-cmr step completes successfully.
NOTE: There is a known issue with trajectory-subsetter that will keep it from running correctly with many variables.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)