### PR TITLE
Harmony 1791 - Usability updates for provider filter in workflow ui

### DIFF
--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -307,7 +307,7 @@ export async function getJobs(
     const isAdminRoute = req.context.isAdminAccess;
     let providerIds = [];
     if (isAdminRoute) {
-      providerIds = await Job.getProviderIdsSnapshot(db);
+      providerIds = await Job.getProviderIdsSnapshot(db, req.context.logger);
     }
     const requestQuery = keysToLowerCase(req.query);
     const fromDateTime = requestQuery.fromdatetime;

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -24,7 +24,6 @@ import { handleWorkItemUpdateWithJobId } from '../backends/workflow-orchestratio
 // Default to retrieving this number of work items per page
 const defaultWorkItemPageSize = 100;
 
-
 /**
  * Maps job status to display class.
  */

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -24,6 +24,8 @@ import { handleWorkItemUpdateWithJobId } from '../backends/workflow-orchestratio
 // Default to retrieving this number of work items per page
 const defaultWorkItemPageSize = 100;
 
+const providerIds = Job.getUniqueProviderIds(db);
+
 /**
  * Maps job status to display class.
  */
@@ -304,6 +306,8 @@ export async function getJobs(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
   try {
+    const ids = await providerIds;
+    console.log(ids);
     const isAdminRoute = req.context.isAdminAccess;
     const requestQuery = keysToLowerCase(req.query);
     const fromDateTime = requestQuery.fromdatetime;

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -23,13 +23,8 @@ import { handleWorkItemUpdateWithJobId } from '../backends/workflow-orchestratio
 
 // Default to retrieving this number of work items per page
 const defaultWorkItemPageSize = 100;
+let providerIds: string[];
 
-let providerIdsPromise: Promise<string[]>;
-try {
-  providerIdsPromise = Job.getUniqueProviderIds(db);
-} catch {
-  providerIdsPromise = Promise.resolve([]);
-}
 
 /**
  * Maps job status to display class.
@@ -311,7 +306,14 @@ export async function getJobs(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
   try {
-    const providerIds = await providerIdsPromise;
+    if (providerIds === undefined) {
+      try {
+        providerIds = await Job.getUniqueProviderIds(db);
+      } catch {
+        providerIds = [];
+        req.context.logger.info('Failed to query provider ids');
+      }
+    }
     console.log(providerIds);
     const isAdminRoute = req.context.isAdminAccess;
     const requestQuery = keysToLowerCase(req.query);

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -23,7 +23,6 @@ import { handleWorkItemUpdateWithJobId } from '../backends/workflow-orchestratio
 
 // Default to retrieving this number of work items per page
 const defaultWorkItemPageSize = 100;
-let providerIds: string[];
 
 
 /**
@@ -306,16 +305,11 @@ export async function getJobs(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
   try {
-    if (providerIds === undefined) {
-      try {
-        providerIds = await Job.getUniqueProviderIds(db);
-      } catch {
-        providerIds = [];
-        req.context.logger.info('Failed to query provider ids');
-      }
-    }
-    console.log(providerIds);
     const isAdminRoute = req.context.isAdminAccess;
+    let providerIds = [];
+    if (isAdminRoute) {
+      providerIds = await Job.getProviderIdsSnapshot(db);
+    }
     const requestQuery = keysToLowerCase(req.query);
     const fromDateTime = requestQuery.fromdatetime;
     const toDateTime = requestQuery.todatetime;

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -24,7 +24,12 @@ import { handleWorkItemUpdateWithJobId } from '../backends/workflow-orchestratio
 // Default to retrieving this number of work items per page
 const defaultWorkItemPageSize = 100;
 
-const providerIdsPromise = Job.getUniqueProviderIds(db);
+let providerIdsPromise: Promise<string[]>;
+try {
+  providerIdsPromise = Job.getUniqueProviderIds(db);
+} catch {
+  providerIdsPromise = Promise.resolve([]);
+}
 
 /**
  * Maps job status to display class.

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -24,7 +24,7 @@ import { handleWorkItemUpdateWithJobId } from '../backends/workflow-orchestratio
 // Default to retrieving this number of work items per page
 const defaultWorkItemPageSize = 100;
 
-const providerIds = Job.getUniqueProviderIds(db);
+const providerIdsPromise = Job.getUniqueProviderIds(db);
 
 /**
  * Maps job status to display class.
@@ -109,8 +109,8 @@ function parseQuery( /* eslint-disable @typescript-eslint/no-explicit-any */
       .filter(option => isAdminAccess && /^user: [A-Za-z0-9\.\_]{4,30}$/.test(option.value));
     const userValues = validUserSelections.map(option => option.value.split('user: ')[1]);
     const validProviderSelections = selectedOptions
-      .filter(option => isAdminAccess && /^prov: [A-Za-z0-9_]{1,100}$/.test(option.value));
-    const providerValues = validProviderSelections.map(option => option.value.split('prov: ')[1].toLowerCase());
+      .filter(option => isAdminAccess && /^provider: [A-Za-z0-9_]{1,100}$/.test(option.value));
+    const providerValues = validProviderSelections.map(option => option.value.split('provider: ')[1].toLowerCase());
     if ((statusValues.length + serviceValues.length + userValues.length + providerValues.length) > maxFilters) {
       throw new RequestValidationError(`Maximum amount of filters (${maxFilters}) was exceeded.`);
     }
@@ -306,8 +306,8 @@ export async function getJobs(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
   try {
-    const ids = await providerIds;
-    console.log(ids);
+    const providerIds = await providerIdsPromise;
+    console.log(providerIds);
     const isAdminRoute = req.context.isAdminAccess;
     const requestQuery = keysToLowerCase(req.query);
     const fromDateTime = requestQuery.fromdatetime;
@@ -336,6 +336,7 @@ export async function getJobs(
       jobs,
       selectAllBox,
       serviceNames: JSON.stringify(serviceNames),
+      providerIds: JSON.stringify(providerIds),
       sortGranules: requestQuery.sortgranules,
       disallowStatusChecked: !tableQuery.allowStatuses ? 'checked' : '',
       disallowServiceChecked: !tableQuery.allowServices ? 'checked' : '',

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -107,7 +107,7 @@ function parseQuery( /* eslint-disable @typescript-eslint/no-explicit-any */
       .filter(option => isAdminAccess && /^user: [A-Za-z0-9\.\_]{4,30}$/.test(option.value));
     const userValues = validUserSelections.map(option => option.value.split('user: ')[1]);
     const validProviderSelections = selectedOptions
-      .filter(option => isAdminAccess && /^provider: [A-Za-z0-9_]{1,100}$/.test(option.value));
+      .filter(option => /^provider: [A-Za-z0-9_]{1,100}$/.test(option.value));
     const providerValues = validProviderSelections.map(option => option.value.split('provider: ')[1].toLowerCase());
     if ((statusValues.length + serviceValues.length + userValues.length + providerValues.length) > maxFilters) {
       throw new RequestValidationError(`Maximum amount of filters (${maxFilters}) was exceeded.`);
@@ -305,10 +305,8 @@ export async function getJobs(
 ): Promise<void> {
   try {
     const isAdminRoute = req.context.isAdminAccess;
-    let providerIds = [];
-    if (isAdminRoute) {
-      providerIds = await Job.getProviderIdsSnapshot(db, req.context.logger);
-    }
+    const providerIds = (await Job.getProviderIdsSnapshot(db, req.context.logger))
+      .map((providerId) => providerId.toUpperCase());
     const requestQuery = keysToLowerCase(req.query);
     const fromDateTime = requestQuery.fromdatetime;
     const toDateTime = requestQuery.todatetime;

--- a/services/harmony/app/models/job.ts
+++ b/services/harmony/app/models/job.ts
@@ -318,7 +318,7 @@ export function getRelatedLinks(rel: string, links: JobLink[]): JobLink[] {
 /**
  * Get all of the unique provider Ids.
  * @param tx - the transaction to use for querying
- * @returns a promise resolving to ann array of provider Ids
+ * @returns a promise resolving to an array of provider Ids
  */
 async function getUniqueProviderIds(tx: Transaction): Promise<string[]> {
   const results = await tx('jobs')

--- a/services/harmony/app/models/job.ts
+++ b/services/harmony/app/models/job.ts
@@ -595,6 +595,19 @@ export class Job extends DBRecord implements JobRecord {
   }
 
   /**
+   * Get all of the unique provider Ids.
+   * @param tx - the transaction to use for querying
+   * @returns a promise resolving to ann array of provider Ids
+   */
+  static async getUniqueProviderIds(tx: Transaction): Promise<string[]> {
+    const results = await tx(Job.table)
+      .whereNotNull('provider_id')
+      .distinct('provider_id');
+    console.log(results);
+    return results.map((job) => job.provider_id);
+  }
+
+  /**
    * Creates a Job instance.
    *
    * @param fields - Object containing fields to set on the record

--- a/services/harmony/app/models/job.ts
+++ b/services/harmony/app/models/job.ts
@@ -20,6 +20,7 @@ import env from '../util/env';
 import JobError from './job-error';
 import { setReadyCountToZero } from './user-work';
 import { Knex } from 'knex';
+import { Logger } from 'winston';
 const { awsDefaultRegion } = env;
 
 // Lazily load the list of unique provider ids, once, when requested
@@ -613,13 +614,15 @@ export class Job extends DBRecord implements JobRecord {
   /**
    * Get a list of unique provider ids (singleton, loaded once per server startup)
    * @param tx - the transaction to use for querying
+   * @param logger - the logger to use
    * @returns list of provider ids as a string[]
    */
-  static async getProviderIdsSnapshot(tx: Transaction): Promise<string[]> {
+  static async getProviderIdsSnapshot(tx: Transaction, logger: Logger): Promise<string[]> {
     if (providerIdsSnapshot === undefined) {
       try {
         providerIdsSnapshot = await getUniqueProviderIds(tx);
-      } catch {
+      } catch (e) {
+        logger.error(e);
         providerIdsSnapshot = [];
       }
     }

--- a/services/harmony/app/views/workflow-ui/jobs/index.mustache.html
+++ b/services/harmony/app/views/workflow-ui/jobs/index.mustache.html
@@ -76,13 +76,13 @@
                             negate users
                         </label>
                     </div>
+                    {{/isAdminRoute}}
                     <div class="form-check">
                         <input type="checkbox" class="form-check-input" name="disallowProvider" {{disallowProviderChecked}}>
                         <label class="form-check-label" for="disallowProvider">
                             negate providers
                         </label>
                     </div>
-                    {{/isAdminRoute}}
                     <div class="input-group mt-2">
                       <span class="input-group-text">page size</span>
                       <input name="limit" type="number" class="form-control" value="{{limit}}">

--- a/services/harmony/app/views/workflow-ui/jobs/index.mustache.html
+++ b/services/harmony/app/views/workflow-ui/jobs/index.mustache.html
@@ -56,7 +56,7 @@
                     <input id="sort-granules" type="hidden" name="sortGranules" value="{{sortGranules}}" />
                     <input name="tableFilter" class="table-filter form-control mb-2" placeholder="add a filter"
                         data-value="{{selectedFilters}}" data-current-user="{{currentUser}}"
-                        data-services="{{serviceNames}}" data-is-admin-route="{{isAdminRoute}}">
+                        data-services="{{serviceNames}}" data-providers="{{providerIds}}" data-is-admin-route="{{isAdminRoute}}">
                     <div class="form-check">
                         <input type="checkbox" class="form-check-input" name="disallowStatus" {{disallowStatusChecked}}>
                         <label class="form-check-label" for="disallowStatus">

--- a/services/harmony/public/js/workflow-ui/jobs/index.js
+++ b/services/harmony/public/js/workflow-ui/jobs/index.js
@@ -10,6 +10,7 @@ params.isAdminRoute = isAdminRoute;
 params.tableFilter = tableFilter.getAttribute('data-value');
 params.currentUser = tableFilter.getAttribute('data-current-user');
 params.services = JSON.parse(tableFilter.getAttribute('data-services'));
+params.providers = JSON.parse(tableFilter.getAttribute('data-providers'));
 
 params.disallowStatus = document.getElementsByName('disallowStatus')[0].checked ? 'on' : '';
 params.disallowService = document.getElementsByName('disallowService')[0].checked ? 'on' : '';

--- a/services/harmony/public/js/workflow-ui/jobs/index.js
+++ b/services/harmony/public/js/workflow-ui/jobs/index.js
@@ -14,9 +14,9 @@ params.providers = JSON.parse(tableFilter.getAttribute('data-providers'));
 
 params.disallowStatus = document.getElementsByName('disallowStatus')[0].checked ? 'on' : '';
 params.disallowService = document.getElementsByName('disallowService')[0].checked ? 'on' : '';
+params.disallowProvider = document.getElementsByName('disallowProvider')[0].checked ? 'on' : '';
 if (isAdminRoute) {
   params.disallowUser = document.getElementsByName('disallowUser')[0].checked ? 'on' : '';
-  params.disallowProvider = document.getElementsByName('disallowProvider')[0].checked ? 'on' : '';
 }
 ['page', 'limit', 'fromDateTime', 'toDateTime', 'tzOffsetMinutes'].forEach((name) => {
   params[name] = document.getElementsByName(name)[0].value;

--- a/services/harmony/public/js/workflow-ui/jobs/jobs-table.js
+++ b/services/harmony/public/js/workflow-ui/jobs/jobs-table.js
@@ -12,10 +12,11 @@ let statuses = [];
  * Build the jobs filter with filter facets like 'status' and 'user'.
   * @param {string} currentUser - the current Harmony user
   * @param {string[]} services - service names from services.yml
+  * @param {string[]} providers - array of provider ids
   * @param {boolean} isAdminRoute - whether the current page is /admin/...
   * @param {object[]} tableFilter - initial tags that will populate the input
  */
-function initFilter(currentUser, services, isAdminRoute, tableFilter) {
+function initFilter(currentUser, services, providers, isAdminRoute, tableFilter) {
   const filterInput = document.querySelector('input[name="tableFilter"]');
   const allowedList = [
     { value: 'status: successful', dbValue: 'successful', field: 'status' },
@@ -32,6 +33,8 @@ function initFilter(currentUser, services, isAdminRoute, tableFilter) {
   allowedList.push(...serviceList);
   if (isAdminRoute) {
     allowedList.push({ value: `user: ${currentUser}`, dbValue: currentUser, field: 'user' });
+    const providerList = providers.map((provider) => ({ value: `provider: ${provider}`, dbValue: provider, field: 'provider' }));
+    allowedList.push(...providerList);
   }
   const allowedValues = allowedList.map((t) => t.value);
   const tagInput = new Tagify(filterInput, {
@@ -44,7 +47,7 @@ function initFilter(currentUser, services, isAdminRoute, tableFilter) {
         // check if the tag loosely resembles a valid EDL username
         return /^user: [A-Za-z0-9._]{4,30}$/.test(tag.value)
         // check if the tag resembles a valid provider ID
-        || /^prov: [A-Za-z0-9_]{1,100}$/.test(tag.value);
+        || /^provider: [A-Za-z0-9_]{1,100}$/.test(tag.value);
       }
       return false;
     },
@@ -240,6 +243,7 @@ const jobsTable = {
    * disallowProvider - whether to load the table with disallow provider "on" or "off".
    * currentUser - the current Harmony user
    * services - service names from services.yml
+   * providers - unique provider ids from the jobs table
    * isAdminRoute - whether the current page is /admin/...
    * tableFilter - initial tags that will populate the input
    * fromDateTime - date time string that constrains by date
@@ -254,7 +258,7 @@ const jobsTable = {
       async () => loadRows(params),
     );
     formatDates('.date-td');
-    initFilter(params.currentUser, params.services, params.isAdminRoute, params.tableFilter);
+    initFilter(params.currentUser, params.services, params.providers, params.isAdminRoute, params.tableFilter);
     initCopyHandler('.copy-request');
     initSelectHandler('.select-job');
     initSelectAllHandler();

--- a/services/harmony/public/js/workflow-ui/jobs/jobs-table.js
+++ b/services/harmony/public/js/workflow-ui/jobs/jobs-table.js
@@ -31,23 +31,21 @@ function initFilter(currentUser, services, providers, isAdminRoute, tableFilter)
   ];
   const serviceList = services.map((service) => ({ value: `service: ${service}`, dbValue: service, field: 'service' }));
   allowedList.push(...serviceList);
+  const providerList = providers.map((provider) => ({ value: `provider: ${provider}`, dbValue: provider, field: 'provider' }));
+  allowedList.push(...providerList);
   if (isAdminRoute) {
     allowedList.push({ value: `user: ${currentUser}`, dbValue: currentUser, field: 'user' });
-    const providerList = providers.map((provider) => ({ value: `provider: ${provider}`, dbValue: provider, field: 'provider' }));
-    allowedList.push(...providerList);
   }
   const allowedValues = allowedList.map((t) => t.value);
   const tagInput = new Tagify(filterInput, {
     whitelist: allowedList,
     validate(tag) {
-      if (allowedValues.includes(tag.value)) {
+      if (allowedValues.includes(tag.value) || /^provider: [A-Za-z0-9_]{1,100}$/.test(tag.value)) {
         return true;
       }
       if (isAdminRoute) {
         // check if the tag loosely resembles a valid EDL username
-        return /^user: [A-Za-z0-9._]{4,30}$/.test(tag.value)
-        // check if the tag resembles a valid provider ID
-        || /^provider: [A-Za-z0-9_]{1,100}$/.test(tag.value);
+        return /^user: [A-Za-z0-9._]{4,30}$/.test(tag.value);
       }
       return false;
     },
@@ -199,12 +197,10 @@ async function loadRows(params) {
   + `&tzOffsetMinutes=${params.tzOffsetMinutes}&dateKind=${params.dateKind}`
   + `&sortGranules=${params.sortGranules}`
   + `&disallowStatus=${params.disallowStatus}`
-  + `&disallowService=${params.disallowService}`;
+  + `&disallowService=${params.disallowService}`
+  + `&disallowProvider=${params.disallowProvider}`;
   if (params.disallowUser) {
     tableUrl += `&disallowUser=${params.disallowUser}`;
-  }
-  if (params.disallowProvider) {
-    tableUrl += `&disallowProvider=${params.disallowProvider}`;
   }
   const res = await fetch(tableUrl, {
     method: 'POST',

--- a/services/harmony/test/workflow-ui/jobs-table.ts
+++ b/services/harmony/test/workflow-ui/jobs-table.ts
@@ -107,7 +107,7 @@ describe('Workflow UI jobs table route', function () {
   describe('a user who  is an admin', function () {
     describe('using the provider ids filter', function () {
       hookAdminWorkflowUIJobRows({ username: 'adam', jobIDs: allJobIds,
-        query: { disallowService: false, tableFilter: '[{"value":"prov: PROVIDER_A","dbValue":"PROVIDER_A","field":"provider"}]' } });
+        query: { disallowService: false, tableFilter: '[{"value":"provider: PROVIDER_A","dbValue":"PROVIDER_A","field":"provider"}]' } });
       it('returns only the job rows with provider a', function () {
         const response = this.res.text;
         expect(response).to.not.contain(`<tr id="job-${boJob2.jobID}" class='job-table-row'>`);
@@ -120,7 +120,7 @@ describe('Workflow UI jobs table route', function () {
   
     describe('using the provider ids filter with improperly cased provider id', function () {
       hookAdminWorkflowUIJobRows({ username: 'adam', jobIDs: allJobIds,
-        query: { disallowService: false, tableFilter: '[{"value":"prov: prOVIDER_A","dbValue":"prOVIDER_A","field":"provider"}]' } });
+        query: { disallowService: false, tableFilter: '[{"value":"provider: prOVIDER_A","dbValue":"prOVIDER_A","field":"provider"}]' } });
       it('lower cases the user defined provider filter, matching jobs with provider_a', function () {
         const response = this.res.text;
         expect(response).to.not.contain(`<tr id="job-${boJob2.jobID}" class='job-table-row'>`);
@@ -133,7 +133,7 @@ describe('Workflow UI jobs table route', function () {
   
     describe('using the provider ids filter with two provider ids', function () {
       hookAdminWorkflowUIJobRows({ username: 'adam', jobIDs: allJobIds,
-        query: { disallowService: false, tableFilter: '[{"value":"prov: prOVIDER_A","dbValue":"prOVIDER_A","field":"provider"},{"value":"prov: prOVIDER_b","dbValue":"prOVIDER_b","field":"provider"}]' } });
+        query: { disallowService: false, tableFilter: '[{"value":"provider: prOVIDER_A","dbValue":"prOVIDER_A","field":"provider"},{"value":"provider: prOVIDER_b","dbValue":"prOVIDER_b","field":"provider"}]' } });
       it('returns jobs matching any of the user defined provider ids', function () {
         const response = this.res.text;
         expect(response).to.not.contain(`<tr id="job-${woodyJob1.jobID}" class='job-table-row'>`);

--- a/services/harmony/test/workflow-ui/jobs.ts
+++ b/services/harmony/test/workflow-ui/jobs.ts
@@ -499,17 +499,17 @@ describe('Workflow UI jobs route', function () {
     describe('who filters by provider, but is not an admin', function () {
       const tableFilter = '[{"value":"provider: provider_z","dbValue":"provider_z","field":"provider"}]';
       hookWorkflowUIJobs({ username: 'woody', disallowProvider: 'on', tableFilter });
-      it('ignores the provider filter, returning all of woody\'s jobs', function () {
+      it('negates the provider filter, returning all of woody\'s jobs', function () {
         const listing = this.res.text;
         expect((listing.match(/job-table-row/g) || []).length).to.equal(3);
       });
-      it('does not return the disallowProvider HTML checkbox', function () {
+      it('does return the disallowProvider HTML checkbox', function () {
         const listing = this.res.text;
-        expect((listing.match(/<input (?=.*name="disallowProvider").*>/g) || []).length).to.equal(0);
+        expect((listing.match(/<input (?=.*name="disallowProvider").*>/g) || []).length).to.equal(1);
       });
-      it('has no provider filters selected', function () {
+      it('has one provider filter selected', function () {
         const listing = this.res.text;
-        expect(listing).to.not.contain(mustache.render('{{provider}}', { provider: 'provider: prov_a' }));
+        expect(listing).to.contain(mustache.render('{{provider}}', { provider: 'provider: provider_z' }));
       });
     });
 

--- a/services/harmony/test/workflow-ui/jobs.ts
+++ b/services/harmony/test/workflow-ui/jobs.ts
@@ -509,7 +509,7 @@ describe('Workflow UI jobs route', function () {
       });
       it('has no provider filters selected', function () {
         const listing = this.res.text;
-        expect(listing).to.not.contain(mustache.render('{{prov}}', { provider: 'provider: prov_a' }));
+        expect(listing).to.not.contain(mustache.render('{{provider}}', { provider: 'provider: prov_a' }));
       });
     });
 
@@ -666,7 +666,7 @@ describe('Workflow UI jobs route', function () {
         });
         it('has the provider filter selected', function () {
           const listing = this.res.text;
-          expect(listing).to.contain(mustache.render('{{prov}}', { provider: 'provider: provider_b' }));
+          expect(listing).to.contain(mustache.render('{{provider}}', { provider: 'provider: provider_b' }));
         });
       });
 
@@ -685,8 +685,8 @@ describe('Workflow UI jobs route', function () {
         });
         it('has the provider b and z filters selected', function () {
           const listing = this.res.text;
-          expect(listing).to.contain(mustache.render('{{prov}}', { provider: 'provider: provider_b' }));
-          expect(listing).to.contain(mustache.render('{{prov}}', { provider: 'provider: provider_z' }));
+          expect(listing).to.contain(mustache.render('{{provider}}', { provider: 'provider: provider_b' }));
+          expect(listing).to.contain(mustache.render('{{provider}}', { provider: 'provider: provider_z' }));
         });
       });
 

--- a/services/harmony/test/workflow-ui/jobs.ts
+++ b/services/harmony/test/workflow-ui/jobs.ts
@@ -497,7 +497,7 @@ describe('Workflow UI jobs route', function () {
     });
 
     describe('who filters by provider, but is not an admin', function () {
-      const tableFilter = '[{"value":"prov: provider_z","dbValue":"provider_z","field":"provider"}]';
+      const tableFilter = '[{"value":"provider: provider_z","dbValue":"provider_z","field":"provider"}]';
       hookWorkflowUIJobs({ username: 'woody', disallowProvider: 'on', tableFilter });
       it('ignores the provider filter, returning all of woody\'s jobs', function () {
         const listing = this.res.text;
@@ -509,7 +509,7 @@ describe('Workflow UI jobs route', function () {
       });
       it('has no provider filters selected', function () {
         const listing = this.res.text;
-        expect(listing).to.not.contain(mustache.render('{{prov}}', { prov: 'prov: prov_a' }));
+        expect(listing).to.not.contain(mustache.render('{{prov}}', { provider: 'provider: prov_a' }));
       });
     });
 
@@ -653,7 +653,7 @@ describe('Workflow UI jobs route', function () {
       });
 
       describe('and the admin filters by provider IN [provider_b]', function () {
-        const tableFilter = '[{"value":"prov: provider_b","dbValue":"provider_b","field":"provider"}]';
+        const tableFilter = '[{"value":"provider: provider_b","dbValue":"provider_b","field":"provider"}]';
         hookAdminWorkflowUIJobs({ username: 'adam', disallowProvider: '', tableFilter });
         it('returns the matching job', function () {
           const listing = this.res.text;
@@ -666,12 +666,12 @@ describe('Workflow UI jobs route', function () {
         });
         it('has the provider filter selected', function () {
           const listing = this.res.text;
-          expect(listing).to.contain(mustache.render('{{prov}}', { prov: 'prov: provider_b' }));
+          expect(listing).to.contain(mustache.render('{{prov}}', { provider: 'provider: provider_b' }));
         });
       });
 
       describe('and the admin filters by provider NOT IN [provider_b, provider_z]', function () {
-        const tableFilter = '[{"value":"prov: provider_b","dbValue":"provider_b","field":"provider"},{"value":"prov: provider_z","dbValue":"provider_z","field":"provider"}]';
+        const tableFilter = '[{"value":"provider: provider_b","dbValue":"provider_b","field":"provider"},{"value":"provider: provider_z","dbValue":"provider_z","field":"provider"}]';
         hookAdminWorkflowUIJobs({ username: 'adam', disallowProvider: 'on', tableFilter });
         it('returns the jobs that do not match providers b and z', function () {
           const listing = this.res.text;
@@ -685,13 +685,13 @@ describe('Workflow UI jobs route', function () {
         });
         it('has the provider b and z filters selected', function () {
           const listing = this.res.text;
-          expect(listing).to.contain(mustache.render('{{prov}}', { prov: 'prov: provider_b' }));
-          expect(listing).to.contain(mustache.render('{{prov}}', { prov: 'prov: provider_z' }));
+          expect(listing).to.contain(mustache.render('{{prov}}', { provider: 'provider: provider_b' }));
+          expect(listing).to.contain(mustache.render('{{prov}}', { provider: 'provider: provider_z' }));
         });
       });
 
       describe('who filters by a particular combination of filter types', function () {
-        const tableFilter = '[{"value":"service: harmony/netcdf-to-zarr","dbValue":"harmony/netcdf-to-zarr","field":"service"},{"value":"user: woody","dbValue":"woody","field":"user"},{"value":"prov: provider_b","dbValue":"provider_b","field":"provider"}]';
+        const tableFilter = '[{"value":"service: harmony/netcdf-to-zarr","dbValue":"harmony/netcdf-to-zarr","field":"service"},{"value":"user: woody","dbValue":"woody","field":"user"},{"value":"provider: provider_b","dbValue":"provider_b","field":"provider"}]';
         hookAdminWorkflowUIJobs({ username: 'adam', tableFilter });
         it('returns the harmony/netcdf-to-zarr job', function () {
           const listing = this.res.text;
@@ -718,7 +718,7 @@ describe('Workflow UI jobs route', function () {
           const listing = this.res.text;
           expect(listing).to.contain(mustache.render('{{service}}', { service: 'service: harmony/netcdf-to-zarr' }));
           expect(listing).to.contain(mustache.render('{{user}}', { user: 'user: woody' }));
-          expect(listing).to.contain(mustache.render('{{provider}}', { provider: 'prov: provider_b' }));
+          expect(listing).to.contain(mustache.render('{{provider}}', { provider: 'provider: provider_b' }));
         });
       });
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1791

## Description
2 updates to the previous PR https://github.com/nasa/harmony/pull/601:
Changes the provider filter from `prov: *` to `provider: *`
Populates the autocomplete filter box for existing providers (from the jobs table)

## Local Test Steps
Submit some jobs, preferably with collections that have different providers. 
- http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng
- http://localhost:3000/C1244165142-GES_DISC/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&subset=lat(-63.325%3A76.325)&subset=lon(-171.0%3A171.0)&granuleId=G1244165734-GES_DISC

Navigate to http://localhost:3000/admin/workflow-ui. Use the provider filter `provider: *` to filter the jobs table.
Restart the server (the provider autocomplete list will get populated once per startup). The autocomplete should now be populated with all providers from the jobs table.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)