### PR TITLE
HARMONY-1884: Convert job_links href field to text type

### DIFF
--- a/db/migrations/20241024193621_convert_job_links_href_to_text.js
+++ b/db/migrations/20241024193621_convert_job_links_href_to_text.js
@@ -1,0 +1,23 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('job_links', (t) => {
+    t.text('href').alter();
+  })
+
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('job_links', (t) => {
+    // I don't anticipate we would ever run this down migration, but if we do, it will truncate
+    // any long urls to be 4096, which is not good, but what else can we do?
+    t.string('href', 4096).alter();
+  })
+
+};


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1884

## Description
Converts job_links href column from varchar(4096) to text to support long urls

## Local Test Steps
1. Run a job (if you haven't already) to put some rows in the job_links table
2. Select the rows in dbViz
3. Run the db migration
4. Check the schema in dbViz and make sure that the job_links href column is now type text
5. Select the rows from job_links and make sure that the hrefs have not changed
6. (optional) manually insert a row with a very long href into the job_links table

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~