### PR TITLE
HARMONY-1939: Bug fix - remove /work-items from paging links

### DIFF
--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -552,6 +552,15 @@ export async function getWorkItemsTable(
     const lastPage = pageLinks.find((l) => l.rel === 'last');
     const nextPage = pageLinks.find((l) => l.rel === 'next');
     const previousPage = pageLinks.find((l) => l.rel === 'prev');
+    const links = [
+      { ...firstPage, linkTitle: 'first' },
+      { ...previousPage, linkTitle: 'previous' },
+      { ...nextPage, linkTitle: 'next' },
+      { ...lastPage, linkTitle: 'last' },
+    ];
+    links.forEach(link => (link.href = link.href ? link.href
+      .replace('/work-items', '')
+      .replace(/(&|\?)checkJobStatus=(true|false)/, '') : ''));
     const paginationDisplay = getPaginationDisplay(pagination);
     setPagingHeaders(res, pagination);
     res.render('workflow-ui/job/work-items-table', {
@@ -562,17 +571,10 @@ export async function getWorkItemsTable(
       statusClass: statusClass[job.status],
       workItems,
       ...workItemRenderingFunctions(job, isAdmin, isLogViewer, req.user),
-      links: [
-        { ...firstPage, linkTitle: 'first' },
-        { ...previousPage, linkTitle: 'previous' },
-        { ...nextPage, linkTitle: 'next' },
-        { ...lastPage, linkTitle: 'last' },
-      ],
+      links,
       linkDisabled() { return (this.href ? '' : 'disabled'); },
       linkHref() {
-        return (this.href ? this.href
-          .replace('/work-items', '')
-          .replace(/(&|\?)checkJobStatus=(true|false)/, '') : '');
+        return this.href;
       },
       ...jobRenderingFunctions(req.context.logger, requestQuery),
     });

--- a/services/harmony/test/workflow-ui/work-items-table.ts
+++ b/services/harmony/test/workflow-ui/work-items-table.ts
@@ -408,6 +408,10 @@ describe('Workflow UI work items table route', function () {
           ['limit=1', 'page=1', `tableFilter=${encodeURIComponent(successfulFilter)}`].forEach((param) => expect(listing).to.contain(
             mustache.render('{{param}}', { param })));
         });
+        it('removes /work-items from the paging links', function () {
+          const listing = this.res.text;
+          expect(listing).to.not.contain('&#x2F;work-items');
+        });
         it('returns only one work item', function () {
           const listing = this.res.text;
           expect(listing).to.contain(mustache.render('<td>{{id}}</td>', { id: 2 }));


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1939

## Description
A bug was introduced where paging links on the individual job page of the workflow ui were taking users to the wrong route (the route for just the work items table vs. the whole page). This should fix that.

## Local Test Steps
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?format=image%2Ftiff
Use the paging links on the work items table and verify they work as expected (takes you to the right page, with CSS applied).

(You can also reproduce the bug on the main branch if you'd like, following the same steps as above.)

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)