### PR TITLE
HARMONY-1772: As a harmony service provider, I want to know the reason service deployments are disabled when I am unable to deploy

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -9,7 +9,7 @@
     "notes": "Will fix in HARMONY-1688",
     "expiry": "2024-08-01"
   },
-  "1096643": {
+  "1097682": {
     "active": true,
     "notes": "Will fix in HARMONY-1650",
     "expiry": "2024-08-01"

--- a/db/db.sql
+++ b/db/db.sql
@@ -127,10 +127,11 @@ CREATE TABLE `user_work` (
 
 CREATE TABLE `service_deployment` (
   `enabled` boolean,
+  `message` varchar(4096),
   `updatedAt` datetime not null
 );
 
-INSERT INTO service_deployment (enabled, updatedAt) VALUES (true, CURRENT_TIMESTAMP);
+INSERT INTO service_deployment (enabled, message, updatedAt) VALUES (true, '', CURRENT_TIMESTAMP);
 
 CREATE TABLE `service_deployments` (
   `id` integer not null primary key autoincrement,

--- a/db/migrations/20240529202226_add_provider_ids.js
+++ b/db/migrations/20240529202226_add_provider_ids.js
@@ -1,15 +1,14 @@
 exports.up = function up(knex) {
-    return knex.schema
-      .alterTable('jobs', (t) => {
-        t.specificType('provider_ids', 'text ARRAY').index('jobs_provider_ids_index', 'GIN');
-      });
-  };
-  
-  exports.down = function down(knex) {
-    return knex.schema
-      .alterTable('jobs', (t) => {
-        t.dropIndex('provider_ids');
-        t.dropColumn('provider_ids');
-      });
-  };
-  
+  return knex.schema
+    .alterTable('jobs', (t) => {
+      t.specificType('provider_ids', 'text ARRAY').index('jobs_provider_ids_index', 'GIN');
+    });
+};
+
+exports.down = function down(knex) {
+  return knex.schema
+    .alterTable('jobs', (t) => {
+      t.dropIndex('provider_ids');
+      t.dropColumn('provider_ids');
+    });
+};

--- a/db/migrations/20240619202027_add_message_to_service_deployment.js
+++ b/db/migrations/20240619202027_add_message_to_service_deployment.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.alterTable('service_deployment', (t) => {
+    t.string('message', 4096);
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.alterTable('service_deployment', (t) => {
+    t.dropColumn('message');
+  });
+};

--- a/docs/guides/managing-existing-services.md
+++ b/docs/guides/managing-existing-services.md
@@ -133,23 +133,24 @@ GET https://harmony.uat.earthdata.nasa.gov/service-deployments-state
 ```
 **Example 10** - Getting the current enable/disable state of the service deployment feature using the `service-image-tag` API
 
-The returned JSON response shows if the service deployment is currently enabled (true) or disabled (false):
+The returned JSON response shows if the service deployment is currently enabled (true) or disabled (false) and any optional message:
 
 ```JSON
 {
-  "enabled": true
+  "enabled": true,
+  "message": "Manually enabled by David"
 }
 ```
 ---
 **Example 11** - Harmony `service-image-tags` response for enable/disable state
 
 ## Enable the service deployment feature
-The user must have admin permission in order to invoke this endpoint.
+The user must have admin permission in order to invoke this endpoint. User can provide an optional message in the JSON body to indicate the reason for enabling. This message will be persisted in database and returned when user retrieves the service deployment state later.
 
 For example:
 
 ```
-curl -XPUT -H 'Authorization: Bearer <your bearer token>' -H 'Content-type: application/json' https://harmony.uat.earthdata.nasa.gov/service-deployments-state -d '{"enabled": true}'
+curl -XPUT -H 'Authorization: Bearer <your bearer token>' -H 'Content-type: application/json' https://harmony.uat.earthdata.nasa.gov/service-deployments-state -d '{"enabled": true, "message": "Manually enabled by David"}'
 ```
 ---
 **Example 12** - Harmony `service-image-tags` request for enabling the service deployment
@@ -158,18 +159,19 @@ The returned JSON response is the same as the get current state of the service d
 
 ```JSON
 {
-  "enabled": true
+  "enabled": true,
+  "message": "Manually enabled by David"
 }
 ```
 **Example 13** - Harmony `/service-image-tags` response for enabling the service deployment
 
 ## Disable the service deployment feature
-The user must have admin permission in order to invoke this endpoint.
+The user must have admin permission in order to invoke this endpoint. User can provide an optional message in the JSON body to indicate the reason for disabling. This message will be persisted in database and returned when user retrieves the service deployment state later.
 
 For example:
 
 ```
-curl -XPUT -H 'Authorization: Bearer <your bearer token>' -H 'Content-type: application/json' https://harmony.uat.earthdata.nasa.gov/service-deployments-state -d '{"enabled": false}'
+curl -XPUT -H 'Authorization: Bearer <your bearer token>' -H 'Content-type: application/json' https://harmony.uat.earthdata.nasa.gov/service-deployments-state -d '{"enabled": false, "message": "Manually disabled by David"}'
 ```
 ---
 **Example 14** - Harmony `service-image-tags` request for disabling the service deployment
@@ -178,7 +180,8 @@ The returned JSON response is the same as the get current state of the service d
 
 ```JSON
 {
-  "enabled": false
+  "enabled": false,
+  "message": "Manually disabled by David"
 }
 ```
 **Example 15** - Harmony `/service-image-tags` response for disabling the service deployment

--- a/services/harmony/.nsprc
+++ b/services/harmony/.nsprc
@@ -1,5 +1,5 @@
 {
-  "1096643": {
+  "1097682": {
     "active": true,
     "notes": "Will fix in HARMONY-1650",
     "expiry": "2024-08-01"

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -5,6 +5,7 @@ import { getEdlGroupInformation, validateUserIsInCoreGroup } from '../util/edl-a
 import { exec } from 'child_process';
 import * as path from 'path';
 import util from 'util';
+import { truncateString } from '@harmony/util/string';
 import db from '../util/db';
 import env from '../util/env';
 import { getRequestRoot } from '../util/url';
@@ -65,7 +66,7 @@ export function ecrImageNameToComponents(name: string): EcrImageNameComponents {
   const match = name.match(componentRegex);
   if (!match) return null;
 
-  const [ _, host, region, repository, tag ] = match;
+  const [_, host, region, repository, tag] = match;
   const registryId = host.split('.')[0]; // the AWS account ID
 
   return {
@@ -155,7 +156,8 @@ async function getEnabledAndMessage(): Promise<{ enabled: boolean, message: stri
  */
 export async function enableServiceDeployment(message: string): Promise<void> {
   await db.transaction(async (tx) => {
-    await tx('service_deployment').update({ enabled: true, message: message });
+    await tx('service_deployment')
+      .update({ enabled: true, message: truncateString(message, 4096) });
   });
 }
 
@@ -345,7 +347,7 @@ async function validateStatusForListServiceRequest(
 async function validateDeploymentState(
   req: HarmonyRequest, res: Response,
 ): Promise<boolean> {
-  if ( (!req.body || req.body.enabled === undefined)) {
+  if ((!req.body || req.body.enabled === undefined)) {
     res.statusCode = 400;
     res.send('\'enabled\' is a required body parameter');
     return false;

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -132,7 +132,6 @@ async function validateTaggedImageIsReachable(
 
 /**
  * Returns the values of the enabled and message fields of the service_deployment table.
- * @param tx - The database transaction
  * @returns An object containing the boolean value of the enabled field and the message string
  */
 async function getEnabledAndMessage(): Promise<{ enabled: boolean, message: string }> {
@@ -183,8 +182,8 @@ async function acquireServiceDeploymentLock(message: string): Promise<boolean> {
 
 /**
  * Validate that the service deployment is enabled
- * @param res - The response object - will be used to send an error if the validation fails
- * @param url - The URL of the image including tag
+ * @param req - The request object
+ * @param res  - The response object - will be used to send an error if the validation fails
  * @returns A Promise containing `true` if the tagged image is reachable, `false` otherwise
  */
 async function validateServiceDeploymentIsEnabled(

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -130,29 +130,32 @@ async function validateTaggedImageIsReachable(
 }
 
 /**
- * Returns value of the enabled field of service_deployment table.
+ * Returns the values of the enabled and message fields of the service_deployment table.
  * @param tx - The database transaction
- * @returns The boolean value of the enabled field
+ * @returns An object containing the boolean value of the enabled field and the message string
  */
-async function getEnabled(): Promise<boolean> {
+async function getEnabledAndMessage(): Promise<{ enabled: boolean, message: string }> {
   let enabled = true;
+  let message = '';
   let results = null;
   await db.transaction(async (tx) => {
-    results = await tx('service_deployment').select('enabled');
+    results = await tx('service_deployment').select('enabled', 'message');
   });
 
   if (results[0].enabled === 0 || results[0].enabled === false) {
     enabled = false;
   }
-  return enabled;
+  [{ message }] = results;
+
+  return { enabled, message };
 }
 
 /**
  * Set the enabled to true in service_deployment table
  */
-export async function enableServiceDeployment(): Promise<void> {
+export async function enableServiceDeployment(message: string): Promise<void> {
   await db.transaction(async (tx) => {
-    await tx('service_deployment').update({ enabled: true });
+    await tx('service_deployment').update({ enabled: true, message: message });
   });
 }
 
@@ -161,12 +164,12 @@ export async function enableServiceDeployment(): Promise<void> {
  * If the enabled value is already false, return false to indicate unable to acquire the lock.
  * @returns a Promise of boolean to indicate if the lock is successfully acquired.
  */
-async function acquireServiceDeploymentLock(): Promise<boolean> {
+async function acquireServiceDeploymentLock(message: string): Promise<boolean> {
   let results = null;
   await db.transaction(async (tx) => {
     results = await tx('service_deployment')
       .where('enabled', true)
-      .update({ enabled: false })
+      .update({ enabled: false, message: message })
       .returning('enabled');
   });
 
@@ -186,10 +189,10 @@ async function validateServiceDeploymentIsEnabled(
   req: HarmonyRequest,
   res: Response,
 ): Promise<boolean> {
-  const enabled = await getEnabled();
+  const { enabled, message } = await getEnabledAndMessage();
   if (!enabled) {
     res.statusCode = 423;
-    res.send('Service deployment is disabled.');
+    res.send(`Service deployment is disabled. Reason: ${message}.`);
     return false;
   }
 
@@ -440,7 +443,7 @@ export async function execDeployScript(
         req.context.logger.info(`Script output: ${line}`);
       });
       // only re-enable the service deployment on successful deployment
-      await enableServiceDeployment();
+      await enableServiceDeployment(`Re-enable service deployment after successful deployment: ${deploymentId}`);
       await db.transaction(async (tx) => {
         await setStatusMessage(tx, deploymentId, 'successful', 'Deployment successful');
       });
@@ -472,18 +475,20 @@ export async function updateServiceImageTag(
     if (! await validation(req, res)) return;
   }
 
-  const lockAcquired = await acquireServiceDeploymentLock();
+  const urlRoot = getRequestRoot(req);
+  const deploymentId = uuid();
+  const message = `Locked for service deployment: ${urlRoot}/service-deployment/${deploymentId}`;
+  const lockAcquired = await acquireServiceDeploymentLock(message);
   if (lockAcquired === false) {
     res.statusCode = 423;
-    const msg = 'Another harmony deployment or service deployment is currently running. '
-      + 'Please try again later. If you believe this is an error, please contact Harmony support.';
+    const result = await getEnabledAndMessage();
+    const msg = `Unable to acquire service deployment lock. Reason: ${result.message}. Try again later.`;
     res.send(msg);
     return;
   }
 
   const { service } = req.params;
   const { tag } = req.body;
-  const deploymentId = uuid();
 
   const deployment = new ServiceDeployment({
     deployment_id: deploymentId,
@@ -499,7 +504,6 @@ export async function updateServiceImageTag(
   });
 
   module.exports.execDeployScript(req, service, tag, deploymentId);
-  const urlRoot = getRequestRoot(req);
   res.statusCode = 202;
   res.send({
     'tag': tag,
@@ -518,9 +522,9 @@ export async function getServiceImageTagState(
 ): Promise<void> {
   if (! await validateUserIsInDeployerOrCoreGroup(req, res)) return;
 
-  const enabled = await getEnabled();
+  const { enabled, message } = await getEnabledAndMessage();
   res.statusCode = 200;
-  res.send({ 'enabled': enabled });
+  res.send({ 'enabled': enabled, 'message': message });
 }
 
 /**
@@ -540,21 +544,25 @@ export async function setServiceImageTagState(
     if (! await validation(req, res)) return;
   }
 
-  const { enabled } = req.body;
+  const { enabled, message } = req.body;
+  let deploymentMsg = '';
   if (enabled === true) {
-    await enableServiceDeployment();
+    deploymentMsg = message ? message : `Manually enabled by ${req.user}`;
+    await enableServiceDeployment(deploymentMsg);
   } else {
     // disable service deployment
-    const lockAcquired = await acquireServiceDeploymentLock();
+    deploymentMsg = message ? message : `Manually disabled by ${req.user}`;
+    const lockAcquired = await acquireServiceDeploymentLock(deploymentMsg);
     if (lockAcquired === false) {
+      const result = await getEnabledAndMessage();
       res.statusCode = 423;
-      res.send('Unable to acquire service deployment lock. Try again later.');
+      res.send(`Unable to acquire service deployment lock. Reason: ${result.message}. Try again later.`);
       return;
     }
   }
 
   res.statusCode = 200;
-  res.send({ 'enabled': enabled });
+  res.send({ 'enabled': enabled, message: deploymentMsg });
 }
 
 /**

--- a/services/harmony/app/middleware/error-handler.ts
+++ b/services/harmony/app/middleware/error-handler.ts
@@ -9,7 +9,7 @@ import {
 import HarmonyRequest from '../models/harmony-request';
 
 const errorTemplate = fs.readFileSync(path.join(__dirname, '../views/server-error.mustache.html'), { encoding: 'utf8' });
-const jsonErrorRoutesRegex = /jobs|capabilities|ogc-api-coverages|stac|metrics|health|configuration|workflow-ui|service-image\/.*\/(?:links|logs|retry)/;
+const jsonErrorRoutesRegex = /jobs|capabilities|ogc-api-coverages|ogc-api-edr|service-deployment(?:s-state)?|stac|metrics|health|configuration|workflow-ui|service-image\/.*\/(?:links|logs|retry)/;
 
 /**
  * Returns true if the provided error should be returned as JSON.

--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -651,6 +651,7 @@ describe('Service image endpoint', async function () {
         it('returns enabled true', async function () {
           expect(this.res.body).to.eql({
             'enabled': true,
+            'message': `Re-enable service deployment after successful deployment: ${deploymentId}`,
           });
         });
       });
@@ -721,16 +722,13 @@ describe('Service image endpoint', async function () {
         });
 
         it('returns the service image enabled true', async function () {
-          expect(this.res.body).to.eql({
-            'enabled': true,
-          });
+          expect(this.res.body.enabled).to.eql(true);
         });
       });
     });
   });
 
   describe('Get service deployment enabled state permission test', async function () {
-    const expectedState = { enabled: true };
     describe('when a user is not in the EDL service deployers or core permissions groups', async function () {
       before(async function () {
         hookRedirect('joe');
@@ -762,7 +760,7 @@ describe('Service image endpoint', async function () {
 
       it('returns the expected result', async function () {
         expect(this.res.status).to.equal(200);
-        expect(this.res.body).to.eql(expectedState);
+        expect(this.res.body.enabled).to.eql(true);
       });
     });
 
@@ -778,7 +776,7 @@ describe('Service image endpoint', async function () {
 
       it('returns the expected result', async function () {
         expect(this.res.status).to.equal(200);
-        expect(this.res.body).to.eql(expectedState);
+        expect(this.res.body.enabled).to.eql(true);
       });
     });
   });
@@ -902,9 +900,7 @@ describe('Service image endpoint', async function () {
         });
 
         it('returns enabled true', async function () {
-          expect(this.res.body).to.eql({
-            'enabled': true,
-          });
+          expect(this.res.body.enabled).to.eql(true);
         });
       });
 
@@ -965,9 +961,7 @@ describe('Service image endpoint', async function () {
         });
 
         it('returns the service enabled true', async function () {
-          expect(this.res.body).to.eql({
-            'enabled': true,
-          });
+          expect(this.res.body.enabled).to.eql(true);
         });
       });
 
@@ -988,6 +982,7 @@ describe('Service image endpoint', async function () {
         it('returns enabled false', async function () {
           expect(this.res.body).to.eql({
             'enabled': false,
+            'message': 'Manually disabled by coraline',
           });
         });
 
@@ -1009,7 +1004,7 @@ describe('Service image endpoint', async function () {
           });
 
           it('returns service deployment is disbabled error message', async function () {
-            expect(this.res.text).to.eql('Service deployment is disabled.');
+            expect(this.res.text).to.eql('Service deployment is disabled. Reason: Manually disabled by coraline.');
           });
         });
 
@@ -1028,7 +1023,7 @@ describe('Service image endpoint', async function () {
           });
 
           it('returns the proper error message', async function () {
-            expect(this.res.text).to.eql('Unable to acquire service deployment lock. Try again later.');
+            expect(this.res.text).to.eql('Unable to acquire service deployment lock. Reason: Manually disabled by coraline. Try again later.');
           });
         });
       });
@@ -1048,9 +1043,7 @@ describe('Service image endpoint', async function () {
         });
 
         it('returns enabled true', async function () {
-          expect(this.res.body).to.eql({
-            'enabled': true,
-          });
+          expect(this.res.body.enabled).to.eql(true);
         });
 
         describe('when deploy service when service deployment is enabled', async function () {
@@ -1274,9 +1267,7 @@ describe('Service self-deployment successful', async function () {
       });
 
       it('returns enabled true', async function () {
-        expect(this.res.body).to.eql({
-          'enabled': true,
-        });
+        expect(this.res.body.enabled).to.eql(true);
       });
     });
 
@@ -1332,7 +1323,7 @@ describe('Service self-deployment failure', async function () {
     after(async function () {
       execStub.restore();
       execDeployScriptStub.restore();
-      await enableServiceDeployment();
+      await enableServiceDeployment('');
       delete this.res;
     });
 
@@ -1399,6 +1390,7 @@ describe('Service self-deployment failure', async function () {
       it('returns enabled false', async function () {
         expect(this.res.body).to.eql({
           'enabled': false,
+          'message': `Locked for service deployment: http://127.0.0.1:4000/service-deployment/${linkDeploymentId}`,
         });
       });
     });

