### PR TITLE
HARMONY-1951: Ensure work failer can run every few minutes without causing problems for the work item update queue.

### DIFF
--- a/services/work-failer/README.md
+++ b/services/work-failer/README.md
@@ -1,12 +1,12 @@
 # Harmony Work Failer
 
 This folder contains the code and build scripts for the Harmony work failer,
-which is responsible for deleting work items and workflow steps  that have 
+which is responsible for deleting work items and workflow steps that have
 not been updated for a (configurable) period of time.
 
 ## Building the Work Failer for Local Use
 
-1. Run `npm build` in this directory to build with the tag `latest`. To use a different tag,
+1. Run `npm run build` in this directory to build with the tag `latest`. To use a different tag,
    run `VERSION=tag npm run build`.
 
 ## Using the Work Failer Locally
@@ -14,10 +14,9 @@ not been updated for a (configurable) period of time.
 1. If you are using an image tag other than `latest` set `WORK_failer_IMAGE=harmonyservices/work-failer:<tag>` in your harmony .env file
 2. Run `bin/deploy-services` from the harmony repository
 
-## Running the Repaer Outside of Docker for Development
+## Running the Work Failer Outside of Docker for Development
 
-If you are doing development of the failer itself it is convenient to run it as a stand-alone process outside of Docker. This can be done by first removing the version running in
-kubernetes then starting up a node.js process to run the updater.
+If you are doing development of the failer itself it is convenient to run it as a stand-alone process outside of Docker. This can be done by first removing the version running in kubernetes then starting up a node.js process to run the work failer.
 1. `kubectl delete deployment harmony-work-failer -n harmony`
 2. `kubectl delete service harmony-work-failer -n harmony`
 3. `npm run start-dev-fast` (from this directory)

--- a/services/work-failer/app/util/env.ts
+++ b/services/work-failer/app/util/env.ts
@@ -23,6 +23,10 @@ class FailerHarmonyEnv extends HarmonyEnv {
   @Min(1)
   failableWorkAgeMinutes: number;
 
+  @IsInt()
+  @Min(-1)
+  maxWorkItemsOnUpdateQueueFailer: number;
+
 }
 
 const localPath = path.resolve(__dirname, '../../env-defaults');

--- a/services/work-failer/app/workers/failer.ts
+++ b/services/work-failer/app/workers/failer.ts
@@ -3,6 +3,8 @@ import { JobStatus } from '../../../harmony/app/models/job';
 import WorkItem, { computeWorkItemDurationOutlierThresholdForJobService, getWorkItemsByUpdateAgeAndStatus } from '../../../harmony/app/models/work-item';
 import db from '../../../harmony/app/util/db';
 import log from '../../../harmony/app/util/log';
+import { WorkItemQueueType } from '../../../harmony/app/util/queue/queue';
+import { getQueueForType } from '../../../harmony/app/util/queue/queue-factory';
 import sleep from '../../../harmony/app/util/sleep';
 import { Worker } from '../../../harmony/app/workers/worker';
 import { WorkItemStatus } from '../../../harmony/app/models/work-item-interface';
