### PR TITLE
Harmony 1613 - Ensure user is sent to page 1 whenever filters are applied

### DIFF
--- a/services/harmony/app/views/workflow-ui/job/index.mustache.html
+++ b/services/harmony/app/views/workflow-ui/job/index.mustache.html
@@ -59,7 +59,8 @@
             <div class="col-2">
                 <form id="work-items-query-form" action="./{{job.jobID}}" method="get" class="pt-2">
                     <input type="hidden" name="jobID" value="{{job.jobID}}" />
-                    <input type="hidden" name="page" value="{{page}}" />
+                    <input type="hidden" name="currentPage" value="{{page}}" />
+                    <input type="hidden" name="page" value="1" />
                     {{> workflow-ui/date-time-picker}}
                     <input name="tableFilter" class="form-control table-filter mb-2" placeholder="add a filter"
                         data-value="{{selectedFilters}}" data-is-admin-route="{{isAdminRoute}}">

--- a/services/harmony/app/views/workflow-ui/jobs/index.mustache.html
+++ b/services/harmony/app/views/workflow-ui/jobs/index.mustache.html
@@ -51,7 +51,8 @@
         <div class="row pb-4">
             <div class="col-2">
                 <form id="jobs-query-form" action="./workflow-ui" method="get" class="pt-2">
-                    <input type="hidden" name="page" value="{{page}}" />
+                    <input type="hidden" name="currentPage" value="{{page}}" />
+                    <input type="hidden" name="page" value="1" />
                     {{> workflow-ui/date-time-picker}}
                     <input id="sort-granules" type="hidden" name="sortGranules" value="{{sortGranules}}" />
                     <input name="tableFilter" class="table-filter form-control mb-2" placeholder="add a filter"

