### PR TITLE
Harmony 1971 - Improve slow query for jobs+labels in jobs and workflow ui admin endpoints

### DIFF
--- a/services/harmony/app/frontends/jobs.ts
+++ b/services/harmony/app/frontends/jobs.ts
@@ -126,7 +126,7 @@ export async function getJobsListing(
     req.context.logger.info(`Get jobs listing for user ${req.user}`);
     const root = getRequestRoot(req);
     const { page, limit } = getPagingParams(req, env.defaultJobListPageSize);
-    const query: JobQuery = { where: {} };
+    const query: JobQuery = { where: {}, orderBy: { field: 'jobs.id', value: 'asc' } };
     query.labels = req.body.label;
 
     if (!req.context.isAdminAccess) {

--- a/services/harmony/app/frontends/jobs.ts
+++ b/services/harmony/app/frontends/jobs.ts
@@ -126,7 +126,7 @@ export async function getJobsListing(
     req.context.logger.info(`Get jobs listing for user ${req.user}`);
     const root = getRequestRoot(req);
     const { page, limit } = getPagingParams(req, env.defaultJobListPageSize);
-    const query: JobQuery = { where: {}, orderBy: { field: 'jobs.id', value: 'asc' } };
+    const query: JobQuery = { where: {}, orderBy: { field: 'jobs.id', value: 'desc' } };
     query.labels = req.body.label;
 
     if (!req.context.isAdminAccess) {

--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -260,7 +260,7 @@ function jobRenderingFunctions(logger: Logger, requestQuery: Record<string, any>
  * @returns JobQuery
  */
 function tableQueryToJobQuery(tableQuery: TableQuery, isAdmin: boolean, user: string, jobIDs?: string[]): JobQuery {
-  const jobQuery: JobQuery = { where: {}, whereIn: {} };
+  const jobQuery: JobQuery = { where: {}, whereIn: {}, orderBy: { field: 'jobs.id', value: 'desc' } };
   if (tableQuery.sortGranules) {
     jobQuery.orderBy = {
       field: 'numInputGranules',


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1971

## Description
This improves the slow query that was hampering endpoints that pull back jobs + their tags (specifically the workflow ui and /jobs) from roughly 5 seconds of page load time to ~2 seconds in my testing.

Old query explain analyze output:
> Limit  (cost=219030.78..219030.79 rows=5 width=689) (actual time=4543.265..4562.898 rows=5 loops=1)
>   ->  Sort  (cost=219030.78..220021.01 rows=396094 width=689) (actual time=4543.263..4562.894 rows=5 loops=1)
>         Sort Key: jobs."createdAt" DESC
>         Sort Method: top-N heapsort  Memory: 31kB
>         ->  GroupAggregate  (cost=159388.48..212451.80 rows=396094 width=689) (actual time=2527.451..4222.021 rows=396094 loops=1)
>               Group Key: jobs.id
>               ->  Gather Merge  (cost=159388.48..205520.15 rows=396094 width=675) (actual time=2527.412..3147.100 rows=396796 loops=1)
>                     Workers Planned: 2
>                     Workers Launched: 2
>                     ->  Sort  (cost=158388.46..158801.05 rows=165039 width=675) (actual time=2366.444..2478.519 rows=132265 loops=3)

New query explain analyze output:
> Limit  (cost=0.97..5.14 rows=5 width=689) (actual time=0.135..0.190 rows=5 loops=1)
>   ->  GroupAggregate  (cost=0.97..330491.09 rows=396094 width=689) (actual time=0.133..0.186 rows=5 loops=1)
>         Group Key: jobs.id
>         ->  Nested Loop Left Join  (cost=0.97..323559.44 rows=396094 width=675) (actual time=0.082..0.137 rows=7 loops=1)
>               ->  Nested Loop Left Join  (cost=0.70..200910.17 rows=396094 width=661) (actual time=0.068..0.107 rows=7 loops=1)
>                     ->  Index Scan Backward using jobs_pkey on jobs  (cost=0.42..69108.91 rows=396094 width=657) (actual time=0.053..0.063 rows=6 loops=1)
>                     ->  Index Scan using jobs_raw_labels_job_id on jobs_raw_labels  (cost=0.28..0.31 rows=2 width=20) (actual time=0.005..0.005 rows=0 loops=6)
>                           Index Cond: (job_id = jobs."jobID")
>               ->  Index Scan using raw_labels_pkey on raw_labels  (cost=0.27..0.31 rows=1 width=22) (actual time=0.002..0.002 rows=0 loops=7)
>                     Index Cond: (id = jobs_raw_labels.label_id)

## Local Test Steps
First, tunnel to a harmony db (that has sufficient data) using the harmony toolbox.

To test the query by itself in order to verify performance you can run:
```sql
explain analyze select "jobs".*, STRING_AGG(raw_labels.value, ',' order by value) AS label_values from "jobs"
    LEFT OUTER JOIN "jobs_raw_labels" ON jobs."jobID" = jobs_raw_labels."job_id"
    LEFT OUTER JOIN "raw_labels" ON jobs_raw_labels."label_id" = raw_labels."id"
GROUP BY
    jobs."id"
ORDER BY
    "createdAt" DESC
LIMIT 10
```
Then switch the order by field to `jobs."id"`.
Verify that the query is significantly faster and uses relevant indexes. Also verify that the jobs returned are the same as what they were prior to switching the order by field, and in the same order.

To test all of this from the users perspective:
- Replace `DATABASE_URL` in your .env with `postgresql://harmony:<sandbox-db-password>@localhost:1234/harmony`
- Start harmony with this branch locally
- Load the admin jobs and admin workflow ui endpoints (it should be fairly fast)
- Get rid of the changes from this pull request and now those pages should load fairly slowly

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested? (if changes made to microservices)