### PR TITLE
HARMONY-1832: Update npm audit skip expiration dates for some vulnerabilities

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -2,22 +2,22 @@
   "1096482": {
     "active": true,
     "notes": "Will fix in HARMONY-1688",
-    "expiry": "2024-08-01"
+    "expiry": "2024-11-01"
   },
   "1096484": {
     "active": true,
     "notes": "Will fix in HARMONY-1688",
-    "expiry": "2024-08-01"
+    "expiry": "2024-11-01"
   },
   "1097682": {
     "active": true,
     "notes": "Will fix in HARMONY-1650",
-    "expiry": "2024-08-01"
+    "expiry": "2024-11-01"
   },
   "1096727": {
     "active": true,
     "notes": "Will fix in HARMONY-1729",
-    "expiry": "2024-08-01"
+    "expiry": "2024-11-01"
   },
   "1097493": {
     "active": true,

--- a/services/harmony/.nsprc
+++ b/services/harmony/.nsprc
@@ -2,22 +2,22 @@
   "1097682": {
     "active": true,
     "notes": "Will fix in HARMONY-1650",
-    "expiry": "2024-08-01"
+    "expiry": "2024-11-01"
   },
   "1096482": {
     "active": true,
     "notes": "Will fix in HARMONY-1700",
-    "expiry": "2024-08-01"
+    "expiry": "2024-11-01"
   },
   "1096484": {
     "active": true,
     "notes": "Will fix in HARMONY-1700",
-    "expiry": "2024-08-01"
+    "expiry": "2024-11-01"
   },
   "1096727": {
     "active": true,
     "notes": "Will fix in HARMONY-1729",
-    "expiry": "2024-08-01"
+    "expiry": "2024-11-01"
   },
   "1097493": {
     "active": true,

--- a/services/service-runner/.nsprc
+++ b/services/service-runner/.nsprc
@@ -2,11 +2,11 @@
   "1097682": {
     "active": true,
     "notes": "Will fix in HARMONY-1650",
-    "expiry": "2024-08-01"
+    "expiry": "2024-11-01"
   },
   "1096727": {
     "active": true,
     "notes": "Will fix in HARMONY-1729",
-    "expiry": "2024-08-01"
+    "expiry": "2024-11-01"
   }
 }

--- a/services/work-failer/.nsprc
+++ b/services/work-failer/.nsprc
@@ -2,6 +2,6 @@
   "1096727": {
     "active": true,
     "notes": "Will fix in HARMONY-1729",
-    "expiry": "2024-08-01"
+    "expiry": "2024-11-01"
   }
 }

--- a/services/work-scheduler/.nsprc
+++ b/services/work-scheduler/.nsprc
@@ -2,11 +2,11 @@
   "1097682": {
     "active": true,
     "notes": "Will fix in HARMONY-1650",
-    "expiry": "2024-08-01"
+    "expiry": "2024-11-01"
   },
   "1096727": {
     "active": true,
     "notes": "Will fix in HARMONY-1729",
-    "expiry": "2024-08-01"
+    "expiry": "2024-11-01"
   }
 }


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1832

## Description
Some of the .nsprc expiration date has expired today. Update npm audit skip expiration dates for some vulnerabilities to later date.

## Local Test Steps
npm install 
npm run test

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)