### PR TITLE
HARMONY-1924: Move paging link construction and STAC catalog creation out of db transaction

### DIFF
--- a/docs/guides/managing-existing-services.md
+++ b/docs/guides/managing-existing-services.md
@@ -112,15 +112,15 @@ The returned JSON response has the fields indicating the current status of the s
 
 ```JSON
 {
-  deploymentId: "befb50e0-e467-4776-86c8-e7218f1123cc",
-  username: "yliu10",
-  service: "giovanni-adapter",
-  tag: "new-version",
-  regressionTestVersion: "1.0.0",
-  status: "successful",
-  message: "Deployment successful",
-  createdAt: "2024-03-29T14:56:29.151Z",
-  updatedAt: "2024-03-29T14:56:29.273Z"
+  "deploymentId": "befb50e0-e467-4776-86c8-e7218f1123cc",
+  "username": "yliu10",
+  "service": "giovanni-adapter",
+  "tag": "new-version",
+  "regressionTestVersion": "1.0.0",
+  "status": "successful",
+  "message": "Deployment successful",
+  "createdAt": "2024-03-29T14:56:29.151Z",
+  "updatedAt": "2024-03-29T14:56:29.273Z"
 }
 ```
 **Example 9** - Harmony get status of service image tag update response

--- a/services/harmony/app/markdown/cloud-access.md
+++ b/services/harmony/app/markdown/cloud-access.md
@@ -1,6 +1,6 @@
 ### <a name="cloud-access-details"></a> Getting in region S3 AWS access keys using the cloud-access API
 
-Harmony supports analysis in place without forcing a user to download the outputs from their requests. The results for each harmony request are stored an AWS S3 bucket in the us-west-2 region. In order to access these results natively in S3 the user can get temporary AWS access credentials using the harmony cloud-access endpoints. Note that data can only be accessed from within the us-west-2 region.
+Harmony supports analysis in place without forcing a user to download the outputs from their requests. The results for each harmony request are stored in an AWS S3 bucket in the us-west-2 region. In order to access these results natively in S3, the user can get temporary AWS access credentials using the harmony cloud-access endpoints. Note that data can only be accessed from within the us-west-2 region.
 
 #### Get AWS S3 access credentials as JSON
 

--- a/services/harmony/app/markdown/endpoints.md
+++ b/services/harmony/app/markdown/endpoints.md
@@ -13,7 +13,7 @@ All of the public endpoints for Harmony users other than the OGC Coverages, EDR,
 | /stac                  | [The API for retrieving STAC catalog and catalog items for processed data](#stac-details)         |
 | /staging-bucket-policy | [The policy generator for external (user) bucket storage](#user-owned-buckets-for-harmony-output) |
 | /versions              | [Returns JSON indicating the image and tag each deployed service is running](#versions-details)   |
-| /service-image-tag              | [The API for managing service image tags/versions](#service-image-tags-details)   |
+| /service-image-tag     | [The API for managing service image tags/versions](https://github.com/nasa/harmony/blob/main/docs/guides/managing-existing-services.md)|
 | /workflow-ui           | The Workflow UI for monitoring and interacting with running jobs                                  |
 ---
 **Table {{tableCounter}}** - Harmony routes other than OGC Coverages and WMS


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1924

## Description
This PR is an attempt to fix the intermittent STAC item retrieval issue in PROD and some unrelated documentation updates.

The STAC item retrieval in PROD is broken most of the time with Internal Server Error. e.g. https://harmony.earthdata.nasa.gov/stac/a740e311-6c04-4639-8cbf-3555612eb4be/1

It appears the db transaction is taking too long to complete sometimes in PROD only. Inspection of code reveals that the paging links construction and STAC catalog creation are done inside the db transaction unnecessarily. For this ticket, we will move these operations out of the db transaction and hopefully it will resolve the issue. If we see more db performance issues, we will write new ticket to further fine tune the performance if needed.

## Local Test Steps
Make sure STAC catalog and item page still works.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)