### PR TITLE
LAADS subset-band-name Service Multiple Band Support

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -559,6 +559,7 @@ https://cmr.uat.earthdata.nasa.gov:
          - application/x-hdf
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${SUBSET_BAND_NAME_IMAGE}
 
   - name: gesdisc/giovanni

--- a/config/services.yml
+++ b/config/services.yml
@@ -554,7 +554,7 @@ https://cmr.uat.earthdata.nasa.gov:
     capabilities:
        subsetting:
          variable: true
-         multiple_variable: false
+         multiple_variable: true
        output_formats:
          - application/x-hdf
     steps:


### PR DESCRIPTION
## Jira Issue ID
LDDS-199

## Description
Added support for multiple band names.

## Local Test Steps

### Setup Environment
```
$ clone this repo: https://git.earthdata.nasa.gov/projects/LDDS/repos/laads-subset_band_name-service/browse
$ conda create --name subset_band_name python=3.9 --channel conda-forge --channel defaults
$ conda activate subset_band_name
$ pip install -r ./harmony_python_interface/pip_requirements.txt
$ pip install -r ./docs/pip_requirements.txt
$ cd docs
$ jupyter notebook
```

* Open `Test_Harmony_Integration.ipynb`
* Run the `Single Granule Test` cells.
* The final Output should say

```
{'Latitude': (('10*nscans:MODIS_SWATH_Type_L1B',
               'Max_EV_frames:MODIS_SWATH_Type_L1B'),
              (-301531136, 1241841664),
              5,
              0),
 'Longitude': (('10*nscans:MODIS_SWATH_Type_L1B',
                'Max_EV_frames:MODIS_SWATH_Type_L1B'),
               (-301531136, 1241841664),
               5,
               1),
 'EV_500_RefSB': (('Band_500M:MODIS_SWATH_Type_L1B',
                   '20*nscans:MODIS_SWATH_Type_L1B',
                   '2*Max_EV_frames:MODIS_SWATH_Type_L1B'),
                  (83886080, -602996736, -1811283968),
                  23,
                  2)}
```

## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)