### PR TITLE
HARMONY-1889: Add support for requesting time or area based averaging

### DIFF
--- a/docs/guides/adapting-new-services.md
+++ b/docs/guides/adapting-new-services.md
@@ -179,6 +179,9 @@ The structure of an entry in the [services.yml](../../config/services.yml) file 
       temporal: true              # Can subset by a time range
       variable: true              # Can subset by UMM-Var variable
       multiple_variable: true     # Can subset multiple variables at once
+    averaging:
+      time: true                  # Can perform averaging over time
+      area: true                  # Can perform averaging over area
     output_formats:               # A list of output mime types the service can produce
       - image/tiff
       - image/png

--- a/services/harmony/app/frontends/ogc-coverages/get-coverage-rangeset.ts
+++ b/services/harmony/app/frontends/ogc-coverages/get-coverage-rangeset.ts
@@ -2,7 +2,7 @@ import { NextFunction, Response } from 'express';
 import DataOperation from '../../models/data-operation';
 import HarmonyRequest from '../../models/harmony-request';
 import wrap from '../../util/array';
-import { handleCrs, handleExtend, handleFormat, handleGranuleIds, handleGranuleNames, handleHeight, handleScaleExtent, handleScaleSize, handleWidth } from '../../util/parameter-parsers';
+import { handleAveragingType, handleCrs, handleExtend, handleFormat, handleGranuleIds, handleGranuleNames, handleHeight, handleScaleExtent, handleScaleSize, handleWidth } from '../../util/parameter-parsers';
 import { createDecrypter, createEncrypter } from '../../util/crypto';
 import env from '../../util/env';
 import { RequestValidationError } from '../../util/errors';
