### PR TITLE
HARMONY-1955: Update service generation to use new harmony_service_lib namespace and fix gdal version to avoid conflict with the installed python library

### DIFF
--- a/service-templates/Dockerfile
+++ b/service-templates/Dockerfile
@@ -1,11 +1,13 @@
 # Add copyright statement here
 
-FROM ghcr.io/osgeo/gdal:alpine-small-latest 
+FROM ghcr.io/osgeo/gdal:alpine-small-3.9.3
 
-RUN apk add bash build-base gcc g++ gfortran openblas-dev cmake python3 python3-dev libffi-dev netcdf-dev libxml2-dev libxslt-dev libjpeg-turbo-dev zlib-dev hdf5 hdf5-dev gdal-dev gdal-tools
-
-RUN python -m ensurepip --upgrade
-RUN pip3 install gdal numpy netCDF4 matplotlib harmony-service-lib
+RUN apk add bash build-base gcc g++ gfortran openblas-dev cmake python3 python3-dev libffi-dev netcdf-dev libxml2-dev libxslt-dev libjpeg-turbo-dev zlib-dev hdf5 hdf5-dev
+RUN  python3 -m venv service-env
+ENV PATH="/service-env/bin:$PATH"
+RUN python3 -m ensurepip --upgrade
+RUN pip3 install numpy netCDF4 matplotlib harmony-service-lib
+RUN pip3 install "gdal==3.9.3"
 
 # Create a new user
 RUN adduser -D -s /bin/sh -h /home/dockeruser -g "" -u 1000 dockeruser

--- a/service-templates/sample_service.py
+++ b/service-templates/sample_service.py
@@ -12,10 +12,10 @@ import os
 from tempfile import mkdtemp
 from pystac import Asset
 
-import harmony
-from harmony.util import generate_output_filename, stage, download
+import harmony_service_lib
+from harmony_service_lib.util import generate_output_filename, stage, download
 
-class ExampleAdapter(harmony.BaseHarmonyAdapter):
+class ExampleAdapter(harmony_service_lib.BaseHarmonyAdapter):
     """
     Shows an example of what a service adapter implementation looks like
     """
@@ -31,7 +31,7 @@ class ExampleAdapter(harmony.BaseHarmonyAdapter):
         ----------
         item : pystac.Item
             the item that should be processed
-        source : harmony.message.Source
+        source : harmony_service_lib.message.Source
             the input source defining the variables, if any, to subset from the item
 
         Returns
@@ -109,12 +109,12 @@ def main():
     """
     parser = argparse.ArgumentParser(prog='example', description='Run an example service')
 
-    harmony.setup_cli(parser)
+    harmony_service_lib.setup_cli(parser)
 
     args = parser.parse_args()
 
-    if (harmony.is_harmony_cli(args)):
-        harmony.run_cli(parser, args, ExampleAdapter)
+    if (harmony_service_lib.is_harmony_cli(args)):
+        harmony_service_lib.run_cli(parser, args, ExampleAdapter)
     else:
         run_cli(args)
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1955

## Description
Update the services generation files to use the new `harmony_service_lib` namespace and to fix the dependency versions to fix python gdal pip install issues.

## Local Test Steps
1. Run the bin/generate-new-service script.  Use whatever service name and organization Answer yes (y) to all the capability prompts. Use collection-id C1233800302-EEDTEST
2. Got to the new directory created by the script
3. Run `build-service`
4. Bootstrap harmony
5. Run the following
```
 curl -Ln -bj "http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&concatenate=true" -o file.hdf
```
6. Open the hdf file in `panoply` (or whatever) to verify it looks like a map of the Earth
7. Open the workflow-ui and make sure the job ran your new service

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [ ] ~Documentation updated (if needed)~
* [x] Harmony in a Box tested? (if changes made to microservices)