### PR TITLE
HARMONY-1873: Add regression image tag support in service deployment.

### DIFF
--- a/db/db.sql
+++ b/db/db.sql
@@ -139,6 +139,7 @@ CREATE TABLE `service_deployments` (
   `username` varchar(255) not null,
   `service` varchar(255) not null,
   `tag` varchar(255) not null,
+  `regression_image_tag` varchar(255),
   `status` text check (`status` in ('running', 'successful', 'failed')) not null,
   `message` varchar(4096),
   `createdAt` datetime not null,

--- a/db/migrations/20240924194257_add_regression_image_tag_to_service_deployments.js
+++ b/db/migrations/20240924194257_add_regression_image_tag_to_service_deployments.js
@@ -1,0 +1,11 @@
+exports.up = function (knex) {
+  return knex.schema.alterTable('service_deployments', (t) => {
+    t.string('regression_image_tag');
+  });
+};
+
+exports.down = function (knex) {
+  return knex.schema.alterTable('service_deployments', (t) => {
+    t.dropColumn('regression_image_tag');
+  });
+};

--- a/docs/guides/managing-existing-services.md
+++ b/docs/guides/managing-existing-services.md
@@ -68,12 +68,12 @@ curl -XPUT https://harmony.uat.earthdata.nasa.gov/service-image-tag/#canonical-s
 ```
 **Example 5** - Updating a specific backend service image tag using the `/service-image-tags` API
 
-The body of the `PUT` request should be a JSON object of the same form as the single service `GET` response in the
-example above:
+The body of the `PUT` request should be a JSON object with a `tag` field indicating the tag of the updated service image and an optional `test` field with the value of the tag of the regression test docker image, the value 'latest' will be used when `test` field is omitted.
 
 ```JSON
 {
-  "tag": "new-version"
+  "tag": "new-version",
+  "test": "1.0.0"
 }
 ```
 **Example 6** - Harmony `/service-image-tags` request body for updating a tag
@@ -116,6 +116,7 @@ The returned JSON response has the fields indicating the current status of the s
   username: "yliu10",
   service: "giovanni-adapter",
   tag: "new-version",
+  regressionImageTag: "1.0.0",
   status: "successful",
   message: "Deployment successful",
   createdAt: "2024-03-29T14:56:29.151Z",

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -498,12 +498,14 @@ export async function updateServiceImageTag(
 
   const { service } = req.params;
   const { tag, test } = req.body;
+  const regressionImageTag = test ? test : 'latest';
 
   const deployment = new ServiceDeployment({
     deployment_id: deploymentId,
     username: req.user,
     service: service,
     tag: tag,
+    regression_image_tag: regressionImageTag,
     status: 'running',
     message: 'Deployment in progress',
   });
@@ -512,7 +514,6 @@ export async function updateServiceImageTag(
     await deployment.save(tx);
   });
 
-  const regressionImageTag = test ? test : 'latest';
   module.exports.execDeployScript(req, service, tag, deploymentId, regressionImageTag);
   res.statusCode = 202;
   res.send({

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -413,16 +413,23 @@ export async function getServiceImageTag(
  * @param req - The request object
  * @param service  - The name of the service to deploy
  * @param tag  - The service image tag to deploy
+ * @param regressionImageTag  - The regression image tag to run the regression test with
  * @param deploymentId  - The deployment id
  */
 export async function execDeployScript(
-  req: HarmonyRequest, service: string, tag: string, deploymentId: string,
+  req: HarmonyRequest,
+  service: string,
+  tag: string,
+  deploymentId: string,
+  regressionImageTag: string,
 ): Promise<void> {
   const currentPath = __dirname;
   const cicdDir = path.join(currentPath, '../../../../../harmony-ci-cd');
 
-  req.context.logger.info(`Execute script: ./bin/exec-deploy-service ${service} ${tag}`);
-  const command = `./bin/exec-deploy-service ${service} ${tag}`;
+  req.context.logger.info(
+    `Execute script: ./bin/exec-deploy-service ${service} ${tag} ${regressionImageTag}`);
+  const command = `./bin/exec-deploy-service ${service} ${tag} ${regressionImageTag}`;
+
   const options = {
     cwd: cicdDir,
   };
@@ -490,7 +497,7 @@ export async function updateServiceImageTag(
   }
 
   const { service } = req.params;
-  const { tag } = req.body;
+  const { tag, test } = req.body;
 
   const deployment = new ServiceDeployment({
     deployment_id: deploymentId,
@@ -505,7 +512,8 @@ export async function updateServiceImageTag(
     await deployment.save(tx);
   });
 
-  module.exports.execDeployScript(req, service, tag, deploymentId);
+  const regressionImageTag = test ? test : 'latest';
+  module.exports.execDeployScript(req, service, tag, deploymentId, regressionImageTag);
   res.statusCode = 202;
   res.send({
     'tag': tag,

--- a/services/harmony/app/models/service-deployment.ts
+++ b/services/harmony/app/models/service-deployment.ts
@@ -9,8 +9,11 @@ export enum ServiceDeploymentStatus {
 }
 
 export type ServiceDeploymentForDisplay =
-  Omit<ServiceDeployment, 'deployment_id' | 'id' | 'validate' | 'save' | 'serialize'> &
-  { deploymentId: ServiceDeployment['deployment_id'] };
+  Omit<ServiceDeployment, 'deployment_id' | 'id' | 'regression_image_tag' | 'validate' | 'save' | 'serialize'> &
+  {
+    deploymentId: ServiceDeployment['deployment_id'],
+    regressionImageTag: ServiceDeployment['regression_image_tag']
+  };
 
 /**
  *
@@ -32,6 +35,9 @@ export default class ServiceDeployment extends Record {
   // The service tag associated with the deployment
   tag: string;
 
+  // The regression image tag to run the regression test with
+  regression_image_tag: string;
+
   // The status of the deployment
   status: string;
 
@@ -39,12 +45,13 @@ export default class ServiceDeployment extends Record {
   message: string;
 
   serialize(): ServiceDeploymentForDisplay {
-    const { deployment_id, username, service, tag, status, message, createdAt, updatedAt } = this;
+    const { deployment_id, username, service, tag, regression_image_tag, status, message, createdAt, updatedAt } = this;
     const serializedDeployment = {
       deploymentId: deployment_id,
       username,
       service,
       tag,
+      regressionImageTag: regression_image_tag,
       status,
       message,
       createdAt,

--- a/services/harmony/test/service-deployment.ts
+++ b/services/harmony/test/service-deployment.ts
@@ -11,26 +11,26 @@ const userErrorMsg = 'User joe does not have permission to access this resource'
 
 describe('List service deployments endpoint', async function () {
   const failedFooDeployment = new ServiceDeployment({ deployment_id: 'abc', service: 'foo-service',
-    username: 'bob', tag: '1', status: ServiceDeploymentStatus.FAILED, message: 'Failed service deployment' });
+    username: 'bob', tag: '1', regression_image_tag: 'latest', status: ServiceDeploymentStatus.FAILED, message: 'Failed service deployment' });
 
   const successfulFooDeployment = new ServiceDeployment({
     deployment_id: 'def', service: 'foo-service',
-    username: 'eve', tag: '1', status: ServiceDeploymentStatus.SUCCESSFUL, message: 'Deployment successful',
+    username: 'eve', tag: '1', regression_image_tag: 'latest', status: ServiceDeploymentStatus.SUCCESSFUL, message: 'Deployment successful',
   });
 
   const runningFooDeployment = new ServiceDeployment({
     deployment_id: 'jkl', service: 'foo-service',
-    username: 'coraline', tag: '1', status: ServiceDeploymentStatus.RUNNING, message: 'Deployment running',
+    username: 'coraline', tag: '1', regression_image_tag: 'latest', status: ServiceDeploymentStatus.RUNNING, message: 'Deployment running',
   });
 
   const successfulBuzzDeployment = new ServiceDeployment({
     deployment_id: 'ghi', service: 'buzz-service',
-    username: 'joe', tag: '1', status: ServiceDeploymentStatus.SUCCESSFUL, message: 'Deployment successful',
+    username: 'joe', tag: '1', regression_image_tag: 'latest', status: ServiceDeploymentStatus.SUCCESSFUL, message: 'Deployment successful',
   });
 
   const runningBuzzDeployment = new ServiceDeployment({
     deployment_id: 'jkl', service: 'buzz-service',
-    username: 'adam', tag: '1', status: ServiceDeploymentStatus.RUNNING, message: 'Deployment running',
+    username: 'adam', tag: '1', regression_image_tag: 'latest', status: ServiceDeploymentStatus.RUNNING, message: 'Deployment running',
   });
 
 

--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -1242,11 +1242,13 @@ describe('Service self-deployment successful', async function () {
       });
 
       it('returns the deployment status successful', async function () {
-        const { deploymentId, username, service, tag, status, message } = this.res.body;
+        const { deploymentId, username, service, tag, regressionImageTag, status, message } = this.res.body;
         expect(deploymentId).to.eql(linkDeploymentId);
         expect(username).to.eql('buzz');
         expect(service).to.eql('harmony-service-example');
         expect(tag).to.eql('foo');
+        // regressionImageTag is set to the default value
+        expect(regressionImageTag).to.eql('latest');
         expect(status).to.eql('successful');
         expect(message).to.eql('Deployment successful');
       });
@@ -1317,7 +1319,7 @@ describe('Service self-deployment failure', async function () {
       execDeployScriptStub.callsArgWith(2, new Error(errorMessage), 'Failure output', '');
 
       hookRedirect('coraline');
-      this.res = await request(this.frontend).put('/service-image-tag/harmony-service-example').use(auth({ username: 'coraline' })).send({ tag: 'foo' });
+      this.res = await request(this.frontend).put('/service-image-tag/harmony-service-example').use(auth({ username: 'coraline' })).send({ tag: 'foo', test: '1.2.3' });
     });
 
     after(async function () {
@@ -1363,11 +1365,13 @@ describe('Service self-deployment failure', async function () {
       });
 
       it('returns the deployment status failed and the proper error message', async function () {
-        const { deploymentId, username, service, tag, status, message } = this.res.body;
+        const { deploymentId, username, service, tag, regressionImageTag, status, message } = this.res.body;
         expect(deploymentId).to.eql(linkDeploymentId);
         expect(username).to.eql('coraline');
         expect(service).to.eql('harmony-service-example');
         expect(tag).to.eql('foo');
+        // regressionImageTag matches the specified regression image tag via the 'test' field in the update request
+        expect(regressionImageTag).to.eql('1.2.3');
         expect(status).to.eql('failed');
         expect(message).to.eql(`Failed service deployment for deploymentId: ${deploymentId}. Error: ${errorMessage}`);
       });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1873

## Description
Add regression image tag support in service deployment.

## Local Test Steps
Verify the db migration can be run up and down without any issue.
Submit a service update request with `test` field to indicate the regression image tag to use for regression test:
```
curl -XPUT -H "Authorization: Bearer token" -H 'Content-type: application/json' http://localhost:3000/service-image-tag/harmony-service-example -d '{"tag": "latest", "test": "0.1.5"}'
```
Then, follow the returned deployment status link to see the deployment status, verify that the specified regression test image tag is returned in response. e.g.
```
{
  "deploymentId": "81c1acd5-57ef-448f-a596-70d28387b5f5",
  "username": "yliu10",
  "service": "harmony-service-example",
  "tag": "latest",
  "regressionImageTag": "0.1.5",
  "status": "successful",
  "message": "Deployment successful",
  "createdAt": "2024-09-24T21:30:39.838Z",
  "updatedAt": "2024-09-24T21:31:23.081Z"
}
```
## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)