@@ -41,6 +41,7 @@ export default function getCoverageRangeset(
   handleScaleSize(operation, query);
   handleHeight(operation, query);
   handleWidth(operation, query);
+  handleAveragingType(operation, query);
 
   operation.interpolationMethod = query.interpolation;
   if (query.forceasync) {

--- a/services/harmony/app/frontends/ogc-edr/get-data-common.ts
+++ b/services/harmony/app/frontends/ogc-edr/get-data-common.ts
@@ -1,7 +1,7 @@
 import DataOperation from '../../models/data-operation';
 import HarmonyRequest from '../../models/harmony-request';
 import wrap from '../../util/array';
-import { handleCrs, handleExtend, handleFormat, handleGranuleIds, handleGranuleNames, handleScaleExtent, handleScaleSize } from '../../util/parameter-parsers';
+import { handleAveragingType, handleCrs, handleExtend, handleFormat, handleGranuleIds, handleGranuleNames, handleScaleExtent, handleScaleSize } from '../../util/parameter-parsers';
 import { createDecrypter, createEncrypter } from '../../util/crypto';
 import env from '../../util/env';
 import { RequestValidationError } from '../../util/errors';
@@ -35,6 +35,7 @@ export function getDataCommon(
   handleCrs(operation, query.crs);
   handleScaleExtent(operation, query);
   handleScaleSize(operation, query);
+  handleAveragingType(operation, query);
 
   operation.interpolationMethod = query.interpolation;
   operation.outputWidth = query.width;

--- a/services/harmony/app/markdown/apis.md
+++ b/services/harmony/app/markdown/apis.md
@@ -71,6 +71,7 @@ As such it accepts parameters in the URL path as well as query parameters.
 | ignoreErrors | if "true", continue processing a request to completion even if some items fail. If "false" immediately fail the request. Defaults to true |
 | destinationUrl | destination url specified by the client; currently only s3 link urls are  supported (e.g. s3://my-bucket-name/mypath) and will result in the job being run asynchronously |
 | variable | the variable(s) to be used for variable subsetting. Multiple variables can be specified as a comma-separated list. This parameter is only used if the url `variable` path element is "parameter_vars" |
+| averagingType | requests the data to be averaged over either time or area |
 ---
 **Table {{tableCounter}}** - Harmony OGC Coverages API query parameters
 
@@ -131,6 +132,7 @@ Currently only the `/position`, `/cube` and `/area` routes are supported for spa
 | subset | get a subset of the coverage by slicing or trimming along one axis. Harmony supports arbitrary dimension names for subsetting on numeric ranges for that dimension. |
 | height | number of rows to return in the output coverage |
 | width | number of columns to return in the output coverage |
+| averagingType | requests the data to be averaged over either time or area |
 ---
 **Table {{tableCounter}}** - Harmony extended parameters for all OGC EDR API routes
 

--- a/services/harmony/app/models/data-operation.ts
+++ b/services/harmony/app/models/data-operation.ts
@@ -310,6 +310,8 @@ export default class DataOperation {
 
   ignoreErrors?: boolean;
 
+  averagingType: string;
+
   destinationUrl: string;
 
   ummCollections: CmrUmmCollection[];

--- a/services/harmony/app/models/services/base-service.ts
+++ b/services/harmony/app/models/services/base-service.ts
@@ -28,6 +28,10 @@ export interface ServiceCapabilities {
     variable?: boolean;
     multiple_variable?: true;
   };
+  averaging?: {
+    time?: boolean;
+    area?: boolean;
+  };
   output_formats?: string[];
   reprojection?: boolean;
   extend?: boolean;

--- a/services/harmony/app/schemas/ogc-api-coverages/1.0.0/ogc-api-coverages-v1.0.0.yml
+++ b/services/harmony/app/schemas/ogc-api-coverages/1.0.0/ogc-api-coverages-v1.0.0.yml
@@ -343,6 +343,7 @@ paths:
         - $ref: "#/components/parameters/grid"
         - $ref: "#/components/parameters/extend"
         - $ref: "#/components/parameters/variable"
+        - $ref: "#/components/parameters/averagingType"
       responses:
         "200":
           description: A coverage's range set.
@@ -384,6 +385,7 @@ paths:
         - $ref: "#/components/parameters/grid"
         - $ref: "#/components/parameters/extend"
         - $ref: "#/components/parameters/variable"
+        - $ref: "#/components/parameters/averagingType"
       requestBody:
         content:
           multipart/form-data:
@@ -984,3 +986,12 @@ components:
         items:
           type: string
           minLength: 1
+    averagingType:
+      name: averagingType
+      in: query
+      description: |
+        requests the data to be averaged over time or area
+      required: false
+      schema:
+        type: string
+

--- a/services/harmony/app/schemas/ogc-api-edr/1.1.0/ogc-api-edr-v1.1.0.yml
+++ b/services/harmony/app/schemas/ogc-api-edr/1.1.0/ogc-api-edr-v1.1.0.yml
@@ -172,6 +172,7 @@ paths:
         - $ref: "#/components/parameters/granuleName"
         - $ref: "#/components/parameters/grid"
         - $ref: "#/components/parameters/extend"
+        - $ref: "#/components/parameters/averagingType"
       responses:
         "200":
           description: A collection's EDR.
@@ -258,6 +259,8 @@ paths:
                   type: string
                 extend:
                   type: string
+                averagingType:
+                  type: string
       responses:
         "200":
           description: A collection's EDR.
@@ -304,6 +307,7 @@ paths:
         - $ref: "#/components/parameters/granuleName"
         - $ref: "#/components/parameters/grid"
         - $ref: "#/components/parameters/extend"
+        - $ref: "#/components/parameters/averagingType"
       responses:
         "200":
           description: A collection's EDR.
@@ -396,6 +400,8 @@ paths:
                   type: string
                 extend:
                   type: string
+                averagingType:
+                  type: string
       responses:
         "200":
           description: A collection's EDR.
@@ -442,6 +448,7 @@ paths:
         - $ref: "#/components/parameters/granuleName"
         - $ref: "#/components/parameters/grid"
         - $ref: "#/components/parameters/extend"
+        - $ref: "#/components/parameters/averagingType"
       responses:
         "200":
           description: A collection's EDR.
@@ -532,6 +539,8 @@ paths:
                   type: string
                 extend:
                   type: string
+                averagingType:
+                  type: string
       responses:
         "200":
           description: A edr description.
@@ -576,6 +585,7 @@ paths:
         - $ref: "#/components/parameters/granuleName"
         - $ref: "#/components/parameters/grid"
         - $ref: "#/components/parameters/extend"
+        - $ref: "#/components/parameters/averagingType"
       responses:
         "200":
           description: A collection's EDR.
@@ -661,6 +671,8 @@ paths:
                   type: string
                 extend:
                   type: string
+                averagingType:
+                  type: string
       responses:
         "200":
           description: A collection's EDR.
@@ -705,6 +717,7 @@ paths:
         - $ref: "#/components/parameters/granuleName"
         - $ref: "#/components/parameters/grid"
         - $ref: "#/components/parameters/extend"
+        - $ref: "#/components/parameters/averagingType"
       responses:
         "200":
           description: A collection's EDR.
@@ -791,6 +804,8 @@ paths:
                   type: string
                 extend:
                   type: string
+                averagingType:
+                  type: string
       responses:
         "200":
           description: A collection's EDR.
@@ -841,6 +856,7 @@ paths:
         - $ref: "#/components/parameters/granuleName"
         - $ref: "#/components/parameters/grid"
         - $ref: "#/components/parameters/extend"
+        - $ref: "#/components/parameters/averagingType"
       responses:
         "200":
           description: A collection's EDR.
@@ -942,6 +958,8 @@ paths:
                 grid:
                   type: string
                 extend:
+                  type: string
+                averagingType:
                   type: string
       responses:
         "200":
@@ -1641,6 +1659,14 @@ components:
       in: query
       description: |
         the name or concept id of the variable to extend
+      required: false
+      schema:
+        type: string
+    averagingType:
+      name: averagingType
+      in: query
+      description: |
+        requests the data to be averaged over time or area
       required: false
       schema:
         type: string

--- a/services/harmony/app/util/parameter-parsers.ts
+++ b/services/harmony/app/util/parameter-parsers.ts
@@ -201,3 +201,22 @@ export function handleWidth(
     }
   }
 }
+
+/**
+ * Handle the averaging parameter in a Harmony query, adding it to the DataOperation
+ * if necessary.
+ *
+ * @param operation - the DataOperation for the request
+ * @param query - the query for the request
+ */
+export function handleAveragingType(
+  operation: DataOperation,
+  query: Record<string, string>): void {
+  if (query.averagingtype) {
+    const value = query.averagingtype.toLowerCase();
+    if (value !== 'time' && value !== 'area') {
+      throw new RequestValidationError('query parameter "averagingType" must be either "time" or "area"');
+    }
+    operation.averagingType = value;
+  }
+}

--- a/services/harmony/test/models/services.ts
+++ b/services/harmony/test/models/services.ts
@@ -107,6 +107,28 @@ describe('services.chooseServiceConfig and services.buildService', function () {
             },
           },
         },
+        {
+          name: 'time-averaging-service',
+          type: { name: 'turbo' },
+          collections: [{ id: collectionId }],
+          capabilities: {
+            averaging: {
+              time: true,
+            },
+            output_formats: ['application/x-netcdf4'],
+          },
+        },
+        {
+          name: 'area-averaging-service',
+          type: { name: 'turbo' },
+          collections: [{ id: collectionId }],
+          capabilities: {
+            averaging: {
+              area: true,
+            },
+            output_formats: ['application/x-netcdf4'],
+          },
+        },
       ];
     });
 
