### PR TITLE
HARMONY-1912: Pass in average to the backend services.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -25,7 +25,7 @@ https://cmr.earthdata.nasa.gov:
 
   - name: harmony/download
     description: Service that performs no processing, it only returns download links for all of the matched granules from the CMR.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -53,7 +53,7 @@ https://cmr.earthdata.nasa.gov:
     description: |
       A service to compose the Giovanni URL and invoke Giovanni service to produce output file to visualize, analyze,
       and access vast amounts of Earth science remote sensing data without having to download the data.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     has_granule_limit: false
     # Replace the next two lines to default to synchronous once bearer tokens are supported by Giovanni
     # default_sync: true
@@ -90,7 +90,7 @@ https://cmr.earthdata.nasa.gov:
       * Variable subsetting supported
       * works with hierarchical groups
       Outputs netcdf4.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -117,7 +117,7 @@ https://cmr.earthdata.nasa.gov:
     description: |
       Service capabale of "concatenating" multiple netCDF files into a single netCDF files.
       The resulting file has an extra dimension with size equal to the number of input files where each slice in that dimension corresponds to the data from one of the inputs.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -156,7 +156,7 @@ https://cmr.earthdata.nasa.gov:
       #### PODAAC concise services
       Service capabale of "concatenating" multiple netCDF files into a single netCDF files.
       The resulting file has an extra dimension with size equal to the number of input files where each slice in that dimension corresponds to the data from one of the inputs.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -193,7 +193,7 @@ https://cmr.earthdata.nasa.gov:
       A service that supports L2 segmented trajectory (**not swath**) data.
       Currently uses the same C++ binary as is on-premises in SDPS, to offer variable, temporal, bounding box spatial and polygon spatial subsetting.
       **This subsetter also ensures valid segment indices and sizes following transformation.**
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -224,7 +224,7 @@ https://cmr.earthdata.nasa.gov:
       plus all those that are required to support meaningful downstream operations upon those data (e.g. associated coordinate variables).
 
       This service is currently operated from the same Docker image as the sds/variable-subsetter service.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -261,7 +261,7 @@ https://cmr.earthdata.nasa.gov:
       plus all those that are required to support meaningful downstream operations upon those data (e.g. associated coordinate variables).
 
       This service is currently operated from the same Docker image as the sds/variable-subsetter service.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -296,7 +296,7 @@ https://cmr.earthdata.nasa.gov:
       The wrapper also retrieves the geolocation file name from the input file Core Metadata and downloads it from S3.
       Works with L1B-L4 granules (L1B and L2 granule SDSs are automatically regridded with default setting granule resolution
           and geographic projection).
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -322,7 +322,7 @@ https://cmr.earthdata.nasa.gov:
   - name: net2cog
     description: |
       Converts NetCDF files to COG. Includes extension for running in NASA Harmony. https://github.com/podaac/net2cog
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -343,7 +343,7 @@ https://cmr.earthdata.nasa.gov:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
       - image: !Env ${NET2COG_IMAGE}
-  
+
   - name: nasa/harmony-gdal-adapter
     description: |
       Service translating Harmony operations to GDAL commands.
@@ -351,7 +351,7 @@ https://cmr.earthdata.nasa.gov:
       and output to NetCDF4 or COG.
       Operates on input file types supported by GDAL (most EOSDIS data).
       Most operations assume L3 data, though it is likely that some work on L2.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -409,7 +409,7 @@ https://cmr.earthdata.nasa.gov:
     description: |
       Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
       The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -454,7 +454,7 @@ https://cmr.earthdata.nasa.gov:
       * Service capable of "concatenating" multiple netCDF files into a single netCDF file.
       The resulting file has an extra dimension with size equal to the number of input files, where each slice in that dimension corresponds to the data from one of the input files.
 
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -503,7 +503,7 @@ https://cmr.earthdata.nasa.gov:
     description: |
       Reference service that can be used to perform most operations supported by Harmony.
       Useful for testing new API features end-to-end on example data but not meant for production use.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -531,7 +531,7 @@ https://cmr.uat.earthdata.nasa.gov:
 
   - name: harmony/download
     description: Service that performs no processing, it only returns download links for all of the matched granules from the CMR.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -561,7 +561,7 @@ https://cmr.uat.earthdata.nasa.gov:
       The wrapper also retrieves the geolocation file name from the input file Core Metadata and downloads it from S3.
       Works with L1B-L4 granules (L1B and L2 granule SDSs are automatically regridded with default setting granule resolution
           and geographic projection).
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -612,7 +612,7 @@ https://cmr.uat.earthdata.nasa.gov:
     description: |
       A service to compose the Giovanni URL and invoke Giovanni service to produce output file to visualize, analyze,
       and access vast amounts of Earth science remote sensing data without having to download the data.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     has_granule_limit: false
     # Replace the next two lines to default to synchronous once bearer tokens are supported by Giovanni
     # default_sync: true
