### PR TITLE
HARMONY-1834: Support cookie-secret header when getting service-deployments-state.

### DIFF
--- a/docs/guides/develop.md
+++ b/docs/guides/develop.md
@@ -32,7 +32,7 @@ Highly Recommended:
 
 Optional:
 * [awscli-local](https://github.com/localstack/awscli-local) - CLI helpers for interacting with localstack
-* [Python](https://www.python.org) version 3.7 - Useful for locally running and testing harmony-docker and other backend services
+* [Python](https://www.python.org) version 3.11 - Useful for locally running and testing harmony-docker and other backend services
 
 ## Set up Environment
 

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -1,6 +1,7 @@
 import { Response, NextFunction } from 'express';
 import HarmonyRequest from '../models/harmony-request';
 import { ECR } from '../util/container-registry';
+import { hasCookieSecret } from '../util/cookie-secret';
 import { getEdlGroupInformation, validateUserIsInCoreGroup } from '../util/edl-api';
 import { exec } from 'child_process';
 import * as path from 'path';
@@ -521,7 +522,8 @@ export async function updateServiceImageTag(
 export async function getServiceImageTagState(
   req: HarmonyRequest, res: Response, _next: NextFunction,
 ): Promise<void> {
-  if (! await validateUserIsInDeployerOrCoreGroup(req, res)) return;
+  if (!hasCookieSecret(req))
+    if (! await validateUserIsInDeployerOrCoreGroup(req, res)) return;
 
   const { enabled, message } = await getEnabledAndMessage();
   res.statusCode = 200;

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -522,8 +522,7 @@ export async function updateServiceImageTag(
 export async function getServiceImageTagState(
   req: HarmonyRequest, res: Response, _next: NextFunction,
 ): Promise<void> {
-  if (!hasCookieSecret(req))
-    if (! await validateUserIsInDeployerOrCoreGroup(req, res)) return;
+  if (!hasCookieSecret(req) && ! await validateUserIsInDeployerOrCoreGroup(req, res)) return;
 
   const { enabled, message } = await getEnabledAndMessage();
   res.statusCode = 200;

--- a/services/harmony/app/routers/router.ts
+++ b/services/harmony/app/routers/router.ts
@@ -139,7 +139,7 @@ const authorizedRoutes = [
   '/service-results/*',
   '/workflow-ui*',
   '/service-image*',
-  '/service-deployment*',
+  '/service-deployment\//*',
   '/ogc-api-edr/.*/collections/*',
 ];
 

--- a/services/harmony/app/util/cookie-secret.ts
+++ b/services/harmony/app/util/cookie-secret.ts
@@ -1,0 +1,16 @@
+import HarmonyRequest from '../models/harmony-request';
+
+/**
+ * Validate that the request has correct cookie secret in header
+ * @param req - The request object
+ * @returns Boolean `true` if the request has correct cookie secret in header, `false` otherwise
+ */
+export function hasCookieSecret(req: HarmonyRequest): boolean {
+  const headerSecret = req.headers['cookie-secret'];
+  const secret = process.env.COOKIE_SECRET;
+  if (headerSecret === secret) {
+    return true;
+  }
+
+  return false;
+}

--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -1397,6 +1397,54 @@ describe('Service self-deployment failure', async function () {
   });
 });
 
+describe('get service deployments state with cookie-secret', async function () {
+  beforeEach(function () {
+    process.env.COOKIE_SECRET = 'cookie-secret-value';
+  });
+
+  hookServersStartStop({ skipEarthdataLogin: true });
+
+  describe('when incorrect cookie-secret header is provided', async function () {
+    before(async function () {
+      this.res = await request(this.frontend)
+        .get('/service-deployments-state')
+        .set('cookie-secret', 'wrong_secret');
+    });
+
+    after(function () {
+      delete this.res;
+    });
+
+    it('rejects the request', async function () {
+      expect(this.res.status).to.equal(403);
+    });
+
+    it('returns a meaningful error message', async function () {
+      expect(this.res.text).to.equal('User undefined does not have permission to access this resource');
+    });
+  });
+
+  describe('when correct cookie-secret header is provided', async function () {
+    before(async function () {
+      this.res = await request(this.frontend)
+        .get('/service-deployments-state')
+        .set('cookie-secret', process.env.COOKIE_SECRET);
+    });
+
+    after(function () {
+      delete this.res;
+    });
+
+    it('returns a status 200', async function () {
+      expect(this.res.status).to.equal(200);
+    });
+
+    it('returns the service enabled true', async function () {
+      expect(this.res.body.enabled).to.eql(true);
+    });
+  });
+});
+
 describe('Update service deployments state with cookie-secret', async function () {
   beforeEach(function () {
     process.env.COOKIE_SECRET = 'cookie-secret-value';


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1834

## Description
Support cookie-secret header when getting service-deployments-state.

## Local Test Steps
curl -i -H "COOKIE-SECRET: xxxxxx"  http://localhost:3000/service-deployments-state


## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)