@@ -174,6 +196,28 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       it('chooses the service that supports dimension extension', function () {
         const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
         expect(serviceConfig.name).to.equal('extend-service');
+      });
+    });
+
+    describe('and the request needs area averaging', function () {
+      beforeEach(function () {
+        this.operation.averagingType = 'area';
+      });
+
+      it('chooses the service that supports area averaging', function () {
+        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        expect(serviceConfig.name).to.equal('area-averaging-service');
+      });
+    });
+
+    describe('and the request needs time averaging', function () {
+      beforeEach(function () {
+        this.operation.averagingType = 'time';
+      });
+
+      it('chooses the service that supports time averaging', function () {
+        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        expect(serviceConfig.name).to.equal('time-averaging-service');
       });
     });
 

--- a/services/harmony/test/parameters/averaging_type.ts
+++ b/services/harmony/test/parameters/averaging_type.ts
@@ -1,0 +1,88 @@
+import { expect } from 'chai';
+// import { hookRedirect } from '../helpers/hooks';
+import { hookRangesetRequest } from '../helpers/ogc-api-coverages';
+import hookServersStartStop from '../helpers/servers';
+import StubService from '../helpers/stub-service';
+
+// Note that there are currently no time or area averaging services in services.yml
+// which is why several of the assertions are using `xit`. Once there are services to
+// support it we should enable the assertions and uncomment out the code to follow
+// the redirects.
+describe('averagingType', function () {
+  const collection = 'C1233800302-EEDTEST';
+  hookServersStartStop();
+
+  describe('when making a request with averagingType time', function () {
+    const averagingTimeQuery = {
+      averagingType: 'time',
+    };
+
+    describe('for a collection that can support it', function () {
+      StubService.hook({ params: { redirect: 'http://example.com' } });
+      hookRangesetRequest('1.0.0', collection, 'all', { query: { ...averagingTimeQuery } });
+      // hookRedirect('anonymous');
+
+      xit('returns a 200 status code for the request', async function () {
+        expect(this.res.status).to.equal(200);
+      });
+
+      xit('specifies to perform time averaging in the operation', async function () {
+        expect(this.service.operation.averagingType).to.equal('time');
+      });
+    });
+
+    describe('for a collection that has no service that can support it', function () {
+      StubService.hook({ params: { redirect: 'http://example.com' } });
+      hookRangesetRequest('1.0.0', collection, 'all', { query: { ...averagingTimeQuery } });
+
+      xit('returns a 400 status code for the request', async function () {
+        expect(this.res.status).to.equal(400);
+      });
+
+      xit('returns a message indicating that no service supports time averaging', async function () {
+        const errorMessage = {
+          'code': 'harmony.UnsupportedOperation',
+          'description': 'Error: the requested combination of operations: time averaging on C1233800302-EEDTEST is unsupported',
+        };
+        expect(this.res.body).to.eql(errorMessage);
+      });
+    });
+  });
+
+  describe('when making a request with averagingType area', function () {
+    const averagingAreaQuery = {
+      averagingType: 'area',
+    };
+
+    describe('for a collection that can support it', function () {
+      StubService.hook({ params: { redirect: 'http://example.com' } });
+      hookRangesetRequest('1.0.0', collection, 'all', { query: { ...averagingAreaQuery } });
+      // hookRedirect('anonymous');
+
+      xit('returns a 200 status code for the request', async function () {
+        expect(this.res.status).to.equal(200);
+      });
+
+      xit('specifies to perform area averaging in the operation', async function () {
+        expect(this.service.operation.averagingType).to.equal('area');
+      });
+    });
+
+    describe('for a collection that has no service that can support it', function () {
+      StubService.hook({ params: { redirect: 'http://example.com' } });
+      hookRangesetRequest('1.0.0', collection, 'all', { query: { ...averagingAreaQuery } });
+
+      it('returns a 422 status code for the request', async function () {
+        expect(this.res.status).to.equal(422);
+      });
+
+      it('returns a message indicating that no service supports area averaging', async function () {
+        const errorMessage = {
+          'code': 'harmony.UnsupportedOperation',
+          'description': 'Error: the requested combination of operations: area averaging on C1233800302-EEDTEST is unsupported',
+        };
+        expect(this.res.body).to.eql(errorMessage);
+      });
+    });
+  });
+});

