### PR TITLE
Harmony 1891 - Display job labels in Workflow UI

### DIFF
--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -568,6 +568,7 @@ export async function getWorkItemsTable(
           .replace('/work-items', '')
           .replace(/(&|\?)checkJobStatus=(true|false)/, '') : '');
       },
+      ...jobRenderingFunctions(req.context.logger, requestQuery),
     });
   } catch (e) {
     req.context.logger.error(e);

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -278,7 +278,7 @@ function tableQueryToJobQuery(tableQuery: TableQuery, isAdmin: boolean, user: st
     };
   }
   if (tableQuery.from || tableQuery.to) {
-    jobQuery.dates = { field: tableQuery.dateKind };
+    jobQuery.dates = { field: `jobs.${tableQuery.dateKind}` };
     jobQuery.dates.from = tableQuery.from;
     jobQuery.dates.to = tableQuery.to;
   }

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -635,7 +635,7 @@ export async function getJobsTable(
     const { tableQuery } = parseQuery(requestQuery, JobStatus, req.context.isAdminAccess);
     const jobQuery = tableQueryToJobQuery(tableQuery, isAdmin, req.user);
     const { page, limit } = getPagingParams(req, env.defaultJobListPageSize, 1, true, true);
-    const jobsRes = await Job.queryAll(db, jobQuery, page, limit);
+    const jobsRes = await Job.queryAll(db, jobQuery, page, limit, true);
     const jobs = jobsRes.data;
     const { pagination } = jobsRes;
     const selectAllChecked = jobs.every((j) => j.hasTerminalStatus() || (jobIDs.indexOf(j.jobID) > -1)) ? 'checked' : '';

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -198,6 +198,12 @@ function jobRenderingFunctions(logger: Logger, requestQuery: Record<string, any>
         return this.request;
       }
     },
