### PR TITLE
Das 1601 remove png jpeg from hga

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -348,7 +348,7 @@ https://cmr.earthdata.nasa.gov:
     description: |
       Service translating Harmony operations to GDAL commands.
       Supports spatial bounding box, temporal, variable, and shapefile, reprojection,
-      and output to NetCDF4, COG, PNG, and GIF.
+      and output to NetCDF4 or COG.
       Operates on input file types supported by GDAL (most EOSDIS data).
       Most operations assume L3 data, though it is likely that some work on L2.
     data_operation_version: '0.19.0'
@@ -370,8 +370,6 @@ https://cmr.earthdata.nasa.gov:
       output_formats:
         - application/x-netcdf4
         - image/tiff
-        - image/png
-        - image/gif
       reprojection: true
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
@@ -929,7 +927,7 @@ https://cmr.uat.earthdata.nasa.gov:
     description: |
       Service translating Harmony operations to GDAL commands.
       Supports spatial bounding box, temporal, variable, and shapefile, reprojection,
-      and output to NetCDF4, COG, PNG, and GIF.
+      and output to NetCDF4 or COG.
       Operates on input file types supported by GDAL (most EOSDIS data).
       Most operations assume L3 data, though it is likely that some work on L2.
     data_operation_version: '0.19.0'
@@ -951,8 +949,6 @@ https://cmr.uat.earthdata.nasa.gov:
       output_formats:
         - application/x-netcdf4
         - image/tiff
-        - image/png
-        - image/gif
       reprojection: true
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}

--- a/services/harmony/test/collection-capabilities.ts
+++ b/services/harmony/test/collection-capabilities.ts
@@ -74,7 +74,7 @@ describe('Testing collection capabilities', function () {
         it('sets the outputFormats field correctly', function () {
           const capabilities = JSON.parse(this.res.text);
           const expectedFormats = [
-            'application/x-netcdf4', 'image/tiff', 'image/png', 'image/gif', 'application/x-zarr',
+            'application/x-netcdf4', 'image/tiff', 'application/x-zarr', 'image/png', 'image/gif',
           ];
           expect(capabilities.outputFormats).to.eql(expectedFormats);
         });
@@ -235,7 +235,7 @@ describe('Testing collection capabilities', function () {
         it('sets the outputFormats field correctly in the version 1 response', function () {
           const capabilities = JSON.parse(this.res.text);
           const expectedFormats = [
-            'application/x-netcdf4', 'image/tiff', 'image/png', 'image/gif', 'application/x-zarr',
+            'application/x-netcdf4', 'image/tiff', 'application/x-zarr', 'image/png', 'image/gif',
           ];
           expect(capabilities.outputFormats).to.eql(expectedFormats);
         });


### PR DESCRIPTION
## Jira Issue ID

DAS-1601 - preliminary work.

## Description

This PR takes the steps towards removing functionality from HGA in favour of HyBIG. HyBIG is now the preferred service to create browse imagery. DAS-1601 is a ticket to remove similar functionality from HGA. We'd held off doing that for a while, because ideally a chain of net2cog and HyBIG should exist to truly replace what we suspect HGA can do. That said, there are no true users of HGA, and very few collections associated with the service. (I've checked with PO.DAAC and they are not using HGA for browse image generation right now)

This PR removes PNG and GIF outputs from the capabilities of HGA. Once deployed, we can give it a few sprints to check people aren't missing the functionality (and point them at HyBIG if they are) and then actually rip out the relevant browse image code from HGA (the actual work for DAS-1601).

## Local Test Steps

* Pull this branch.
* Start a local Harmony-in-a-Box instance with `harmony-gdal-adapter` in the `LOCALLY_DEPLOYED_SERVICES` environment variable in `.env`.
* Run the latest version of the [HGA regression test suite](https://github.com/nasa/harmony-regression-tests/blob/main/test/hga/HGA_Regression.ipynb). (Because this is being run against your local instance, you'll have to run the tests from a local Jupyter notebook server)
* Note - if you have issues running things on a Mac with an M1 chip, you can use the updates in [this branch of HGA](https://github.com/nasa/harmony-gdal-adapter/pull/32) to build a local version of the HGA image that should run on your machine.
* Second note - both Matt and I were finding the latest version of Harmony-in-a-Box to be a bit flaky.

## PR Acceptance Checklist
* ~~Acceptance criteria met~~ - this is preliminary to ensure we can rip out the code for the ticket.
* [ x] Tests added/updated (if needed) and passing
* ~~Documentation updated (if needed)~~