@@ -649,7 +649,7 @@ https://cmr.uat.earthdata.nasa.gov:
       * Variable subsetting supported
       * works with hierarchical groups
       Outputs netcdf4.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -676,7 +676,7 @@ https://cmr.uat.earthdata.nasa.gov:
     description: |
       Service capabale of "concatenating" multiple netCDF files into a single netCDF files.
       The resulting file has an extra dimension with size equal to the number of input files where each slice in that dimension corresponds to the data from one of the inputs.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -715,7 +715,7 @@ https://cmr.uat.earthdata.nasa.gov:
       #### PODAAC concise service
       Service capabale of "concatenating" multiple netCDF files into a single netCDF files.
       The resulting file has an extra dimension with size equal to the number of input files where each slice in that dimension corresponds to the data from one of the inputs.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -751,7 +751,7 @@ https://cmr.uat.earthdata.nasa.gov:
     description: |
       Takes NetCDF-4 input files and projects input swath variables to an output grid.
       Target CRS, output grid dimensions, extents and/or resolutions can be specified in the Harmony request.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -776,7 +776,7 @@ https://cmr.uat.earthdata.nasa.gov:
   - name: sds/harmony-regridder
     description: |
       The Harmony Regridding Service for L3/L4 collections
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -804,7 +804,7 @@ https://cmr.uat.earthdata.nasa.gov:
       The Variable Subsetter provides _only_ variable subsetting.
       Accesses NetCDF-4 files hosted in Hyrax cloud service (OPeNDAP), and retrieves the requested list of variables,
       plus all those that are required to support meaningful downstream operations upon those data (e.g. associated coordinate variables).
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -831,7 +831,7 @@ https://cmr.uat.earthdata.nasa.gov:
     description: |
       The service takes input HDF-5 or GeoTIFF file and GeoJSON shape file,
       masks science (non-coordinate) variables such that pixel values outside of the GeoJSON shape are set to a fill value.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -853,7 +853,7 @@ https://cmr.uat.earthdata.nasa.gov:
       A service that supports L2 segmented trajectory (**not swath**) data.
       Currently uses the same C++ binary as is on-premises in SDPS, to offer variable, temporal, bounding box spatial and polygon spatial subsetting.
       **This subsetter also ensures valid segment indices and sizes following transformation.**
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -882,7 +882,7 @@ https://cmr.uat.earthdata.nasa.gov:
   - name: harmony/example
     description: |
       An example service for testing harmony http service integration. This service isn't docker-based or make GDAL calls - it does not actually do anything with the data files.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     enabled: !Env ${EXAMPLE_SERVICES}
     type:
       name: http
@@ -900,7 +900,7 @@ https://cmr.uat.earthdata.nasa.gov:
   - name: net2cog
     description: |
       Converts NetCDF files to COG. Includes extension for running in NASA Harmony. https://github.com/podaac/net2cog
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -930,7 +930,7 @@ https://cmr.uat.earthdata.nasa.gov:
       and output to NetCDF4 or COG.
       Operates on input file types supported by GDAL (most EOSDIS data).
       Most operations assume L3 data, though it is likely that some work on L2.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -962,7 +962,7 @@ https://cmr.uat.earthdata.nasa.gov:
       JPEG outputs. This includes, where necessary, conversion to a GIBS
       supported Coordinate Reference System (CRS). Other projections can be
       requested, but will not be compatible with GIBS.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -994,7 +994,7 @@ https://cmr.uat.earthdata.nasa.gov:
       plus all those that are required to support meaningful downstream operations upon those data (e.g. associated coordinate variables).
 
       This service is currently operated from the same Docker image as the sds/variable-subsetter service.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -1031,7 +1031,7 @@ https://cmr.uat.earthdata.nasa.gov:
       plus all those that are required to support meaningful downstream operations upon those data (e.g. associated coordinate variables).
 
       This service is currently operated from the same Docker image as the sds/variable-subsetter service.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -1064,7 +1064,7 @@ https://cmr.uat.earthdata.nasa.gov:
     description: |
       Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
       The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -1102,7 +1102,7 @@ https://cmr.uat.earthdata.nasa.gov:
       #### Harmony netcdf-to-zarr service
       Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
       The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -1146,7 +1146,7 @@ https://cmr.uat.earthdata.nasa.gov:
       Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
       The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
 
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -1184,7 +1184,7 @@ https://cmr.uat.earthdata.nasa.gov:
     description: |
       Reference service that can be used to perform most operations supported by Harmony.
       Useful for testing new API features end-to-end on example data but not meant for production use.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:
@@ -1232,7 +1232,7 @@ https://cmr.uat.earthdata.nasa.gov:
       * Service capable of "concatenating" multiple netCDF files into a single netCDF file.
       The resulting file has an extra dimension with size equal to the number of input files, where each slice in that dimension corresponds to the data from one of the input files.
       The resulting file has an extra dimension with size equal to the number of input files, where each slice in that dimension corresponds to the data from one of the input files.
