### PR TITLE
Harmony 1950 - X-Request-Id header

### DIFF
--- a/scripts/service-comparison.ts
+++ b/scripts/service-comparison.ts
@@ -162,7 +162,7 @@ async function runComparisons(environments = allEnvironments): Promise<void> {
     const harmonyServiceConfigs = loadServiceConfigs(environment)
       .filter((config) => config.umm_s); // Ignore any service definitions that do not point to a UMM-S record
     const ummConceptIds = harmonyServiceConfigs.map((config) => config.umm_s);
-    const ummRecords = await getServicesByIds(ummConceptIds, null);
+    const ummRecords = await getServicesByIds({ id: 'harmony-service-comparison-script' }, ummConceptIds, null);
     const ummRecordsMap = createUmmRecordsMap(ummRecords);
     for (const harmonyConfig of harmonyServiceConfigs) {
       const ummRecord = ummRecordsMap[harmonyConfig.umm_s];

--- a/services/harmony/app/frontends/capabilities.ts
+++ b/services/harmony/app/frontends/capabilities.ts
@@ -73,7 +73,7 @@ async function loadCollectionInfo(req: HarmonyRequest): Promise<CmrCollection> {
   } else if (collectionid && shortname) {
     throw new RequestValidationError('Must specify only one of collectionId or shortName, not both');
   } else if (collectionid) {
-    collections = await getCollectionsByIds([collectionid], req.accessToken);
+    collections = await getCollectionsByIds(req.context, [collectionid], req.accessToken);
     if (collections.length === 0) {
       const message = `${collectionid} must be a CMR collection identifier, but `
         + 'we could not find a matching collection. Please make sure the collection ID '
@@ -82,7 +82,7 @@ async function loadCollectionInfo(req: HarmonyRequest): Promise<CmrCollection> {
     }
     pickedCollection = collections[0];
   } else {
-    collections = await getCollectionsByShortName(shortname, req.accessToken);
+    collections = await getCollectionsByShortName(req.context, shortname, req.accessToken);
     if (collections.length === 0) {
       const message = `Unable to find collection short name ${shortname} in the CMR. Please `
         + ' make sure the short name is correct and that you have access to the collection.';
@@ -96,7 +96,7 @@ async function loadCollectionInfo(req: HarmonyRequest): Promise<CmrCollection> {
       pickedCollection = harmonyCollection || pickedCollection;
     }
   }
-  pickedCollection.variables = await getVariablesForCollection(pickedCollection, req.accessToken);
+  pickedCollection.variables = await getVariablesForCollection(req.context, pickedCollection, req.accessToken);
   return pickedCollection;
 }
 

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -244,7 +244,7 @@ async function validateUserIsInDeployerOrCoreGroup(
   req: HarmonyRequest, res: Response,
 ): Promise<boolean> {
   const { hasCorePermissions, isServiceDeployer } = await getEdlGroupInformation(
-    req.user, req.context.logger,
+    req.context, req.user,
   );
 
   if (!isServiceDeployer && !hasCorePermissions) {

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -551,7 +551,7 @@ export async function getWorkItemsTable(
   try {
     const isAdminRoute = req.context.isAdminAccess;
     const { isAdmin, isLogViewer } = await getEdlGroupInformation(
-      req.user, req.context.logger,
+      req.context, req.user,
     );
     const isAdminOrLogViewer = isAdmin || isLogViewer;
     const job = await getJobIfAllowed(jobID, req.user, isAdmin, req.accessToken, true);
@@ -617,7 +617,7 @@ export async function getWorkItemTableRow(
   const { jobID, id } = req.params;
   try {
     const { isAdmin, isLogViewer } = await getEdlGroupInformation(
-      req.user, req.context.logger,
+      req.context, req.user,
     );
     const isAdminOrLogViewer = isAdmin || isLogViewer;
     const job = await getJobIfAllowed(jobID, req.user, isAdmin, req.accessToken, true);
@@ -727,7 +727,7 @@ export async function getWorkItemLogs(
   const { id, jobID } = req.params;
   try {
     const { isAdmin, isLogViewer } = await getEdlGroupInformation(
-      req.user, req.context.logger,
+      req.context, req.user,
     );
     const isAdminOrLogViewer = isAdmin || isLogViewer;
     if (!isAdminOrLogViewer) {

--- a/services/harmony/app/middleware/cmr-collection-reader.ts
+++ b/services/harmony/app/middleware/cmr-collection-reader.ts
@@ -43,7 +43,7 @@ async function verifyEulaAcceptance(collections: CmrCollection[], req: HarmonyRe
   for (const collection of collections) {
     if (collection.eula_identifiers) {
       for (const eulaId of collection.eula_identifiers) {
-        const eulaInfo: EdlUserEulaInfo = await verifyUserEula(req.user, eulaId, req.context.logger);
+        const eulaInfo: EdlUserEulaInfo = await verifyUserEula(req.context, req.user, eulaId);
         if (eulaInfo.statusCode == 404 && eulaInfo.acceptEulaUrl) { // EULA wasn't accepted
           acceptEulaUrls.push(eulaInfo.acceptEulaUrl);
         } else if (eulaInfo.statusCode == 404) {

--- a/services/harmony/app/middleware/cmr-collection-reader.ts
+++ b/services/harmony/app/middleware/cmr-collection-reader.ts
@@ -5,6 +5,7 @@ import { ForbiddenError, NotFoundError, ServerError } from '../util/errors';
 import HarmonyRequest from '../models/harmony-request';
 import { listToText } from '@harmony/util/string';
 import { EdlUserEulaInfo, verifyUserEula } from '../util/edl-api';
+import RequestContext from '../models/request-context';
 
 // CMR Collection IDs separated by delimiters of single "+" or single whitespace
 // (some clients may translate + to space)
@@ -20,13 +21,14 @@ const EDR_COLLECTION_ROUTE_REGEX = /^\/ogc-api-edr\/.*\/collections\/(.*)\//;
  * Loads the variables for the given collection from the CMR and sets the collection's
  * "variables" attribute to the result
  *
+ * @param context - The context for the user's request
  * @param collection - The collection whose variables should be loaded
  * @param token - Access token for user request
  * @returns Resolves when the loading completes
  */
-async function loadVariablesForCollection(collection: CmrCollection, token: string): Promise<void> {
+async function loadVariablesForCollection(context: RequestContext, collection: CmrCollection, token: string): Promise<void> {
   const c = collection; // We are mutating collection
-  c.variables = await getVariablesForCollection(collection, token);
+  c.variables = await getVariablesForCollection(context, collection, token);
 }
 
 /**
@@ -96,7 +98,7 @@ async function cmrCollectionReader(req: HarmonyRequest, res, next: NextFunction)
       req.collectionIds = collectionIds;
       req.context.logger.info(`Matched CMR concept IDs: ${collectionIds}`);
 
-      req.collections = await getCollectionsByIds(collectionIds, req.accessToken);
+      req.collections = await getCollectionsByIds(req.context, collectionIds, req.accessToken);
       const { collections } = req;
 
       await verifyEulaAcceptance(collections, req);
@@ -118,7 +120,7 @@ async function cmrCollectionReader(req: HarmonyRequest, res, next: NextFunction)
 
       const promises = [];
       for (const collection of collections) {
-        promises.push(loadVariablesForCollection(collection, req.accessToken));
+        promises.push(loadVariablesForCollection(req.context, collection, req.accessToken));
       }
       await Promise.all(promises);
     } else {
@@ -133,7 +135,7 @@ async function cmrCollectionReader(req: HarmonyRequest, res, next: NextFunction)
           shortName = shortNameMatch[2].substr(1, shortNameMatch[2].length - 2);
         }
 
-        const collections = await getCollectionsByShortName(shortName, req.accessToken);
+        const collections = await getCollectionsByShortName(req.context, shortName, req.accessToken);
         let pickedCollection = collections[0];
         if (collections.length > 1) {
           // If there are multiple collections matching prefer a collection that is configured
@@ -146,7 +148,7 @@ async function cmrCollectionReader(req: HarmonyRequest, res, next: NextFunction)
 
           req.collections = [pickedCollection];
           req.collectionIds = [pickedCollection.id];
-          await loadVariablesForCollection(pickedCollection, req.accessToken);
+          await loadVariablesForCollection(req.context, pickedCollection, req.accessToken);
           if (collections.length > 1) {
             const collectionLandingPage = `${cmrApiConfig.baseURL}/concepts/${pickedCollection.id}`;
             req.context.messages.push(`There were ${collections.length} collections that matched the`

--- a/services/harmony/app/middleware/cmr-granule-locator.ts
+++ b/services/harmony/app/middleware/cmr-granule-locator.ts
@@ -194,6 +194,7 @@ async function cmrGranuleLocatorTurbo(
       if ( req.context.serviceConfig.steps[0].image.match('harmonyservices/query-cmr:.*') ) {
         cmrQuery.collection_concept_id = source.collection;
         const { hits, sessionKey } = await queryGranulesWithSearchAfter(
+          req.context,
           req.accessToken,
           maxGranules,
           cmrQuery,
@@ -280,6 +281,7 @@ async function cmrGranuleLocatorNonTurbo(
         cmrQuery.geojson = operation.geojson;
       }
       cmrResponse = await queryGranulesForCollection(
+        req.context,
         source.collection,
         cmrQuery,
         req.accessToken,

--- a/services/harmony/app/middleware/cmr-umm-collection-reader.ts
+++ b/services/harmony/app/middleware/cmr-umm-collection-reader.ts
@@ -13,7 +13,7 @@ async function cmrUmmCollectionReader(req: HarmonyRequest, res, next: NextFuncti
   try {
     const hasUmmConditional = req.context.serviceConfig?.steps?.filter((s) => s.conditional?.umm_c);
     if (hasUmmConditional && hasUmmConditional.length > 0) {
-      req.operation.ummCollections = await getUmmCollectionsByIds(req.collectionIds, req.accessToken);
+      req.operation.ummCollections = await getUmmCollectionsByIds(req.context, req.collectionIds, req.accessToken);
     }
     next();
   } catch (error) {

--- a/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
+++ b/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
@@ -21,11 +21,10 @@ export default function buildEdlAuthorizer(paths: Array<string | RegExp> = []): 
     if (authHeader) {
       const match = authHeader.match(BEARER_TOKEN_REGEX);
       if (match) {
-        const { logger } = req.context;
         const userToken = match[1];
         try {
           // Get the username for the provided token from EDL
-          const username = await getUserIdRequest(userToken, logger);
+          const username = await getUserIdRequest(req.context, userToken);
           req.user = username;
           req.accessToken = userToken;
           req.authorized = true;

--- a/services/harmony/app/middleware/permission-groups.ts
+++ b/services/harmony/app/middleware/permission-groups.ts
@@ -17,7 +17,7 @@ export async function admin(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
   try {
-    const { isAdmin } = await getEdlGroupInformation(req.user, req.context.logger);
+    const { isAdmin } = await getEdlGroupInformation(req.context, req.user);
     if (isAdmin) {
       req.context.isAdminAccess = true;
       next();
@@ -43,7 +43,7 @@ export async function core(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
   try {
-    const { hasCorePermissions } = await getEdlGroupInformation(req.user, req.context.logger);
+    const { hasCorePermissions } = await getEdlGroupInformation(req.context, req.user);
     if (hasCorePermissions) {
       req.context.isCoreAccess = true;
       next();

--- a/services/harmony/app/models/job.ts
+++ b/services/harmony/app/models/job.ts
@@ -990,6 +990,7 @@ export class Job extends DBRecord implements JobRecord {
    */
   async collectionsHaveEulaRestriction(accessToken: string): Promise<boolean> {
     const cmrCollections = await getCollectionsByIds(
+      { 'id': this.requestId },
       this.collectionIds,
       accessToken,
       CmrTagKeys.HasEula,
@@ -1007,7 +1008,7 @@ export class Job extends DBRecord implements JobRecord {
    * @returns true or false
    */
   async collectionsHaveGuestReadRestriction(accessToken: string): Promise<boolean> {
-    const permissionsMap: CmrPermissionsMap = await getPermissions(this.collectionIds, accessToken);
+    const permissionsMap: CmrPermissionsMap = await getPermissions({ 'id': this.requestId }, this.collectionIds, accessToken);
     return this.collectionIds.some((collectionId) => (
       !permissionsMap[collectionId]
         || !(permissionsMap[collectionId].indexOf(CmrPermission.Read) > -1)));

--- a/services/harmony/app/util/grids.ts
+++ b/services/harmony/app/util/grids.ts
@@ -41,7 +41,7 @@ export async function parseGridMiddleware(
     try {
       validateNoConflictingGridParameters(query);
       const gridName = query.grid;
-      const grids = await getGridsByName(gridName, req.accessToken );
+      const grids = await getGridsByName(req.context, gridName, req.accessToken );
       if (grids.length > 1) {
         req.context.logger.warn(`Multiple grids returned for name ${gridName}, choosing the first one returned by CMR.`);
       } else if (grids.length == 0) {

--- a/services/harmony/test/helpers/caching-hooks.ts
+++ b/services/harmony/test/helpers/caching-hooks.ts
@@ -13,7 +13,7 @@ hookProcessSchedulerQueue();
 
 process.env.REPLAY = process.env.REPLAY || 'record';
 import replay from 'replay';
-// Update replay.headers to avoid recording 'X-Requested-Id', but still record other 'X-*' headers
+// Update replay.headers to avoid recording 'X-Request-Id', but still record other 'X-*' headers
 replay.headers = replay.headers.filter((re) => re.toString() != /^x-/.toString());
 replay.headers.push(/^(?!x-request-id$)x-/);
 

--- a/services/harmony/test/helpers/caching-hooks.ts
+++ b/services/harmony/test/helpers/caching-hooks.ts
@@ -12,7 +12,10 @@ hookGetQueueUrlForService();
 hookProcessSchedulerQueue();
 
 process.env.REPLAY = process.env.REPLAY || 'record';
-require('replay');
+import replay from 'replay';
+// Update replay.headers to avoid recording 'X-Requested-Id', but still record other 'X-*' headers
+replay.headers = replay.headers.filter((re) => re.toString() != /^x-/.toString());
+replay.headers.push(/^(?!x-request-id$)x-/);
 
 // Patch our requests so they work repeatably in node-replay with multipart form
 // data.

--- a/services/harmony/test/helpers/caching-hooks.ts
+++ b/services/harmony/test/helpers/caching-hooks.ts
@@ -3,6 +3,7 @@ import { before, after } from 'mocha';
 import { stub, SinonStub } from 'sinon';
 import { hookGetQueueForType, hookGetQueueForUrl, hookGetQueueUrlForService, hookGetWorkSchedulerQueue, hookProcessSchedulerQueue } from './queue';
 import * as cmr from '../../app/util/cmr';
+import RequestContext from '../../app/models/request-context';
 
 hookGetQueueForType();
 hookGetQueueForUrl();
@@ -39,7 +40,7 @@ before(function () {
 
   // Stub fetchPost to provide a string body rather than a FormData stream
   stub(cmr, 'fetchPost').callsFake(async function (
-    path: string, formData: FormData, headers: { [key: string]: string },
+    context: RequestContext, path: string, formData: FormData, headers: { [key: string]: string },
   ): Promise<cmr.CmrResponse> {
     // Read the body into a stream
     const chunks = [];
@@ -49,7 +50,7 @@ before(function () {
       formData.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
       formData.resume();
     });
-    return originalFetchPost(path, body, headers);
+    return originalFetchPost(context, path, body, headers);
   });
 });
 

--- a/services/harmony/test/util/cmr.ts
+++ b/services/harmony/test/util/cmr.ts
@@ -2,12 +2,16 @@ import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { CmrRelatedUrl, CmrUmmVariable, getVariablesByIds, getAllVariables, CmrQuery, queryGranuleUsingMultipartForm } from '../../app/util/cmr';
 
+const fakeContext = {
+  id: '1234',
+};
+
 describe('util/cmr', function () {
   describe('getVariablesByIds', function () {
     it('returns a valid response, given a huge number of variables', async function () {
       const validVariableId = 'V1233801695-EEDTEST';
       const ids = [...Array(300).keys()].map((num) => `V${num}-YOCLOUD`).concat(validVariableId);
-      const variables = await getVariablesByIds(ids, '');
+      const variables = await getVariablesByIds(fakeContext, ids, '');
       expect(variables.length).to.eql(1);
     });
 
@@ -21,7 +25,7 @@ describe('util/cmr', function () {
         Format: 'XML',
         MimeType: 'application/XML',
       }];
-      const redVariable: CmrUmmVariable = (await getVariablesByIds(['V1233801695-EEDTEST'], ''))[0];
+      const redVariable: CmrUmmVariable = (await getVariablesByIds(fakeContext, ['V1233801695-EEDTEST'], ''))[0];
       const redVariableRelatedUrls: CmrRelatedUrl[] = redVariable.umm.RelatedURLs;
       expect(expectedRelatedUrls).to.deep.equal(redVariableRelatedUrls);
     });
@@ -34,7 +38,7 @@ describe('util/cmr', function () {
         concept_id: variableIds,
         page_size: 1, // requires paging through 4 pages
       };
-      const variables = await getAllVariables(query, '');
+      const variables = await getAllVariables(fakeContext, query, '');
       expect(variables.length).to.eql(4);
     });
   });
@@ -45,14 +49,14 @@ describe('util/cmr', function () {
         concept_id: 'C1233800302-EEDTEST',
         readable_granule_name: '*oceania_east',
       };
-      const results = await queryGranuleUsingMultipartForm(query, '');
+      const results = await queryGranuleUsingMultipartForm(fakeContext, query, '');
       expect(results.hits).to.equal(16);
 
       const querySingleMatch: CmrQuery = {
         concept_id: 'C1233800302-EEDTEST',
         readable_granule_name: '*01_08_7f00ff_oceania_east',
       };
-      const singleMatchResults = await queryGranuleUsingMultipartForm(querySingleMatch, '');
+      const singleMatchResults = await queryGranuleUsingMultipartForm(fakeContext, querySingleMatch, '');
       expect(singleMatchResults.hits).to.equal(1);
     });
 
@@ -61,14 +65,14 @@ describe('util/cmr', function () {
         concept_id: 'C1233800302-EEDTEST',
         readable_granule_name: '001_*_east',
       };
-      const results = await queryGranuleUsingMultipartForm(query, '');
+      const results = await queryGranuleUsingMultipartForm(fakeContext, query, '');
       expect(results.hits).to.equal(2);
 
       const querySingleMatch: CmrQuery = {
         concept_id: 'C1233800302-EEDTEST',
         readable_granule_name: '001_*_7f00ff_oceania_east',
       };
-      const singleMatchResults = await queryGranuleUsingMultipartForm(querySingleMatch, '');
+      const singleMatchResults = await queryGranuleUsingMultipartForm(fakeContext, querySingleMatch, '');
       expect(singleMatchResults.hits).to.equal(1);
     });
 
@@ -77,14 +81,14 @@ describe('util/cmr', function () {
         concept_id: 'C1233800302-EEDTEST',
         readable_granule_name: '001_*',
       };
-      const results = await queryGranuleUsingMultipartForm(query, '');
+      const results = await queryGranuleUsingMultipartForm(fakeContext, query, '');
       expect(results.hits).to.equal(12);
 
       const querySingleMatch: CmrQuery = {
         concept_id: 'C1233800302-EEDTEST',
         readable_granule_name: '001_08_7f00ff_oceania_eas*',
       };
-      const singleMatchResults = await queryGranuleUsingMultipartForm(querySingleMatch, '');
+      const singleMatchResults = await queryGranuleUsingMultipartForm(fakeContext, querySingleMatch, '');
       expect(singleMatchResults.hits).to.equal(1);
     });
 
@@ -93,7 +97,7 @@ describe('util/cmr', function () {
         concept_id: 'C1233800302-EEDTEST',
         readable_granule_name: '?01_08_7f00ff_oceania_east',
       };
-      const results = await queryGranuleUsingMultipartForm(query, '');
+      const results = await queryGranuleUsingMultipartForm(fakeContext, query, '');
       expect(results.hits).to.equal(1);
     });
 
@@ -102,7 +106,7 @@ describe('util/cmr', function () {
         concept_id: 'C1233800302-EEDTEST',
         readable_granule_name: '001_08_7f00ff_?ceania_east',
       };
-      const results = await queryGranuleUsingMultipartForm(query, '');
+      const results = await queryGranuleUsingMultipartForm(fakeContext, query, '');
       expect(results.hits).to.equal(1);
     });
 
@@ -111,7 +115,7 @@ describe('util/cmr', function () {
         concept_id: 'C1233800302-EEDTEST',
         readable_granule_name: '001_08_7f00ff_oceania_eas?',
       };
-      const results = await queryGranuleUsingMultipartForm(query, '');
+      const results = await queryGranuleUsingMultipartForm(fakeContext, query, '');
       expect(results.hits).to.equal(1);
     });
   });

--- a/services/harmony/test/util/edl-api.ts
+++ b/services/harmony/test/util/edl-api.ts
@@ -3,7 +3,6 @@ import { expect } from 'chai';
 import {
   getEdlGroupInformation,
 } from '../../app/util/edl-api';
-import logger from '../../app/util/log';
 import { stubEdlRequest, token, unstubEdlRequest } from '../helpers/auth';
 
 describe('util/edl-api', function () {
@@ -20,19 +19,19 @@ describe('util/edl-api', function () {
     });
     describe('when the user is not part of the service deployers group', function () {
       it('returns isServiceDeployer:false', async function () {
-        const groups = await getEdlGroupInformation('joe', logger);
+        const groups = await getEdlGroupInformation({ id: '1234' }, 'joe');
         expect(groups.isServiceDeployer).is.false;
       });
     });
     describe('when the user is part of the service deployers and log viewers group', function () {
       it('returns isServiceDeployer:true', async function () {
-        const groups = await getEdlGroupInformation('eve', logger);
+        const groups = await getEdlGroupInformation({ id: '1234' }, 'eve');
         expect(groups.isServiceDeployer).is.true;
       });
     });
     describe('when the user is part of the service deployers group', function () {
       it('returns isServiceDeployer:true', async function () {
-        const groups = await getEdlGroupInformation('buzz', logger);
+        const groups = await getEdlGroupInformation({ id: '1234' }, 'buzz');
         expect(groups.isServiceDeployer).is.true;
       });
     });

--- a/services/harmony/test/workflow-ui/work-items-table.ts
+++ b/services/harmony/test/workflow-ui/work-items-table.ts
@@ -227,7 +227,7 @@ describe('Workflow UI work items table route', function () {
           expect(listing).to.contain(mustache.render(
             `{{#labels}}
           <span class="badge bg-label">{{.}}</span>
-          {{/labels}}`, 
+          {{/labels}}`,
             { labels: targetJob.labels }));
           expect(listing).to.contain('job-url-text');
           expect(listing).to.contain('copy-request');

--- a/services/query-cmr/app/query.ts
+++ b/services/query-cmr/app/query.ts
@@ -14,7 +14,7 @@ export interface DataSource {
 /**
  * Queries a single page of CMR granules using search after parameters, generating a STAC catalog for
  * each granule in the page.
- * @param - requestId - The request ID of the job associated with this search
+ * @param requestId - The request ID of the job associated with this search
  * @param token - The token to use for the query
  * @param scrollId - Scroll session id used in the CMR-Scroll-Id header for granule search
  * @param maxCmrGranules - The maximum size of the page to request from CMR

--- a/services/query-cmr/app/query.ts
+++ b/services/query-cmr/app/query.ts
@@ -14,6 +14,7 @@ export interface DataSource {
 /**
  * Queries a single page of CMR granules using search after parameters, generating a STAC catalog for
  * each granule in the page.
+ * @param - requestId - The request ID of the job associated with this search
  * @param token - The token to use for the query
  * @param scrollId - Scroll session id used in the CMR-Scroll-Id header for granule search
  * @param maxCmrGranules - The maximum size of the page to request from CMR
@@ -25,6 +26,7 @@ export interface DataSource {
  * cmr hits.
  */
 async function querySearchAfter(
+  requestId: string,
   token: string,
   scrollId: string,
   maxCmrGranules: number,
@@ -36,6 +38,7 @@ async function querySearchAfter(
     [sessionKey, searchAfter] = scrollId.split(':', 2);
   }
   const cmrResponse = await queryGranulesWithSearchAfter(
+    { 'id': requestId },
     token,
     maxCmrGranules,
     null,
@@ -103,7 +106,7 @@ export async function queryGranules(
 ): Promise<[number, number[], StacCatalog[], string, number]> {
   const { unencryptedAccessToken } = operation;
   const [totalItemsSize, outputItemSizes, catalogs, newScrollId, hits] =
-    await querySearchAfter(unencryptedAccessToken, scrollId, maxCmrGranules, logger);
+    await querySearchAfter(operation.requestId, unencryptedAccessToken, scrollId, maxCmrGranules, logger);
 
   return [totalItemsSize, outputItemSizes, catalogs, newScrollId, hits];
 }

--- a/services/query-cmr/test/query-granules.ts
+++ b/services/query-cmr/test/query-granules.ts
@@ -16,6 +16,7 @@ import { CmrError } from '../../harmony/app/util/errors';
 chai.use(require('chai-as-promised'));
 
 const operation = new DataOperation({
+  requestId: 'aaaaaaaa-bbbb-1234-cccc-dddddddddddd',
   unencryptedAccessToken: 'shhhhh!',
   sources: [{ collection: 'C001-TEST' }, { collection: 'C002-TEST' }],
 });
@@ -48,7 +49,7 @@ async function formDataToString(formdata: CombinedStream): Promise<string> {
  * @returns key/value pairs of form data name to value
  */
 async function fetchPostArgsToFields(
-  [_, formdata],
+  [_a, _b, formdata],
 ): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
   const data = (await formDataToString(formdata)).replace(/----+[0-9]+-*\r\n/g, '');
   const result = {};


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1850


## Description
Adds X-Request-Id header to CMR and EDL calls to support end-to-end tracking

## Local Test Steps
1. Run job
2. Look in the CMR logs for the 'x-request-id' header. This can be seen in the CMR CloudWatch logs using the following filter:
```
{$.x-request-id = "<YOUR ID>"}
```
You should see several log lines. The one that is for umm_json is from the qeury-cmr.


## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~
* [x] Harmony in a Box tested? (if changes made to microservices)
