### PR TITLE
HARMONY-1956: Remove duplicates from label list

### DIFF
--- a/services/harmony/app/models/label.ts
+++ b/services/harmony/app/models/label.ts
@@ -246,7 +246,8 @@ export async function getLabelsForUser(
 ): Promise<string[]> {
   const query = trx(`${USERS_LABELS_TABLE}`)
     .select('value')
-    .orderBy('updatedAt', 'desc')
+    .groupBy('value')
+    .orderByRaw(`max("${USERS_LABELS_TABLE}"."updatedAt") desc`)
     .limit(count)
     .modify((queryBuilder) => {
       if (!isAdminRoute) {

--- a/services/harmony/test/helpers/db.ts
+++ b/services/harmony/test/helpers/db.ts
@@ -6,7 +6,7 @@ import { stub } from 'sinon';
 import util from 'util';
 import db from '../../app/util/db';
 
-export const tables = ['jobs', 'work_items', 'workflow_steps', 'job_links', 'user_work', 'job_errors', 'batches', 'batch_items'];
+export const tables = ['jobs', 'work_items', 'workflow_steps', 'job_links', 'user_work', 'job_errors', 'batches', 'batch_items', 'raw_labels', 'jobs_raw_labels', 'users_labels'];
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const exec = util.promisify(require('child_process').exec);

--- a/services/harmony/test/labels/label_crud.ts
+++ b/services/harmony/test/labels/label_crud.ts
@@ -18,7 +18,7 @@ describe('Get Labels', function () {
     const trx = await db.transaction();
     await joeJob.save(trx);
     await jillJob.save(trx);
-    trx.commit();
+    await trx.commit();
   });
 
   describe('When getting labels using the admin route', function () {

--- a/services/harmony/test/labels/label_crud.ts
+++ b/services/harmony/test/labels/label_crud.ts
@@ -37,6 +37,22 @@ describe('Get Labels', function () {
       });
     });
   });
+
+  describe('When multiple users add labels', function () {
+    it('returns the most recently used labels', async function () {
+      await addJobsLabels(this.frontend, [joeJob.jobID], ['one'], 'joe');
+      await addJobsLabels(this.frontend, [joeJob.jobID], ['two'], 'joe');
+      await addJobsLabels(this.frontend, [jillJob.jobID], ['three', 'four'], 'jill');
+      // get up to three labels across all users
+      const labels = await getLabelsForUser(
+        db,
+        'adam',
+        3,
+        true,
+      );
+      expect(labels).deep.equal(['three', 'four', 'two']);
+    });
+  });
 });
 
 describe('Job label CRUD', function () {

--- a/services/harmony/test/labels/label_crud.ts
+++ b/services/harmony/test/labels/label_crud.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { profanity } from '@2toad/profanity';
-import { hookTransaction } from '../helpers/db';
+import { hookTransaction, truncateAll } from '../helpers/db';
 import { buildJob, getFirstJob } from '../helpers/jobs';
 import { addJobsLabels, deleteJobsLabels } from '../helpers/labels';
 import hookServersStartStop from '../helpers/servers';
@@ -13,12 +13,12 @@ describe('Get Labels', function () {
   const joeJob = buildJob({ username: 'joe' });
   const jillJob = buildJob({ username: 'jill' });
   hookServersStartStop({ skipEarthdataLogin: false });
-  hookTransaction();
   before(async function () {
-    await joeJob.save(this.trx);
-    await jillJob.save(this.trx);
-    this.trx.commit();
-    this.trx = null;
+    await truncateAll();
+    const trx = await db.transaction();
+    await joeJob.save(trx);
+    await jillJob.save(trx);
+    trx.commit();
   });
 
   describe('When getting labels using the admin route', function () {
@@ -31,14 +31,12 @@ describe('Get Labels', function () {
           db,
           'adam',
           10,
-          true
+          true,
         );
         expect(labels).deep.equal(['foo', 'boo', 'bar']);
       });
     });
   });
-
-
 });
 
 describe('Job label CRUD', function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1956

## Description
Fixes a bug where duplicate labels were showing up in the dropdown filter list when using the admin route.

## Local Test Steps
* Create a job with labels
* Use dbViz to get the id for one of the labels, e.g.,`foo`:
```
select id from raw_labels where value='foo'
```
* Use dbViz to add a row to the `users_labels` with a new username pointing to an existing label, e.g., `edltest` and `foo`
```
insert into users_labels values(<id from above select>, 'edltest', 'foo', now(), now());
```
`edltest` does not have to be a real user.
* Open http://localhost:3000/admin/workflow-ui and start typing `label` in the filter box. You should to see the duplicate label more than once.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~