--- a/services/service-runner/.nsprc
+++ b/services/service-runner/.nsprc
@@ -1,5 +1,5 @@
 {
-  "1096643": {
+  "1097682": {
     "active": true,
     "notes": "Will fix in HARMONY-1650",
     "expiry": "2024-08-01"

--- a/services/work-scheduler/.nsprc
+++ b/services/work-scheduler/.nsprc
@@ -1,5 +1,5 @@
 {
-  "1096643": {
+  "1097682": {
     "active": true,
     "notes": "Will fix in HARMONY-1650",
     "expiry": "2024-08-01"


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1772

## Description
As a harmony service provider, I want to know the reason service deployments are disabled when I am unable to deploy

## Local Test Steps
Manually change the `execDeployScript` command in service-image-tags.ts to something like a `sleep 30` that can be executed locally, e.g.
```
// const command = `./bin/exec-deploy-service ${service} ${tag}`;
const command = 'sleep 30';
```

Then, try to enable/disable service deployment state with and without an optional message field and verify when getting the service deployment state, the result reflect the correct state and message used in the enable/disable call.

See below for a couple of the example requests:
```
curl -H "Authorization: Bearer <token>" http://localhost:3000/service-deployments-state

curl -i -XPUT -H "Authorization: Bearer <token>" -H 'Content-type: application/json' http://localhost:3000/service-deployments-state -d '{"enabled": true, "message": "some custom message"}'
```

Then, run something similar to the following simulating common enable/disable and self deployment scenarios:

### Manually disable service deployment
curl -i -XPUT -H "Authorization: Bearer <token>" -H 'Content-type: application/json' http://localhost:3000/service-deployments-state -d '{"enabled": false, "message": "Disable for local testing"}'

### Try to deploy a service, and verify the deployment failed with status code 423 and message indicating service deployment is locked for local testing.
`Service deployment is disabled. Reason: Disable for local testing.`

### Manually enable service deployment
curl -i -XPUT -H "Authorization: Bearer <token>" -H 'Content-type: application/json' http://localhost:3000/service-deployments-state -d '{"enabled": true}'

### Deploy a service with a specified tag
curl -i -XPUT -H "Authorization: Bearer <token>" -H 'Content-type: application/json' http://localhost:3000/service-image-tag/harmony-service-example -d '{"tag": "latest"}'

### Get service-deployments-state, it should show service deployment is disabled and the message indicating it is locked for service deployment with a link to the service deployment status url. e.g.
{"enabled":false,"message":"Locked for service deployment: http://localhost:3000/service-deployment/e791620b-c676-4163-84fe-f225ca14d355"}

### After the sleep time expires, get the service-deployments-state again, it should show the service-deployments-state is enabled. e.g.
{"enabled":true,"message":"Re-enable service deployment after successful deployment: e791620b-c676-4163-84fe-f225ca14d355"}

And there is a lot of other scenarios that you can test with.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)