### PR TITLE
Harmony 1796 - Deployments returned in descending order of the creation date

### DIFF
--- a/services/harmony/app/models/service-deployment.ts
+++ b/services/harmony/app/models/service-deployment.ts
@@ -100,6 +100,7 @@ export async function getDeploymentById(tx: Transaction, deploymentId: string): 
 export async function getDeployments(tx: Transaction, status?: ServiceDeploymentStatus, service?: string): Promise<ServiceDeployment[]> {
   const query = tx(ServiceDeployment.table)
     .select()
+    .orderBy('createdAt', 'desc')
     .modify((queryBuilder) => {
       if (status) {
         void queryBuilder.where('status', status);

--- a/services/harmony/test/service-deployment.ts
+++ b/services/harmony/test/service-deployment.ts
@@ -46,7 +46,7 @@ describe('List service deployments endpoint', async function () {
   hookTransaction();
 
   before(async function () {
-    // set dates so that we can test ordering
+    // set dates so that we can test ordering (expecting order by createdAt, desc)
     MockDate.set('2021-01-01T14:12:05.000Z');
     await failedFooDeployment.save(this.trx);
     MockDate.set('2021-01-02T14:12:05.000Z');


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1796

## Description
Deployments are now returned in descending order of the creation date.

## Local Test Steps
Add this code (which seeds the database with deployments) to server.ts, toward the end of the `buildFrontendServer` function, and restart Harmony:
```javascript
const failedFooDeployment = new ServiceDeployment({ deployment_id: '01f90511-109c-417c-8b17-0a5046ae562c', service: 'foo-service',
    username: 'bob', tag: '1', status: ServiceDeploymentStatus.FAILED, message: 'Failed service deployment' });
const successfulFooDeployment = new ServiceDeployment({
  deployment_id: 'b7a527a1-487e-4a6f-9e77-0083ac1b800b', service: 'foo-service',
  username: 'eve', tag: '1', status: ServiceDeploymentStatus.SUCCESSFUL, message: 'Deployment successful',
});
const runningFooDeployment = new ServiceDeployment({
  deployment_id: '349bacf9-fc25-4a69-9901-a6b01c59acd4', service: 'foo-service',
  username: 'coraline', tag: '1', status: ServiceDeploymentStatus.RUNNING, message: 'Deployment running',
});
const successfulBuzzDeployment = new ServiceDeployment({
  deployment_id: '61ba9eb9-3015-4c2c-8a1b-17c9050f333b', service: 'buzz-service',
  username: 'joe', tag: '1', status: ServiceDeploymentStatus.SUCCESSFUL, message: 'Deployment successful',
});
const runningBuzzDeployment = new ServiceDeployment({
  deployment_id: '6bd4ac04-2cff-40a0-a5a8-419ef8125db3', service: 'buzz-service',
  username: 'adam', tag: '1', status: ServiceDeploymentStatus.RUNNING, message: 'Deployment running',
});
setTimeout(() => {
  failedFooDeployment.save(db).catch((e) => console.log(e));
}, 1000);
setTimeout(() => {
  successfulFooDeployment.save(db).catch((e) => console.log(e));
}, 2000);
setTimeout(() => {
  runningFooDeployment.save(db).catch((e) => console.log(e));
}, 3000);
setTimeout(() => {
  successfulBuzzDeployment.save(db).catch((e) => console.log(e));
}, 4000);
setTimeout(() => {
  runningBuzzDeployment.save(db).catch((e) => console.log(e));
}, 5000);
```
Hit the http://localhost:3000/service-deployment endpoint and verify that newest deployments are returned first. This ordering should hold regardless of which filters are applied (e.g. `?status=running`).

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)