### PR TITLE
TRT-588 - Add variable subsetting option to HyBIG.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -397,6 +397,8 @@ https://cmr.earthdata.nasa.gov:
         bbox: false
         shape: false
         temporal: false
+        variable: true
+        multiple_variable: false
       output_formats:
         - image/png
         - image/jpeg
@@ -976,6 +978,8 @@ https://cmr.uat.earthdata.nasa.gov:
         bbox: false
         shape: false
         temporal: false
+        variable: true
+        multiple_variable: false
       output_formats:
         - image/png
         - image/jpeg


### PR DESCRIPTION
## Jira Issue ID

TRT-588

## Description

This PR updates HyBIG to allow for variable subsetting (only one variable). This is to support browse image generation for PREFIRE, which requires a custom colour map, currently specified via a UMM-Var record.

## Local Test Steps

* Pull this branch.
* Pull [this branch](https://github.com/nasa/harmony-regression-tests/tree/TRT-588-HyBIG-variable) for the regression tests. (Unless [this PR](https://github.com/nasa/harmony-regression-tests/pull/105) is already merged - if so `main` will work)
* Stand up a local Harmony instance with [the latest HyBIG image](https://github.com/nasa/harmony-browse-image-generator/pkgs/container/harmony-browse-image-generator) (there are no actual changes to HyBIG).
* Run the updated HyBIG regression test notebook against your local Harmony instance. It should all pass, including the PREFIRE test at the end.
* Visually inspect the tiles. Those with data going through them should have data that has a non-greyscale colour map (see example screenshot attached).

## PR Acceptance Checklist
* [x] Acceptance criteria met
* ~~Tests added/updated (if needed) and~~ passing
* ~~Documentation updated (if needed)~~


![Screenshot 2024-10-16 at 2 41 19 PM](https://github.com/user-attachments/assets/6caa5a8b-3b18-4f78-8e0d-b8f6ebc27e01)