### PR TITLE
HARMONY-1942: Add optional use of krelay for port forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ built-in Kubernetes cluster (including `kubectl`) which can be enabled in prefer
 * [openssl](https://www.openssl.org/) Read [this installation guide](https://github.com/openssl/openssl/blob/master/NOTES-WINDOWS.md) if you're a Windows user and openssl is not installed on your machine already.
 * [envsubst](https://pypi.org/project/envsubst) - Used to substitute environment variable placeholders inside configuration files.
 * [Earthdata Login token in UAT](https://uat.urs.earthdata.nasa.gov) - You will need to create an account and then use the "Generate Token" link from your profile page to obtain a token.
+* (optional) [k9s](https://k9scli.io/) - An easy to use GUI for `kubectl`. `k9s` makes it easy to monitor and control your local kubernetes cluster.
+* (optional) [krelay](https://github.com/knight42/krelay?tab=readme-ov-file#installation) - If you are running into problems with port forwarding, `krelay` may help.
 
 2. Download this repository (or download the zip file from GitHub)
 ```bash
@@ -36,7 +38,12 @@ git clone https://github.com/nasa/harmony.git
   ```
    Edit the `.env` file if you want to add any image tags for a custom service (see the `env-defaults` file). You can skip this step for now if you just want to use the default service tags.
 
-4. Run the bootstrap script and answer the prompts (if any)
+4. (optional) Tell Harmony to use `krelay` for port forwarding. You must have installed `krelay` using the link above. This is only advised if you are having issues with the standard port forwarding. One advantage to `krelay` over the standard port forwarding is that with `krelay` the port forwarding will survive pod restarts.
+```bash
+export USE_KRELAY=true
+```
+
+5. Run the bootstrap script and answer the prompts (if any)
 ```bash
 cd harmony && ./bin/bootstrap-harmony
 ```

--- a/bin/port-forward
+++ b/bin/port-forward
@@ -63,6 +63,9 @@ function start_port_forwarding() {
 function stop_port_forwarding() {
   local service_name="$1"
   local process_name="kubectl -n harmony port-forward service/${service_name}"
+  if [ "$USE_KRELAY" == "true" ]; then
+    process_name="kubectl-relay service/${service_name}"
+  fi
   local running=$(pgrep -f "${process_name}")
   if [ -n "${running}" ]; then
     echo "Stopping port forwarding for service: ${service_name}"
@@ -76,6 +79,9 @@ function stop_port_forwarding() {
 function is_port_forwarding_running() {
   local service_name="$1"
   local process_name="kubectl -n harmony port-forward service/${service_name}"
+  if [ "$USE_KRELAY" == "true" ]; then
+    process_name="kubectl-relay service/${service_name}"
+  fi
   pgrep -f "${process_name}" >/dev/null
 }
 

--- a/bin/port-forward
+++ b/bin/port-forward
@@ -52,7 +52,7 @@ function start_port_forwarding() {
   if [ "$USE_KRELAY" == "true" ]; then
     echo "Using krelay to set up port forwarding for $service_name"
     nohup kubectl relay "service/${service_name}" "${args[@]}" -n harmony > "logs/port-forward-${service_name}.log" 2>&1 &
-    # krelay does not have a good way to indicate that it is ready, so we have to restort to this for right now
+    # krelay does not have a good way to indicate that it is ready, so we have to resort to this for right now
     sleep 3
   else
     nohup kubectl -n harmony port-forward "service/${service_name}" "${args[@]}" > "logs/port-forward-${service_name}.log" 2>&1 &

--- a/bin/port-forward
+++ b/bin/port-forward
@@ -49,7 +49,14 @@ function start_port_forwarding() {
   fi
 
   kubectl wait -n harmony --for=condition=ready pod -l app="$service_name" --timeout=120s
-  nohup kubectl -n harmony port-forward "service/${service_name}" "${args[@]}" > "logs/port-forward-${service_name}.log" 2>&1 &
+  if [ "$USE_KRELAY" == "true" ]; then
+    echo "Using krelay to set up port forwarding for $service_name"
+    nohup kubectl relay "service/${service_name}" "${args[@]}" -n harmony > "logs/port-forward-${service_name}.log" 2>&1 &
+    # krelay does not have a good way to indicate that it is ready, so we have to restort to this for right now
+    sleep 3
+  else
+    nohup kubectl -n harmony port-forward "service/${service_name}" "${args[@]}" > "logs/port-forward-${service_name}.log" 2>&1 &
+  fi
   echo "Port forwarding started for service: ${service_name}, port pairs: ${port_pairs[*]}"
 }
 

--- a/bin/start-all
+++ b/bin/start-all
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# stop any running krelay pods
+kubectl delete pods -l app=krelay-server
+
 # start postgress, localstack, and harmony in the harmony namespace in the local kubernetes cluster
 
 ./bin/start-postgres-localstack

--- a/bin/stop-harmony-and-services
+++ b/bin/stop-harmony-and-services
@@ -16,6 +16,8 @@ fi
 bin/port-forward stop harmony
 bin/port-forward stop localstack
 bin/port-forward stop postgres
+# delete all the krelay pods
+kubectl delete pods -l app=krelay-server
 kubectl delete ns harmony
 
 # stop any services running in development mode


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1942


## Description
This PR adds support for using [krelay](https://github.com/knight42/krelay) to handle port-forwarding. The primary advantage to `krelay` is that port forwarding will survive pod restarts. Using `krelay` is optional (controlled by the USE_KRELAY env var), and defaults to not using it.

## Local Test Steps
1. kill your locally running harmony
```
./bin/stop-harmony-and-services`
```
2.  Check out this branch
3. Enable `krelay`
```
export USE_KRELAY=true
```
4. Run Harmony in a Box (Harmony in k8s)
5. Verify that Harmony runs correctly (workflow-ui, etc.)
6. Use `kubectl` or `k9s` to kill off the harmony pod
7. Wait for the harmony pod to retart
8. Verify harmony is still accessible (workflow-ui, etc.)

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] ~Tests added/updated (if needed) and passing~
* [x] Documentation updated (if needed)
* [x] Harmony in a Box tested? (if changes made to microservices)