### PR TITLE
HARMONY-1806: Update error logging when handling STAC parsing exception.

### DIFF
--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -564,13 +564,14 @@ export async function preprocessWorkItem(
     durationMs = new Date().getTime() - resultStartTime;
     logger.debug('timing.HWIUWJI.getResultItemSize.end', { durationMs });
   } catch (e) {
-    errorMessage = 'Could not get result item file size from output STAC';
+    if (catalogItems) {
+      errorMessage = 'Cannot get result item file size from output STAC';
+    } else {
+      errorMessage = 'Cannot parse STAC catalog output from service';
+    }
+
     logger.error(errorMessage);
-    logger.error('Caught exception:', {
-      message: e.message,
-      name: e.name,
-      stack: e.stack,
-    });
+    logger.error(`Caught exception: ${e.message}`, { name: e.name, stack: e.stack });
     status = WorkItemStatus.FAILED;
   }
   const result: WorkItemPreprocessInfo = {

--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -564,9 +564,13 @@ export async function preprocessWorkItem(
     durationMs = new Date().getTime() - resultStartTime;
     logger.debug('timing.HWIUWJI.getResultItemSize.end', { durationMs });
   } catch (e) {
-    errorMessage = 'Could not get result item file size';
+    errorMessage = 'Could not get result item file size from output STAC';
     logger.error(errorMessage);
-    logger.error(e);
+    logger.error('Caught exception:', {
+      message: e.message,
+      name: e.name,
+      stack: e.stack,
+    });
     status = WorkItemStatus.FAILED;
   }
   const result: WorkItemPreprocessInfo = {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1806

## Description
Update error logging when handling STAC parsing exception.

## Local Test Steps
Submit a harmony request that will cause STAC parsing exception (due to a bug in l2ss-py) and verify that Harmony logs the stacktrace properly in the log. e.g. 
http://localhost:3000/C1261072645-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&subset=lat(34.84931%3A35.83342)&subset=lon(-125.57812%3A-124.73438)&subset=time(%222023-11-15T18%3A00%3A00%2B00%3A00%22%3A%222023-11-18T07%3A00%3A00%2B00%3A00%22)&skipPreview=true&concatenate=true

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)