### PR TITLE
Harmony 1961

### DIFF
--- a/packages/util/tsconfig.build.json
+++ b/packages/util/tsconfig.build.json
@@ -10,7 +10,10 @@
       "allowJs": true,
       "noImplicitAny": false,
       "sourceMap": true,
-      "outDir": "built"
+      "outDir": "built",
+      "typeRoots": [
+        "node_modules/@types"
+      ]
   },
   "include": ["."],
   "exclude": ["./node_modules", "coverage"]

--- a/packages/util/tsconfig.json
+++ b/packages/util/tsconfig.json
@@ -10,7 +10,10 @@
       "allowJs": true,
       "noImplicitAny": false,
       "sourceMap": true,
-      "outDir": "built"
+      "outDir": "built",
+      "typeRoots": [
+        "node_modules/@types"
+      ]
   },
   "include": ["."],
   "exclude": ["./node_modules", "coverage"]

--- a/scripts/service-comparison.ts
+++ b/scripts/service-comparison.ts
@@ -162,7 +162,7 @@ async function runComparisons(environments = allEnvironments): Promise<void> {
     const harmonyServiceConfigs = loadServiceConfigs(environment)
       .filter((config) => config.umm_s); // Ignore any service definitions that do not point to a UMM-S record
     const ummConceptIds = harmonyServiceConfigs.map((config) => config.umm_s);
-    const ummRecords = await getServicesByIds({ id: 'harmony-service-comparison-script' }, ummConceptIds, null);
+    const ummRecords = await getServicesByIds(ummConceptIds, null);
     const ummRecordsMap = createUmmRecordsMap(ummRecords);
     for (const harmonyConfig of harmonyServiceConfigs) {
       const ummRecord = ummRecordsMap[harmonyConfig.umm_s];

--- a/services/harmony/app/backends/deployment-callback.ts
+++ b/services/harmony/app/backends/deployment-callback.ts
@@ -3,6 +3,7 @@ import HarmonyRequest from '../models/harmony-request';
 import * as services from '../models/services/index';
 import env from '../util/env';
 import _ from 'lodash';
+import { asyncLocalStorage } from '../util/async-store';
 
 /**
  * Express.js handler that handls deployment callback message for deploying a service.
@@ -20,7 +21,8 @@ import _ from 'lodash';
  * @param res - The response to send to the client
  */
 export default async function handleCallbackMessage(req: HarmonyRequest, res: Response): Promise<void> {
-  const logger = req.context.logger.child({ component: 'snsHandler.handleCallbackMessage' });
+  const context = asyncLocalStorage.getStore();
+  const logger = context.logger.child({ component: 'snsHandler.handleCallbackMessage' });
   const headerSecret = req.headers['cookie-secret'];
   const secret = process.env.COOKIE_SECRET;
   logger.info(`handleCallbackMessage: ${JSON.stringify(req.body)}`);

--- a/services/harmony/app/backends/workflow-orchestration/workflow-orchestration.ts
+++ b/services/harmony/app/backends/workflow-orchestration/workflow-orchestration.ts
@@ -8,6 +8,7 @@ import { getQueueForType  } from '../../util/queue/queue-factory';
 import { getWorkFromQueue, getWorkFromDatabase, WorkItemData } from './work-item-polling';
 import WorkItemUpdate from '../../models/work-item-update';
 import DataOperation from '../../models/data-operation';
+import { asyncLocalStorage } from '../../util/async-store';
 
 const MAX_TRY_COUNT = 1;
 const RETRY_DELAY = 1000 * 120;
@@ -23,7 +24,8 @@ const QUERY_CMR_SERVICE_REGEX = /harmonyservices\/query-cmr:.*/;
 export async function getWork(
   req: HarmonyRequest, res: Response, next: NextFunction, tryCount = 1,
 ): Promise<void> {
-  const reqLogger = req.context.logger;
+  const context = asyncLocalStorage.getStore();
+  const reqLogger = context.logger;
   const { serviceID, podName } = req.query;
   // reqLogger.info(`Getting work for service ${serviceID} and pod ${podName}`);
 
@@ -125,7 +127,8 @@ export async function updateWorkItem(req: HarmonyRequest, res: Response): Promis
     outputItemSizes,
     duration,
   };
-  const workItemLogger = req.context.logger.child({ workItemId: update.workItemID });
+  const context = asyncLocalStorage.getStore();
+  const workItemLogger = context.logger.child({ workItemId: update.workItemID });
   const queueType = results?.length > 1 ? WorkItemQueueType.LARGE_ITEM_UPDATE : WorkItemQueueType.SMALL_ITEM_UPDATE;
   await queueWorkItemUpdate(operation.requestId, update, operation, queueType, workItemLogger);
 

--- a/services/harmony/app/frontends/configuration.ts
+++ b/services/harmony/app/frontends/configuration.ts
@@ -3,6 +3,7 @@ import { configureLogLevel } from '../util/log';
 import HarmonyRequest from '../models/harmony-request';
 import { keysToLowerCase } from '../util/object';
 import { RequestValidationError } from '../util/errors';
+import { asyncLocalStorage } from '../util/async-store';
 
 /**
  * Admin interface for configuring Harmony.
@@ -20,16 +21,17 @@ export async function setLogLevel(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
   const query = keysToLowerCase(req.query);
+  const context = asyncLocalStorage.getStore();
   try {
     const queryKeys = Object.keys(query);
     if (!(queryKeys.length === 1) || queryKeys[0] != 'level') {
       throw new RequestValidationError('Must set log level using a single query parameter (level).');
     }
     const result = configureLogLevel(query.level.toLowerCase());
-    req.context.logger.info(result);
+    context.logger.info(result);
     res.json({ result });
   } catch (e) {
-    req.context.logger.error(e);
+    context.logger.error(e);
     next(e);
   }
 }

--- a/services/harmony/app/frontends/jobs.ts
+++ b/services/harmony/app/frontends/jobs.ts
@@ -214,7 +214,7 @@ export async function changeJobState(
   next: NextFunction,
   jobFn: (jobID: string, logger: Logger, username: string, token: string) => Promise<void>,
 ): Promise<void> {
-const context = asyncLocalStorage.getStore();
+  const context = asyncLocalStorage.getStore();
   try {
     const { jobID } = req.params;
     validateJobId(jobID);
@@ -255,7 +255,7 @@ export async function changeJobsState(
 ): Promise<void> {
   let processedCount = 0;
   try {
-  const context = asyncLocalStorage.getStore();
+    const context = asyncLocalStorage.getStore();
     const { jobIDs } = req.body;
     let username: string;
     const isAdmin = await isAdminUser(req);
@@ -287,7 +287,7 @@ export async function cancelJob(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
   const { jobID } = req.params;
-const context = asyncLocalStorage.getStore();
+  const context = asyncLocalStorage.getStore();
   context.logger.info(`Cancel requested for job ${jobID} by user ${req.user}`);
   await changeJobState(req, res, next, cancelAndSaveJob);
 }
@@ -304,7 +304,7 @@ const context = asyncLocalStorage.getStore();
 export async function resumeJob(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
-const context = asyncLocalStorage.getStore();
+  const context = asyncLocalStorage.getStore();
   context.logger.info(`Resume requested for job ${req.params.jobID} by user ${req.user}`);
   await changeJobState(req, res, next, resumeAndSaveJob);
 }
@@ -322,7 +322,7 @@ const context = asyncLocalStorage.getStore();
 export async function skipJobPreview(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
-const context = asyncLocalStorage.getStore();
+  const context = asyncLocalStorage.getStore();
   context.logger.info(`Skip preview requested for job ${req.params.jobID} by user ${req.user}`);
   await changeJobState(req, res, next, skipPreviewAndSaveJob);
 }
@@ -339,7 +339,7 @@ const context = asyncLocalStorage.getStore();
 export async function pauseJob(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
-const context = asyncLocalStorage.getStore();
+  const context = asyncLocalStorage.getStore();
   context.logger.info(`Pause requested for job ${req.params.jobID} by user ${req.user}`);
   await changeJobState(req, res, next, pauseAndSaveJob);
 }
@@ -355,7 +355,7 @@ const context = asyncLocalStorage.getStore();
 export async function cancelJobs(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
-const context = asyncLocalStorage.getStore();
+  const context = asyncLocalStorage.getStore();
   context.logger.info(`Cancel requested for jobs ${req.body.jobIDs} by user ${req.user}`);
   await changeJobsState(req, next, cancelAndSaveJob);
   res.status(200).json({ status: 'canceled' });
@@ -372,7 +372,7 @@ const context = asyncLocalStorage.getStore();
 export async function resumeJobs(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
-const context = asyncLocalStorage.getStore();
+  const context = asyncLocalStorage.getStore();
   context.logger.info(`Resume requested for jobs ${req.body.jobIDs} by user ${req.user}`);
   await changeJobsState(req, next, resumeAndSaveJob);
   res.status(200).json({ status: 'running' });
@@ -389,7 +389,7 @@ const context = asyncLocalStorage.getStore();
 export async function skipJobsPreview(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
-const context = asyncLocalStorage.getStore();
+  const context = asyncLocalStorage.getStore();
   context.logger.info(`Skip preview requested for jobs ${req.body.jobIDs} by user ${req.user}`);
   await changeJobsState(req, next, skipPreviewAndSaveJob);
   res.status(200).json({ status: 'running' });
@@ -406,7 +406,7 @@ const context = asyncLocalStorage.getStore();
 export async function pauseJobs(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
-const context = asyncLocalStorage.getStore();
+  const context = asyncLocalStorage.getStore();
   context.logger.info(`Pause requested for jobs ${req.body.jobIDs} by user ${req.user}`);
   await changeJobsState(req, next, pauseAndSaveJob);
   res.status(200).json({ status: 'paused' });

--- a/services/harmony/app/frontends/labels.ts
+++ b/services/harmony/app/frontends/labels.ts
@@ -6,6 +6,7 @@ import { addLabelsToJobs, deleteLabelsFromJobs } from '../models/label';
 import db from '../util/db';
 import { isAdminUser } from '../util/edl-api';
 import { keysToLowerCase } from '../util/object';
+import { asyncLocalStorage } from '../util/async-store';
 
 /**
  * Express.js handler that adds one or more labels to a job `(PUT /labels)`.
@@ -30,7 +31,8 @@ export async function addJobLabels(
     res.status(201);
     res.send('OK');
   } catch (e) {
-    req.context.logger.error(e);
+    const context = asyncLocalStorage.getStore();
+    context.logger.error(e);
     next(e);
   }
 }
@@ -58,7 +60,8 @@ export async function deleteJobLabels(
     res.status(204);
     res.send();
   } catch (e) {
-    req.context.logger.error(e);
+    const context = asyncLocalStorage.getStore();
+    context.logger.error(e);
     next(e);
   }
 }

--- a/services/harmony/app/frontends/ogc-coverages/get-coverage-rangeset.ts
+++ b/services/harmony/app/frontends/ogc-coverages/get-coverage-rangeset.ts
@@ -10,22 +10,24 @@ import { keysToLowerCase } from '../../util/object';
 import { ParameterParseError } from '../../util/parameter-parsing-helpers';
 import { parseVariables } from '../../util/variables';
 import { parsePointParam, parseSubsetParams, subsetParamsToBbox, subsetParamsToTemporal } from './util/subset-parameter-parsing';
+import { asyncLocalStorage } from '../../util/async-store';
 /**
  * Express middleware that responds to OGC API - Coverages coverage
  * rangeset requests.  Responds with the actual coverage data.
  *
  * @param req - The request sent by the client
- * @param res - The response to send to the client
+ * @param res - The response to send to the client (not used)
  * @param next - The next express handler
  * @throws RequestValidationError - Thrown if the request has validation problems and
  *   cannot be performed
  */
 export default function getCoverageRangeset(
   req: HarmonyRequest,
-  res: Response,
+  _res: Response,
   next: NextFunction,
 ): void {
-  req.context.frontend = 'ogcCoverages';
+  const context = asyncLocalStorage.getStore();
+  context.frontend = 'ogcCoverages';
   const query = keysToLowerCase(req.query);
 
   const encrypter = createEncrypter(env.sharedSecretKey);

--- a/services/harmony/app/frontends/ogc-edr/get-data-common.ts
+++ b/services/harmony/app/frontends/ogc-edr/get-data-common.ts
@@ -10,6 +10,7 @@ import { ParameterParseError } from '../../util/parameter-parsing-helpers';
 import { parseVariables } from '../../util/variables';
 import { parseDatetime } from './util/helper';
 import { parseSubsetParams } from '../ogc-coverages/util/subset-parameter-parsing';
+import { asyncLocalStorage } from '../../util/async-store';
 
 /**
  * Common code for OGC EDR spatial queries.
@@ -21,7 +22,8 @@ import { parseSubsetParams } from '../ogc-coverages/util/subset-parameter-parsin
 export function getDataCommon(
   req: HarmonyRequest,
 ): void {
-  req.context.frontend = 'ogcEdr';
+  const context = asyncLocalStorage.getStore();
+  context.frontend = 'ogcEdr';
   const query = keysToLowerCase(req.query);
 
   const encrypter = createEncrypter(env.sharedSecretKey);

--- a/services/harmony/app/frontends/service-results.ts
+++ b/services/harmony/app/frontends/service-results.ts
@@ -66,7 +66,6 @@ export async function getServiceResult(req, res, next: NextFunction): Promise<vo
 
   const objectStore = objectStoreForProtocol('s3');
   if (objectStore) {
-    const context = asyncLocalStorage.getStore();
     try {
       context.logger.info(`Signing ${url}`);
       const result = await objectStore.signGetObject(url, { 'A-userid': req.user });

--- a/services/harmony/app/frontends/stac.ts
+++ b/services/harmony/app/frontends/stac.ts
@@ -10,6 +10,7 @@ import stacItemCreate from './stac-item';
 import stacCatalogCreate from './stac-catalog';
 import db from '../util/db';
 import env from '../util/env';
+import { asyncLocalStorage } from '../util/async-store';
 
 /**
  * Generic handler for STAC requests
@@ -100,7 +101,8 @@ export async function getStacCatalog(req, res, next): Promise<void> {
       }, pagingParams,
     );
   } catch (e) {
-    req.context.logger.error(e);
+    const context = asyncLocalStorage.getStore();
+    context.logger.error(e);
     next(e);
   }
 }
@@ -135,7 +137,8 @@ export async function getStacItem(req, res, next): Promise<void> {
       linkType,
     );
   } catch (e) {
-    req.context.logger.error(e);
+    const context = asyncLocalStorage.getStore();
+    context.logger.error(e);
     next(e);
   }
 }

--- a/services/harmony/app/frontends/staging-bucket-policy.ts
+++ b/services/harmony/app/frontends/staging-bucket-policy.ts
@@ -1,3 +1,4 @@
+import { asyncLocalStorage } from '../util/async-store';
 import { RequestValidationError } from '../util/errors';
 import SecureTokenService from '../util/sts';
 
@@ -88,7 +89,8 @@ export async function getStagingBucketPolicy(req, res): Promise<void> {
     policyTemplate.Statement[1].Resource = `arn:aws:s3:::${bucket}`;
     res.send(policyTemplate);
   } catch (e) {
-    const { logger } = req.context;
+    const context = asyncLocalStorage.getStore();
+    const { logger } = context;
     logger.error(e);
     throw new RequestValidationError('Failed to generate bucket policy. Bucket policy generation is only available on AWS Harmony deployments');
   }

--- a/services/harmony/app/frontends/versions.ts
+++ b/services/harmony/app/frontends/versions.ts
@@ -7,6 +7,7 @@ import { getServiceConfigs } from '../models/services';
 import { ServiceConfig } from '../models/services/base-service';
 import HarmonyRequest from '../models/harmony-request';
 import { TurboServiceParams } from '../models/services/turbo-service';
+import { asyncLocalStorage } from '../util/async-store';
 
 interface ServiceVersion {
   name: string;
@@ -70,7 +71,8 @@ async function getServiceForDisplay(
  */
 export default async function getVersions(req: HarmonyRequest, res: Response): Promise<void> {
   const ecr = defaultContainerRegistry();
-  const logger = req.context.logger.child({ component: 'versions.getVersions' });
+  const context = asyncLocalStorage.getStore();
+  const logger = context.logger.child({ component: 'versions.getVersions' });
   const turboServices = await Promise.all((getServiceConfigs() as ServiceConfig<TurboServiceParams>[])
     .filter((s) => s.type.name === 'turbo')
     .map((service) => getServiceForDisplay(service, ecr, logger)));

--- a/services/harmony/app/frontends/wms.ts
+++ b/services/harmony/app/frontends/wms.ts
@@ -16,6 +16,7 @@ import * as urlUtil from '../util/url';
 import { handleGranuleNames } from '../util/parameter-parsers';
 import env from '../util/env';
 import { getVariablesForCollection } from '../util/variables';
+import { asyncLocalStorage } from '../util/async-store';
 
 const readFile = promisify(fs.readFile);
 
@@ -257,7 +258,8 @@ function getMap(req, res, next: NextFunction): void {
  * @param next - The next function in the chain
  */
 export default async function wmsFrontend(req, res, next: NextFunction): Promise<void> {
-  req.context.frontend = 'wms';
+  const context = asyncLocalStorage.getStore();
+  context.frontend = 'wms';
   const query = keysToLowerCase(req.query);
   req.wmsQuery = query;
 
@@ -280,7 +282,7 @@ export default async function wmsFrontend(req, res, next: NextFunction): Promise
   } catch (e) {
     // TODO: Handle 'exceptions' param (HARMONY-40)
     if (e instanceof RequestValidationError) {
-      req.context.logger.error(e.message);
+      context.logger.error(e.message);
       return requestError(res, e.message);
     }
 

--- a/services/harmony/app/middleware/cmr-collection-reader.ts
+++ b/services/harmony/app/middleware/cmr-collection-reader.ts
@@ -5,7 +5,6 @@ import { ForbiddenError, NotFoundError, ServerError } from '../util/errors';
 import HarmonyRequest from '../models/harmony-request';
 import { listToText } from '@harmony/util/string';
 import { EdlUserEulaInfo, verifyUserEula } from '../util/edl-api';
-import RequestContext from '../models/request-context';
 import { asyncLocalStorage } from '../util/async-store';
 
 // CMR Collection IDs separated by delimiters of single "+" or single whitespace

--- a/services/harmony/app/middleware/cmr-umm-collection-reader.ts
+++ b/services/harmony/app/middleware/cmr-umm-collection-reader.ts
@@ -1,6 +1,7 @@
 import { NextFunction } from 'express';
 import { getUmmCollectionsByIds } from '../util/cmr';
 import HarmonyRequest from '../models/harmony-request';
+import { asyncLocalStorage } from '../util/async-store';
 
 /**
  * Express.js middleware that reads the UMM JSON format of the collections and load them into operation
@@ -11,9 +12,10 @@ import HarmonyRequest from '../models/harmony-request';
  */
 async function cmrUmmCollectionReader(req: HarmonyRequest, res, next: NextFunction): Promise<void> {
   try {
-    const hasUmmConditional = req.context.serviceConfig?.steps?.filter((s) => s.conditional?.umm_c);
+    const context = asyncLocalStorage.getStore();
+    const hasUmmConditional = context.serviceConfig?.steps?.filter((s) => s.conditional?.umm_c);
     if (hasUmmConditional && hasUmmConditional.length > 0) {
-      req.operation.ummCollections = await getUmmCollectionsByIds(req.context, req.collectionIds, req.accessToken);
+      req.operation.ummCollections = await getUmmCollectionsByIds(req.collectionIds, req.accessToken);
     }
     next();
   } catch (error) {

--- a/services/harmony/app/middleware/concatenation.ts
+++ b/services/harmony/app/middleware/concatenation.ts
@@ -3,6 +3,7 @@ import { ParameterParseError, parseBoolean } from '../util/parameter-parsing-hel
 import HarmonyRequest from '../models/harmony-request';
 import { RequestValidationError } from '../util/errors';
 import { keysToLowerCase } from '../util/object';
+import { asyncLocalStorage } from '../util/async-store';
 
 /**
  * Middleware to determine whether the request should concatenate results. Called prior
@@ -48,7 +49,8 @@ export function postServiceConcatenationHandler(
   req: HarmonyRequest, _res: Response, next: NextFunction,
 ): void {
   const query = keysToLowerCase(req.query);
-  const { operation, context } = req;
+  const { operation } = req;
+  const context = asyncLocalStorage.getStore();
 
   if (!operation) {
     return next();

--- a/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
+++ b/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
@@ -1,7 +1,6 @@
 import { RequestHandler } from 'express';
 import HarmonyRequest from '../models/harmony-request';
 import { getUserIdRequest } from '../util/edl-api';
-import { asyncLocalStorage } from '../util/async-store';
 
 const BEARER_TOKEN_REGEX = new RegExp('^Bearer ([-a-zA-Z0-9._~+/]+)$', 'i');
 

--- a/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
+++ b/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
@@ -1,6 +1,7 @@
 import { RequestHandler } from 'express';
 import HarmonyRequest from '../models/harmony-request';
 import { getUserIdRequest } from '../util/edl-api';
+import { asyncLocalStorage } from '../util/async-store';
 
 const BEARER_TOKEN_REGEX = new RegExp('^Bearer ([-a-zA-Z0-9._~+/]+)$', 'i');
 
@@ -24,7 +25,7 @@ export default function buildEdlAuthorizer(paths: Array<string | RegExp> = []): 
         const userToken = match[1];
         try {
           // Get the username for the provided token from EDL
-          const username = await getUserIdRequest(req.context, userToken);
+          const username = await getUserIdRequest(userToken);
           req.user = username;
           req.accessToken = userToken;
           req.authorized = true;

--- a/services/harmony/app/middleware/error-handler.ts
+++ b/services/harmony/app/middleware/error-handler.ts
@@ -7,6 +7,7 @@ import {
   getEndUserErrorMessage, getCodeForError,
 } from '../util/errors';
 import HarmonyRequest from '../models/harmony-request';
+import { asyncLocalStorage } from '../util/async-store';
 
 const errorTemplate = fs.readFileSync(path.join(__dirname, '../views/server-error.mustache.html'), { encoding: 'utf8' });
 const jsonErrorRoutesRegex = /jobs|labels|capabilities|ogc-api-coverages|ogc-api-edr|service-deployment(?:s-state)?|service-image-tag|stac|metrics|health|configuration|workflow-ui\/.*\/(?:links|logs|retry)/;
@@ -50,7 +51,8 @@ export default function errorHandler(
   const message = getEndUserErrorMessage(error);
   const code = getCodeForError(error);
 
-  req.context.logger.error(error);
+  const context = asyncLocalStorage.getStore();
+  context.logger.error(error);
 
   if (shouldReturnJson(error, req)) {
     res.status(statusCode).json(buildJsonErrorResponse(code, message));

--- a/services/harmony/app/middleware/extend.ts
+++ b/services/harmony/app/middleware/extend.ts
@@ -1,13 +1,15 @@
 import { NextFunction } from 'express';
 import HarmonyRequest from '../models/harmony-request';
+import { asyncLocalStorage } from '../util/async-store';
 
 /**
  * Set the request operation extendDimensions value to the default if applicable
  * @param req - The client request
  */
 export function setExtendDimensionsDefault(req: HarmonyRequest): void {
-  const extend = req.context.serviceConfig?.capabilities?.extend;
-  const defaultExtendDimensions = req.context.serviceConfig?.capabilities?.default_extend_dimensions;
+  const context = asyncLocalStorage.getStore();
+  const extend = context.serviceConfig?.capabilities?.extend;
+  const defaultExtendDimensions = context.serviceConfig?.capabilities?.default_extend_dimensions;
   // set extendDimension to the default if there is one configured and no provided value
   if (extend && defaultExtendDimensions && !req.operation?.extendDimensions) {
     req.operation.extendDimensions = defaultExtendDimensions;

--- a/services/harmony/app/middleware/log-for-routes.ts
+++ b/services/harmony/app/middleware/log-for-routes.ts
@@ -1,5 +1,6 @@
 import HarmonyRequest from '../models/harmony-request';
 import { Response, NextFunction, RequestHandler } from 'express';
+import { asyncLocalStorage } from '../util/async-store';
 
 /**
  * Log a string using middleware.
@@ -13,13 +14,14 @@ import { Response, NextFunction, RequestHandler } from 'express';
  */
 export default function logForRoutes(message: string, listType: 'allow' | 'deny' = 'deny', pathList: RegExp[] = [], logLevel = 'info'): RequestHandler {
   return (req: HarmonyRequest, res: Response, next: NextFunction): void => {
+    const context = asyncLocalStorage.getStore();
     if (!pathList.length) {
-      req.context.logger.log(logLevel, message);
+      context.logger.log(logLevel, message);
       return next();
     }
     const matchFound = pathList.some((p) => req.path.match(p));
     if ((listType === 'deny' && !matchFound) || (listType === 'allow' && matchFound)) {
-      req.context.logger.log(logLevel, message);
+      context.logger.log(logLevel, message);
       return next();
     }
     return next();

--- a/services/harmony/app/middleware/parameter-validation.ts
+++ b/services/harmony/app/middleware/parameter-validation.ts
@@ -10,6 +10,7 @@ import env from '../util/env';
 import { getRequestRoot } from '../util/url';
 import { validateNoConflictingGridParameters } from '../util/grids';
 import { checkLabel } from '../models/label';
+import { asyncLocalStorage } from '../util/async-store';
 
 const { awsDefaultRegion } = env;
 
@@ -93,7 +94,8 @@ async function validateBucketIsInRegion(req: HarmonyRequest, destinationUrl: str
  */
 async function validateDestinationUrlWritable(req: HarmonyRequest, destinationUrl: string): Promise<void> {
   try {
-    const requestId = req.context.id;
+    const context = asyncLocalStorage.getStore();
+    const requestId = context.id;
     const requestUrl = destinationUrl.endsWith('/') ? destinationUrl + requestId : destinationUrl + '/' + requestId;
     const statusUrl = requestUrl + '/harmony-job-status-link';
     const statusLink = getRequestRoot(req) + '/jobs/' + requestId;

--- a/services/harmony/app/middleware/service-selection.ts
+++ b/services/harmony/app/middleware/service-selection.ts
@@ -3,6 +3,7 @@ import { ServiceConfig } from '../models/services/base-service';
 import HarmonyRequest from '../models/harmony-request';
 import { chooseServiceConfig, getServiceConfigs } from '../models/services';
 import { CmrCollection } from '../util/cmr';
+import { asyncLocalStorage } from '../util/async-store';
 
 /**
  * Add collections to service configs
@@ -47,10 +48,12 @@ export function addCollectionsToServicesByAssociation(collections: CmrCollection
 export default function chooseService(
   req: HarmonyRequest, _res: Response, next: NextFunction,
 ): void {
-  const { operation, context } = req;
+  const { operation } = req;
   if (!operation?.sources) {
     return next();
   }
+
+  const context = asyncLocalStorage.getStore();
 
   let serviceConfig: ServiceConfig<unknown>;
   const configs = addCollectionsToServicesByAssociation(req.collections);

--- a/services/harmony/app/models/harmony-request.ts
+++ b/services/harmony/app/models/harmony-request.ts
@@ -29,7 +29,7 @@ export function addRequestContextToOperation(
   req: HarmonyRequest, _res: Response, next: NextFunction,
 ): void {
   const context = asyncLocalStorage.getStore();
-  const { operation} = req;
+  const { operation } = req;
 
   if (!operation) return next();
 

--- a/services/harmony/app/models/job.ts
+++ b/services/harmony/app/models/job.ts
@@ -990,7 +990,6 @@ export class Job extends DBRecord implements JobRecord {
    */
   async collectionsHaveEulaRestriction(accessToken: string): Promise<boolean> {
     const cmrCollections = await getCollectionsByIds(
-      { 'id': this.requestId },
       this.collectionIds,
       accessToken,
       CmrTagKeys.HasEula,
@@ -1008,7 +1007,7 @@ export class Job extends DBRecord implements JobRecord {
    * @returns true or false
    */
   async collectionsHaveGuestReadRestriction(accessToken: string): Promise<boolean> {
-    const permissionsMap: CmrPermissionsMap = await getPermissions({ 'id': this.requestId }, this.collectionIds, accessToken);
+    const permissionsMap: CmrPermissionsMap = await getPermissions(this.collectionIds, accessToken);
     return this.collectionIds.some((collectionId) => (
       !permissionsMap[collectionId]
         || !(permissionsMap[collectionId].indexOf(CmrPermission.Read) > -1)));

--- a/services/harmony/app/server.ts
+++ b/services/harmony/app/server.ts
@@ -71,10 +71,8 @@ function addRequestLogger(appLogger: Logger, ignorePaths: RegExp[] = []): Reques
  * AsyncLocalStorage. Also adds requestUrl to the logger info object.
  *
  * @param appLogger - Request specific application logger
- * @param ignorePaths - Don't log the request url and method if the req.path matches these patterns
  */
-function generateContextMiddleware(appLogger: Logger, ignorePaths: RegExp[] = []): RequestHandler {
-  const context = asyncLocalStorage.getStore();
+function generateContextMiddleware(appLogger: Logger): RequestHandler {
   return (req: HarmonyRequest, _res: Response, next: NextFunction): void => {
     const requestId = req.params.requestId || uuid();
     const requestUrl = req.url;

--- a/services/harmony/app/server.ts
+++ b/services/harmony/app/server.ts
@@ -80,9 +80,8 @@ function generateContextMiddleware(appLogger: Logger): RequestHandler {
     context.logger = appLogger.child({ requestId, requestUrl });
 
     // perform the request using the context
-    asyncLocalStorage.run(context, () => {
-      next();
-    });
+    asyncLocalStorage.enterWith(context);
+    next();
   };
 }
 

--- a/services/harmony/app/util/async-store.ts
+++ b/services/harmony/app/util/async-store.ts
@@ -1,0 +1,4 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import RequestContext from '../models/request-context';
+
+export const asyncLocalStorage = new AsyncLocalStorage<RequestContext>();

--- a/services/harmony/app/util/cmr.ts
+++ b/services/harmony/app/util/cmr.ts
@@ -30,10 +30,6 @@ const acceptJsonHeader = {
   Accept: 'application/json',
 };
 
-const jsonContentTypeHeader = {
-  'Content-Type': 'application/json',
-};
-
 export enum CmrPermission {
   Read = 'read',
   Update = 'update',
@@ -855,7 +851,6 @@ export async function getVariablesByIds(
 export async function getVariablesForCollection(
   collection: CmrCollection, token: string,
 ): Promise<Array<CmrUmmVariable>> {
-  const context = asyncLocalStorage.getStore();
   const varIds = collection.associations && collection.associations.variables;
   if (varIds) {
     return getVariablesByIds(varIds, token);

--- a/services/harmony/app/util/edl-api.ts
+++ b/services/harmony/app/util/edl-api.ts
@@ -2,12 +2,11 @@ import * as axios from 'axios';
 import { hasCookieSecret } from './cookie-secret';
 import { ForbiddenError } from './errors';
 import { Response } from 'express';
+import { asyncLocalStorage } from './async-store';
 import env from './env';
 import HarmonyRequest from '../models/harmony-request';
 import { oauthOptions } from '../middleware/earthdata-login-oauth-authorizer';
 import { ClientCredentials, AccessToken } from 'simple-oauth2';
-import RequestContext from '../models/request-context';
-import { Logger } from 'winston';
 
 const edlUserRequestUrl = `${env.oauthHost}/oauth/tokens/user`;
 const edlUserGroupsBaseUrl = `${env.oauthHost}/api/user_groups/groups_for_user`;
@@ -19,10 +18,11 @@ let harmonyClientToken: AccessToken; // valid for 30 days
 
 /**
  * Returns the bearer token to use in all EDL requests from Harmony
- * @param logger - The logger associated with the request
  * @returns The client bearer token
  */
-export async function getClientCredentialsToken(logger: Logger): Promise<string> {
+export async function getClientCredentialsToken(): Promise<string> {
+  const context = asyncLocalStorage.getStore();
+  const { logger } = context;
   try {
     if (oauth2 === undefined) {
       oauth2 = new ClientCredentials(oauthOptions);
@@ -43,16 +43,16 @@ export async function getClientCredentialsToken(logger: Logger): Promise<string>
  * Makes a request to the EDL users endpoint to validate a token and return the user ID
  * associated with that token.
  *
- * @param context - Information related to the user's request
  * @param userToken - The user's token
  * @returns the username associated with the token
  * @throws ForbiddenError if the token is invalid
  */
-export async function getUserIdRequest(context: RequestContext, userToken: string)
+export async function getUserIdRequest(userToken: string)
   : Promise<string> {
+  const context = asyncLocalStorage.getStore();
   const { logger } = context;
   try {
-    const clientToken = await getClientCredentialsToken(context.logger);
+    const clientToken = await getClientCredentialsToken();
     const response = await axios.default.post(
       edlUserRequestUrl,
       null,
@@ -75,15 +75,15 @@ export async function getUserIdRequest(context: RequestContext, userToken: strin
 /**
  * Returns the groups to which a user belongs
  *
- * @param context - Information related to the user's request
  * @param username - The EDL username
  * @returns the groups to which the user belongs
  */
-async function getUserGroups(context: RequestContext, username: string)
+async function getUserGroups(username: string)
   : Promise<string[]> {
+  const context = asyncLocalStorage.getStore();
   const { logger } = context;
   try {
-    const clientToken = await getClientCredentialsToken(context.logger);
+    const clientToken = await getClientCredentialsToken();
     const response = await axios.default.get(
       `${edlUserGroupsBaseUrl}/${username}`, { headers: { Authorization: `Bearer ${clientToken}`, 'X-Request-Id': context.id } },
     );
@@ -106,14 +106,13 @@ export interface EdlGroupMembership {
 /**
  * Returns the harmony relevant group information for a user with two keys isAdmin and isLogViewer.
  *
- * @param context - Information related to the user's request
  * @param username - The EDL username
  * @returns A promise which resolves to info about whether the user is an admin, log viewer or service deployer,
  * and has core permissions (e.g. allowing user to access server configuration endpoints)
  */
-export async function getEdlGroupInformation(context: RequestContext, username: string)
+export async function getEdlGroupInformation(username: string)
   : Promise<EdlGroupMembership> {
-  const groups = await getUserGroups(context, username);
+  const groups = await getUserGroups(username);
   let isAdmin = false;
   if (groups.includes(env.adminGroupId)) {
     isAdmin = true;
@@ -142,8 +141,8 @@ export async function getEdlGroupInformation(context: RequestContext, username: 
  * @param req - the harmony request
  */
 export async function isAdminUser(req: HarmonyRequest): Promise<boolean> {
-  const isAdmin = req.context.isAdminAccess ||
-    (await getEdlGroupInformation(req.context, req.user)).isAdmin;
+  const context = asyncLocalStorage.getStore();
+  const isAdmin = context.isAdminAccess || (await getEdlGroupInformation(req.user)).isAdmin;
   return isAdmin;
 }
 
@@ -156,18 +155,18 @@ export interface EdlUserEulaInfo {
 /**
  * Check whether the user has accepted a EULA.
  *
- * @param context - Information related to the user's request
  * @param username - The EDL username
  * @param eulaId - The id of the EULA (from the collection metadata)
  * @returns A promise which resolves to info about whether the user has accepted a EULA,
  * and if not, where they can go to accept it
  */
-export async function verifyUserEula(context: RequestContext, username: string, eulaId: string)
+export async function verifyUserEula(username: string, eulaId: string)
   : Promise<EdlUserEulaInfo> {
   let statusCode: number;
   let eulaResponse: { msg: string, error: string, accept_eula_url: string };
   try {
-    const clientToken = await getClientCredentialsToken(context.logger);
+    const context = asyncLocalStorage.getStore();
+    const clientToken = await getClientCredentialsToken();
     const response = await axios.default.get(
       edlVerifyUserEulaUrl(username, eulaId), { headers: { Authorization: `Bearer ${clientToken}`, 'X-Request-Id': context.id } },
     );
@@ -195,9 +194,7 @@ export async function validateUserIsInCoreGroup(
 ): Promise<boolean> {
   // if request has cookie-secret header, it is in the core permissions group
   if (! hasCookieSecret(req)) {
-    const { hasCorePermissions } = await getEdlGroupInformation(
-      req.context, req.user,
-    );
+    const { hasCorePermissions } = await getEdlGroupInformation(req.user);
 
     if (!hasCorePermissions) {
       res.statusCode = 403;

--- a/services/harmony/app/util/errors.ts
+++ b/services/harmony/app/util/errors.ts
@@ -1,4 +1,5 @@
 import { Application } from 'express';
+import { asyncLocalStorage } from './async-store';
 
 /* eslint-disable max-classes-per-file */ // This file creates multiple tag classes
 export class HttpError extends Error {
@@ -132,11 +133,13 @@ export function handleOpenApiErrors(app: Application): void {
     }
     res.status(statusCode).json(buildJsonErrorResponse(code, message));
 
+    const context = asyncLocalStorage.getStore();
+
     if (statusCode < 500) {
-      req.context.logger.error(`[${code}] ${message}`);
+      context.logger.error(`[${code}] ${message}`);
     } else {
       // Make sure we get stack traces when we throw an unexpected exception
-      req.context.logger.error(err);
+      context.logger.error(err);
     }
   });
 }

--- a/services/harmony/app/util/grids.ts
+++ b/services/harmony/app/util/grids.ts
@@ -5,6 +5,7 @@ import { getGridsByName } from './cmr';
 import parseCRS from './crs';
 import { RequestValidationError } from './errors';
 import { keysToLowerCase } from './object';
+import { asyncLocalStorage } from './async-store';
 
 /**
  * Throws an error if the grid name parameter is included along with regridding parameters.
@@ -40,10 +41,11 @@ export async function parseGridMiddleware(
   if (query.grid) {
     try {
       validateNoConflictingGridParameters(query);
+      const context = asyncLocalStorage.getStore();
       const gridName = query.grid;
-      const grids = await getGridsByName(req.context, gridName, req.accessToken );
+      const grids = await getGridsByName(gridName, req.accessToken );
       if (grids.length > 1) {
-        req.context.logger.warn(`Multiple grids returned for name ${gridName}, choosing the first one returned by CMR.`);
+        context.logger.warn(`Multiple grids returned for name ${gridName}, choosing the first one returned by CMR.`);
       } else if (grids.length == 0) {
         throw new RequestValidationError(`Unknown grid ${gridName}`);
       }

--- a/services/harmony/app/util/parameter-parsers.ts
+++ b/services/harmony/app/util/parameter-parsers.ts
@@ -8,6 +8,7 @@ import { ParameterParseError, parseMultiValueParameter, parseNumber } from './pa
 import HarmonyRequest from '../models/harmony-request';
 import { parseAcceptHeader } from './content-negotiation';
 import { RequestValidationError } from './errors';
+import { asyncLocalStorage } from './async-store';
 
 /**
  * Helper function to convert parameter parsing errors into 400 errors for an end
@@ -157,8 +158,9 @@ export function handleFormat(
   if (format) {
     operation.outputFormat = format;
   } else if (req.headers.accept) {
+    const context = asyncLocalStorage.getStore();
     const acceptedMimeTypes = parseAcceptHeader(req.headers.accept);
-    req.context.requestedMimeTypes = acceptedMimeTypes
+    context.requestedMimeTypes = acceptedMimeTypes
       .map((v: { mimeType: string }) => v.mimeType)
       .filter((v) => v);
   }

--- a/services/harmony/test/helpers/caching-hooks.ts
+++ b/services/harmony/test/helpers/caching-hooks.ts
@@ -3,7 +3,6 @@ import { before, after } from 'mocha';
 import { stub, SinonStub } from 'sinon';
 import { hookGetQueueForType, hookGetQueueForUrl, hookGetQueueUrlForService, hookGetWorkSchedulerQueue, hookProcessSchedulerQueue } from './queue';
 import * as cmr from '../../app/util/cmr';
-import RequestContext from '../../app/models/request-context';
 
 hookGetQueueForType();
 hookGetQueueForUrl();

--- a/services/harmony/test/helpers/caching-hooks.ts
+++ b/services/harmony/test/helpers/caching-hooks.ts
@@ -43,7 +43,7 @@ before(function () {
 
   // Stub fetchPost to provide a string body rather than a FormData stream
   stub(cmr, 'fetchPost').callsFake(async function (
-    context: RequestContext, path: string, formData: FormData, headers: { [key: string]: string },
+    path: string, formData: FormData, headers: { [key: string]: string },
   ): Promise<cmr.CmrResponse> {
     // Read the body into a stream
     const chunks = [];
@@ -53,7 +53,7 @@ before(function () {
       formData.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
       formData.resume();
     });
-    return originalFetchPost(context, path, body, headers);
+    return originalFetchPost(path, body, headers);
   });
 });
 

--- a/services/harmony/test/helpers/ogc-api-coverages.ts
+++ b/services/harmony/test/helpers/ogc-api-coverages.ts
@@ -120,8 +120,6 @@ export function postRangesetRequest(
   Object.keys(form).forEach((key) => {
     if (key === 'shapefile') {
       req = req.attach(key, form[key].path, { contentType: form[key].mimetype, filename: 'foobar' });
-
-      // req = req.attach(key, form[key].path, 'foobar');
     } else {
       req = req.field(key, form[key]);
     }

--- a/services/harmony/test/middleware/extend.ts
+++ b/services/harmony/test/middleware/extend.ts
@@ -1,37 +1,42 @@
 import { expect } from 'chai';
 import { describe, it, beforeEach } from 'mocha';
+import { v4 as uuid } from 'uuid';
+import { asyncLocalStorage } from '../../app/util/async-store';
 import HarmonyRequest from '../../app/models/harmony-request';
 import DataOperation from '../../app/models/data-operation';
 import { setExtendDimensionsDefault } from '../../app/middleware/extend';
+import RequestContext from '../../app/models/request-context';
 
 describe('extend serivce default value', function () {
+  const collectionId = 'C123-TEST';
+  const requestContext = new RequestContext(uuid());
+  requestContext.serviceConfig = {
+    name: 'extend-service',
+    type: { name: 'turbo' },
+    collections: [{ id: collectionId }],
+    capabilities: {
+      extend: true,
+      default_extend_dimensions: ['mirror_step'],
+    },
+  };
+
   beforeEach(function () {
-    const collectionId = 'C123-TEST';
     const shortName = 'harmony_example';
     const versionId = '1';
     const operation = new DataOperation();
     operation.addSource(collectionId, shortName, versionId);
     const harmonyRequest = {
       operation: operation,
-      context: {
-        serviceConfig: {
-          name: 'extend-service',
-          type: { name: 'turbo' },
-          collections: [{ id: collectionId }],
-          capabilities: {
-            extend: true,
-            default_extend_dimensions: ['mirror_step'],
-          },
-        },
-      },
     } as HarmonyRequest;
     this.req = harmonyRequest;
   });
 
   describe('and the request does not provide dimension extension', function () {
     it('extendDimensions is set to the default', function () {
-      setExtendDimensionsDefault(this.req);
-      expect(this.req.operation.extendDimensions).to.eql(['mirror_step']);
+      asyncLocalStorage.run(requestContext, () => {
+        setExtendDimensionsDefault(this.req);
+        expect(this.req.operation.extendDimensions).to.eql(['mirror_step']);
+      });
     });
   });
 
@@ -41,39 +46,43 @@ describe('extend serivce default value', function () {
     });
 
     it('extendDimensions is set to the provided value, not the default', function () {
-      setExtendDimensionsDefault(this.req);
-      expect(this.req.operation.extendDimensions).to.eql(['lat', 'lon']);
+      asyncLocalStorage.run(requestContext, () => {
+        setExtendDimensionsDefault(this.req);
+        expect(this.req.operation.extendDimensions).to.eql(['lat', 'lon']);
+      });
     });
   });
 });
 
 describe('extend serivce misconfigured without default value', function () {
+  const collectionId = 'C123-TEST';
+  const requestContext = new RequestContext(uuid());
+  requestContext.serviceConfig = {
+    name: 'extend-service',
+    type: { name: 'turbo' },
+    collections: [{ id: collectionId }],
+    capabilities: {
+      extend: true,
+    },
+  };
+
   beforeEach(function () {
-    const collectionId = 'C123-TEST';
     const shortName = 'harmony_example';
     const versionId = '1';
     const operation = new DataOperation();
     operation.addSource(collectionId, shortName, versionId);
     const harmonyRequest = {
       operation: operation,
-      context: {
-        serviceConfig: {
-          name: 'extend-service',
-          type: { name: 'turbo' },
-          collections: [{ id: collectionId }],
-          capabilities: {
-            extend: true,
-          },
-        },
-      },
     } as HarmonyRequest;
     this.req = harmonyRequest;
   });
 
   describe('and the request does not provide dimension extension', function () {
     it('extendDimensions is set to the default', function () {
-      setExtendDimensionsDefault(this.req);
-      expect(this.req.operation.extendDimensions).to.not.exist;
+      asyncLocalStorage.run(requestContext, () => {
+        setExtendDimensionsDefault(this.req);
+        expect(this.req.operation.extendDimensions).to.not.exist;
+      });
     });
   });
 
@@ -83,8 +92,10 @@ describe('extend serivce misconfigured without default value', function () {
     });
 
     it('extendDimensions is set to the provided value, not the default', function () {
-      setExtendDimensionsDefault(this.req);
-      expect(this.req.operation.extendDimensions).to.eql(['lat', 'lon']);
+      asyncLocalStorage.run(requestContext, () => {
+        setExtendDimensionsDefault(this.req);
+        expect(this.req.operation.extendDimensions).to.eql(['lat', 'lon']);
+      });
     });
   });
 });

--- a/services/harmony/test/util/cmr.ts
+++ b/services/harmony/test/util/cmr.ts
@@ -10,7 +10,7 @@ const fakeContext = {
 describe('util/cmr', function () {
   describe('getVariablesByIds', function () {
     it('returns a valid response, given a huge number of variables', async function () {
-      asyncLocalStorage.run(fakeContext, async () => {
+      await asyncLocalStorage.run(fakeContext, async () => {
         const validVariableId = 'V1233801695-EEDTEST';
         const ids = [...Array(300).keys()].map((num) => `V${num}-YOCLOUD`).concat(validVariableId);
         const variables = await getVariablesByIds(ids, '');
@@ -19,7 +19,7 @@ describe('util/cmr', function () {
     });
 
     it('contains related URLs when the CMR variable has them', async function () {
-      asyncLocalStorage.run(fakeContext, async () => {
+      await asyncLocalStorage.run(fakeContext, async () => {
         const expectedRelatedUrls: CmrRelatedUrl[] = [{
           URL: 'https://colormap_server.earthdata.nasa.gov/sea_surface_temperature/green-based',
           URLContentType: 'VisualizationURL',
@@ -38,7 +38,7 @@ describe('util/cmr', function () {
 
   describe('getAllVariables', function () {
     it('successfully retrieves all variables over multiple pages', async function () {
-      asyncLocalStorage.run(fakeContext, async () => {
+      await asyncLocalStorage.run(fakeContext, async () => {
         const variableIds = ['V1233801695-EEDTEST', 'V1233801696-EEDTEST', 'V1233801716-EEDTEST', 'V1233801717-EEDTEST'];
         const query = {
           concept_id: variableIds,
@@ -52,7 +52,7 @@ describe('util/cmr', function () {
 
   describe('when issuing a granuleName query with wildcards', function () {
     it('it handles * at the beginning', async function () {
-      asyncLocalStorage.run(fakeContext, async () => {
+      await asyncLocalStorage.run(fakeContext, async () => {
         const query: CmrQuery = {
           concept_id: 'C1233800302-EEDTEST',
           readable_granule_name: '*oceania_east',
@@ -71,7 +71,7 @@ describe('util/cmr', function () {
     });
 
     it('it handles * in the middle', async function () {
-      asyncLocalStorage.run(fakeContext, async () => {
+      await asyncLocalStorage.run(fakeContext, async () => {
         const query: CmrQuery = {
           concept_id: 'C1233800302-EEDTEST',
           readable_granule_name: '001_*_east',
@@ -89,7 +89,7 @@ describe('util/cmr', function () {
     });
 
     it('it handles * at the end', async function () {
-      asyncLocalStorage.run(fakeContext, async () => {
+      await asyncLocalStorage.run(fakeContext, async () => {
         const query: CmrQuery = {
           concept_id: 'C1233800302-EEDTEST',
           readable_granule_name: '001_*',
@@ -107,7 +107,7 @@ describe('util/cmr', function () {
     });
 
     it('it handles ? at the beginning', async function () {
-      asyncLocalStorage.run(fakeContext, async () => {
+      await asyncLocalStorage.run(fakeContext, async () => {
         const query: CmrQuery = {
           concept_id: 'C1233800302-EEDTEST',
           readable_granule_name: '?01_08_7f00ff_oceania_east',
@@ -118,7 +118,7 @@ describe('util/cmr', function () {
     });
 
     it('it handles ? in the middle', async function () {
-      asyncLocalStorage.run(fakeContext, async () => {
+      await asyncLocalStorage.run(fakeContext, async () => {
         const query: CmrQuery = {
           concept_id: 'C1233800302-EEDTEST',
           readable_granule_name: '001_08_7f00ff_?ceania_east',
@@ -129,7 +129,7 @@ describe('util/cmr', function () {
     });
 
     it('it handles ? at the end', async function () {
-      asyncLocalStorage.run(fakeContext, async () => {
+      await asyncLocalStorage.run(fakeContext, async () => {
         const query: CmrQuery = {
           concept_id: 'C1233800302-EEDTEST',
           readable_granule_name: '001_08_7f00ff_oceania_eas?',

--- a/services/harmony/test/util/cmr.ts
+++ b/services/harmony/test/util/cmr.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
+import { asyncLocalStorage } from '../../app/util/async-store';
 import { CmrRelatedUrl, CmrUmmVariable, getVariablesByIds, getAllVariables, CmrQuery, queryGranuleUsingMultipartForm } from '../../app/util/cmr';
 
 const fakeContext = {
@@ -9,114 +10,133 @@ const fakeContext = {
 describe('util/cmr', function () {
   describe('getVariablesByIds', function () {
     it('returns a valid response, given a huge number of variables', async function () {
-      const validVariableId = 'V1233801695-EEDTEST';
-      const ids = [...Array(300).keys()].map((num) => `V${num}-YOCLOUD`).concat(validVariableId);
-      const variables = await getVariablesByIds(fakeContext, ids, '');
-      expect(variables.length).to.eql(1);
+      asyncLocalStorage.run(fakeContext, async () => {
+        const validVariableId = 'V1233801695-EEDTEST';
+        const ids = [...Array(300).keys()].map((num) => `V${num}-YOCLOUD`).concat(validVariableId);
+        const variables = await getVariablesByIds(ids, '');
+        expect(variables.length).to.eql(1);
+      });
     });
 
     it('contains related URLs when the CMR variable has them', async function () {
-      const expectedRelatedUrls: CmrRelatedUrl[] = [{
-        URL: 'https://colormap_server.earthdata.nasa.gov/sea_surface_temperature/green-based',
-        URLContentType: 'VisualizationURL',
-        Type: 'Color Map',
-        Subtype: 'Harmony GDAL',
-        Description: 'This is a sample way of designating a colormap for a specific variable record.',
-        Format: 'XML',
-        MimeType: 'application/XML',
-      }];
-      const redVariable: CmrUmmVariable = (await getVariablesByIds(fakeContext, ['V1233801695-EEDTEST'], ''))[0];
-      const redVariableRelatedUrls: CmrRelatedUrl[] = redVariable.umm.RelatedURLs;
-      expect(expectedRelatedUrls).to.deep.equal(redVariableRelatedUrls);
+      asyncLocalStorage.run(fakeContext, async () => {
+        const expectedRelatedUrls: CmrRelatedUrl[] = [{
+          URL: 'https://colormap_server.earthdata.nasa.gov/sea_surface_temperature/green-based',
+          URLContentType: 'VisualizationURL',
+          Type: 'Color Map',
+          Subtype: 'Harmony GDAL',
+          Description: 'This is a sample way of designating a colormap for a specific variable record.',
+          Format: 'XML',
+          MimeType: 'application/XML',
+        }];
+        const redVariable: CmrUmmVariable = (await getVariablesByIds(['V1233801695-EEDTEST'], ''))[0];
+        const redVariableRelatedUrls: CmrRelatedUrl[] = redVariable.umm.RelatedURLs;
+        expect(expectedRelatedUrls).to.deep.equal(redVariableRelatedUrls);
+      });
     });
   });
 
   describe('getAllVariables', function () {
     it('successfully retrieves all variables over multiple pages', async function () {
-      const variableIds = ['V1233801695-EEDTEST', 'V1233801696-EEDTEST', 'V1233801716-EEDTEST', 'V1233801717-EEDTEST'];
-      const query = {
-        concept_id: variableIds,
-        page_size: 1, // requires paging through 4 pages
-      };
-      const variables = await getAllVariables(fakeContext, query, '');
-      expect(variables.length).to.eql(4);
+      asyncLocalStorage.run(fakeContext, async () => {
+        const variableIds = ['V1233801695-EEDTEST', 'V1233801696-EEDTEST', 'V1233801716-EEDTEST', 'V1233801717-EEDTEST'];
+        const query = {
+          concept_id: variableIds,
+          page_size: 1, // requires paging through 4 pages
+        };
+        const variables = await getAllVariables(query, '');
+        expect(variables.length).to.eql(4);
+      });
     });
   });
 
   describe('when issuing a granuleName query with wildcards', function () {
     it('it handles * at the beginning', async function () {
-      const query: CmrQuery = {
-        concept_id: 'C1233800302-EEDTEST',
-        readable_granule_name: '*oceania_east',
-      };
-      const results = await queryGranuleUsingMultipartForm(fakeContext, query, '');
-      expect(results.hits).to.equal(16);
+      asyncLocalStorage.run(fakeContext, async () => {
+        const query: CmrQuery = {
+          concept_id: 'C1233800302-EEDTEST',
+          readable_granule_name: '*oceania_east',
+        };
+        const results = await queryGranuleUsingMultipartForm(query, '');
+        expect(results.hits).to.equal(16);
 
-      const querySingleMatch: CmrQuery = {
-        concept_id: 'C1233800302-EEDTEST',
-        readable_granule_name: '*01_08_7f00ff_oceania_east',
-      };
-      const singleMatchResults = await queryGranuleUsingMultipartForm(fakeContext, querySingleMatch, '');
-      expect(singleMatchResults.hits).to.equal(1);
+        const querySingleMatch: CmrQuery = {
+          concept_id: 'C1233800302-EEDTEST',
+          readable_granule_name: '*01_08_7f00ff_oceania_east',
+        };
+        const singleMatchResults = await queryGranuleUsingMultipartForm(querySingleMatch, '');
+        expect(singleMatchResults.hits).to.equal(1);
+      });
+
     });
 
     it('it handles * in the middle', async function () {
-      const query: CmrQuery = {
-        concept_id: 'C1233800302-EEDTEST',
-        readable_granule_name: '001_*_east',
-      };
-      const results = await queryGranuleUsingMultipartForm(fakeContext, query, '');
-      expect(results.hits).to.equal(2);
+      asyncLocalStorage.run(fakeContext, async () => {
+        const query: CmrQuery = {
+          concept_id: 'C1233800302-EEDTEST',
+          readable_granule_name: '001_*_east',
+        };
+        const results = await queryGranuleUsingMultipartForm(query, '');
+        expect(results.hits).to.equal(2);
 
-      const querySingleMatch: CmrQuery = {
-        concept_id: 'C1233800302-EEDTEST',
-        readable_granule_name: '001_*_7f00ff_oceania_east',
-      };
-      const singleMatchResults = await queryGranuleUsingMultipartForm(fakeContext, querySingleMatch, '');
-      expect(singleMatchResults.hits).to.equal(1);
+        const querySingleMatch: CmrQuery = {
+          concept_id: 'C1233800302-EEDTEST',
+          readable_granule_name: '001_*_7f00ff_oceania_east',
+        };
+        const singleMatchResults = await queryGranuleUsingMultipartForm(querySingleMatch, '');
+        expect(singleMatchResults.hits).to.equal(1);
+      });
     });
 
     it('it handles * at the end', async function () {
-      const query: CmrQuery = {
-        concept_id: 'C1233800302-EEDTEST',
-        readable_granule_name: '001_*',
-      };
-      const results = await queryGranuleUsingMultipartForm(fakeContext, query, '');
-      expect(results.hits).to.equal(12);
+      asyncLocalStorage.run(fakeContext, async () => {
+        const query: CmrQuery = {
+          concept_id: 'C1233800302-EEDTEST',
+          readable_granule_name: '001_*',
+        };
+        const results = await queryGranuleUsingMultipartForm(query, '');
+        expect(results.hits).to.equal(12);
 
-      const querySingleMatch: CmrQuery = {
-        concept_id: 'C1233800302-EEDTEST',
-        readable_granule_name: '001_08_7f00ff_oceania_eas*',
-      };
-      const singleMatchResults = await queryGranuleUsingMultipartForm(fakeContext, querySingleMatch, '');
-      expect(singleMatchResults.hits).to.equal(1);
+        const querySingleMatch: CmrQuery = {
+          concept_id: 'C1233800302-EEDTEST',
+          readable_granule_name: '001_08_7f00ff_oceania_eas*',
+        };
+        const singleMatchResults = await queryGranuleUsingMultipartForm(querySingleMatch, '');
+        expect(singleMatchResults.hits).to.equal(1);
+      });
     });
 
     it('it handles ? at the beginning', async function () {
-      const query: CmrQuery = {
-        concept_id: 'C1233800302-EEDTEST',
-        readable_granule_name: '?01_08_7f00ff_oceania_east',
-      };
-      const results = await queryGranuleUsingMultipartForm(fakeContext, query, '');
-      expect(results.hits).to.equal(1);
+      asyncLocalStorage.run(fakeContext, async () => {
+        const query: CmrQuery = {
+          concept_id: 'C1233800302-EEDTEST',
+          readable_granule_name: '?01_08_7f00ff_oceania_east',
+        };
+        const results = await queryGranuleUsingMultipartForm(query, '');
+        expect(results.hits).to.equal(1);
+      });
     });
 
     it('it handles ? in the middle', async function () {
-      const query: CmrQuery = {
-        concept_id: 'C1233800302-EEDTEST',
-        readable_granule_name: '001_08_7f00ff_?ceania_east',
-      };
-      const results = await queryGranuleUsingMultipartForm(fakeContext, query, '');
-      expect(results.hits).to.equal(1);
+      asyncLocalStorage.run(fakeContext, async () => {
+        const query: CmrQuery = {
+          concept_id: 'C1233800302-EEDTEST',
+          readable_granule_name: '001_08_7f00ff_?ceania_east',
+        };
+        const results = await queryGranuleUsingMultipartForm(query, '');
+        expect(results.hits).to.equal(1);
+      });
     });
 
     it('it handles ? at the end', async function () {
-      const query: CmrQuery = {
-        concept_id: 'C1233800302-EEDTEST',
-        readable_granule_name: '001_08_7f00ff_oceania_eas?',
-      };
-      const results = await queryGranuleUsingMultipartForm(fakeContext, query, '');
-      expect(results.hits).to.equal(1);
+      asyncLocalStorage.run(fakeContext, async () => {
+        const query: CmrQuery = {
+          concept_id: 'C1233800302-EEDTEST',
+          readable_granule_name: '001_08_7f00ff_oceania_eas?',
+        };
+        const results = await queryGranuleUsingMultipartForm(query, '');
+        expect(results.hits).to.equal(1);
+      });
     });
   });
 

--- a/services/harmony/test/util/edl-api.ts
+++ b/services/harmony/test/util/edl-api.ts
@@ -4,6 +4,11 @@ import {
   getEdlGroupInformation,
 } from '../../app/util/edl-api';
 import { stubEdlRequest, token, unstubEdlRequest } from '../helpers/auth';
+import { asyncLocalStorage } from '../../app/util/async-store';
+
+const fakeContext = {
+  id: '1234',
+};
 
 describe('util/edl-api', function () {
   describe('getEdlGroupInformation', function () {
@@ -19,20 +24,26 @@ describe('util/edl-api', function () {
     });
     describe('when the user is not part of the service deployers group', function () {
       it('returns isServiceDeployer:false', async function () {
-        const groups = await getEdlGroupInformation({ id: '1234' }, 'joe');
-        expect(groups.isServiceDeployer).is.false;
+        asyncLocalStorage.run(fakeContext, async () => {
+          const groups = await getEdlGroupInformation('joe');
+          expect(groups.isServiceDeployer).is.false;
+        });
       });
     });
     describe('when the user is part of the service deployers and log viewers group', function () {
       it('returns isServiceDeployer:true', async function () {
-        const groups = await getEdlGroupInformation({ id: '1234' }, 'eve');
-        expect(groups.isServiceDeployer).is.true;
+        asyncLocalStorage.run(fakeContext, async () => {
+          const groups = await getEdlGroupInformation('eve');
+          expect(groups.isServiceDeployer).is.true;
+        });
       });
     });
     describe('when the user is part of the service deployers group', function () {
       it('returns isServiceDeployer:true', async function () {
-        const groups = await getEdlGroupInformation({ id: '1234' }, 'buzz');
-        expect(groups.isServiceDeployer).is.true;
+        asyncLocalStorage.run(fakeContext, async () => {
+          const groups = await getEdlGroupInformation('buzz');
+          expect(groups.isServiceDeployer).is.true;
+        });
       });
     });
   });

--- a/services/harmony/test/util/edl-api.ts
+++ b/services/harmony/test/util/edl-api.ts
@@ -24,7 +24,7 @@ describe('util/edl-api', function () {
     });
     describe('when the user is not part of the service deployers group', function () {
       it('returns isServiceDeployer:false', async function () {
-        asyncLocalStorage.run(fakeContext, async () => {
+        await asyncLocalStorage.run(fakeContext, async () => {
           const groups = await getEdlGroupInformation('joe');
           expect(groups.isServiceDeployer).is.false;
         });
@@ -32,7 +32,7 @@ describe('util/edl-api', function () {
     });
     describe('when the user is part of the service deployers and log viewers group', function () {
       it('returns isServiceDeployer:true', async function () {
-        asyncLocalStorage.run(fakeContext, async () => {
+        await asyncLocalStorage.run(fakeContext, async () => {
           const groups = await getEdlGroupInformation('eve');
           expect(groups.isServiceDeployer).is.true;
         });
@@ -40,7 +40,7 @@ describe('util/edl-api', function () {
     });
     describe('when the user is part of the service deployers group', function () {
       it('returns isServiceDeployer:true', async function () {
-        asyncLocalStorage.run(fakeContext, async () => {
+        await asyncLocalStorage.run(fakeContext, async () => {
           const groups = await getEdlGroupInformation('buzz');
           expect(groups.isServiceDeployer).is.true;
         });

--- a/services/harmony/tsconfig.base.json
+++ b/services/harmony/tsconfig.base.json
@@ -10,6 +10,9 @@
     "allowJs": true,
     "noImplicitAny": false,
     "sourceMap": true,
-    "outDir": "built"
+    "outDir": "built",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
   }
 }

--- a/services/query-cmr/app/query.ts
+++ b/services/query-cmr/app/query.ts
@@ -38,7 +38,6 @@ async function querySearchAfter(
     [sessionKey, searchAfter] = scrollId.split(':', 2);
   }
   const cmrResponse = await queryGranulesWithSearchAfter(
-    { 'id': requestId },
     token,
     maxCmrGranules,
     null,

--- a/services/query-cmr/app/routers/router.ts
+++ b/services/query-cmr/app/routers/router.ts
@@ -6,7 +6,6 @@ import { createEncrypter, createDecrypter } from '../../../harmony/app/util/cryp
 import { queryGranules } from '../query';
 import { objectStoreForProtocol } from '../../../harmony/app/util/object-store';
 import { ServerError } from '../../../harmony/app/util/errors';
-import { Logger } from 'winston';
 import RequestContext from '../../../harmony/app/models/request-context';
 import { asyncLocalStorage } from '../../../harmony/app/util/async-store';
 
@@ -80,7 +79,7 @@ async function doWorkHandler(req: Request, res: Response, next: NextFunction): P
   let workLogger;
   try {
     const workReq: QueryCmrRequest = req.body;
-    const { requestId } = workReq.harmonyInput as any;
+    const { requestId } = workReq.harmonyInput as { requestId: string };
     const context = new RequestContext(requestId);
     workLogger = logger.child({ workItemId: workReq.workItemId });
     context.logger = workLogger;

--- a/services/query-cmr/test/query-granules.ts
+++ b/services/query-cmr/test/query-granules.ts
@@ -49,7 +49,7 @@ async function formDataToString(formdata: CombinedStream): Promise<string> {
  * @returns key/value pairs of form data name to value
  */
 async function fetchPostArgsToFields(
-  [_a, _b, formdata],
+  [_a, formdata],
 ): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
   const data = (await formDataToString(formdata)).replace(/----+[0-9]+-*\r\n/g, '');
   const result = {};

--- a/services/query-cmr/test/query-granules.ts
+++ b/services/query-cmr/test/query-granules.ts
@@ -6,7 +6,7 @@ import chai, { expect } from 'chai';
 import { describe, it } from 'mocha';
 import * as sinon from 'sinon';
 import * as fetch from 'node-fetch';
-import { Stream } from 'form-data';
+import { Stream } from 'stream';
 import { queryGranules } from '../app/query';
 import * as cmr from '../../harmony/app/util/cmr';
 import DataOperation from '../../harmony/app/models/data-operation';

--- a/services/query-cmr/tsconfig.base.json
+++ b/services/query-cmr/tsconfig.base.json
@@ -10,6 +10,9 @@
       "allowJs": true,
       "noImplicitAny": false,
       "sourceMap": true,
-      "outDir": "built"
+      "outDir": "built",
+      "typeRoots": [
+        "node_modules/@types"
+      ]
   }
 }

--- a/services/work-failer/tsconfig.base.json
+++ b/services/work-failer/tsconfig.base.json
@@ -12,6 +12,9 @@
     "noImplicitAny": false,
     "sourceMap": true,
     "outDir": "built",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
   },
   "include": [
     "./app",

--- a/services/work-reaper/tsconfig.base.json
+++ b/services/work-reaper/tsconfig.base.json
@@ -13,6 +13,9 @@
     "noImplicitAny": false,
     "sourceMap": true,
     "outDir": "built",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
   },
   "include": [
     "./app",

--- a/services/work-scheduler/tsconfig.json
+++ b/services/work-scheduler/tsconfig.json
@@ -11,7 +11,10 @@
       "noImplicitAny": false,
       "resolveJsonModule": true,
       "sourceMap": true,
-      "outDir": "built"
+      "outDir": "built",
+      "typeRoots": [
+        "node_modules/@types"
+      ]
   },
   "include": ["./app", "./test"]
 }

--- a/services/work-updater/tsconfig.json
+++ b/services/work-updater/tsconfig.json
@@ -10,7 +10,10 @@
       "allowJs": true,
       "noImplicitAny": false,
       "sourceMap": true,
-      "outDir": "built"
+      "outDir": "built",
+      "typeRoots": [
+        "node_modules/@types"
+      ]
   },
   "include": ["./app", "./test"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,9 @@
     "allowJs": true,
     "noImplicitAny": false,
     "sourceMap": true,
-    "outDir": "built"
+    "outDir": "built",
+    "typeRoots": [
+      "node_modules/@types"
+    ]
   }
 }


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1961

## Description
Use AsyncLocalStorage to access context/logger in functions instead of passing it down a call stack.

## Local Test Steps

This is not ready to merge, but I wanted to put it out there to help us decide if we want to go the ASyncLocalStorage route. All the tests are passing, and Harmony in a Box works, but for some reason local development is not (the harmony server can't seem to talk to localstack).

I have not replaced all of the places in the code where we pass a logger down the call stack, but I have replaced quite a few. There are already many changes, so I wanted to get some input before I keep going.

There was some weirdness when calling `asyncLocalStorage.run`, so I had to replace it with `asyncLocalStorage.enterWith`. Apparently there is some problem using `asyncLocalStorage.run with `express` https://github.com/nodejs/node/issues/37207. I don't really understand the difference between the two functions (the explanation was over my head), which makes me nervous that we might run into weird behavior.

Also, I'm not sure that having to read the context wherever we need it is less code than just passing it around. golang has a `context` API and they explicitly pass contexts around rather than using an implicit approach like `AsyncLocalStorage`, so there is that, I guess. One big pain is that using `AsyncLocalStorage` means we need to use `run` or `enterWith` in all the tests that call those functions. This is kind of a pain. We could change are code to use things like a default logger or default context if one is not passed in (we do that already in a couple of places), but that means we logic in our functions just to support test invocations, which I find icky.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [x] Harmony in a Box tested? (if changes made to microservices)