### PR TITLE
add UAT service config for asf/opera-rtc-s1-browse

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -1304,3 +1304,29 @@ https://cmr.uat.earthdata.nasa.gov:
         operations: ['concatenate']
         conditional:
           exists: ['concatenate']
+
+  - name: asf/opera-rtc-s1-browse
+    description: Service that generates GIBS-compliant browse imagery for the OPERA_L2_RTC-S1 collection
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/asf/opera-rtc-s1-browse
+    umm_s: S1271728813-ASF
+    maximum_sync_granules: 0
+    capabilities:
+      concatenation: false
+      subsetting:
+        bbox: false
+        variable: false
+        temporal: false
+      output_formats:
+        - image/png
+      reprojection: true
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+      - image: !Env ${OPERA_RTC_S1_BROWSE_IMAGE}
+      - image: !Env ${HYBIG_IMAGE}

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -517,3 +517,9 @@ NET2COG_LIMITS_CPU=128m
 NET2COG_LIMITS_MEMORY=512Mi
 NET2COG_INVOCATION_ARGS='./docker-entrypoint.sh'
 NET2COG_QUEUE_URLS='["ghcr.io/podaac/net2cog:SIT,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/net2cog.fifo"]'
+
+OPERA_RTC_S1_BROWSE_IMAGE=ghcr.io/asfhyp3/opera-rtc-s1-browse:latest
+OPERA_RTC_S1_BROWSE_REQUESTS_MEMORY=512Mi
+OPERA_RTC_S1_BROWSE_LIMITS_MEMORY=512Mi
+OPERA_RTC_S1_BROWSE_INVOCATION_ARGS='/usr/local/bin/_entrypoint.sh python -m opera_rtc_s1_browse.harmony_service'
+OPERA_RTC_S1_BROWSE_SERVICE_QUEUE_URLS='["ghcr.io/asfhyp3/opera-rtc-s1-browse:latest,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/opera-rtc-s1-browse.fifo"]'

--- a/services/harmony/test/versions.ts
+++ b/services/harmony/test/versions.ts
@@ -44,6 +44,7 @@ describe('Versions endpoint', function () {
           'harmony/swath-projector-netcdf-to-zarr',
           'harmony/service-example',
           'l2-subsetter-batchee-stitchee-concise',
+          'asf/opera-rtc-s1-browse',
         ]);
       });
 


### PR DESCRIPTION
https://harmony.uat.earthdata.nasa.gov/C1259974840-ASF/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?granuleId=G1260014889-ASF&format=image/png should produce three output files:

# `.png` browse image
![59e72e542944395cd4ec4fcbb76f13852dadfd3d27460ade67027b0fb498e_rgb](https://github.com/user-attachments/assets/9687f60b-d582-48cb-a3ea-a0fb350a2467)

# `.pgw` world file
```
0.0002746662669663458
0.0
0.0
-0.00027461902098253427
-177.46826490379303
69.45012719494066
```

# `.aux.xml` file
```
<PAMDataset>
  <SRS dataAxisToSRSAxisMapping="2,1">GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]</SRS>
  <GeoTransform> -1.7746840223692652e+02,  2.7466626696634580e-04,  0.0000000000000000e+00,  6.9450264504451155e+01,  0.0000000000000000e+00, -2.7461902098253427e-04</GeoTransform>
</PAMDataset>
```
