### PR TITLE
HARMONY-1947, HARMONY-1917: As a harmony service provider, I want temporal subsetting information included in the collection capabilities endpoint.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,3 +11,4 @@
 * [ ] Acceptance criteria met
 * [ ] Tests added/updated (if needed) and passing
 * [ ] Documentation updated (if needed)
+* [ ] Harmony in a Box tested? (if changes made to microservices)

--- a/services/harmony/app/frontends/capabilities.ts
+++ b/services/harmony/app/frontends/capabilities.ts
@@ -29,6 +29,7 @@ interface CollectionCapabilitiesV1 {
   variableSubset: boolean;
   bboxSubset: boolean;
   shapeSubset: boolean;
+  temporalSubset: boolean;
   concatenate: boolean;
   reproject: boolean;
   outputFormats: string[];
@@ -43,6 +44,7 @@ interface CollectionCapabilitiesV2 {
   variableSubset: boolean;
   bboxSubset: boolean;
   shapeSubset: boolean;
+  temporalSubset: boolean;
   concatenate: boolean;
   reproject: boolean;
   outputFormats: string[];
@@ -140,6 +142,7 @@ async function getCollectionCapabilitiesV1(collection: CmrCollection)
     && matchingServices.some((s) => s.capabilities.subsetting.variable === true);
   const bboxSubset = matchingServices.some((s) => s.capabilities.subsetting.bbox === true);
   const shapeSubset = matchingServices.some((s) => s.capabilities.subsetting.shape === true);
+  const temporalSubset = matchingServices.some((s) => s.capabilities.subsetting.temporal === true);
   const concatenate = matchingServices.some((s) => s.capabilities.concatenation === true);
   const reproject = matchingServices.some((s) => s.capabilities.reprojection === true);
   const outputFormats = new Set(matchingServices.flatMap((s) => s.capabilities.output_formats));
@@ -147,7 +150,7 @@ async function getCollectionCapabilitiesV1(collection: CmrCollection)
   const shortName = collection.short_name;
   const services = matchingServices.map((s) => _.pick(s, ['name', 'capabilities']));
   const capabilities = {
-    conceptId, shortName, variableSubset, bboxSubset, shapeSubset,
+    conceptId, shortName, variableSubset, bboxSubset, shapeSubset, temporalSubset,
     concatenate, reproject, outputFormats: Array.from(outputFormats), services, variables, capabilitiesVersion,
   };
   return capabilities;
@@ -171,6 +174,7 @@ async function getCollectionCapabilitiesV2(collection: CmrCollection)
     && matchingServices.some((s) => s.capabilities.subsetting.variable === true);
   const bboxSubset = matchingServices.some((s) => s.capabilities.subsetting.bbox === true);
   const shapeSubset = matchingServices.some((s) => s.capabilities.subsetting.shape === true);
+  const temporalSubset = matchingServices.some((s) => s.capabilities.subsetting.temporal === true);
   const concatenate = matchingServices.some((s) => s.capabilities.concatenation === true);
   const reproject = matchingServices.some((s) => s.capabilities.reprojection === true);
   const outputFormats = new Set(matchingServices.flatMap((s) => s.capabilities.output_formats));
@@ -178,7 +182,7 @@ async function getCollectionCapabilitiesV2(collection: CmrCollection)
   const shortName = collection.short_name;
   const services = matchingServices.map((s) => getServiceV2(s));
   const capabilities = {
-    conceptId, shortName, variableSubset, bboxSubset, shapeSubset,
+    conceptId, shortName, variableSubset, bboxSubset, shapeSubset, temporalSubset,
     concatenate, reproject, outputFormats: Array.from(outputFormats), services, variables, capabilitiesVersion,
   };
   return capabilities;

--- a/services/harmony/app/frontends/docs/service-docs-markdown-it-plugin.ts
+++ b/services/harmony/app/frontends/docs/service-docs-markdown-it-plugin.ts
@@ -33,7 +33,7 @@ function getServiceTable(md: MarkDownIt, serviceCaps: ServiceCapabilities): unkn
   // main header
   tableTokens.push(new Token('table_row_open', 'tr', 1));
   const titleHeader = new Token('table_header_open', 'th', 1);
-  titleHeader.attrPush(['colspan', '7']);
+  titleHeader.attrPush(['colspan', '8']);
   titleHeader.attrPush(['class', 'table_title']);
   tableTokens.push(titleHeader);
   let itemToken = new Token('inline', '', 0);
@@ -47,7 +47,7 @@ function getServiceTable(md: MarkDownIt, serviceCaps: ServiceCapabilities): unkn
   // first sub header
   tableTokens.push(new Token('table_row_open', 'tr', 1));
   const subsettingHeader = new Token('table_header_open', 'th', 1);
-  subsettingHeader.attrPush(['colspan', '4']);
+  subsettingHeader.attrPush(['colspan', '5']);
   tableTokens.push(subsettingHeader);
   itemToken = new Token('inline', '', 0);
   itemToken.content = 'subsetting';
@@ -100,6 +100,15 @@ function getServiceTable(md: MarkDownIt, serviceCaps: ServiceCapabilities): unkn
   tableTokens.push(headerToken);
   itemToken = new Token('inline', '', 0);
   itemToken.content = 'shape';
+  itemToken.type = 'text';
+  itemToken.children = [];
+  tableTokens.push(itemToken);
+  tableTokens.push(new Token('table_header_close', 'td', -1));
+  headerToken = new Token('table_header_open', 'th', 1);
+  headerToken.attrPush(['class', 'subheader']);
+  tableTokens.push(headerToken);
+  itemToken = new Token('inline', '', 0);
+  itemToken.content = 'temporal';
   itemToken.type = 'text';
   itemToken.children = [];
   tableTokens.push(itemToken);
@@ -170,6 +179,13 @@ function getServiceTable(md: MarkDownIt, serviceCaps: ServiceCapabilities): unkn
   tableTokens.push(new Token('table_data_open', 'td', 1));
   itemToken = new Token('inline', '', 0);
   itemToken.content = serviceCaps.subsetting.shape ? 'Y' : 'N';
+  itemToken.type = 'text';
+  itemToken.children = [];
+  tableTokens.push(itemToken);
+  tableTokens.push(new Token('table_data_close', 'td', -1));
+  tableTokens.push(new Token('table_data_open', 'td', 1));
+  itemToken = new Token('inline', '', 0);
+  itemToken.content = serviceCaps.subsetting.temporal ? 'Y' : 'N';
   itemToken.type = 'text';
   itemToken.children = [];
   tableTokens.push(itemToken);

--- a/services/harmony/app/models/services/base-service.ts
+++ b/services/harmony/app/models/services/base-service.ts
@@ -25,6 +25,7 @@ export interface ServiceCapabilities {
   subsetting?: {
     bbox?: boolean;
     shape?: boolean;
+    temporal?: boolean;
     variable?: boolean;
     multiple_variable?: true;
   };

--- a/services/harmony/test/collection-capabilities.ts
+++ b/services/harmony/test/collection-capabilities.ts
@@ -29,7 +29,7 @@ describe('Testing collection capabilities', function () {
 
         it('includes all of the expected fields in the response according to the default version', function () {
           const expectedFields = [
-            'conceptId', 'shortName', 'variableSubset', 'bboxSubset', 'shapeSubset',
+            'conceptId', 'shortName', 'variableSubset', 'bboxSubset', 'shapeSubset', 'temporalSubset',
             'concatenate', 'reproject', 'outputFormats', 'services', 'variables', 'capabilitiesVersion',
           ];
           const capabilities = JSON.parse(this.res.text);
@@ -59,6 +59,11 @@ describe('Testing collection capabilities', function () {
         it('sets the shapeSubset field correctly', function () {
           const capabilities = JSON.parse(this.res.text);
           expect(capabilities.shapeSubset).to.equal(true);
+        });
+
+        it('sets the temporalSubset field correctly', function () {
+          const capabilities = JSON.parse(this.res.text);
+          expect(capabilities.temporalSubset).to.equal(true);
         });
 
         it('sets the concatenate field correctly', function () {
@@ -190,7 +195,7 @@ describe('Testing collection capabilities', function () {
 
         it('includes all of the expected fields in the version 1 response', function () {
           const expectedFields = [
-            'conceptId', 'shortName', 'variableSubset', 'bboxSubset', 'shapeSubset',
+            'conceptId', 'shortName', 'variableSubset', 'bboxSubset', 'shapeSubset', 'temporalSubset',
             'concatenate', 'reproject', 'outputFormats', 'services', 'variables', 'capabilitiesVersion',
           ];
           const capabilities = JSON.parse(this.res.text);
@@ -220,6 +225,11 @@ describe('Testing collection capabilities', function () {
         it('sets the shapeSubset field correctly in the version 1 response', function () {
           const capabilities = JSON.parse(this.res.text);
           expect(capabilities.shapeSubset).to.equal(true);
+        });
+
+        it('sets the temporalSubset field correctly in the version 1 response', function () {
+          const capabilities = JSON.parse(this.res.text);
+          expect(capabilities.temporalSubset).to.equal(true);
         });
 
         it('sets the concatenate field correctly in the version 1 response', function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1947, HARMONY-1917

## Description
As a harmony service provider, I want temporal subsetting information included in the collection capabilities endpoint.
Also updated the PR Acceptance Checklist to include testing harmony in a box reminder.

## Local Test Steps
Verify `temporalSubset` field is included in the latest collection capabilities response. e.g.
http://localhost:3000/capabilities?collectionId=C1242267295-EEDTEST

Verify `temporal` field is included in the service capabilities documentation under the `subsetting` section.
http://localhost:3000/docs#service-capabilities

The checklist change will work once this PR is merged.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)