### PR TITLE
HARMONY-1787: Remove variables from operation before sending work-item update

### DIFF
--- a/services/service-runner/app/workers/pull-worker.ts
+++ b/services/service-runner/app/workers/pull-worker.ts
@@ -222,6 +222,12 @@ async function _pullAndDoWork(repeat = true): Promise<void> {
       workItem.duration = Date.now() - startTime;
       // call back to Harmony to mark the work unit as complete or failed
       workItemLogger.debug(`Sending response to Harmony for results of work item with id ${workItem.id} for job id ${workItem.jobID}`);
+
+      // don't need to send variables back
+      for (const source of workItem.operation.sources) {
+        source.variables = [];
+      }
+
       try {
         await axiosUpdateWork.put(`${workUrl}/${workItem.id}`, workItem);
       } catch (e) {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1787

## Description
Removes variables from operation before sending work-item update to save memory

## Local Test Steps
Run some queries to make sure nothing has changed

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)