### PR TITLE
HARMONY-1827: Add cookie-secret header support to service-deployments-state endpoint

### DIFF
--- a/services/harmony/app/server.ts
+++ b/services/harmony/app/server.ts
@@ -37,6 +37,9 @@ export function requestFilter(req, propName): expressWinston.RequestFilter {
     if (headersObj.authorization) {
       headersObj.authorization = redactedString;
     }
+    if (headersObj['cookie-secret']) {
+      headersObj['cookie-secret'] = redactedString;
+    }
     return headersObj;
   }
   return req[propName];

--- a/services/harmony/app/util/edl-api.ts
+++ b/services/harmony/app/util/edl-api.ts
@@ -186,6 +186,13 @@ export async function verifyUserEula(username: string, eulaId: string, logger: L
 export async function validateUserIsInCoreGroup(
   req: HarmonyRequest, res: Response,
 ): Promise<boolean> {
+  // if request has cookie-secret header, it is in the core permissions group
+  const headerSecret = req.headers['cookie-secret'];
+  const secret = process.env.COOKIE_SECRET;
+  if (headerSecret === secret) {
+    return true;
+  }
+
   const { hasCorePermissions } = await getEdlGroupInformation(
     req.user, req.context.logger,
   );

--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -1396,3 +1396,55 @@ describe('Service self-deployment failure', async function () {
     });
   });
 });
+
+describe('Update service deployments state with cookie-secret', async function () {
+  beforeEach(function () {
+    process.env.COOKIE_SECRET = 'cookie-secret-value';
+  });
+
+  hookServersStartStop({ skipEarthdataLogin: true });
+
+  describe('when incorrect cookie-secret header is provided', async function () {
+    before(async function () {
+      this.res = await request(this.frontend)
+        .put('/service-deployments-state')
+        .send({ enabled: true })
+        .set('cookie-secret', 'wrong_secret')
+        .set('Content-Type', 'application/json');
+    });
+
+    after(function () {
+      delete this.res;
+    });
+
+    it('rejects the request', async function () {
+      expect(this.res.status).to.equal(403);
+    });
+
+    it('returns a meaningful error message', async function () {
+      expect(this.res.text).to.equal('User undefined does not have permission to access this resource');
+    });
+  });
+
+  describe('when correct cookie-secret header is provided', async function () {
+    before(async function () {
+      this.res = await request(this.frontend)
+        .put('/service-deployments-state')
+        .send({ enabled: true })
+        .set('cookie-secret', process.env.COOKIE_SECRET)
+        .set('Content-Type', 'application/json');
+    });
+
+    after(function () {
+      delete this.res;
+    });
+
+    it('returns a status 200', async function () {
+      expect(this.res.status).to.equal(200);
+    });
+
+    it('returns the service enabled true', async function () {
+      expect(this.res.body.enabled).to.eql(true);
+    });
+  });
+});

--- a/services/harmony/test/util/log.ts
+++ b/services/harmony/test/util/log.ts
@@ -20,6 +20,11 @@ describe('request logging filter', function () {
     const filtered = requestFilter(filtReq, 'headers');
     expect(filtered).to.deep.equal({ authorization: '<redacted>', Host: 'host-value' });
   });
+  it('returns a <redacted> cookie-secret header, leaving other headers intact', function () {
+    const filtReq: FilterRequest = { headers: { 'cookie-secret': 'secret-value', Host: 'host-value' } } as any as FilterRequest;
+    const filtered = requestFilter(filtReq, 'headers');
+    expect(filtered).to.deep.equal({ 'cookie-secret': '<redacted>', Host: 'host-value' });
+  });
 });
 
 describe('util/log', function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1827

## Description
Add cookie-secret header support to service-deployments-state endpoint

## Local Test Steps
Verify service-deployments-state can be enabled/disabled using COOKIE-SECRET:

curl -i -XPUT -H "COOKIE-SECRET: cookie secret value" -H 'Content-type: application/json' http://localhost:3000/service-deployments-state -d '{"enabled": false, "message": "Disabled using COOKIE-SECRET"}'

curl -i -XPUT -H "COOKIE-SECRET: cookie secret value" -H 'Content-type: application/json' http://localhost:3000/service-deployments-state -d '{"enabled": true, "message": "Enabled using COOKIE-SECRET"}'

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)