--- a/services/harmony/test/parameters/averaging_type.ts
+++ b/services/harmony/test/parameters/averaging_type.ts
@@ -85,4 +85,23 @@ describe('averagingType', function () {
       });
     });
   });
+
+  describe('when making a request with an invalid averagingType', function () {
+    const badAveragingQuery = {
+      averagingType: 'no not that',
+    };
+    hookRangesetRequest('1.0.0', collection, 'all', { query: { ...badAveragingQuery } });
+
+    it('returns a 400 status code for the request', async function () {
+      expect(this.res.status).to.equal(400);
+    });
+
+    it('returns a message indicating that the averagingType value is invalid', async function () {
+      const errorMessage = {
+        'code': 'harmony.RequestValidationError',
+        'description': 'Error: query parameter "averagingType" must be either "time" or "area"',
+      };
+      expect(this.res.body).to.eql(errorMessage);
+    });
+  });
 });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1889

## Description
This is to prepare for new time averaging and area averaging services in development by Giovanni. An end user can now use the `averagingType` parameter to request either 'time' or 'area' averaging. If averaging is requested, the request will be limited to only services that support that type of averaging.

## Local Test Steps
Since at the moment no services are configured as supporting time or area you can submit any request with the parameter `averagingType=time` or `averagingType=area` and verify that the request is rejected with an appropriate message.

To verify that the capabilities logic will match correctly you can manually modify one of the services in services.yml to add the following to the capabilities section (or some combination of true/false to different services):
```
averaging:
  time: true
  area: true
```
Then submit a request to verify the request gets directed to that service. I was testing with harmony-service-example using this request for area averaging:
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng&averagingType=area

and for time averaging:
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng&averagingType=area

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)