### PR TITLE
Harmony 1934

### DIFF
--- a/ENV_CHANGELOG.md
+++ b/ENV_CHANGELOG.md
@@ -2,8 +2,13 @@
 Any changes to the environment variables will be documented in this file in chronological
 order with the most recent changes first.
 
+# 2024-10-23
+### Added
+- LABELS_ALLOW_LIST - comma-separated list of values that are explicitly allowed for labels
+- LABELS_FORBID_LIST - comma-separated list of values that are explicitly forbidden for labels
+
 ## 2024-08-30
-### Added  
+### Added
 - Added environment defaults for NET2COG service
 
 ## 2024-07-31

--- a/services/harmony/app/frontends/labels.ts
+++ b/services/harmony/app/frontends/labels.ts
@@ -24,7 +24,6 @@ export async function addJobLabels(
   try {
     await db.transaction(async (trx) => {
       const lowerCaseBody = keysToLowerCase(req.body);
-      console.log(`BODY: ${JSON.stringify(lowerCaseBody)}`);
       await addLabelsToJobs(trx, lowerCaseBody.jobid, req.user, lowerCaseBody.label, isAdmin);
     });
 

--- a/services/harmony/app/markdown/apis.md
+++ b/services/harmony/app/markdown/apis.md
@@ -66,7 +66,7 @@ As such it accepts parameters in the URL path as well as query parameters.
 | height | number of rows to return in the output coverage |
 | forceAsync | if "true", override the default API behavior and always treat the request as asynchronous |
 | format | the mime-type of the output format to return |
-| label | the label(s) to add for the job that runs the request. Multiple labels can be specified as a comma-separated list. A label can contain any characters up to a 255 character limit, but if a label contains commas the request can only be a POST with with the label field in the body. Labels are always converted to lower case.
+| label | the label(s) to add for the job that runs the request. Multiple labels can be specified as a comma-separated list. A label can contain any characters up to a 255 character limit, but if a label contains commas the request can only be a POST with with the label field in the body. It is best practice to avoid commas in labels. Labels will be rejected if deemed inappropriate. Labels are always converted to lower case.
 | maxResults | limits the number of input files processed in the request |
 | skipPreview | if "true", override the default API behavior and never auto-pause jobs |
 | ignoreErrors | if "true", continue processing a request to completion even if some items fail. If "false" immediately fail the request. Defaults to true |
@@ -126,7 +126,7 @@ Currently only the `/position`, `/cube`, `/trajectory` and `/area` routes are su
 | grid | the name of the output grid to use for regridding requests. The name must match the UMM  |grid name in the CMR.
 | ignoreErrors | if "true", continue processing a request to completion even if some items fail. If "false" immediately fail the request. Defaults to true |
 | interpolation | specify the interpolation method used during reprojection and scaling |
-| label | the label(s) to add for the job that runs the request. Multiple labels can be specified as a comma-separated list or as an array in the JSON body for POST requests. A label can contain any characters up to a 255 character limit, but if a label contains commas the request can only be a POST. Labels are always converted to lower case.
+| label | the label(s) to add for the job that runs the request. Multiple labels can be specified as a comma-separated list. A label can contain any characters up to a 255 character limit, but if a label contains commas the request can only be a POST with with the label field in the body. It is best practice to avoid commas in labels. Labels will be rejected if deemed inappropriate. Labels are always converted to lower case.
 | maxResults | limits the number of input files processed in the request |
 | scaleExtent | scale the resulting coverage along one axis to a given extent |
 | scaleSize | scale the resulting coverage along one axis to a given size |

--- a/services/harmony/app/models/label.ts
+++ b/services/harmony/app/models/label.ts
@@ -1,3 +1,4 @@
+import { profanity, CensorType } from '@2toad/profanity';
 import { Transaction } from '../util/db';
 import { Job } from './job';
 import { NotFoundError, RequestValidationError } from '../util/errors';
@@ -14,11 +15,16 @@ export const USERS_LABELS_TABLE = 'users_labels';
  * @returns An error message if the label is not valid, null otherwise
  */
 export function checkLabel(label: string): string {
+  let message = null;
+
   if (label.length > 255) {
-    const message = 'Labels may not exceed 255 characters in length.';
-    return message;
+    message = 'Labels may not exceed 255 characters in length.';
+  } else if (profanity.exists(label, ['en', 'de', 'es', 'fr'])) {
+    const censored = profanity.censor(label, CensorType.AllVowels, ['en', 'de', 'es', 'fr']);
+    message = `${censored} is not an allowed label`;
   }
-  return null;
+
+  return message;
 }
 
 /**

--- a/services/harmony/app/server.ts
+++ b/services/harmony/app/server.ts
@@ -8,6 +8,8 @@ import { promisify } from 'util';
 import * as http from 'http';
 import * as https from 'https';
 import { Logger } from 'winston';
+import { profanity } from '@2toad/profanity';
+import env from './util/env';
 import errorHandler from './middleware/error-handler';
 import logForRoutes from './middleware/log-for-routes';
 import router, { RouterConfig } from './routers/router';
@@ -196,6 +198,19 @@ export function start(config: Record<string, string>): {
   frontend: http.Server | https.Server;
   backend: http.Server | https.Server;
 } {
+
+  // add explicitly allowed words for label filter
+  let allowList = [];
+  if (env.labelsAllowList) {
+    allowList = env.labelsAllowList.split(',');
+  }
+  profanity.whitelist.addWords(allowList);
+  // set explicitly forbidden words for label filter
+  let forbiddenList = [];
+  if (env.labelsForbidList) {
+    forbiddenList = env.labelsForbidList.split(',');
+  }
+  profanity.addWords(forbiddenList);
 
   // Log unhandled promise rejections and do not crash the node process
   process.on('unhandledRejection', (reason, _promise) => {

--- a/services/harmony/app/util/env.ts
+++ b/services/harmony/app/util/env.ts
@@ -112,6 +112,10 @@ class HarmonyServerEnv extends HarmonyEnv {
   wktPrecision: number;
 
   locallyDeployedServices: string;
+
+  labelsAllowList: string;
+
+  labelsForbidList: string;
 }
 
 const localPath = path.resolve(__dirname, '../../env-defaults');

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -135,6 +135,11 @@ MAX_DATA_OPERATION_CACHE_SIZE=512000000
 # WKT POINT/LINESTRING to POLYGON conversion side length, 0.0001 is about 11 meters in precision
 WKT_PRECISION=0.0001
 
+# Comma-separated list of label values that are explicitly allowed
+LABELS_ALLOW_LIST=
+# Comma-separated list of label values that are explicitly forbidden
+LABELS_FORBID_LIST=
+
 #############################################################################
 #                        OAuth 2 (Earthdata Login)                          #
 #                                                                           #

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -137,8 +137,9 @@ WKT_PRECISION=0.0001
 
 # Comma-separated list of label values that are explicitly allowed
 LABELS_ALLOW_LIST=
-# Comma-separated list of label values that are explicitly forbidden
-LABELS_FORBID_LIST=
+# Comma-separated list of label values that are explicitly forbidden, with the first one just
+# for demo purposes
+LABELS_FORBID_LIST=this_is_a_forbidden_label
 
 #############################################################################
 #                        OAuth 2 (Earthdata Login)                          #

--- a/services/harmony/package-lock.json
+++ b/services/harmony/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@2toad/profanity": "^3.0.1",
         "@aws-sdk/client-ecr": "^3.437.0",
         "@aws-sdk/client-s3": "^3.437.0",
         "@aws-sdk/client-sqs": "^3.437.0",
@@ -199,6 +200,15 @@
       "engines": {
         "node": "^22.5.1",
         "npm": ">=8"
+      }
+    },
+    "node_modules/@2toad/profanity": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@2toad/profanity/-/profanity-3.0.1.tgz",
+      "integrity": "sha512-WqAljnXnxsdUmwJT2VDTHZ6IAMgktnobLtBSdGFQYFLB1kh7q+QqzpxY4rRAWU4lSYvGUykJ+xv5wJ3IZYBuzQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -22485,6 +22495,11 @@
     }
   },
   "dependencies": {
+    "@2toad/profanity": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@2toad/profanity/-/profanity-3.0.1.tgz",
+      "integrity": "sha512-WqAljnXnxsdUmwJT2VDTHZ6IAMgktnobLtBSdGFQYFLB1kh7q+QqzpxY4rRAWU4lSYvGUykJ+xv5wJ3IZYBuzQ=="
+    },
     "@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",

--- a/services/harmony/package.json
+++ b/services/harmony/package.json
@@ -55,6 +55,7 @@
   "author": "NASA EOSDIS Harmony team",
   "license": "Apache-2.0",
   "dependencies": {
+    "@2toad/profanity": "^3.0.1",
     "@aws-sdk/client-ecr": "^3.437.0",
     "@aws-sdk/client-s3": "^3.437.0",
     "@aws-sdk/client-sqs": "^3.437.0",

--- a/services/harmony/test/models/label.ts
+++ b/services/harmony/test/models/label.ts
@@ -1,12 +1,22 @@
 
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
+import { profanity } from '@2toad/profanity';
 import { buildJob, getFirstJob } from '../helpers/jobs';
 import { hookTransactionEach } from '../helpers/db';
 import { checkLabel, normalizeLabel, setLabelsForJob } from '../../app/models/label';
 
 // unit tests for `checkLabel`
 describe('checkLabel', function () {
+  before(function () {
+    profanity.whitelist.addWords(['butt']);
+    profanity.addWords(['foo']);
+  });
+  after(function () {
+    profanity.whitelist.removeWords(['butt']);
+    profanity.removeWords(['foo']);
+  });
+
   it('should return null for valid labels', function () {
     // Examples of valid labels
     const validLabels = [
@@ -26,16 +36,21 @@ describe('checkLabel', function () {
   it('should return an error message for invalid labels', function () {
     // Examples of invalid labels
     const invalidLabels = [
-      'a'.repeat(256), // Exceeds maximum length
+      ['a'.repeat(256), 'Labels may not exceed 255 characters in length.'],
+      ['foo', 'f** is not an allowed label'],
     ];
 
-    const errorMessage = 'Labels may not exceed 255 characters in length.';
-
-    invalidLabels.forEach(label => {
+    for (const [label, errorMessage] of invalidLabels) {
       const result = checkLabel(label);
       expect(result).to.equal(errorMessage);
-    });
+    }
   });
+
+  it('should not return an error for labels on the allow list', function () {
+    const result = checkLabel('butt');
+    expect(result).to.equal(null);
+  });
+
 });
 
 // unit tests for `normalizeLabel`


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1934

## Description
Add validation of labels to forbid certain words. Includes ability to explicitly allow or forbid specific words, in addition to defaults for English, Spanish, French, German

## Local Test Steps
Try to start a job or add labels to a job using some curse words. (This may be the most fun we will ever have testing Harmony). If you don't know any, ask Chris; he knows loads of them. Or you use the fake one I added to the forbidden list just for demo purposes, "this_is_a_forbidden_label".

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)