### PR TITLE
Add prod entry for net2cog

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -319,6 +319,30 @@ https://cmr.earthdata.nasa.gov:
         is_sequential: true
       - image: !Env ${GEOLOCO_IMAGE}
 
+  - name: net2cog
+    description: |
+      Converts NetCDF files to COG. Includes extension for running in NASA Harmony. https://github.com/podaac/net2cog
+    data_operation_version: '0.19.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/harmony/net2cog
+    umm_s: S3177988677-POCLOUD
+    capabilities:
+      subsetting:
+        variable: true
+      output_formats:
+        - image/tiff
+        # Don't know how specific/accuate this should be. This is (as far as I can tell) the 'official' mime-type that specifies COG. Got this value from https://github.com/opengeospatial/CloudOptimizedGeoTIFF/issues/1 and from pystac media type constant https://pystac.readthedocs.io/en/stable/api/media_type.html
+        - image/tiff; application=geotiff; profile=cloud-optimized
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${NET2COG_IMAGE}
+  
   - name: nasa/harmony-gdal-adapter
     description: |
       Service translating Harmony operations to GDAL commands.


### PR DESCRIPTION
## Jira Issue ID

N/A

Follow on from https://github.com/nasa/harmony/pull/619

## Description

Add production entry for net2cog after production readiness check in. 

Recording: https://wiki.earthdata.nasa.gov/download/attachments/168039791/net2cog_Production_Readiness_Check-In.mp4?version=1&modificationDate=1725577666728&api=v2
Slides: https://wiki.earthdata.nasa.gov/download/attachments/168039791/net2cog%20Production%20Readiness%20Check-In.pdf?version=1&modificationDate=1725900943577&api=v2

## Local Test Steps

N/A

## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)