--- a/services/harmony/public/js/workflow-ui/job/index.js
+++ b/services/harmony/public/js/workflow-ui/job/index.js
@@ -9,7 +9,7 @@ async function init() {
   // Retrieve the parameters (from the original page request)
   // that will be used to poll for work items
   const params = {};
-  ['page', 'limit', 'jobID', 'fromDateTime', 'toDateTime', 'tzOffsetMinutes'].forEach((name) => {
+  ['currentPage', 'limit', 'jobID', 'fromDateTime', 'toDateTime', 'tzOffsetMinutes'].forEach((name) => {
     params[name] = document.getElementsByName(name)[0].value;
   });
   params.tableFilter = document.getElementsByName('tableFilter')[0].getAttribute('data-value');

--- a/services/harmony/public/js/workflow-ui/job/work-items-table.js
+++ b/services/harmony/public/js/workflow-ui/job/work-items-table.js
@@ -35,7 +35,7 @@ import PubSub from '../../pub-sub.js';
  * @returns Boolean indicating whether the job is still running
  */
 async function load(params, checkJobStatus) {
-  let tableUrl = `./${params.jobID}/work-items?page=${params.page}&limit=${params.limit}&checkJobStatus=${checkJobStatus}`;
+  let tableUrl = `./${params.jobID}/work-items?page=${params.currentPage}&limit=${params.limit}&checkJobStatus=${checkJobStatus}`;
   tableUrl += `&tableFilter=${encodeURIComponent(params.tableFilter)}&disallowStatus=${params.disallowStatus}`;
   tableUrl += `&fromDateTime=${encodeURIComponent(params.fromDateTime)}&toDateTime=${encodeURIComponent(params.toDateTime)}`;
   tableUrl += `&tzOffsetMinutes=${params.tzOffsetMinutes}&dateKind=${params.dateKind}`;
@@ -131,7 +131,7 @@ export default {
    * @param {object} params - Parameters that define what will appear in the table.
    * Params contains the follwing attributes:
    * jobId - id of the job that the work items are linked to.
-   * page - page number for the work items.
+   * currentPage - page number for the work items.
    * limit - limit on the number of work items in a page.
    * disallowStatus - whether to load the table with disallow status "on" or "off".
    * tableFilter - a list of filter objects (as a string).

--- a/services/harmony/public/js/workflow-ui/jobs/index.js
+++ b/services/harmony/public/js/workflow-ui/jobs/index.js
@@ -18,7 +18,7 @@ params.disallowProvider = document.getElementsByName('disallowProvider')[0].chec
 if (isAdminRoute) {
   params.disallowUser = document.getElementsByName('disallowUser')[0].checked ? 'on' : '';
 }
-['page', 'limit', 'fromDateTime', 'toDateTime', 'tzOffsetMinutes'].forEach((name) => {
+['currentPage', 'limit', 'fromDateTime', 'toDateTime', 'tzOffsetMinutes'].forEach((name) => {
   params[name] = document.getElementsByName(name)[0].value;
 });
 params.dateKind = document.getElementById('dateKindUpdated').checked ? 'updatedAt' : 'createdAt';

--- a/services/harmony/public/js/workflow-ui/jobs/jobs-table.js
+++ b/services/harmony/public/js/workflow-ui/jobs/jobs-table.js
@@ -192,7 +192,7 @@ function initSelectAllHandler() {
 async function loadRows(params) {
   let tableUrl = './workflow-ui/jobs';
   tableUrl += `?tableFilter=${encodeURIComponent(params.tableFilter)}`
-  + `&page=${params.page}&limit=${params.limit}`
+  + `&page=${params.currentPage}&limit=${params.limit}`
   + `&fromDateTime=${encodeURIComponent(params.fromDateTime)}&toDateTime=${encodeURIComponent(params.toDateTime)}`
   + `&tzOffsetMinutes=${params.tzOffsetMinutes}&dateKind=${params.dateKind}`
   + `&sortGranules=${params.sortGranules}`
@@ -231,7 +231,7 @@ const jobsTable = {
    * Initialize the jobs table.
    * @param {object} params - Parameters that define what will appear in the table.
    * Params contains the follwing attributes:
-   * page - page number for the jobs
+   * currentPage - page number for the jobs
    * limit - limit on the number of jobs in a page
    * disallowStatus - whether to load the table with disallow status "on" or "off".
    * disallowService - whether to load the table with disallow service "on" or "off".

--- a/services/harmony/test/workflow-ui/job.ts
+++ b/services/harmony/test/workflow-ui/job.ts
@@ -95,6 +95,15 @@ describe('Workflow UI job route', function () {
           expect(listing).to.contain(`<input name="limit" type="number" class="form-control" value="${env.maxPageSize}">`);
         });
       });
+      describe('requests page 2', function () {
+        hookWorkflowUIJob({ jobID: nonShareableJob.jobID, username: 'woody', query: { page: 2 } });
+        it('sets the current page number to 2', function () {
+          expect(this.res.text).to.contain('<input type="hidden" name="currentPage" value="2" />');
+        });
+        it('sets the page number to 1 for filter submissions', function () {
+          expect(this.res.text).to.contain('<input type="hidden" name="page" value="1" />');
+        });
+      });
       describe('requests 0 work items', function () {
         hookWorkflowUIJob({ jobID: nonShareableJob.jobID, username: 'woody', query: { limit: 0 } });
         it('sets the page limit input to 1', function () {

--- a/services/harmony/test/workflow-ui/jobs.ts
+++ b/services/harmony/test/workflow-ui/jobs.ts
@@ -341,6 +341,12 @@ describe('Workflow UI jobs route', function () {
         const listing = this.res.text;
         expect(listing).to.contain('2-2 of 3 (page 2 of 3)');
       });
+      it('sets the current page number to 2', function () {
+        expect(this.res.text).to.contain('<input type="hidden" name="currentPage" value="2" />');
+      });
+      it('sets the page number to 1 for filter submissions', function () {
+        expect(this.res.text).to.contain('<input type="hidden" name="page" value="1" />');
+      });
     });
 
     describe('who has 3 jobs and asks for page 3, with a limit of 1', function () {
@@ -695,7 +701,6 @@ describe('Workflow UI jobs route', function () {
         hookAdminWorkflowUIJobs({ username: 'adam', tableFilter });
         it('returns the harmony/netcdf-to-zarr job', function () {
           const listing = this.res.text;
-          console.log(listing);
           expect((listing.match(/job-table-row/g) || []).length).to.equal(1);
           const serviceExampleTd = mustache.render('<td>{{service}}</td>', { service: 'harmony/service-example' });
           const serviceExampleRegExp = new RegExp(serviceExampleTd, 'g');


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1613

## Description
This fixes an issue where a user applies filters in the Workflow UI and then ends up on a page with unexpected results because the page number was maintained. E.g. you may be on page 5 (with three rows of jobs), you add a filter and click the apply button, and the server returns page 5 again, but this time with no results on it. 

What should happen is that they are sent to page 1 instead. (This is the expected behavior according to @chris-durbin.)

## Local Test Steps
Verify that when a user clicks the "submit" button on the Workflow UI, they should be sent to the first page. 

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)