### PR TITLE
HARMONY-1914: Reduce the noise in the frontend logs when setting the log level to debug

### DIFF
--- a/services/harmony/app/backends/workflow-orchestration/work-item-polling.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-polling.ts
@@ -187,7 +187,7 @@ export async function makeWorkScheduleRequest(serviceID: string): Promise<void> 
  */
 export async function getWorkFromQueue(serviceID: string, reqLogger: Logger): Promise<WorkItemData | null> {
   const queueUrl = getQueueUrlForService(serviceID);
-  reqLogger.debug(`Short polling for work from queue ${queueUrl} for service ${serviceID}`);
+  reqLogger.silly(`Short polling for work from queue ${queueUrl} for service ${serviceID}`);
 
   const queue = getQueueForUrl(queueUrl);
   if (!queue) {
@@ -197,7 +197,7 @@ export async function getWorkFromQueue(serviceID: string, reqLogger: Logger): Pr
   // get a message from the service queue without using long-polling
   let queueItem = await queue.getMessage(0);
   if (!queueItem) {
-    reqLogger.debug(`No work found on queue ${queueUrl} for service ${serviceID} - requesting work from scheduler`);
+    reqLogger.silly(`No work found on queue ${queueUrl} for service ${serviceID} - requesting work from scheduler`);
     // put a message on the scheduler queue asking it to schedule some WorkItems for this service
     await makeWorkScheduleRequest(serviceID);
 
@@ -205,12 +205,11 @@ export async function getWorkFromQueue(serviceID: string, reqLogger: Logger): Pr
     await processSchedulerQueue(reqLogger);
 
     // long poll for work before giving up
-    reqLogger.debug(`Long polling for work on queue ${queueUrl} for service ${serviceID}`);
+    reqLogger.silly(`Long polling for work on queue ${queueUrl} for service ${serviceID}`);
     queueItem = await queue.getMessage();
   }
 
   if (queueItem) {
-    // reqLogger.debug(`Found work item ${JSON.stringify(queueItem, null, 2)} on queue ${queueUrl}`);
     reqLogger.debug(`Found work item on queue ${queueUrl}`);
     // normally we would process this before deleting the message, but we instead are relying on
     // our retry mechanism to requeue the message if the worker fails
@@ -242,7 +241,7 @@ export async function getWorkFromQueue(serviceID: string, reqLogger: Logger): Pr
       reqLogger.error(`Error updating work item status to running: ${err.message}`);
     }
   } else {
-    reqLogger.debug(`No work found on queue ${queueUrl} for service ${serviceID}`);
+    reqLogger.silly(`No work found on queue ${queueUrl} for service ${serviceID}`);
   }
 
   return null;

--- a/services/harmony/app/routers/router.ts
+++ b/services/harmony/app/routers/router.ts
@@ -70,11 +70,11 @@ function logged(fn: RequestHandler): RequestHandler {
     req.context.logger = child;
     const startTime = new Date().getTime();
     try {
-      child.debug('Invoking middleware');
+      child.silly('Invoking middleware');
       return fn(req, res, next);
     } finally {
       const msTaken = new Date().getTime() - startTime;
-      child.debug('Completed middleware', { durationMs: msTaken });
+      child.silly('Completed middleware', { durationMs: msTaken });
       if (req.context.logger === child) {
         // Other middlewares may have changed the logger.  This generally happens
         // when `next()` is an async call that the middleware doesn't await.  Note


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1914

## Description
Moves some log messages from debug to silly to reduce the amount of noise when polling for work as well as middleware function calls when hitting endpoints.

## Local Test Steps
By default make sure no log messages are logged when no frontend endpoints are being called (ensure that backend services polling for work with nothing to do in the system does not cause any messages to be logged).

Verify when hitting endpoints like submitting a request using the coverages API or requesting /jobs that no messages saying "Invoking middleware" or "Completed middleware" are called.

Set `LOG_LEVEL=silly` in your .env file and restart harmony. Verify that the polling messages are logged again and the Invoking and Completed middleware messages are called.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)