+    jobLabelsDisplay(): string {
+      return this.labels.map((label) => {
+        const labelText = truncateString(label, 30);
+        return `<span class="badge bg-label" title="${label}">${labelText}</span>`;
+      }).join(' ');
+    },
     jobMessage(): string {
       if (this.message) {
         return truncateString(this.message, 100);

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -314,7 +314,7 @@ export async function getJobs(
     const { tableQuery, originalValues } = parseQuery(requestQuery, JobStatus, isAdminRoute);
     const jobQuery = tableQueryToJobQuery(tableQuery, isAdminRoute, req.user);
     const { page, limit } = getPagingParams(req, env.defaultJobListPageSize, 1, true, true);
-    const { data: jobs, pagination } = await Job.queryAll(db, jobQuery, page, limit);
+    const { data: jobs, pagination } = await Job.queryAll(db, jobQuery, page, limit, true);
     setPagingHeaders(res, pagination);
     const pageLinks = getPagingLinks(req, pagination, true);
     const firstPage = pageLinks.find((l) => l.rel === 'first');

--- a/services/harmony/app/models/job.ts
+++ b/services/harmony/app/models/job.ts
@@ -333,7 +333,8 @@ async function getUniqueProviderIds(tx: Transaction): Promise<string[]> {
 /**
  * Sets the fields on the where clauses (see JobQuery) to be prefixed with a table name to avoid
  * ambiguities when joining with other tables
- * @param query - the where clauses to process
+ * @param table - the table name to prefix to the field name
+ * @param whereClauses - the where clauses to process
  * @returns An object with its fields prefixed with the table name
  */
 function setTableNameForWhereClauses(table: string, whereClauses: {}): {} {

--- a/services/harmony/app/models/job.ts
+++ b/services/harmony/app/models/job.ts
@@ -500,7 +500,7 @@ export class Job extends DBRecord implements JobRecord {
 
     if (includeLabels) {
       query = tx(Job.table)
-        .select(`${Job.table}.*`, tx.raw(`STRING_AGG(${LABELS_TABLE}.value, ',') AS label_values`))
+        .select(`${Job.table}.*`, tx.raw(`STRING_AGG(${LABELS_TABLE}.value, ',' order by value) AS label_values`))
         .leftOuterJoin(`${JOBS_LABELS_TABLE}`, `${Job.table}.jobID`, '=', `${JOBS_LABELS_TABLE}.job_id`)
         .leftOuterJoin(`${LABELS_TABLE}`, `${JOBS_LABELS_TABLE}.label_id`, '=', `${LABELS_TABLE}.id`)
         .where(setTableNameForWhereClauses(Job.table, constraints.where))

--- a/services/harmony/app/models/label.ts
+++ b/services/harmony/app/models/label.ts
@@ -40,7 +40,7 @@ export async function getLabelsForJob(
 ): Promise<string[]> {
   const query = trx('jobs_labels')
     .where({ job_id: jobID })
-    .orderBy(['jobs_labels.id'])
+    .orderBy(['labels.value'])
     .innerJoin('labels', 'jobs_labels.label_id', '=', 'labels.id')
     .select(['labels.value']);
 

--- a/services/harmony/app/util/env.ts
+++ b/services/harmony/app/util/env.ts
@@ -1,4 +1,4 @@
-import { IsInt, IsNotEmpty, Matches, Min } from 'class-validator';
+import { IsInt, IsNotEmpty, IsPositive, Matches, Min } from 'class-validator';
 import { HarmonyEnv, memorySizeRegex } from '@harmony/util/env';
 import _ from 'lodash';
 import * as path from 'path';
@@ -108,6 +108,7 @@ class HarmonyServerEnv extends HarmonyEnv {
   @Min(1)
   maxDataOperationCacheSize: number;
 
+  @IsPositive()
   wktPrecision: number;
 
   locallyDeployedServices: string;

--- a/services/harmony/app/util/job.ts
+++ b/services/harmony/app/util/job.ts
@@ -256,9 +256,10 @@ export async function getJobIfAllowed(
   isAdmin: boolean,
   accessToken: string,
   enableShareability: boolean,
+  includeLabels = true,
 ): Promise<Job> {
   validateJobId(jobID);
-  const { job } = await Job.byJobID(db, jobID, false, false, false);
+  const { job } = await Job.byJobID(db, jobID, false, includeLabels, false);
   if (!job) {
     throw new NotFoundError();
   }

--- a/services/harmony/app/views/workflow-ui/job/work-item-table-row.mustache.html
+++ b/services/harmony/app/views/workflow-ui/job/work-item-table-row.mustache.html
@@ -2,7 +2,7 @@
   <th scope="row">{{workflowStepIndex}}</th>
   <td>{{workflowItemStep}}</td>
   <td>{{id}}</td>
-  <td><span class="badge bg-{{workflowItemBadge}}">{{status}}</span></td>
+  <td><span class="badge rounded-pill bg-{{workflowItemBadge}}">{{status}}</span></td>
   {{#isAdminOrLogViewer}}
   <td>{{{workflowItemLogsButton}}}</td>
   {{/isAdminOrLogViewer}}

--- a/services/harmony/app/views/workflow-ui/job/work-items-table.mustache.html
+++ b/services/harmony/app/views/workflow-ui/job/work-items-table.mustache.html
@@ -1,5 +1,18 @@
-<div id="job-alert" class="alert alert-{{statusClass}} overflow-auto" role="alert">
+<div class="job-alert alert alert-{{statusClass}} overflow-auto" role="alert">
     {{job.message}}
+</div>
+
+<div class="d-flex flex-row justify-content-between mb-2 mt-1">
+    <div>
+        <i class="bi bi-copy text-primary copy-request" data-text="{{job.request}}"
+            data-truncated="{{jobRequestIsTruncated}}"></i>
+        <span title="{{jobRequest}}" class="text-muted job-url-text">{{job.request}}</span>
+    </div>
+    <div>
+        <span class="badge bg-label">The Light</span>
+        <span class="badge bg-label">Light Cool</span>
+        <span class="badge bg-label">LightABC</span>
+    </div>
 </div>
 
 <table class="table table-sm">

--- a/services/harmony/app/views/workflow-ui/job/work-items-table.mustache.html
+++ b/services/harmony/app/views/workflow-ui/job/work-items-table.mustache.html
@@ -2,18 +2,11 @@
     {{job.message}}
 </div>
 
-<div class="d-flex flex-row justify-content-between mb-2 mt-1">
-    <div>
-        <i class="bi bi-copy text-primary copy-request" data-text="{{job.request}}"
-            data-truncated="{{jobRequestIsTruncated}}"></i>
-        <span title="{{jobRequest}}" class="text-muted job-url-text">{{job.request}}</span>
-    </div>
-    <div>
-        <span class="badge bg-label">The Light</span>
-        <span class="badge bg-label">Light Cool</span>
-        <span class="badge bg-label">LightABC</span>
-    </div>
+{{#job}}
+<div class="mb-2 mt-1">
+    {{> workflow-ui/request-preview}}
 </div>
+{{/job}}
 
 <table class="table table-sm">
     <thead class="sticky-top bg-white">
@@ -23,7 +16,8 @@
             <th scope="col">id</th>
             <th scope="col">status</th>
             {{#isAdminOrLogViewer}}
-            <th class="helpful-th" scope="col" title="Links to logs (including all retries) for each work item.">logs</th>
+            <th class="helpful-th" scope="col" title="Links to logs (including all retries) for each work item.">logs
+            </th>
             {{/isAdminOrLogViewer}}
             {{#canShowRetryColumn}}
             <th scope="col">retry</th>

--- a/services/harmony/app/views/workflow-ui/job/work-items-table.mustache.html
+++ b/services/harmony/app/views/workflow-ui/job/work-items-table.mustache.html
@@ -16,8 +16,7 @@
             <th scope="col">id</th>
             <th scope="col">status</th>
             {{#isAdminOrLogViewer}}
-            <th class="helpful-th" scope="col" title="Links to logs (including all retries) for each work item.">logs
-            </th>
+            <th class="helpful-th" scope="col" title="Links to logs (including all retries) for each work item.">logs</th>
             {{/isAdminOrLogViewer}}
             {{#canShowRetryColumn}}
             <th scope="col">retry</th>

--- a/services/harmony/app/views/workflow-ui/jobs/job-table-row.mustache.html
+++ b/services/harmony/app/views/workflow-ui/jobs/job-table-row.mustache.html
@@ -5,14 +5,24 @@
     {{#isAdminRoute}}
     <td>{{username}}</td>
     {{/isAdminRoute}}
-    <td><span class="badge bg-{{jobBadge}}">{{status}}</span></td>
+    <td><span class="badge rounded-pill bg-{{jobBadge}}">{{status}}</span></td>
     <td id="message-td" title="{{message}}">{{jobMessage}}</td>
     <td>{{numInputGranules}}</td>
     <td>{{progress}}%</td>
     <td class="date-td" data-time="{{jobCreatedAt}}"></td>
     <td class="date-td" data-time="{{jobUpdatedAt}}"></td>
 </tr>
-<th id="copy-{{jobID}}" class="job-url-th" colspan="9">
-    <i class="bi bi-copy text-primary copy-request" data-text="{{request}}" data-truncated="{{jobRequestIsTruncated}}"></i>
-    <span title="{{jobRequest}}" class="text-muted job-url-text">{{jobRequestDisplay}}</span>
+<th id="copy-{{jobID}}" class="job-url-th" colspan="12">
+    <div class="d-flex flex-row justify-content-between">
+        <div>
+            <i class="bi bi-copy text-primary copy-request" data-text="{{request}}"
+                data-truncated="{{jobRequestIsTruncated}}"></i>
+            <span title="{{jobRequest}}" class="text-muted job-url-text">{{jobRequestDisplay}}</span>
+        </div>
+        <div>
+            <span class="badge bg-label">The Light</span>
+            <span class="badge bg-label">Light Cool</span>
+            <span class="badge bg-label">LightABC</span>
+        </div>
+    </div>
 </th>

--- a/services/harmony/app/views/workflow-ui/jobs/job-table-row.mustache.html
+++ b/services/harmony/app/views/workflow-ui/jobs/job-table-row.mustache.html
@@ -13,16 +13,5 @@
     <td class="date-td" data-time="{{jobUpdatedAt}}"></td>
 </tr>
 <th id="copy-{{jobID}}" class="job-url-th" colspan="12">
-    <div class="d-flex flex-row justify-content-between">
-        <div>
-            <i class="bi bi-copy text-primary copy-request" data-text="{{request}}"
-                data-truncated="{{jobRequestIsTruncated}}"></i>
-            <span title="{{jobRequest}}" class="text-muted job-url-text">{{jobRequestDisplay}}</span>
-        </div>
-        <div>
-            <span class="badge bg-label">The Light</span>
-            <span class="badge bg-label">Light Cool</span>
-            <span class="badge bg-label">LightABC</span>
-        </div>
-    </div>
+    {{> workflow-ui/request-preview}}
 </th>

--- a/services/harmony/app/views/workflow-ui/request-preview.mustache.html
+++ b/services/harmony/app/views/workflow-ui/request-preview.mustache.html
@@ -5,8 +5,8 @@
         <span title="{{jobRequest}}" class="text-muted job-url-text">{{jobRequestDisplay}}</span>
     </div>
     <div>
-        <span class="badge bg-label">The Light</span>
-        <span class="badge bg-label">Light Cool</span>
-        <span class="badge bg-label">LightABC</span>
+        {{#labels}}
+        <span class="badge bg-label">{{.}}</span>
+        {{/labels}}
     </div>
 </div>

--- a/services/harmony/app/views/workflow-ui/request-preview.mustache.html
+++ b/services/harmony/app/views/workflow-ui/request-preview.mustache.html
@@ -5,8 +5,6 @@
         <span title="{{jobRequest}}" class="text-muted job-url-text">{{jobRequestDisplay}}</span>
     </div>
     <div class="ml-1">
-        {{#labels}}
-        <span class="badge bg-label">{{.}}</span>
-        {{/labels}}
+        {{{jobLabelsDisplay}}}
     </div>
 </div>

--- a/services/harmony/app/views/workflow-ui/request-preview.mustache.html
+++ b/services/harmony/app/views/workflow-ui/request-preview.mustache.html
@@ -4,7 +4,7 @@
             data-truncated="{{jobRequestIsTruncated}}"></i>
         <span title="{{jobRequest}}" class="text-muted job-url-text">{{jobRequestDisplay}}</span>
     </div>
-    <div>
+    <div class="ml-1">
         {{#labels}}
         <span class="badge bg-label">{{.}}</span>
         {{/labels}}

--- a/services/harmony/app/views/workflow-ui/request-preview.mustache.html
+++ b/services/harmony/app/views/workflow-ui/request-preview.mustache.html
@@ -1,0 +1,12 @@
+<div class="d-flex flex-row justify-content-between">
+    <div>
+        <i class="bi bi-copy text-primary copy-request" data-text="{{request}}"
+            data-truncated="{{jobRequestIsTruncated}}"></i>
+        <span title="{{jobRequest}}" class="text-muted job-url-text">{{jobRequestDisplay}}</span>
+    </div>
+    <div>
+        <span class="badge bg-label">The Light</span>
+        <span class="badge bg-label">Light Cool</span>
+        <span class="badge bg-label">LightABC</span>
+    </div>
+</div>

--- a/services/harmony/public/css/workflow-ui/default.css
+++ b/services/harmony/public/css/workflow-ui/default.css
@@ -51,3 +51,7 @@
 .bg-label {
     background-color: #92a7ba !important;
 }
+
+.job-alert {
+    margin-bottom: 0;
+}

--- a/services/harmony/public/css/workflow-ui/default.css
+++ b/services/harmony/public/css/workflow-ui/default.css
@@ -47,3 +47,7 @@
 #workflow-ui-jobs-table .job-table-row {
     border-bottom-color: white;
 }
+
+.bg-label {
+    background-color: #92a7ba !important;
+}

--- a/services/harmony/public/js/workflow-ui/job/work-items-table.js
+++ b/services/harmony/public/js/workflow-ui/job/work-items-table.js
@@ -1,4 +1,4 @@
-import { formatDates } from '../table.js';
+import { formatDates, initCopyHandler } from '../table.js';
 import toasts from '../toasts.js';
 import PubSub from '../../pub-sub.js';
 
@@ -45,6 +45,7 @@ async function load(params, checkJobStatus) {
     document.getElementById('workflow-items-table-container').innerHTML = template;
     bindRetryButtonClickHandler('tr button.retry-button');
     formatDates('.date-td');
+    initCopyHandler('.copy-request');
     return true;
   }
   return false;

--- a/services/harmony/public/js/workflow-ui/jobs/jobs-table.js
+++ b/services/harmony/public/js/workflow-ui/jobs/jobs-table.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-param-reassign */
-import { formatDates } from '../table.js';
-import toasts from '../toasts.js';
+import { formatDates, initCopyHandler } from '../table.js';
 import PubSub from '../../pub-sub.js';
 
 // all of the currently selected job IDs
@@ -59,56 +58,6 @@ function initFilter(currentUser, services, providers, isAdminRoute, tableFilter)
   });
   const initialTags = JSON.parse(tableFilter);
   tagInput.addTags(initialTags);
-}
-
-/**
- * Fallback method for copying text to clipboard.
- * @param {string} text - the text to copy
- */
-function fallbackCopyTextToClipboard(text) {
-  const textArea = document.createElement('textarea');
-  textArea.value = text;
-  // Avoid scrolling to bottom
-  textArea.style.top = '0';
-  textArea.style.left = '0';
-  textArea.style.position = 'fixed';
-  document.body.appendChild(textArea);
-  textArea.focus();
-  textArea.select();
-  try {
-    document.execCommand('copy');
-  } finally {
-    document.body.removeChild(textArea);
-  }
-}
-
-/**
- * Method for copying the text to the clipboard.
- * @param {string} text - the text to copy
- */
-async function copyTextToClipboard(text) {
-  if (!navigator.clipboard) {
-    fallbackCopyTextToClipboard(text);
-    return;
-  }
-  await navigator.clipboard.writeText(text);
-}
-
-/**
- * Intitialize the copy click handler for all copy buttons.
- * @param {string} selector - defines which button(s) to bind the handler to
- */
-async function initCopyHandler(selector) {
-  // https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript
-  document.querySelectorAll(selector).forEach((el) => {
-    el.addEventListener('click', (event) => {
-      copyTextToClipboard(event.target.getAttribute('data-text'));
-      const isTruncated = event.target.getAttribute('data-truncated') === 'true';
-      toasts.showUpper(
-          `✅ Copied to clipboard${isTruncated ? '. WARNING: this request text was truncated due to length constraints.' : ''}`,
-      );
-    });
-  });
 }
 
 /**

--- a/services/harmony/public/js/workflow-ui/table.js
+++ b/services/harmony/public/js/workflow-ui/table.js
@@ -1,3 +1,5 @@
+import toasts from './toasts.js';
+
 /**
  * Format all of the dates in the user's browser timezone.
  * @param {string} selector - the selector to use in querySelectorAll to
@@ -25,9 +27,60 @@ function initTooltips(querySelector) {
 }
 
 /**
+ * Fallback method for copying text to clipboard.
+ * @param {string} text - the text to copy
+ */
+function fallbackCopyTextToClipboard(text) {
+  const textArea = document.createElement('textarea');
+  textArea.value = text;
+  // Avoid scrolling to bottom
+  textArea.style.top = '0';
+  textArea.style.left = '0';
+  textArea.style.position = 'fixed';
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+  try {
+    document.execCommand('copy');
+  } finally {
+    document.body.removeChild(textArea);
+  }
+}
+
+/**
+ * Method for copying the text to the clipboard.
+ * @param {string} text - the text to copy
+ */
+async function copyTextToClipboard(text) {
+  if (!navigator.clipboard) {
+    fallbackCopyTextToClipboard(text);
+    return;
+  }
+  await navigator.clipboard.writeText(text);
+}
+
+/**
+ * Intitialize the copy click handler for all copy buttons.
+ * @param {string} selector - defines which button(s) to bind the handler to
+ */
+async function initCopyHandler(selector) {
+  // https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript
+  document.querySelectorAll(selector).forEach((el) => {
+    el.addEventListener('click', (event) => {
+      copyTextToClipboard(event.target.getAttribute('data-text'));
+      const isTruncated = event.target.getAttribute('data-truncated') === 'true';
+      toasts.showUpper(
+          `✅ Copied to clipboard${isTruncated ? '. WARNING: this request text was truncated due to length constraints.' : ''}`,
+      );
+    });
+  });
+}
+
+/**
  * Utility for commonly used table logic.
  */
 export {
   formatDates,
   initTooltips,
+  initCopyHandler,
 };

--- a/services/harmony/test/jobs/jobs-listing.ts
+++ b/services/harmony/test/jobs/jobs-listing.ts
@@ -128,7 +128,7 @@ describe('Jobs listing route', function () {
         // need to use a consistent sort since the timestamps in sqlite are not fine-grained
         // enough to guarantee the jobs are returned in the order they are created
         const labels = jobs.sort((jobA, jobB) => jobA.progress - jobB.progress).map((j) => j.labels);
-        expect(labels).deep.equal([[], woodyJob2Labels, woodyJob1Labels]);
+        expect(labels).deep.equal([[], ['bazz', 'foo'], ['bar', 'foo']]);
       });
 
       it("does not include data links in any job's list of links", function () {

--- a/services/harmony/test/jobs/jobs-listing.ts
+++ b/services/harmony/test/jobs/jobs-listing.ts
@@ -19,7 +19,7 @@ const woodyJob1 = buildJob({
   numInputGranules: 3,
 });
 
-const woodyJob1Labels = ['foo', 'bar'];
+const woodyJob1Labels = ['foo', 'bar', '0', 'a', 'z'];
 
 const woodyJob2 = buildJob({
   username: 'woody',
@@ -123,12 +123,12 @@ describe('Jobs listing route', function () {
         expect(itemLinks[0].href).to.match(new RegExp(`/jobs/${jobs[0].jobID}$`));
       });
 
-      it('includes labels in the jobs links', function () {
+      it('includes labels in the jobs links, sorted alphabetically', function () {
         const jobs = JSON.parse(this.res.text).jobs.map((j) => new Job(j)) as Job[];
         // need to use a consistent sort since the timestamps in sqlite are not fine-grained
         // enough to guarantee the jobs are returned in the order they are created
         const labels = jobs.sort((jobA, jobB) => jobA.progress - jobB.progress).map((j) => j.labels);
-        expect(labels).deep.equal([[], ['bazz', 'foo'], ['bar', 'foo']]);
+        expect(labels).deep.equal([[], ['bazz', 'foo'], ['0', 'a', 'bar', 'foo', 'z']]);
       });
 
       it("does not include data links in any job's list of links", function () {

--- a/services/harmony/test/jobs/jobs-status.ts
+++ b/services/harmony/test/jobs/jobs-status.ts
@@ -55,7 +55,7 @@ function itIncludesADataExpirationField(): void {
 }
 
 describe('Individual job status route', function () {
-  const aJobLabels = ['foo', 'bar'];
+  const aJobLabels = ['foo', 'bar', '000', 'z-label'];
   hookServersStartStop({ skipEarthdataLogin: false });
   hookTransaction();
   before(async function () {
@@ -129,9 +129,9 @@ describe('Individual job status route', function () {
         expect(previewSkipLinks.length).to.equal(0);
       });
 
-      it('includes job labels', function () {
+      it('includes sorted job labels', function () {
         const job = new Job(JSON.parse(this.res.text));
-        expect(job.labels).deep.equal(aJobLabels);
+        expect(job.labels).deep.equal(['000', 'bar', 'foo', 'z-label']);
       });
 
       itIncludesADataExpirationField();

--- a/services/harmony/test/models/label.ts
+++ b/services/harmony/test/models/label.ts
@@ -62,7 +62,7 @@ describe('label CRUD', function () {
     it('sets the labels for the job', async function () {
       await setLabelsForJob(this.trx, this.job.jobID, this.job.username, labels);
       const newJob = await getFirstJob(this.trx);
-      expect(newJob.labels).deep.equal(labels);
+      expect(newJob.labels).deep.equal(['bar', 'foo']);
     });
   });
 

--- a/services/harmony/test/parameters/label.ts
+++ b/services/harmony/test/parameters/label.ts
@@ -91,7 +91,7 @@ describe('labels', function () {
       it('converts the labels to lowercase', async function () {
         const jobStatus = JSON.parse(this.res.text);
         const job = await Job.byJobID(db, jobStatus.jobID, false, true, false);
-        expect(job.job.labels).deep.equal(['bar', 'buzz', 'bazz']);
+        expect(job.job.labels).deep.equal(['bar', 'bazz', 'buzz']);
       });
     });
 
@@ -107,7 +107,7 @@ describe('labels', function () {
       it('adds the labels to the job', async function () {
         const jobStatus = JSON.parse(this.res.text);
         const job = await Job.byJobID(db, jobStatus.jobID, false, true, false);
-        expect(job.job.labels).deep.equal(['b🙂ar', 'bu#!zz']);
+        expect(job.job.labels).deep.equal(['bu#!zz', 'b🙂ar']);
       });
     });
 
@@ -119,7 +119,7 @@ describe('labels', function () {
       it('trims the whitespace and adds the labels to the job', async function () {
         const jobStatus = JSON.parse(this.res.text);
         const job = await Job.byJobID(db, jobStatus.jobID, false, true, false);
-        expect(job.job.labels).deep.equal(['bar', 'buzz', 'bazz', 'foo']);
+        expect(job.job.labels).deep.equal(['bar', 'bazz', 'buzz', 'foo']);
       });
     });
 

--- a/services/harmony/test/workflow-ui/jobs-table.ts
+++ b/services/harmony/test/workflow-ui/jobs-table.ts
@@ -9,6 +9,7 @@ import * as sinon from 'sinon';
 import * as services from '../../app/models/services';
 import MockDate from 'mockdate';
 import * as mustache from 'mustache';
+import { setLabelsForJob } from '../../app/models/label';
 
 
 
@@ -33,6 +34,7 @@ describe('Workflow UI jobs table route', function () {
     await boJob2.save(this.trx);
     await adamJob1.save(this.trx);
     await woodyJob1.save(this.trx);
+    await setLabelsForJob(this.trx, woodyJob1.jobID, woodyJob1.username, ['my-label']);
     this.trx.commit();
   });
   after(function () {
@@ -47,6 +49,18 @@ describe('Workflow UI jobs table route', function () {
       expect(response).to.not.contain(`<tr id="job-${boJob1.jobID}" class='job-table-row'>`);
       expect(response).contains(`<tr id="job-${boJob2.jobID}" class='job-table-row'>`);
       expect((response.match(/job-table-row/g) || []).length).to.eq(1);
+    });
+  });
+
+  describe('a user requesting a job with a label', function () {
+    hookWorkflowUIJobRows({ username: 'woody', jobIDs: [woodyJob1.jobID] });
+    it('returns the expected label(s) for the job', function () {
+      const listing = this.res.text;
+      expect(listing).to.contain(mustache.render(
+        `{{#labels}}
+      <span class="badge bg-label">{{.}}</span>
+      {{/labels}}`, 
+        { labels: woodyJob1.labels }));
     });
   });
 

--- a/services/harmony/test/workflow-ui/jobs.ts
+++ b/services/harmony/test/workflow-ui/jobs.ts
@@ -134,7 +134,7 @@ describe('Workflow UI jobs route', function () {
       await sidJob3.save(this.trx);
       await sidJob4.save(this.trx);
 
-      await setLabelsForJob(this.trx, woodyJob1.jobID, woodyJob1.username, ['blue-label', 'yellow-label']);
+      await setLabelsForJob(this.trx, woodyJob1.jobID, woodyJob1.username, ['blue-label', 'z-last-label', 'yellow-label', '1st-label']);
       await setLabelsForJob(this.trx, sidJob1.jobID, sidJob1.username, ['label-1', 'label-2']);
 
       this.trx.commit();
@@ -180,13 +180,11 @@ describe('Workflow UI jobs route', function () {
         expect((listing.match(/job-table-row/g) || []).length).to.equal(3);
       });
 
-      it('displays the labels for the user\'s jobs', function () {
-        const listing = this.res.text;
+      it('displays the sorted labels for the user\'s jobs', function () {
+        const listing = this.res.text;  
         expect(listing).to.contain(mustache.render(
-          `{{#labels}}
-        <span class="badge bg-label">{{.}}</span>
-        {{/labels}}`, 
-          { labels: woodyJob1.labels }));
+          '{{#labels}} <span class="badge bg-label" title="{{.}}">{{.}}</span>{{/labels}}', 
+          { labels: ['1st-label', 'blue-label', 'yellow-label', 'z-last-label'] }));
       });
 
       it('does not return jobs for other users', function () {
@@ -591,15 +589,11 @@ describe('Workflow UI jobs route', function () {
         it('displays the labels for those jobs', function () {
           const listing = this.res.text;
           expect(listing).to.contain(mustache.render(
-            `{{#labels}}
-          <span class="badge bg-label">{{.}}</span>
-          {{/labels}}`, 
-            { labels: woodyJob1.labels }));
+            '{{#labels}} <span class="badge bg-label" title="{{.}}">{{.}}</span>{{/labels}}', 
+            { labels: ['1st-label', 'blue-label', 'yellow-label', 'z-last-label'] }));
           expect(listing).to.contain(mustache.render(
-            `{{#labels}}
-          <span class="badge bg-label">{{.}}</span>
-          {{/labels}}`, 
-            { labels: sidJob1.labels }));
+            '{{#labels}} <span class="badge bg-label" title="{{.}}">{{.}}</span>{{/labels}}', 
+            { labels: ['label-1', 'label-2'] }));
         });
       });
 

--- a/services/harmony/test/workflow-ui/jobs.ts
+++ b/services/harmony/test/workflow-ui/jobs.ts
@@ -378,9 +378,9 @@ describe('Workflow UI jobs route', function () {
       it('returns only failed jobs', function () {
         const listing = this.res.text;
         expect((listing.match(/job-table-row/g) || []).length).to.equal(1);
-        expect(listing).to.contain(`<span class="badge bg-danger">${JobStatus.FAILED.valueOf()}</span>`);
-        expect(listing).to.not.contain(`<span class="badge bg-success">${JobStatus.SUCCESSFUL.valueOf()}</span>`);
-        expect(listing).to.not.contain(`<span class="badge bg-info">${JobStatus.RUNNING.valueOf()}</span>`);
+        expect(listing).to.contain(`<span class="badge rounded-pill bg-danger">${JobStatus.FAILED.valueOf()}</span>`);
+        expect(listing).to.not.contain(`<span class="badge rounded-pill bg-success">${JobStatus.SUCCESSFUL.valueOf()}</span>`);
+        expect(listing).to.not.contain(`<span class="badge rounded-pill bg-info">${JobStatus.RUNNING.valueOf()}</span>`);
       });
       it('does not have disallowStatus HTML checked', function () {
         const listing = this.res.text;
@@ -400,9 +400,9 @@ describe('Workflow UI jobs route', function () {
       it('returns failed and successful jobs', function () {
         const listing = this.res.text;
         expect((listing.match(/job-table-row/g) || []).length).to.equal(2);
-        expect(listing).to.contain(`<span class="badge bg-danger">${JobStatus.FAILED.valueOf()}</span>`);
-        expect(listing).to.contain(`<span class="badge bg-success">${JobStatus.SUCCESSFUL.valueOf()}</span>`);
-        expect(listing).to.not.contain(`<span class="badge bg-info">${JobStatus.RUNNING.valueOf()}</span>`);
+        expect(listing).to.contain(`<span class="badge rounded-pill bg-danger">${JobStatus.FAILED.valueOf()}</span>`);
+        expect(listing).to.contain(`<span class="badge rounded-pill bg-success">${JobStatus.SUCCESSFUL.valueOf()}</span>`);
+        expect(listing).to.not.contain(`<span class="badge rounded-pill bg-info">${JobStatus.RUNNING.valueOf()}</span>`);
       });
       it('does not have disallowStatus HTML checked', function () {
         const listing = this.res.text;
@@ -440,9 +440,9 @@ describe('Workflow UI jobs route', function () {
       it('returns all jobs that are not failed or successful', function () {
         const listing = this.res.text;
         expect((listing.match(/job-table-row/g) || []).length).to.equal(1);
-        expect(listing).to.not.contain(`<span class="badge bg-danger">${JobStatus.FAILED.valueOf()}</span>`);
-        expect(listing).to.not.contain(`<span class="badge bg-success">${JobStatus.SUCCESSFUL.valueOf()}</span>`);
-        expect(listing).to.contain(`<span class="badge bg-info">${JobStatus.RUNNING.valueOf()}</span>`);
+        expect(listing).to.not.contain(`<span class="badge rounded-pill bg-danger">${JobStatus.FAILED.valueOf()}</span>`);
+        expect(listing).to.not.contain(`<span class="badge rounded-pill bg-success">${JobStatus.SUCCESSFUL.valueOf()}</span>`);
+        expect(listing).to.contain(`<span class="badge rounded-pill bg-info">${JobStatus.RUNNING.valueOf()}</span>`);
       });
       it('does have disallowStatus HTML checked', function () {
         const listing = this.res.text;
@@ -532,9 +532,9 @@ describe('Workflow UI jobs route', function () {
         const netcdfToZarrRegExp = new RegExp(netcdfToZarrTd, 'g');
         expect((listing.match(netcdfToZarrRegExp) || []).length).to.equal(1);
 
-        expect(listing).to.contain(`<span class="badge bg-danger">${JobStatus.FAILED.valueOf()}</span>`);
-        expect(listing).to.not.contain(`<span class="badge bg-success">${JobStatus.SUCCESSFUL.valueOf()}</span>`);
-        expect(listing).to.not.contain(`<span class="badge bg-info">${JobStatus.RUNNING.valueOf()}</span>`);
+        expect(listing).to.contain(`<span class="badge rounded-pill bg-danger">${JobStatus.FAILED.valueOf()}</span>`);
+        expect(listing).to.not.contain(`<span class="badge rounded-pill bg-success">${JobStatus.SUCCESSFUL.valueOf()}</span>`);
+        expect(listing).to.not.contain(`<span class="badge rounded-pill bg-info">${JobStatus.RUNNING.valueOf()}</span>`);
       });
       it('has the appropriate HTML (un)checked', function () {
         const listing = this.res.text;
@@ -603,13 +603,13 @@ describe('Workflow UI jobs route', function () {
         it('returns jobs with the aforementioned statuses', function () {
           const listing = this.res.text;
           expect((listing.match(/job-table-row/g) || []).length).to.equal(4);
-          expect(listing).to.contain(`<span class="badge bg-warning">${JobStatus.RUNNING_WITH_ERRORS.valueOf()}</span>`);
-          expect(listing).to.contain(`<span class="badge bg-success">${JobStatus.COMPLETE_WITH_ERRORS.valueOf()}</span>`);
-          expect(listing).to.contain(`<span class="badge bg-warning">${JobStatus.PAUSED.valueOf()}</span>`);
-          expect(listing).to.contain(`<span class="badge bg-info">${JobStatus.PREVIEWING.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-danger">${JobStatus.FAILED.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-success">${JobStatus.SUCCESSFUL.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-info">${JobStatus.RUNNING.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-warning">${JobStatus.RUNNING_WITH_ERRORS.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-success">${JobStatus.COMPLETE_WITH_ERRORS.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-warning">${JobStatus.PAUSED.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-info">${JobStatus.PREVIEWING.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-danger">${JobStatus.FAILED.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-success">${JobStatus.SUCCESSFUL.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-info">${JobStatus.RUNNING.valueOf()}</span>`);
         });
         it('does not have disallowStatus HTML checked', function () {
           const listing = this.res.text;
@@ -635,13 +635,13 @@ describe('Workflow UI jobs route', function () {
         it('returns jobs without the aforementioned statuses', function () {
           const listing = this.res.text;
           expect((listing.match(/job-table-row/g) || []).length).to.equal(4);
-          expect(listing).to.not.contain(`<span class="badge bg-warning">${JobStatus.RUNNING_WITH_ERRORS.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-success">${JobStatus.COMPLETE_WITH_ERRORS.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-warning">${JobStatus.PAUSED.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-info">${JobStatus.PREVIEWING.valueOf()}</span>`);
-          expect(listing).to.contain(`<span class="badge bg-danger">${JobStatus.FAILED.valueOf()}</span>`);
-          expect(listing).to.contain(`<span class="badge bg-success">${JobStatus.SUCCESSFUL.valueOf()}</span>`);
-          expect(listing).to.contain(`<span class="badge bg-info">${JobStatus.RUNNING.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-warning">${JobStatus.RUNNING_WITH_ERRORS.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-success">${JobStatus.COMPLETE_WITH_ERRORS.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-warning">${JobStatus.PAUSED.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-info">${JobStatus.PREVIEWING.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-danger">${JobStatus.FAILED.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-success">${JobStatus.SUCCESSFUL.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-info">${JobStatus.RUNNING.valueOf()}</span>`);
         });
         it('does have disallowStatus HTML checked', function () {
           const listing = this.res.text;
@@ -709,9 +709,9 @@ describe('Workflow UI jobs route', function () {
           const netcdfToZarrRegExp = new RegExp(netcdfToZarrTd, 'g');
           expect((listing.match(netcdfToZarrRegExp) || []).length).to.equal(1);
   
-          expect(listing).to.contain(`<span class="badge bg-danger">${JobStatus.FAILED.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-success">${JobStatus.SUCCESSFUL.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-info">${JobStatus.RUNNING.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-danger">${JobStatus.FAILED.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-success">${JobStatus.SUCCESSFUL.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-info">${JobStatus.RUNNING.valueOf()}</span>`);
         });
         it('has the appropriate HTML (un)checked', function () {
           const listing = this.res.text;

--- a/services/harmony/test/workflow-ui/jobs.ts
+++ b/services/harmony/test/workflow-ui/jobs.ts
@@ -11,6 +11,7 @@ import env from '../../app/util/env';
 import { auth } from '../helpers/auth';
 import { renderNavLink } from './helpers';
 import MockDate from 'mockdate';
+import { setLabelsForJob } from '../../app/models/label';
 
 
 // Example jobs to use in tests
@@ -133,6 +134,9 @@ describe('Workflow UI jobs route', function () {
       await sidJob3.save(this.trx);
       await sidJob4.save(this.trx);
 
+      await setLabelsForJob(this.trx, woodyJob1.jobID, woodyJob1.username, ['blue-label', 'yellow-label']);
+      await setLabelsForJob(this.trx, sidJob1.jobID, sidJob1.username, ['label-1', 'label-2']);
+
       this.trx.commit();
       MockDate.reset();
     });
@@ -174,6 +178,15 @@ describe('Workflow UI jobs route', function () {
         [woodyJob1.request, woodyJob2.request, woodySyncJob.request]
           .forEach((req) => expect(listing).to.contain(mustache.render('{{req}}', { req })));
         expect((listing.match(/job-table-row/g) || []).length).to.equal(3);
+      });
+
+      it('displays the labels for the user\'s jobs', function () {
+        const listing = this.res.text;
+        expect(listing).to.contain(mustache.render(
+          `{{#labels}}
+        <span class="badge bg-label">{{.}}</span>
+        {{/labels}}`, 
+          { labels: woodyJob1.labels }));
       });
 
       it('does not return jobs for other users', function () {
@@ -573,6 +586,20 @@ describe('Workflow UI jobs route', function () {
           const listing = this.res.text;
           expect(listing).to.contain('<td>woody</td>');
           expect(listing).to.contain('<td>buzz</td>');
+        });
+
+        it('displays the labels for those jobs', function () {
+          const listing = this.res.text;
+          expect(listing).to.contain(mustache.render(
+            `{{#labels}}
+          <span class="badge bg-label">{{.}}</span>
+          {{/labels}}`, 
+            { labels: woodyJob1.labels }));
+          expect(listing).to.contain(mustache.render(
+            `{{#labels}}
+          <span class="badge bg-label">{{.}}</span>
+          {{/labels}}`, 
+            { labels: sidJob1.labels }));
         });
       });
 

--- a/services/harmony/test/workflow-ui/work-items-table-row.ts
+++ b/services/harmony/test/workflow-ui/work-items-table-row.ts
@@ -284,11 +284,11 @@ describe('Workflow UI work items table row route', function () {
         it('returns the running work item', function () {
           const listing = this.res.text;
           expect((listing.match(/work-item-table-row/g) || []).length).to.equal(1);
-          expect(listing).to.not.contain(`<span class="badge bg-danger">${WorkItemStatus.FAILED.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-success">${WorkItemStatus.SUCCESSFUL.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-secondary">${WorkItemStatus.CANCELED.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-primary">${WorkItemStatus.READY.valueOf()}</span>`);
-          expect(listing).to.contain(`<span class="badge bg-info">${WorkItemStatus.RUNNING.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-danger">${WorkItemStatus.FAILED.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-success">${WorkItemStatus.SUCCESSFUL.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-secondary">${WorkItemStatus.CANCELED.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-primary">${WorkItemStatus.READY.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-info">${WorkItemStatus.RUNNING.valueOf()}</span>`);
         });
       });
     });

--- a/services/harmony/test/workflow-ui/work-items-table.ts
+++ b/services/harmony/test/workflow-ui/work-items-table.ts
@@ -222,7 +222,7 @@ describe('Workflow UI work items table route', function () {
           const listing = this.res.text;
           expect(listing).to.contain(mustache.render('<th scope="col">retry</th>', {}));
         });
-        it('returns the request details for the job', function () {
+        it('returns the job details (like labels and request URL)', function () {
           const listing = this.res.text;
           expect(listing).to.contain(mustache.render(
             `{{#labels}}
@@ -230,6 +230,7 @@ describe('Workflow UI work items table route', function () {
           {{/labels}}`, 
             { labels: targetJob.labels }));
           expect(listing).to.contain('job-url-text');
+          expect(listing).to.contain('copy-request');
         });
       });
 

--- a/services/harmony/test/workflow-ui/work-items-table.ts
+++ b/services/harmony/test/workflow-ui/work-items-table.ts
@@ -342,7 +342,7 @@ describe('Workflow UI work items table route', function () {
         });
         it('returns a SUCCESSFUL work item', function () {
           const listing = this.res.text;
-          expect(listing).to.contain(`<span class="badge bg-success">${WorkItemStatus.SUCCESSFUL.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-success">${WorkItemStatus.SUCCESSFUL.valueOf()}</span>`);
         });
       });
 
@@ -357,7 +357,7 @@ describe('Workflow UI work items table route', function () {
         });
         it('returns a QUEUED work item', function () {
           const listing = this.res.text;
-          expect(listing).to.contain(`<span class="badge bg-warning">${WorkItemStatus.QUEUED.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-warning">${WorkItemStatus.QUEUED.valueOf()}</span>`);
         });
       });
 
@@ -402,7 +402,7 @@ describe('Workflow UI work items table route', function () {
         });
         it('returns a SUCCESSFUL work item', function () {
           const listing = this.res.text;
-          expect(listing).to.contain(`<span class="badge bg-success">${WorkItemStatus.SUCCESSFUL.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-success">${WorkItemStatus.SUCCESSFUL.valueOf()}</span>`);
         });
       });
 
@@ -425,7 +425,7 @@ describe('Workflow UI work items table route', function () {
         });
         it('returns a SUCCESSFUL work item', function () {
           const listing = this.res.text;
-          expect(listing).to.contain(`<span class="badge bg-success">${WorkItemStatus.SUCCESSFUL.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-success">${WorkItemStatus.SUCCESSFUL.valueOf()}</span>`);
         });
       });
 
@@ -442,11 +442,11 @@ describe('Workflow UI work items table route', function () {
         it('returns only running work items', function () {
           const listing = this.res.text;
           expect((listing.match(/work-item-table-row/g) || []).length).to.equal(2);
-          expect(listing).to.not.contain(`<span class="badge bg-danger">${WorkItemStatus.FAILED.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-success">${WorkItemStatus.SUCCESSFUL.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-secondary">${WorkItemStatus.CANCELED.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-primary">${WorkItemStatus.READY.valueOf()}</span>`);
-          expect(listing).to.contain(`<span class="badge bg-info">${WorkItemStatus.RUNNING.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-danger">${WorkItemStatus.FAILED.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-success">${WorkItemStatus.SUCCESSFUL.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-secondary">${WorkItemStatus.CANCELED.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-primary">${WorkItemStatus.READY.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-info">${WorkItemStatus.RUNNING.valueOf()}</span>`);
         });
       });
     });
@@ -542,12 +542,12 @@ describe('Workflow UI work items table route', function () {
         it('returns only non-running work items', function () {
           const listing = this.res.text;
           expect((listing.match(/work-item-table-row/g) || []).length).to.equal(4);
-          expect(listing).to.not.contain(`<span class="badge bg-danger">${WorkItemStatus.FAILED.valueOf()}</span>`);
-          expect(listing).to.contain(`<span class="badge bg-success">${WorkItemStatus.SUCCESSFUL.valueOf()}</span>`);
-          expect(listing).to.contain(`<span class="badge bg-warning">${WorkItemStatus.QUEUED.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-secondary">${WorkItemStatus.CANCELED.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-primary">${WorkItemStatus.READY.valueOf()}</span>`);
-          expect(listing).to.not.contain(`<span class="badge bg-info">${WorkItemStatus.RUNNING.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-danger">${WorkItemStatus.FAILED.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-success">${WorkItemStatus.SUCCESSFUL.valueOf()}</span>`);
+          expect(listing).to.contain(`<span class="badge rounded-pill bg-warning">${WorkItemStatus.QUEUED.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-secondary">${WorkItemStatus.CANCELED.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-primary">${WorkItemStatus.READY.valueOf()}</span>`);
+          expect(listing).to.not.contain(`<span class="badge rounded-pill bg-info">${WorkItemStatus.RUNNING.valueOf()}</span>`);
         });
       });
 

--- a/services/harmony/test/workflow-ui/work-items-table.ts
+++ b/services/harmony/test/workflow-ui/work-items-table.ts
@@ -13,6 +13,7 @@ import { WorkItemStatus } from '../../app/models/work-item-interface';
 import { getWorkItemById } from '../../app/models/work-item';
 import db from '../../app/util/db';
 import MockDate from 'mockdate';
+import { setLabelsForJob } from '../../app/models/label';
 
 // main objects used in the tests
 const targetJob = buildJob({ status: JobStatus.FAILED, username: 'bo' });
@@ -145,6 +146,8 @@ describe('Workflow UI work items table route', function () {
       const shareableStep2 = buildWorkflowStep({ jobID: shareableJob.jobID, stepIndex: 2 });
       await shareableStep2.save(this.trx);
 
+      await setLabelsForJob(this.trx, targetJob.jobID, targetJob.username, ['my-label']);
+
       this.trx.commit();
       MockDate.reset();
     });
@@ -218,6 +221,15 @@ describe('Workflow UI work items table route', function () {
         it('returns a column for the retry buttons', async function () {
           const listing = this.res.text;
           expect(listing).to.contain(mustache.render('<th scope="col">retry</th>', {}));
+        });
+        it('returns the request details for the job', function () {
+          const listing = this.res.text;
+          expect(listing).to.contain(mustache.render(
+            `{{#labels}}
+          <span class="badge bg-label">{{.}}</span>
+          {{/labels}}`, 
+            { labels: targetJob.labels }));
+          expect(listing).to.contain('job-url-text');
         });
       });
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1891

## Description
Users will now see labels for jobs on all pages of the Workflow UI.

On the jobs page, each row will contain the job's label(s) on the bottom right corner of the row.

<img width="1250" alt="Screenshot 2024-10-08 at 11 12 21 AM" src="https://github.com/user-attachments/assets/d6c138b2-f9c3-411d-8e24-e519973b21a7">

On the individual job page, a similar view will be displayed, which will also include the request URL, which I had intended to add in HARMONY-1497. The look of this may evolve in the future but for now I'm mainly going for consistency.

<img width="1237" alt="Screenshot 2024-10-08 at 11 12 03 AM" src="https://github.com/user-attachments/assets/c7b6a4ec-54de-4c7b-98d5-55e60f818fc8">

## Local Test Steps
1. Make a request http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?granuleId=G1233800343-EEDTEST&format=image%2Ftiff&label=hi&label=there
2. Look at the labels http://localhost:3000/workflow-ui?page=1&limit=10

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)