-    data_operation_version: '0.19.0'
+    data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
       params:

--- a/docs/guides/adapting-new-services.md
+++ b/docs/guides/adapting-new-services.md
@@ -155,7 +155,7 @@ The structure of an entry in the [services.yml](../../config/services.yml) file 
 
 ```yaml
 - name: harmony/service-example    # A unique identifier string for the service, conventionally <team>/<service>
-  data_operation_version: '0.19.0' # The version of the data-operation messaging schema to use
+  data_operation_version: '0.20.0' # The version of the data-operation messaging schema to use
   has_granule_limit: true          # Optional flag indicating whether we will impose granule limts for the request. Default to true.
   default_sync: false              # Optional flag indicating whether we will force the request to run synchrously. Default to false.
   type:                            # Configuration for service invocation

--- a/services/harmony/app/models/data-operation.ts
+++ b/services/harmony/app/models/data-operation.ts
@@ -9,7 +9,7 @@ import { Encrypter, Decrypter } from '../util/crypto';
 import { cmrVarToHarmonyVar, HarmonyVariable } from '../util/variables';
 import { isValidUri } from '../util/url';
 
-export const CURRENT_SCHEMA_VERSION = '0.19.0';
+export const CURRENT_SCHEMA_VERSION = '0.20.0';
 
 /**
  * Synchronously reads and parses the JSON Schema at the given path
@@ -41,6 +41,15 @@ let _schemaVersions: SchemaVersion[];
 function schemaVersions(): SchemaVersion[] {
   if (_schemaVersions) return _schemaVersions;
   _schemaVersions = [
+    {
+      version: '0.20.0',
+      schema: readSchema('0.20.0'),
+      down: (model): unknown => {
+        const revertedModel = _.cloneDeep(model);
+        delete revertedModel.average;
+        return revertedModel;
+      },
+    },
     {
       version: '0.19.0',
       schema: readSchema('0.19.0'),
@@ -310,8 +319,6 @@ export default class DataOperation {
 
   ignoreErrors?: boolean;
 
-  average: string;
-
   destinationUrl: string;
 
   ummCollections: CmrUmmCollection[];
@@ -473,6 +480,22 @@ export default class DataOperation {
    */
   set shouldConcatenate(value: boolean) {
     this.model.concatenate = value;
+  }
+
+  /**
+   * Gets the averaging method to use
+   *
+   * @returns the averaging method to use
+   */
+  get average(): string {
+    return this.model.average;
+  }
+
+  /**
+   * Sets the averaging method to use
+   */
+  set average(value: string) {
+    this.model.average = value;
   }
 
   /**

--- a/services/harmony/app/schemas/data-operation/0.20.0/data-operation-v0.20.0.json
+++ b/services/harmony/app/schemas/data-operation/0.20.0/data-operation-v0.20.0.json
@@ -1,0 +1,566 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://harmony.earthdata.nasa.gov/schemas/data-operation-v0.20.0.json",
+    "$ref": "#/definitions/DataOperation",
+    "definitions": {
+      "DataOperation": {
+        "type": "object",
+        "title": "DataOperation",
+        "description": "Describes an operation to be performed by backend services",
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "JSON schema location",
+            "type": "string"
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Source"
+            }
+          },
+          "format": {
+            "$ref": "#/definitions/Format"
+          },
+          "subset": {
+            "$ref": "#/definitions/Subset"
+          },
+          "extendDimensions": {
+            "type": "array",
+            "title": "Extend Dimensions",
+            "description": "The names or concept IDs of the dimensions that should be extended.",
+            "examples": [
+              ["lat", "lon"]
+            ],
+            "items": {
+              "type": "string"
+            }
+          },
+          "temporal": {
+            "description": "The time which should be used as the range for temporal subsetting",
+            "$ref": "#/definitions/Temporal"
+          },
+          "callback": {
+            "name": "Callback URL",
+            "description": "The URL that non-HTTP services must POST to when their execution is complete (HTTP services simply return a response).  Set query param \"redirect=\" with a URL to redirect the user to a service result (preferred).  Set the Content-Type header and POST bytes in order to send a file directly to the user.  Set query param \"error=\" with a message to provide a service error.",
+            "type": "string",
+            "format": "uri",
+            "qt-uri-protocols": [
+              "http",
+              "https"
+            ]
+          },
+          "stagingLocation": {
+            "name": "Result staging prefix",
+            "description": "An object store (S3) URL prefix under which services may elect to put their output.  Services must have write access to the Harmony staging bucket for the deployed environment to use this value.  The location will be unique per Harmony request but services are responsible for ensuring no name clashes occur within a single request.  The prefix will end in a \"/\" character",
+            "type": "string",
+            "examples": [
+              "s3://example-bucket/public/organization-name/service-name/1234567/"
+            ]
+          },
+          "user": {
+            "name": "Earthdata Login Username",
+            "description": "The name of the user on behalf of whom Harmony is acting",
+            "type": "string"
+          },
+          "accessToken": {
+            "name": "Earthdata Login Token",
+            "description": "The encrypted EDL token of the user on behalf of whom Harmony is acting",
+            "type": "string"
+          },
+          "client": {
+            "name": "Client ID",
+            "description": "An identifier indicating the client submitting the request",
+            "type": "string"
+          },
+          "version": {
+            "name": "Version number",
+            "description": "Identifies which schema version and Harmony callback protocol is being used",
+            "type": "string"
+          },
+          "isSynchronous": {
+            "name": "Synchronous request mode",
+            "description": "True if the request is going to be returned synchronously back to the end user. Note a backend service can still use a callback URL to indicate completion.",
+            "type": "boolean"
+          },
+          "requestId": {
+            "name": "Request identifier",
+            "description": "UUID to uniquely identify a request.",
+            "type": "string",
+            "format": "uuid"
+          },
+          "concatenate": {
+            "name": "Concatenate outputs",
+            "description": "True if the service should concatenate multiple input files into a single output file.",
+            "type": "boolean"
+          },
+          "average": {
+            "name": "Averaging method",
+            "description": "When provided the service should return the average of the inputs based on the averaging method.",
+            "examples": ["time", "area"],
+            "type": "string"
+          },
+          "extraArgs": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "format",
+          "sources",
+          "subset",
+          "user",
+          "accessToken",
+          "client",
+          "version",
+          "requestId",
+          "stagingLocation"
+        ]
+      },
+      "Format": {
+        "type": "object",
+        "title": "Format",
+        "description": "Service parameters pertaining to the output file's format",
+        "additionalProperties": false,
+        "properties": {
+          "crs": {
+            "type": "string",
+            "description": "The requested output projection in Proj4",
+            "examples": [
+              "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"
+            ]
+          },
+          "srs": {
+            "type": ["object", "null"],
+            "description": "SRS / CRS information for requested output projection",
+            "additionalProperties": false,
+            "properties": {
+              "proj4": {
+                "type": "string",
+                "description": "The requested output projection in Proj4",
+                "examples": [
+                  "+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs"
+                ]
+              },
+              "wkt": {
+                "type": "string",
+                "description": "The requested output projection in WKT",
+                "examples": [
+                  "PROJCS[ ... ]"
+                ]
+              },
+              "epsg": {
+                "type": "string",
+                "description": "The requested output projection in EPSG. Optional; empty string when absent.",
+                "examples": [
+                  "EPSG:7030"
+                ]
+              }
+            },
+            "required": []
+          },
+          "isTransparent": {
+            "type": "boolean",
+            "description": "If set to true, no data areas should be set to transparent in the output"
+          },
+          "mime": {
+            "type": "string",
+            "description": "The requested mime type of the output file",
+            "examples": [
+              "image/tiff",
+              "application/x-netcdf4"
+            ]
+          },
+          "width": {
+            "type": "number",
+            "description": "For image output, the requested image width in pixels"
+          },
+          "height": {
+            "type": "number",
+            "description": "For image output, the requested image height in pixels"
+          },
+          "dpi": {
+            "type": "integer",
+            "description": "For image output, the dots-per-inch resolution of the output image"
+          },
+          "interpolation": {
+            "type": "string",
+            "description": "The interpolation method to be used during reprojection and scaling",
+            "examples": [
+              "near",
+              "bilinear"
+            ]
+          },
+          "scaleExtent": {
+            "$ref": "#/definitions/ScaleExtent"
+          },
+          "scaleSize": {
+            "$ref": "#/definitions/ScaleSize"
+          }
+        },
+        "required": []
+      },
+      "Source": {
+        "type": "object",
+        "title": "Source",
+        "description": "A group of files which come from a common collection and will have a common set of variables operated on",
+        "additionalProperties": false,
+        "properties": {
+          "collection": {
+            "type": "string",
+            "description": "The CMR Collection ID that has the variables and granules in this data source",
+            "examples": ["C1233800302-EEDTEST"]
+          },
+          "shortName": {
+            "type": "string",
+            "description": "The CMR short-name for this data source",
+            "examples": ["harmony_example"]
+          },
+          "versionId": {
+            "type": "string",
+            "description": "The CMR version-id for this data source",
+            "examples": ["1"]
+          },
+          "variables": {
+            "type": "array",
+            "description": "A list of variables the caller would like provided in the output.  If this attribute is null or absent, the service should provide all available variables in the output.",
+            "default": "all",
+            "items": {
+              "$ref": "#/definitions/Variable"
+            }
+          },
+          "coordinateVariables": {
+            "type": "array",
+            "description": "A list of coordinate variables for the source collection. A service may want to include the coordinate variables in the output.",
+            "default": "all",
+            "items": {
+              "$ref": "#/definitions/Variable"
+            }
+          },
+          "granules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Granule"
+            }
+          }
+        },
+        "required": [
+          "collection"
+        ]
+      },
+      "Granule": {
+        "type": "object",
+        "title": "Granule",
+        "description": "A granule file the caller would like included in the output.",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The CMR granule identifier",
+            "examples": [
+              "G1233800343-EEDTEST"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the granule (GranuleID, GranuleUR), typically corresponding to the data file name",
+            "examples": [
+              "001_00_7f00ff_global.nc"
+            ]
+          },
+          "url": {
+            "type": "string",
+            "description": "The URL or relative file path where the granule data file can be accessed.  This may be behind Earthdata Login."
+          },
+          "bbox": {
+            "description": "The bounding box for the granule.  Coordinates are [West, South, East, North].",
+            "examples": [
+              [-100.5, 30.4, -99.5, 31.4]
+            ],
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 4,
+            "maxItems": 4
+          },
+          "temporal": {
+            "description": "Time range for the granule",
+            "$ref": "#/definitions/Temporal"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "url"
+        ]
+      },
+      "Variable": {
+        "type": "object",
+        "title": "Variable",
+        "description": "A variable which the caller would like provided in the output",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The CMR ID of the variable",
+            "examples": [ "V1233801695-EEDTEST" ]
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the variable in the data file",
+            "examples": [ "red_var" ]
+          },
+          "fullPath": {
+            "type": "string",
+            "description": "The variable's absolute path within the file, including hierarchy.  Derived from UMM-Var group path combined with name.  If the group path is not set, this is the name",
+            "examples": [ "data/colors/red_var", "red_var" ]
+          },
+          "relatedUrls": {
+            "type": "array",
+            "description": "A list of the variable's related URL objects.",
+            "items": {
+              "$ref": "#/definitions/RelatedUrl"
+            }
+          },
+          "type": {
+            "type": "string",
+            "description": "The UMM Variable VariableType",
+            "examples": ["SCIENCE_VARIABLE", "QUALITY_VARIABLE", "ANCILLARY_VARIABLE", "COORDINATE", "OTHER"]
+          },
+          "subtype": {
+            "type": "string",
+            "description": "The UMM Variable VariableSubType",
+            "examples": ["SCIENCE_SCALAR", "SCIENCE_VECTOR", "SCIENCE_ARRAY", "SCIENCE_EVENTFLAG", "LATITUDE", "LONGITUDE", "TIME", "OTHER"]
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "fullPath"
+        ]
+      },
+      "Subset": {
+        "type": "object",
+        "title": "Subset",
+        "description": "Subsetting request parameters",
+        "additionalProperties": false,
+        "properties": {
+          "bbox": {
+            "name": "Bounding Box",
+            "description": "The bounding box which should be used for spatial subsetting.  Coordinates are [West, South, East, North].",
+            "examples": [
+              [-100.5, 30.4, -99.5, 31.4]
+            ],
+            "default": [-180, -90, 180, 90],
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "minItems": 4,
+            "maxItems": 4
+          },
+          "point": {
+            "description": "Spatial point query parameter. Coordinates are [Longitude, Latitude].",
+            "$ref": "#/definitions/SpatialPoint"
+          },
+          "shape": {
+            "description": "Reference to a shape within which the service should spatially subset. The shape can either be a URI to a GeoJSON object store (S3) or a GeoJSON string.",
+            "oneOf": [
+              {
+                "$ref": "#/definitions/RemoteResource"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
+          "dimensions": {
+            "description": "Dimensions to subset against.",
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Dimension"
+            }
+          }
+        },
+        "required": []
+      },
+      "Temporal": {
+        "type": "object",
+        "title": "Temporal",
+        "description": "Temporal parameters for a date/time range",
+        "additionalProperties": false,
+        "properties": {
+          "start": {
+            "name": "Start time",
+            "description": "The start date/time. The format is an RFC-3339 datetime.",
+            "type": "string",
+            "format": "date-time"
+          },
+          "end": {
+            "name": "End time",
+            "description": "The end date/time. The format is an RFC-3339 datetime.",
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": []
+      },
+      "SpatialPoint": {
+        "type": "array",
+        "title": "Point",
+        "description": "Spatial point query parameter. Coordinates are [Longitude, Latitude].",
+        "examples": [
+          [-100.5, 31.4]
+        ],
+        "items": {
+          "type": "number"
+        },
+        "minItems": 2,
+        "maxItems": 2
+      },
+      "ScaleExtent": {
+        "type": "object",
+        "title": "ScaleExtent",
+        "description": "Target grid extent",
+        "additionalProperties": false,
+        "properties": {
+          "x": {
+            "type": "object",
+            "description": "X dimension scale extent.",
+            "additionalProperties": false,
+            "properties": {
+              "min": {
+                "type": "number",
+                "description": "Minimum x of the scale extent."
+              },
+              "max": {
+                "type": "number",
+                "description": "Maximum x of the scale extent."
+              }
+            },
+            "required": []
+          },
+          "y": {
+            "type": "object",
+            "description": "Y dimension scale extent.",
+            "additionalProperties": false,
+            "properties": {
+              "min": {
+                "type": "number",
+                "description": "Minimum y of the scale extent."
+              },
+              "max": {
+                "type": "number",
+                "description": "Maximum y of the scale extent."
+              }
+            },
+            "required": []
+          }
+        },
+        "required": []
+      },
+      "ScaleSize": {
+        "type": "object",
+        "title": "ScaleSize",
+        "description": "Target grid scale size",
+        "additionalProperties": false,
+        "properties": {
+          "x": {
+            "type": "number",
+            "description": "Row scale size"
+          },
+          "y": {
+            "type": "number",
+            "description": "Column scale size."
+          }
+        },
+        "required": []
+      },
+      "RemoteResource": {
+        "type": "object",
+        "description": "A remote resource which needs to be downloaded before use",
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string",
+            "description": "The URI of the remote resource",
+            "examples": [ "s3://example-bucket/some/path/resource.ext" ]
+          },
+          "type": {
+            "type": "string",
+            "description": "The content type of the resource",
+            "examples": [ "application/geo+json" ]
+          }
+        },
+        "required": [
+          "href",
+          "type"
+        ]
+      },
+      "RelatedUrl": {
+        "type": "object",
+        "title": "RelatedUrl",
+        "description": "A related URL from the CMR",
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "type": "string",
+            "description": "Points to an external resource or location on the web (data access location, project home page, relevant software packages, etc.)"
+          },
+          "urlContentType": {
+            "type": "string",
+            "description": "A keyword which describes the content of a link at a high level.",
+            "examples": ["CollectionURL", "PublicationURL", "DataCenterURL", "DistributionURL", "DataContactURL", "VisualizationURL"]
+          },
+          "type": {
+            "type": "string",
+            "description": "A keyword which specifies the content of a link.",
+            "examples": ["GET DATA", "HOME PAGE", "Color Map"]
+          },
+          "subtype": {
+            "type": "string",
+            "description": "A keyword which further specifies the content of a link.",
+            "examples": ["Harmony GDAL", "GITC", "Giovanni"]
+          },
+          "description": {
+            "type": "string",
+            "description": "Explains where the link navigates and the type of information it contains."
+          },
+          "format": {
+            "type": "string",
+            "description": "The format of the data.",
+            "examples": ["ASCII", "GIF", "JPEG"]
+          },
+          "mimeType": {
+            "type": "string",
+            "description": "The mime type of the data.",
+            "examples": ["application/json", "application/x-hdf", "image/png"]
+          }
+        },
+        "required": []
+      },
+      "Dimension": {
+        "type": "object",
+        "title": "Dimension",
+        "description": "Information on how to subset the data file for a dimension.",
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the dimension of the variable represented in the data field.",
+            "examples": ["XDim"]
+          },
+          "min": {
+            "type": "number",
+            "description": "The minimum value for the dimension."
+          },
+          "max": {
+            "type": "number",
+            "description": "The maximum value for the dimension."
+          }
+        },
+        "required": ["name"]
+      }
+    }
+  }

--- a/services/harmony/app/schemas/data-operation/CHANGELOG.md
+++ b/services/harmony/app/schemas/data-operation/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.20.0] - 2024-10-10
+### Added
+- average - The averaging method to use. Initially Giovanni plans to support 'time' or 'area' averaging.
+
 ## [0.19.0] - 2024-04-10
 ### Added
 - extraArgs - The extra arguments that will be passed to service worker

--- a/services/harmony/app/schemas/data-operation/README.md
+++ b/services/harmony/app/schemas/data-operation/README.md
@@ -14,8 +14,8 @@
 - [ ] Update all of the batch<n>-operation.json files in [test/resources/data-operation-samples](../../../test/resources/data-operation-samples)
 - [ ] Update [test/resources/data-operation-samples/multiple-collections-operation.json](../../../test/resources/data-operation-samples/multiple-collections-operation.json)
 - [ ] Update [example/service-operation.json](../../../example/service-operation.json) to reference the updated schema and have any required fields
-- [ ] Update [harmony-service-lib-py](../../../../../../../../harmony-service-lib-py/harmony/message.py) to parse the new schema
-- [ ] Update [harmony-service-lib-py/tests/example_messages.py](../../../../../../../../harmony-service-lib-py/tests/example_messages.py) to use the new schema
+- [ ] Update [harmony-service-lib-py](../../../../../../harmony-service-lib-py/harmony_service_lib/message.py) to parse the new schema
+- [ ] Update [harmony-service-lib-py/tests/example_messages.py](../../../../../../harmony-service-lib-py/tests/example_messages.py) to use the new schema
 - [ ] Update [harmony-service-lib-py/tests/test_message.py](../../../../../../harmony-service-lib-py/tests/test_message.py) to use the new schema version and add / alter any necessary checks
 - [ ] Update [harmony-service-lib-py/example/example_message.json](../../../../../../harmony-service-lib-py/example/example_message.json) to use the new schema
 - [ ] Update [harmony-service-example/example/harmony-operation.json](../../../../../../harmony-service-example/example/harmony-operation.json) to use the new schema

--- a/services/harmony/example/service-operation.json
+++ b/services/harmony/example/service-operation.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "../app/schemas/data-operation/0.18.0/data-operation-v0.19.0.json",
-  "version": "0.18.0",
+  "$schema": "../app/schemas/data-operation/0.20.0/data-operation-v0.20.0.json",
+  "version": "0.20.0",
   "callback": "http://localhost/some-path",
   "stagingLocation": "s3://example-bucket/public/some-org/some-service/some-uuid/",
   "user": "jdoe",
@@ -98,6 +98,7 @@
   "requestId": "c045c793-19f1-43b5-9547-c87a5c7dfadb",
   "client": "harmony-sit",
   "concatenate": false,
+  "average": "time",
   "extraArgs": {
     "cut": false
   }

--- a/services/harmony/test/helpers/data-operation.ts
+++ b/services/harmony/test/helpers/data-operation.ts
@@ -6,6 +6,7 @@ import { v4 as uuid } from 'uuid';
 export const samplesDir = './test/resources/data-operation-samples';
 
 export const versions = [
+  '0.20.0',
   '0.19.0',
   '0.18.0',
   '0.17.0',

--- a/services/harmony/test/models/data-operation.ts
+++ b/services/harmony/test/models/data-operation.ts
@@ -11,7 +11,8 @@ const expectedOutput = parseSchemaFile(`valid-operation-v${versions[0]}.json`);
 // The fields that all operations should contain
 const baseFields = new Set([
   'client', 'callback', 'stagingLocation', 'sources', 'format', 'user', 'accessToken',
-  'subset', 'isSynchronous', 'requestId', 'version', 'concatenate', 'extendDimensions', 'extraArgs',
+  'subset', 'isSynchronous', 'requestId', 'version', 'concatenate', 'extendDimensions',
+  'extraArgs', 'average',
 ]);
 
 describe('DataOperation', () => {

--- a/services/harmony/test/resources/data-operation-samples/batch1-operation.json
+++ b/services/harmony/test/resources/data-operation-samples/batch1-operation.json
@@ -131,6 +131,7 @@
   "stagingLocation": "s3://localStagingBucket/public/harmony/gdal/232110b5-5267-4b31-9057-70afd0673f65/",
   "callback": "http://example.com/callback",
   "concatenate": false,
+  "average": "time",
   "extraArgs": {
     "cut": false
   },

--- a/services/harmony/test/resources/data-operation-samples/batch2-operation.json
+++ b/services/harmony/test/resources/data-operation-samples/batch2-operation.json
@@ -131,6 +131,7 @@
   "stagingLocation": "s3://localStagingBucket/public/harmony/gdal/232110b5-5267-4b31-9057-70afd0673f65/",
   "callback": "http://example.com/callback",
   "concatenate": false,
+  "average": "time",
   "extraArgs": {
     "cut": false
   },

--- a/services/harmony/test/resources/data-operation-samples/batch3-operation.json
+++ b/services/harmony/test/resources/data-operation-samples/batch3-operation.json
@@ -70,6 +70,7 @@
   "stagingLocation": "s3://localStagingBucket/public/harmony/gdal/232110b5-5267-4b31-9057-70afd0673f65/",
   "callback": "http://example.com/callback",
   "concatenate": false,
+  "average": "time",
   "extraArgs": {
     "cut": false
   },

--- a/services/harmony/test/resources/data-operation-samples/batch4-operation.json
+++ b/services/harmony/test/resources/data-operation-samples/batch4-operation.json
@@ -131,6 +131,7 @@
   "stagingLocation": "s3://localStagingBucket/public/harmony/gdal/232110b5-5267-4b31-9057-70afd0673f65/",
   "callback": "http://example.com/callback",
   "concatenate": false,
+  "average": "time",
   "extraArgs": {
     "cut": false
   },

--- a/services/harmony/test/resources/data-operation-samples/batch5-operation.json
+++ b/services/harmony/test/resources/data-operation-samples/batch5-operation.json
@@ -116,6 +116,7 @@
   "stagingLocation": "s3://localStagingBucket/public/harmony/gdal/232110b5-5267-4b31-9057-70afd0673f65/",
   "callback": "http://example.com/callback",
   "concatenate": false,
+  "average": "time",
   "extraArgs": {
     "cut": false
   },

--- a/services/harmony/test/resources/data-operation-samples/multiple-collections-operation.json
+++ b/services/harmony/test/resources/data-operation-samples/multiple-collections-operation.json
@@ -377,6 +377,7 @@
   "stagingLocation": "s3://localStagingBucket/public/harmony/gdal/232110b5-5267-4b31-9057-70afd0673f65/",
   "callback": "http://example.com/callback",
   "concatenate": false,
+  "average": "time",
   "extraArgs": {
     "cut": false
   },

--- a/services/harmony/test/resources/data-operation-samples/valid-operation-input.json
+++ b/services/harmony/test/resources/data-operation-samples/valid-operation-input.json
@@ -105,8 +105,9 @@
     "end": "2020-02-20T15:00:00.000Z"
   },
   "concatenate": false,
+  "average": "time",
   "extraArgs": {
     "cut": false
   },
-  "version": "0.19.0"
+  "version": "0.20.0"
 }

--- a/services/harmony/test/resources/data-operation-samples/valid-operation-v0.20.0.json
+++ b/services/harmony/test/resources/data-operation-samples/valid-operation-v0.20.0.json
@@ -1,0 +1,113 @@
+{
+    "client": "harmony-test",
+    "callback": "http://example.com/callback",
+    "stagingLocation": "s3://some-bucket/public/some/prefix/",
+    "sources": [
+      {
+        "collection": "C1233800302-EEDTEST",
+        "shortName": "harmony_example",
+        "versionId": "1",
+        "variables": [{
+          "id": "V1233801717-EEDTEST",
+          "name": "alpha_var",
+          "fullPath": "data/colors/red_var",
+          "relatedUrls": [
+            {
+              "description" : "This URL points to some text data.",
+              "urlContentType" : "DistributionURL",
+              "type" : "GET DATA" ,
+              "url" : "http://example.com/file649.txt"
+            }
+          ],
+          "type": "SCIENCE_VARIABLE",
+          "subtype": "SCIENCE_ARRAY"
+        }],
+        "coordinateVariables": [{
+          "id": "V1233801718-EEDTEST",
+          "name": "lat",
+          "fullPath": "lat",
+          "type": "COORDINATE",
+          "subtype": "LATITUDE"
+        }],
+        "granules": [
+          {
+            "id": "G1233800343-EEDTEST",
+            "name": "001_00_7f00ff_global.nc",
+            "url": "http://opendap.two.example.com",
+            "bbox": [
+              -100.5,
+              30.4,
+              -99.5,
+              31.4
+            ],
+            "temporal": {
+              "start": "1999-01-01T10:00:00.000Z",
+              "end": "2020-02-20T15:00:00.000Z"
+            }
+          }
+        ]
+      }
+    ],
+    "format": {
+      "mime": "image/png",
+      "interpolation": "near",
+      "scaleExtent": {
+        "x": {
+          "min": 0.5,
+          "max": 125
+        },
+        "y": {
+          "min": 52,
+          "max": 75.22
+        }
+      },
+      "scaleSize": {
+        "x": 14.2,
+        "y": 35
+      },
+      "crs": "CRS84",
+      "srs": {
+        "proj4": "+proj=longlat +datum=WGS84 +no_defs",
+        "wkt": "GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.0174532925199433,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]]",
+        "epsg": "EPSG:4326"
+      },
+      "width": 120,
+      "height": 225
+    },
+    "user": "test-user",
+    "accessToken": "FxLhvhM8JsmdxJHk4Edsmyn7Z0s5tkXe:4M2RrCrhVbS0IKxicg+ix567em1W5UDV9dSdkn3m",
+    "subset": {
+      "bbox": [
+        -130,
+        -45,
+        130,
+        45
+      ],
+      "point": [
+        -130,
+        45
+      ],
+      "shape": {
+        "href": "s3://example-bucket/some/path/resource.ext",
+        "type": "application/geo+json"
+      },
+      "dimensions": [{
+        "name": "XDim",
+        "min": 0.5,
+        "max": 12.0
+      }]
+    },
+    "extendDimensions": ["lat", "lon"],
+    "isSynchronous": true,
+    "requestId": "c045c793-19f1-43b5-9547-c87a5c7dfadb",
+    "temporal": {
+      "start": "1999-01-01T10:00:00.000Z",
+      "end": "2020-02-20T15:00:00.000Z"
+    },
+    "concatenate": false,
+    "average": "time",
+    "extraArgs": {
+      "cut": false
+    },
+    "version": "0.20.0"
+  }


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1912

## Description
Adds support for the average parameter which specifies the averaging method to use for averaging services. This will be for the Giovanni services to know whether the request is for 'time' or 'area' averaging.

## Local Test Steps
Since no services currently support time or area averaging you will need to modify one of the services in services.yml to add to the capabilities section (I tested with harmony-service-example):
```
averaging:
  time: true
  average: true
```

Then submit a request:
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng&average=time

Check the database in the workflow_steps table to verify the data operation field in the data includes "average": "time".

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)