### PR TITLE
HARMONY-1920: Fixed EDR collection shortName matching regex.

### DIFF
--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -324,7 +324,7 @@ describe('Service image endpoint', async function () {
       describe('when the service does exist', async function () {
         before(async function () {
           hookRedirect('joe');
-          this.res = await request(this.frontend).get('/service-image-tag/hoss').use(auth({ username: 'joe' }));
+          this.res = await request(this.frontend).get('/service-image-tag/trajectory-subsetter').use(auth({ username: 'joe' }));
         });
 
         after(function () {
@@ -367,7 +367,7 @@ describe('Service image endpoint', async function () {
       describe('when the service does exist', async function () {
         before(async function () {
           hookRedirect('buzz');
-          this.res = await request(this.frontend).get('/service-image-tag/hoss').use(auth({ username: 'buzz' }));
+          this.res = await request(this.frontend).get('/service-image-tag/trajectory-subsetter').use(auth({ username: 'buzz' }));
         });
 
         after(function () {
@@ -412,7 +412,7 @@ describe('Service image endpoint', async function () {
       describe('when the service does exist', async function () {
         before(async function () {
           hookRedirect('coraline');
-          this.res = await request(this.frontend).get('/service-image-tag/hoss').use(auth({ username: 'coraline' }));
+          this.res = await request(this.frontend).get('/service-image-tag/trajectory-subsetter').use(auth({ username: 'coraline' }));
         });
 
         after(function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1920

## Description
Fixed EDR collection shortName matching regex.

## Local Test Steps
Add trajectory-subsetter as one of the locally deployed service

Run Harmony Coverage request with collection short name and verify the request runs on the correct collection.
e.g. `http://localhost:3000/harmony_example/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?maxResults=1&outputCrs=EPSG%3A31975&format=image%2Fpng`

Run Harmony EDR request with collection short name and verify the request runs on the correct collection.
e.g. `http://localhost:3000/ogc-api-edr/1.1.0/collections/harmony_example/trajectory?maxResults=1&parameter-name=all&coords=LINESTRING(9.51728%209.950%2C%2016.4064%2017.40134)`

Verify `http://localhost:3000/service-image-tag/trajectory-subsetter` returns the correct image tag of the trajectory-subsetter service.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)