### PR TITLE
Harmony 1819 - Preserve filters when navigating back to the jobs page from the job page of the Workflow UI

### DIFF
--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -343,9 +343,9 @@ export async function getJobs(
       disallowProviderChecked: !tableQuery.allowProviders ? 'checked' : '',
       toDateTime,
       fromDateTime,
-      dateQuery: `?fromDateTime=${encodeURIComponent(fromDateTime || '')}&toDateTime=${encodeURIComponent(toDateTime || '')}` +
-        `&dateKind=${dateKind}&tzOffsetMinutes=${requestQuery.tzoffsetminutes || ''}`,
-      jobsLinkQuery: `&jobsLinkQuery=${encodeURIComponent(currentPage.href)}`,
+      jobLinkQuery: `?fromDateTime=${encodeURIComponent(fromDateTime || '')}&toDateTime=${encodeURIComponent(toDateTime || '')}` +
+        `&dateKind=${dateKind}&tzOffsetMinutes=${requestQuery.tzoffsetminutes || ''}` +
+        `&jobsLink=${encodeURIComponent(currentPage.href)}`,
       updatedAtChecked: dateKind == 'updatedAt' ? 'checked' : '',
       createdAtChecked: dateKind != 'updatedAt' ? 'checked' : '',
       selectedFilters: originalValues,
@@ -397,7 +397,7 @@ export async function getJob(
       version,
       isAdminRoute: req.context.isAdminAccess,
       isAdminOrOwner: job.belongsToOrIsAdmin(req.user, isAdmin),
-      jobsLink: requestQuery.jobslinkquery || (req.context.isAdminAccess ? '/admin/workflow-ui' : '/workflow-ui'),
+      jobsLink: requestQuery.jobslink || (req.context.isAdminAccess ? '/admin/workflow-ui' : '/workflow-ui'),
     });
   } catch (e) {
     req.context.logger.error(e);

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -321,6 +321,7 @@ export async function getJobs(
     const lastPage = pageLinks.find((l) => l.rel === 'last');
     const nextPage = pageLinks.find((l) => l.rel === 'next');
     const previousPage = pageLinks.find((l) => l.rel === 'prev');
+    const currentPage = pageLinks.find((l) => l.rel === 'self');
     const paginationDisplay = getPaginationDisplay(pagination);
     const selectAllBox = jobs.some((j) => !j.hasTerminalStatus()) ?
       '<input id="select-jobs" type="checkbox" title="select/deselect all jobs" autocomplete="off">' : '';
@@ -344,6 +345,7 @@ export async function getJobs(
       fromDateTime,
       dateQuery: `?fromDateTime=${encodeURIComponent(fromDateTime || '')}&toDateTime=${encodeURIComponent(toDateTime || '')}` +
         `&dateKind=${dateKind}&tzOffsetMinutes=${requestQuery.tzoffsetminutes || ''}`,
+      jobsLinkQuery: `&jobsLinkQuery=${encodeURIComponent(currentPage.href)}`,
       updatedAtChecked: dateKind == 'updatedAt' ? 'checked' : '',
       createdAtChecked: dateKind != 'updatedAt' ? 'checked' : '',
       selectedFilters: originalValues,
@@ -395,6 +397,7 @@ export async function getJob(
       version,
       isAdminRoute: req.context.isAdminAccess,
       isAdminOrOwner: job.belongsToOrIsAdmin(req.user, isAdmin),
+      jobsLink: requestQuery.jobslinkquery || (req.context.isAdminAccess ? '/admin/workflow-ui' : '/workflow-ui'),
     });
   } catch (e) {
     req.context.logger.error(e);

--- a/services/harmony/app/views/workflow-ui/job/index.mustache.html
+++ b/services/harmony/app/views/workflow-ui/job/index.mustache.html
@@ -40,12 +40,11 @@
         aria-label="breadcrumb">
         <div class="breadcrumb  d-flex flex-row justify-content-between">
             <ol class="breadcrumb p-0 m-0">
+                <li class="breadcrumb-item"><a href="{{{jobsLink}}}">Jobs</a></li>
                 {{#isAdminRoute}}
-                <li class="breadcrumb-item"><a href="/admin/workflow-ui">Jobs</a></li>
                 <li class="breadcrumb-item active" aria-current="page">{{job.jobID}} (<a href="/admin/jobs/{{job.jobID}}">Job Status</a>)</li>
                 {{/isAdminRoute}}
                 {{^isAdminRoute}}
-                <li class="breadcrumb-item"><a href="/workflow-ui">Jobs</a></li>
                 <li class="breadcrumb-item active" aria-current="page">{{job.jobID}} (<a href="/jobs/{{job.jobID}}">Job Status</a>)</li>
                 {{/isAdminRoute}}
             </ol>

--- a/services/harmony/app/views/workflow-ui/jobs/job-table-row.mustache.html
+++ b/services/harmony/app/views/workflow-ui/jobs/job-table-row.mustache.html
@@ -1,6 +1,6 @@
 <tr id="job-{{jobID}}" class='job-table-row'>
     <td>{{{jobSelectBox}}}</td>
-    <th scope="row"><a href="workflow-ui/{{jobID}}{{dateQuery}}">{{jobID}}</a></th>
+    <th scope="row"><a href="workflow-ui/{{jobID}}{{dateQuery}}{{jobsLinkQuery}}">{{jobID}}</a></th>
     <td>{{service_name}}</td>
     {{#isAdminRoute}}
     <td>{{username}}</td>

--- a/services/harmony/app/views/workflow-ui/jobs/job-table-row.mustache.html
+++ b/services/harmony/app/views/workflow-ui/jobs/job-table-row.mustache.html
@@ -1,6 +1,6 @@
 <tr id="job-{{jobID}}" class='job-table-row'>
     <td>{{{jobSelectBox}}}</td>
-    <th scope="row"><a href="workflow-ui/{{jobID}}{{dateQuery}}{{jobsLinkQuery}}">{{jobID}}</a></th>
+    <th scope="row"><a href="workflow-ui/{{jobID}}{{jobLinkQuery}}">{{jobID}}</a></th>
     <td>{{service_name}}</td>
     {{#isAdminRoute}}
     <td>{{username}}</td>

--- a/services/harmony/test/workflow-ui/job.ts
+++ b/services/harmony/test/workflow-ui/job.ts
@@ -81,6 +81,13 @@ describe('Workflow UI job route', function () {
           expect(listing).to.contain('<input name="limit" type="number" class="form-control" value="1">');
         });
       });
+      describe('requests their own job from the jobs page', function () {
+        hookWorkflowUIJob({ jobID: nonShareableJob.jobID, username: 'woody', query: { limit: 1, jobsLink: 'http://localhost:3000/admin/workflow-ui?page=1&limit=10' } });
+        it('returns a breadcrumb that includes the jobs page link, with filters intact', async function () {
+          const listing = this.res.text;
+          expect(listing).to.contain(mustache.render('<a href="http://localhost:3000/admin/workflow-ui?page=1&limit=10">Jobs</a>', {}));
+        });
+      });
       describe('requests more than the max limit of work items', function () {
         hookWorkflowUIJob({ jobID: nonShareableJob.jobID, username: 'woody', query: { limit: 9999999999 } });
         it('sets the page limit input to the expected value', function () {

--- a/services/harmony/test/workflow-ui/job.ts
+++ b/services/harmony/test/workflow-ui/job.ts
@@ -82,10 +82,10 @@ describe('Workflow UI job route', function () {
         });
       });
       describe('requests their own job from the jobs page', function () {
-        hookWorkflowUIJob({ jobID: nonShareableJob.jobID, username: 'woody', query: { limit: 1, jobsLink: 'http://localhost:3000/admin/workflow-ui?page=1&limit=10' } });
+        hookWorkflowUIJob({ jobID: nonShareableJob.jobID, username: 'woody', query: { limit: 1, jobsLink: 'http://localhost:3000/admin/workflow-ui?page=1&limit=10&status=failed' } });
         it('returns a breadcrumb that includes the jobs page link, with filters intact', async function () {
           const listing = this.res.text;
-          expect(listing).to.contain(mustache.render('<a href="http://localhost:3000/admin/workflow-ui?page=1&limit=10">Jobs</a>', {}));
+          expect(listing).to.contain(mustache.render('<a href="http://localhost:3000/admin/workflow-ui?page=1&limit=10&status=failed">Jobs</a>', {}));
         });
       });
       describe('requests more than the max limit of work items', function () {

--- a/services/harmony/test/workflow-ui/job.ts
+++ b/services/harmony/test/workflow-ui/job.ts
@@ -81,7 +81,7 @@ describe('Workflow UI job route', function () {
           expect(listing).to.contain('<input name="limit" type="number" class="form-control" value="1">');
         });
       });
-      describe('requests their own job from the jobs page', function () {
+      describe('requests their own job from the jobs page, providing a jobsLink query parameter', function () {
         hookWorkflowUIJob({ jobID: nonShareableJob.jobID, username: 'woody', query: { limit: 1, jobsLink: 'http://localhost:3000/admin/workflow-ui?page=1&limit=10&status=failed' } });
         it('returns a breadcrumb that includes the jobs page link, with filters intact', async function () {
           const listing = this.res.text;


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1819

## Description
Modifies the "Jobs" breadcrumb link (on the job page of the Workflow UI) so that filters are preserved when navigating back to the jobs table page.

![Screenshot 2024-07-23 at 4 07 26 PM](https://github.com/user-attachments/assets/6d162f3d-c6e4-41a8-909c-d0a6348661d6)

## Local Test Steps
1. navigate to http://localhost:3000/admin/workflow-ui
2. add filters (like `status: failed`) and submit
3. click a job link (to navigate to the job page)
4. click the "Jobs" breadcrumb link
5. the filters from step 2 should be preserved

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)