@@ -73,9 +75,14 @@ export default class Failer implements Worker {
   /**
    * Find work items that're older than lastUpdateOlderThanMinutes and call handleWorkItemUpdate.
    * @param lastUpdateOlderThanMinutes - upper limit on the duration since the last update
+   * @param failerDisabledDelay - number of ms to sleep when the failer is disabled because
+   * there are too many items on the work item update queue. Override to a small value in tests.
    * @returns Resolves when the request is complete
    */
-  async handleWorkItemUpdates(lastUpdateOlderThanMinutes: number): Promise<void> {
+  async handleWorkItemUpdates(
+    lastUpdateOlderThanMinutes: number,
+    failerDisabledDelay = 3000,
+  ): Promise<void> {
     let done = false;
     let startingId = 0;
     let numExpired = 0;
@@ -83,6 +90,15 @@ export default class Failer implements Worker {
     log.info('Work failer processing started.');
 
     while (!done) {
+      if (env.maxWorkItemsOnUpdateQueueFailer !== -1) {
+        const smallUpdateQueue = getQueueForType(WorkItemQueueType.SMALL_ITEM_UPDATE);
+        const updateQueueCount = await smallUpdateQueue.getApproximateNumberOfMessages();
+        if (updateQueueCount > env.maxWorkItemsOnUpdateQueueFailer) {
+          log.warn(`Work item update queue is too large with ${updateQueueCount} items, will not fail more work`);
+          await sleep(failerDisabledDelay);
+          continue;
+        }
+      }
       const { workItems, jobServiceThresholds, maxId: newId } = await this.getExpiredWorkItems(lastUpdateOlderThanMinutes, startingId, batchSize);
 
       if (newId > startingId) {

--- a/services/work-failer/env-defaults
+++ b/services/work-failer/env-defaults
@@ -10,3 +10,7 @@ FAILABLE_WORK_AGE_MINUTES=5
 
 # The batch size used by work-failer. Set it to 0 will effectively disable work-failer.
 WORK_FAILER_BATCH_SIZE=1000
+
+# Maximum number of work items allowed on the work item update queue before halting failing work items
+# Set the value to -1 to always fail work items
+MAX_WORK_ITEMS_ON_UPDATE_QUEUE_FAILER=1000

--- a/services/work-failer/test/work-failer.ts
+++ b/services/work-failer/test/work-failer.ts
@@ -99,7 +99,7 @@ describe('WorkFailer', function () {
     let oldItems = [];
     it('proccesses work item updates for items that are RUNNING and have not been updated for the specified duration', async function () {
       MockDate.set('1/2/2000'); // some items should now be a day old
-      await workFailer.handleWorkItemUpdates(failDurationMinutes);
+      await workFailer.handleWorkItemUpdates(failDurationMinutes, 1);
 
       // check that both old items were re-queued
       const twoOldJobItems = (await getWorkItemsByJobId(db, twoOldJob.jobID)).workItems;
@@ -169,7 +169,7 @@ describe('WorkFailer', function () {
         // have been running for a whole day and should get picked up again by the WorkFailer
         MockDate.set(failerDate);
 
-        await workFailer.handleWorkItemUpdates(failDurationMinutes);
+        await workFailer.handleWorkItemUpdates(failDurationMinutes, 1);
 
         items = (await getWorkItemsByJobId(db, job.jobID)).workItems;
 

--- a/services/work-reaper/README.md
+++ b/services/work-reaper/README.md
@@ -1,7 +1,7 @@
 # Harmony Work Reaper
 
 This folder contains the code and build scripts for the Harmony work reaper,
-which is responsible for deleting work items and workflow steps  that have 
+which is responsible for deleting work items and workflow steps that have
 not been updated for a (configurable) period of time.
 
 ## Building the Work Reaper for Local Use
@@ -14,17 +14,17 @@ not been updated for a (configurable) period of time.
 1. If you are using an image tag other than `latest` set `WORK_REAPER_IMAGE=harmonyservices/work-reaper:<tag>` in your harmony .env file
 2. Run `bin/deploy-services` from the harmony repository
 
-## Running the Repaer Outside of Docker for Development
+## Running the Reaper Outside of Docker for Development
 
-If you are doing development of the reaper itself it is convenient to run it as a stand-alone process outside of Docker. This can be done by first removing the version running in
-kubernetes then starting up a node.js process to run the updater.
+If you are doing development of the reaper itself it is convenient to run it as a stand-alone process outside of Docker.
+This can be done by first removing the version running in kubernetes then starting up a node.js process to run the reaper.
 1. `kubectl delete deployment harmony-work-reaper -n harmony`
 2. `kubectl delete service harmony-work-reaper -n harmony`
 3. `npm run start-dev-fast` (from this directory)
 
 ## Pushing the Docker Image to ECR
 
-If you want to do sandbox deployments with your custom updater image then you need to
+If you want to do sandbox deployments with your custom reaper image then you need to
 push it to ECR. This can be done as follows:
 
 1. (only needed if building on Mac to build for AMD64 architecture)


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1951

## Description
Ensure work failer can run every few minutes without causing problems for the work item update queue.

## Local Test Steps
Tested in Sandbox to run a 110k request and verify that work failer will only be run when the work items on the small work item queue is smaller than the configured MAX_WORK_ITEMS_ON_UPDATE_QUEUE_FAILER

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [x] Harmony in a Box tested? (if changes made to microservices)