### PR TITLE
HARMONY-1782: Add auto-populated information about the current PREVIEW_THRESHOLD to the online docs

### DIFF
--- a/services/harmony/app/frontends/docs/docs.ts
+++ b/services/harmony/app/frontends/docs/docs.ts
@@ -76,7 +76,7 @@ function markdownInterpolate(token: string, mappings: { [key: string]: () => str
  * @param root - The root of the URL for the environment.
  * @returns a promise that resolves to a string.
  */
-async function generateDocumentation(root: string): Promise<string> {
+export async function generateDocumentation(root: string): Promise<string> {
   let { tableCount, exampleCount } = await getTableAndExampleCounts();
   let exampleCollectionId = UAT_COLLECTION_ID;
   if (root === PROD_ROOT) {
@@ -106,6 +106,7 @@ async function generateDocumentation(root: string): Promise<string> {
         root: () => root,
         exampleCounter: () => `${exampleCount--}`,
         tableCounter: () => `${tableCount--}`,
+        previewThreshold: () => `${env.previewThreshold}`,
       });
     })
     // interpolate values in non-inline tags

--- a/services/harmony/app/markdown/jobs.md
+++ b/services/harmony/app/markdown/jobs.md
@@ -108,6 +108,8 @@ granules are processed. This allows the user to examine the output to make sure 
 look right before waiting for the entire job to complete. If things looks good, the
 user can resume the paused job, if not they can cancel the paused job.
 
+**Note:** The current threshold in this environment for the number of granules that will trigger automatic pausing of a job is **{{previewThreshold}}**.
+
 If a user wishes to skip this step they can pass the `skipPreview` flag mentioned in the
 [Services API section](#using-the-service-apis), or they can tell an already running job
 to skip the preview using the following:

--- a/services/harmony/test/documentation-page.ts
+++ b/services/harmony/test/documentation-page.ts
@@ -7,8 +7,19 @@ import env from '../app/util/env';
 import version from '../app/util/version';
 import { hookDocumentationPage } from './helpers/documentation-page';
 
+const TEST_PREVIEW_THRESHOLD = 1234;
+
 describe('Documentation page', function () {
   hookServersStartStop();
+
+  let currentPreviewThreshold;
+  before(function () {
+    currentPreviewThreshold = env.previewThreshold;
+    env.previewThreshold = TEST_PREVIEW_THRESHOLD;
+  });
+  after(function () {
+    env.previewThreshold = currentPreviewThreshold;
+  });
 
   describe('when hitting the Harmony documentation page URL', function () {
     hookDocumentationPage();
@@ -84,6 +95,10 @@ describe('Documentation page', function () {
 
     it('provides a section on the jobs API and the workflow-UI', function () {
       expect(this.res.text).to.include('<h3 id="monitoring-jobs-with-the-jobs-api-and-the-workflow-ui"');
+    });
+
+    it('includes a statement documenting the preview threshold', function () {
+      expect(this.res.text).to.include(`<p><strong>Note:</strong> The current threshold in this environment for the number of granules that will trigger automatic pausing of a job is <strong>${TEST_PREVIEW_THRESHOLD}</strong>.</p>`);
     });
 
     it('provides a section on the stac endpoints', function () {


### PR DESCRIPTION
## Jira Issue ID

HARMONY-1782

## Description
Adds  a line in the jobs management section of the docs giving the exact number of granules that will trigger an auto-pause of a job.

## Local Test Steps
1. Run this branch and open the docs
```
http://locahosthost:3000/docs
```
2. verify that there is a line in the job management section that gives the exact number of granules that will trigger an auto-pause. It should be something like

```
Note: The current threshold in this environment for the number of granules that will trigger automatic pausing of a job is 100.
```

3. Change `PREVIEW_THRESHOLD` in services/harmony/env-defaults (or in .env) to something different and restart harmony
4. Verify that the line now uses the new value

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)