### PR TITLE
HARMONY-1958: Allow service chains to skip validating variables exist in the CMR

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -677,10 +677,11 @@ https://cmr.uat.earthdata.nasa.gov:
           <<: *default-turbo-env
           STAGING_PATH: public/gesdisc/giovanni
     umm_s: S1258984104-GES_DISC
-    collections:
-      - id: C1215802935-GES_DISC
-        variables:
-        - V1268438218-GES_DISC
+    validate_variables: false
+    # collections:
+    #   - id: C1215802935-GES_DISC
+    #     variables:
+    #     - V1268438218-GES_DISC
     capabilities:
       subsetting:
         temporal: true
@@ -1286,6 +1287,7 @@ https://cmr.uat.earthdata.nasa.gov:
         - image/png
         - image/gif
       reprojection: true
+    # validate_variables: false
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true

--- a/config/services.yml
+++ b/config/services.yml
@@ -677,11 +677,10 @@ https://cmr.uat.earthdata.nasa.gov:
           <<: *default-turbo-env
           STAGING_PATH: public/gesdisc/giovanni
     umm_s: S1258984104-GES_DISC
-    validate_variables: false
-    # collections:
-    #   - id: C1215802935-GES_DISC
-    #     variables:
-    #     - V1268438218-GES_DISC
+    collections:
+      - id: C1215802935-GES_DISC
+        variables:
+        - V1268438218-GES_DISC
     capabilities:
       subsetting:
         temporal: true
@@ -1287,7 +1286,6 @@ https://cmr.uat.earthdata.nasa.gov:
         - image/png
         - image/gif
       reprojection: true
-    # validate_variables: false
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true

--- a/docs/guides/adapting-new-services.md
+++ b/docs/guides/adapting-new-services.md
@@ -187,6 +187,7 @@ The structure of an entry in the [services.yml](../../config/services.yml) file 
       - image/png
       - image/gif
     reprojection: true            # The service supports reprojection
+  validate_variables: true        # Whether to validate the requested variables exist in the CMR. Defaults to true.
   steps:
       - image: !Env ${QUERY_CMR_IMAGE} # The image to use for the first step in the chain
       - image: !Env ${HARMONY_EXAMPLE_IMAGE}     # The image to use for the second step in the chain

--- a/services/harmony/app/frontends/capabilities.ts
+++ b/services/harmony/app/frontends/capabilities.ts
@@ -85,7 +85,7 @@ async function loadCollectionInfo(req: HarmonyRequest): Promise<CmrCollection> {
     collections = await getCollectionsByShortName(req.context, shortname, req.accessToken);
     if (collections.length === 0) {
       const message = `Unable to find collection short name ${shortname} in the CMR. Please `
-        + ' make sure the short name is correct and that you have access to the collection.';
+        + 'make sure the short name is correct and that you have access to the collection.';
       throw new NotFoundError(message);
     }
     pickedCollection = collections[0];

--- a/services/harmony/app/frontends/ogc-coverages/get-coverage-rangeset.ts
+++ b/services/harmony/app/frontends/ogc-coverages/get-coverage-rangeset.ts
@@ -12,7 +12,7 @@ import { parseVariables } from '../../util/variables';
 import { parsePointParam, parseSubsetParams, subsetParamsToBbox, subsetParamsToTemporal } from './util/subset-parameter-parsing';
 /**
  * Express middleware that responds to OGC API - Coverages coverage
- * rangeset requests.  Responds with the actual coverage data.
+ * rangeset requests. Responds with the actual coverage data.
  *
  * @param req - The request sent by the client
  * @param res - The response to send to the client
@@ -87,11 +87,8 @@ export default function getCoverageRangeset(
   }
 
   const queryVars = req.query.variable as string | string[];
-  const varInfos = parseVariables(req.collections, req.params.collectionId, queryVars);
-  for (const varInfo of varInfos) {
-    operation.addSource(varInfo.collectionId, varInfo.shortName, varInfo.versionId,
-      varInfo.variables, varInfo.coordinateVariables);
-  }
+  const requestedVariables = parseVariables(req.params.collectionId, queryVars);
+  req.context.requestedVariables = requestedVariables;
 
   req.operation = operation;
   next();

--- a/services/harmony/app/frontends/ogc-coverages/index.ts
+++ b/services/harmony/app/frontends/ogc-coverages/index.ts
@@ -60,7 +60,7 @@ function TODO(req: HarmonyRequest, res: Response): void {
 function getSpecification(req: HarmonyRequest, res: Response): void {
   // Defined inline because the index file deals with the YAML spec.
   res.append('Content-type', 'text/openapi+yaml;version=3.0');
-  res.send(openApiContent.replace('no-default-cmr-collection', req.collectionIds.join('/')));
+  res.send(openApiContent.replace('no-default-cmr-collection', req.context.collectionIds.join('/')));
 }
 
 /**

--- a/services/harmony/app/frontends/ogc-edr/get-data-common.ts
+++ b/services/harmony/app/frontends/ogc-edr/get-data-common.ts
@@ -77,11 +77,8 @@ export function getDataCommon(
     queryVars = ['all'];
   }
 
-  const varInfos = parseVariables(req.collections, 'parameter_vars', queryVars);
-  for (const varInfo of varInfos) {
-    operation.addSource(varInfo.collectionId, varInfo.shortName, varInfo.versionId,
-      varInfo.variables, varInfo.coordinateVariables);
-  }
+  const requestedVariables = parseVariables('parameter_vars', queryVars);
+  req.context.requestedVariables = requestedVariables;
 
   req.operation = operation;
 }

--- a/services/harmony/app/frontends/wms.ts
+++ b/services/harmony/app/frontends/wms.ts
@@ -264,7 +264,7 @@ export default async function wmsFrontend(req, res, next: NextFunction): Promise
   try {
     validateParamIn(query, 'service', ['WMS']);
     validateParamIn(query, 'request', ['GetCapabilities', 'GetMap']);
-    if (!req.collections.every(services.isCollectionSupported)) {
+    if (!req.context.collections.every(services.isCollectionSupported)) {
       throw new NotFoundError('There is no service configured to support transformations on the provided collection via WMS.');
     }
 

--- a/services/harmony/app/middleware/cmr-granule-locator.ts
+++ b/services/harmony/app/middleware/cmr-granule-locator.ts
@@ -29,7 +29,7 @@ enum GranuleLimitReason {
  * @returns the collection from the request that has the given id
  */
 function getCollectionFromRequest(req: HarmonyRequest, collectionId: string): CmrCollection {
-  return req.collections.find((collection) => collection.id === collectionId);
+  return req.context.collections.find((collection) => collection.id === collectionId);
 }
 
 /**

--- a/services/harmony/app/middleware/cmr-umm-collection-reader.ts
+++ b/services/harmony/app/middleware/cmr-umm-collection-reader.ts
@@ -13,12 +13,12 @@ async function cmrUmmCollectionReader(req: HarmonyRequest, res, next: NextFuncti
   try {
     const hasUmmConditional = req.context.serviceConfig?.steps?.filter((s) => s.conditional?.umm_c);
     if (hasUmmConditional && hasUmmConditional.length > 0) {
-      req.operation.ummCollections = await getUmmCollectionsByIds(req.context, req.collectionIds, req.accessToken);
+      req.operation.ummCollections = await getUmmCollectionsByIds(req.context, req.context.collectionIds, req.accessToken);
     }
     next();
   } catch (error) {
-    req.collectionIds = [];
-    req.collections = [];
+    req.context.collectionIds = [];
+    req.context.collections = [];
     next(error);
   }
 }

--- a/services/harmony/app/middleware/restricted-variables.ts
+++ b/services/harmony/app/middleware/restricted-variables.ts
@@ -1,0 +1,61 @@
+import { NextFunction, Response } from 'express';
+import HarmonyRequest from '../models/harmony-request';
+import { RequestValidationError } from '../util/errors';
+import DataOperation, { DataSource } from '../models/data-operation';
+import { ServiceCollection, ServiceConfig } from '../models/services/base-service';
+import { partial } from 'lodash';
+
+/**
+ * Determines whether or not a given ServiceCollection supports a given DataSource, i.e.,
+ * the Service Collection has a matching collection id and variables
+ *
+ * @param source - The DataSource from an operation
+ * @param servColl - The ServiceCollection defined in services.yml
+ * @returns `true` if the collections are the same and if variables are not defined
+ * for the service collection or all the variables in the source are also in the service
+ * collection, `false` otherwise
+ */
+function isServiceCollectionMatch(source: DataSource, servColl: ServiceCollection): boolean {
+  return servColl.id === source.collection &&
+    (!servColl.variables || source.variables?.every((v) => servColl.variables?.includes(v.id)));
+}
+
+/**
+ * Returns true if all of the collections in the given operation can be operated on by
+ * the given service.
+ *
+ * @param operation - The operation to match
+ * @param serviceConfig - A configuration for a single service from services.yml
+ * @returns true if all collections in the operation are compatible with the service and
+ *     false otherwise
+ */
+function isEveryVariableSupported(
+  operation: DataOperation,
+  serviceConfig: ServiceConfig<unknown>,
+): boolean {
+  return serviceConfig.capabilities?.all_collections || operation.sources.every((source) => {
+    const rval = serviceConfig.collections?.some(partial(isServiceCollectionMatch, source));
+    return rval;
+  });
+}
+
+/**
+ * Middleware to only allow a subset of UMM-Var variables to be used with a service chain
+ * with the list of variables configured in services.yml
+ * @param req - The client request, containing an operation
+ * @param res - The client response
+ * @param next - The next function in the middleware chain
+ */
+export default function validateRestrictedVariables(
+  req: HarmonyRequest, _res: Response, next: NextFunction,
+): void {
+  const { operation, context } = req;
+  if (!operation?.sources) {
+    return next();
+  }
+  if (!isEveryVariableSupported(operation, context.serviceConfig)) {
+    const error = new RequestValidationError('Not all variables selected can be subset');
+    return next(error);
+  }
+  return next();
+}

--- a/services/harmony/app/middleware/service-selection.ts
+++ b/services/harmony/app/middleware/service-selection.ts
@@ -59,7 +59,6 @@ export default function chooseService(
   } catch (e) {
     return next(e);
   }
-  console.log(`CDD: Chose service config: ${serviceConfig.name}`);
   context.serviceConfig = serviceConfig;
   return next();
 }

--- a/services/harmony/app/middleware/service-selection.ts
+++ b/services/harmony/app/middleware/service-selection.ts
@@ -53,12 +53,13 @@ export default function chooseService(
   }
 
   let serviceConfig: ServiceConfig<unknown>;
-  const configs = addCollectionsToServicesByAssociation(req.collections);
+  const configs = addCollectionsToServicesByAssociation(req.context.collections);
   try {
     serviceConfig = chooseServiceConfig(operation, context, configs);
   } catch (e) {
     return next(e);
   }
+  console.log(`CDD: Chose service config: ${serviceConfig.name}`);
   context.serviceConfig = serviceConfig;
   return next();
 }

--- a/services/harmony/app/models/harmony-request.ts
+++ b/services/harmony/app/models/harmony-request.ts
@@ -1,5 +1,4 @@
 import { Response, NextFunction, Request } from 'express';
-// import { CmrCollection } from '../util/cmr';
 import RequestContext from './request-context';
 import DataOperation from './data-operation';
 
@@ -8,8 +7,6 @@ import DataOperation from './data-operation';
  */
 export default interface HarmonyRequest extends Request {
   context: RequestContext;
-  // collections: CmrCollection[];
-  // collectionIds: string[];
   operation: DataOperation;
   user: string;
   accessToken: string;

--- a/services/harmony/app/models/harmony-request.ts
+++ b/services/harmony/app/models/harmony-request.ts
@@ -1,5 +1,5 @@
 import { Response, NextFunction, Request } from 'express';
-import { CmrCollection } from '../util/cmr';
+// import { CmrCollection } from '../util/cmr';
 import RequestContext from './request-context';
 import DataOperation from './data-operation';
 
@@ -8,8 +8,8 @@ import DataOperation from './data-operation';
  */
 export default interface HarmonyRequest extends Request {
   context: RequestContext;
-  collections: CmrCollection[];
-  collectionIds: string[];
+  // collections: CmrCollection[];
+  // collectionIds: string[];
   operation: DataOperation;
   user: string;
   accessToken: string;

--- a/services/harmony/app/models/request-context.ts
+++ b/services/harmony/app/models/request-context.ts
@@ -1,5 +1,6 @@
 import { Logger } from 'winston';
 import { ServiceConfig } from './services/base-service';
+import { CmrCollection } from '../util/cmr';
 
 interface ShapefileObject {
   typeName?: string;
@@ -35,6 +36,12 @@ export default class RequestContext {
   messages?: string[];
 
   startTime?: Date;
+
+  requestedVariables?: string[];
+
+  collectionIds?: string[];
+
+  collections?: CmrCollection[];
 
   /**
    * Creates an instance of RequestContext.

--- a/services/harmony/app/models/services/base-service.ts
+++ b/services/harmony/app/models/services/base-service.ts
@@ -84,6 +84,7 @@ export interface ServiceConfig<ServiceParamType> {
   message?: string;
   maximum_sync_granules?: number;
   steps?: ServiceStep[];
+  validate_variables?: boolean;
 }
 
 /**

--- a/services/harmony/app/models/services/index.ts
+++ b/services/harmony/app/models/services/index.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'js-yaml';
-import _, { get as getIn, partial } from 'lodash';
+// import _, { get as getIn, partial } from 'lodash';
+import _, { get as getIn } from 'lodash';
 
 import logger from '../../util/log';
 import { HttpError, NotFoundError, ServerError } from '../../util/errors';
@@ -11,8 +12,10 @@ import { addCollectionsToServicesByAssociation } from '../../middleware/service-
 import { listToText, Conjunction, isInteger } from '@harmony/util/string';
 import TurboService from './turbo-service';
 import HttpService from './http-service';
-import DataOperation, { DataSource } from '../data-operation';
-import BaseService, { ServiceCollection, ServiceConfig } from './base-service';
+// import DataOperation, { DataSource } from '../data-operation';
+import DataOperation from '../data-operation';
+// import BaseService, { ServiceCollection, ServiceConfig } from './base-service';
+import BaseService, { ServiceConfig } from './base-service';
 import RequestContext from '../request-context';
 import env from '../../util/env';
 
@@ -220,10 +223,10 @@ function supportsConcatenation(configs: ServiceConfig<unknown>[]): ServiceConfig
  * for the service collection or all the variables in the source are also in the service
  * collection, `false` otherwise
  */
-function isServiceCollectionMatch(source: DataSource, servColl: ServiceCollection): boolean {
-  return servColl.id === source.collection &&
-    (!servColl.variables || source.variables?.every((v) => servColl.variables?.includes(v.id)));
-}
+// function isServiceCollectionMatch(source: DataSource, servColl: ServiceCollection): boolean {
+//   return servColl.id === source.collection &&
+//     (!servColl.variables || source.variables?.every((v) => servColl.variables?.includes(v.id)));
+// }
 
 /**
  * Returns true if all of the collections in the given operation can be operated on by
@@ -236,12 +239,19 @@ function isServiceCollectionMatch(source: DataSource, servColl: ServiceCollectio
  */
 function isCollectionMatch(
   operation: DataOperation,
+  context: RequestContext,
   serviceConfig: ServiceConfig<unknown>,
 ): boolean {
-  return serviceConfig.capabilities?.all_collections || operation.sources.every((source) => {
-    const rval = serviceConfig.collections?.some(partial(isServiceCollectionMatch, source));
-    return rval;
+  return serviceConfig.capabilities?.all_collections || context.collectionIds.every((collectionId) => {
+    if (serviceConfig.name === 'harmony/service-example') console.log(`CDD Checking matches for ${collectionId} in ${serviceConfig.collections.map((sc) => sc.id)} for service ${serviceConfig.name}`);
+    const allCollections = serviceConfig.collections?.map((sc) => sc.id);
+    if (allCollections.includes(collectionId)) console.log(`Found collection ${collectionId} in ${allCollections}`);
+    return serviceConfig.collections?.map((sc) => sc.id).includes(collectionId);
   });
+  // return serviceConfig.capabilities?.all_collections || operation.sources.every((source) => {
+  //   const rval = serviceConfig.collections?.some(partial(isServiceCollectionMatch, source));
+  //   return rval;
+  // });
 }
 
 /**
@@ -324,11 +334,14 @@ function requiresConcatenation(operation: DataOperation): boolean {
 
 /**
  * Returns true if the operation requires variable subsetting
- * @param operation - The operation to perform.
+ * @param context - Additional context that's not part of the operation, but influences the
+ *     choice regarding the service to use
  * @returns true if the provided operation requires variable subsetting and false otherwise
  */
-function requiresVariableSubsetting(operation: DataOperation): boolean {
-  return operation.shouldVariableSubset;
+function requiresVariableSubsetting(context: RequestContext): boolean {
+  // console.log(`Context is ${JSON.stringify(context)}`);
+  // console.log(`Requested variables length is : ${context.requestedVariables?.length} and boolean is ${context.requestedVariables?.length > 0}`);
+  return context.requestedVariables?.length > 0;
 }
 
 /**
@@ -487,10 +500,12 @@ function supportsAreaAveraging(configs: ServiceConfig<unknown>[]): ServiceConfig
 export class UnsupportedOperation extends HttpError {
   operation: DataOperation;
 
+  context: RequestContext;
+
   requestedOperations: string[];
 
-  constructor(operation: DataOperation, requestedOperations: string[]) {
-    const collections = operation.sources.map((s) => s.collection);
+  constructor(operation: DataOperation, context: RequestContext, requestedOperations: string[]) {
+    const collections = context.collectionIds;
 
     let message = `no operations can be performed on ${listToText(collections)}`;
     if (requestedOperations.length > 0) {
@@ -499,6 +514,7 @@ export class UnsupportedOperation extends HttpError {
     }
     super(422, message);
     this.operation = operation;
+    this.context = context;
     this.requestedOperations = requestedOperations;
   }
 }
@@ -526,7 +542,7 @@ function filterConcatenationMatches(
   }
 
   if (matches.length === 0) {
-    throw new UnsupportedOperation(operation, requestedOperations);
+    throw new UnsupportedOperation(operation, context, requestedOperations);
   }
   return matches;
 }
@@ -547,9 +563,9 @@ function filterCollectionMatches(
   configs: ServiceConfig<unknown>[],
   requestedOperations: string[],
 ): ServiceConfig<unknown>[] {
-  const matches = configs.filter((config) => isCollectionMatch(operation, config));
+  const matches = configs.filter((config) => isCollectionMatch(operation, context, config));
   if (matches.length === 0) {
-    throw new UnsupportedOperation(operation, requestedOperations);
+    throw new UnsupportedOperation(operation, context, requestedOperations);
   }
   return matches;
 }
@@ -572,13 +588,15 @@ function filterVariableSubsettingMatches(
   requestedOperations: string[],
 ): ServiceConfig<unknown>[] {
   let matches = configs;
-  if (requiresVariableSubsetting(operation)) {
+  if (requiresVariableSubsetting(context)) {
     requestedOperations.push('variable subsetting');
+    console.log(`CDD Before there were ${matches.length} matches: ${matches.map((s) => s.name)}`);
     matches = supportsVariableSubsetting(configs);
+    console.log(`CDD After there were ${matches.length} matches`);
   }
 
   if (matches.length === 0) {
-    throw new UnsupportedOperation(operation, requestedOperations);
+    throw new UnsupportedOperation(operation, context, requestedOperations);
   }
   return matches;
 }
@@ -612,7 +630,7 @@ function filterOutputFormatMatches(
   }
 
   if (services.length === 0) {
-    throw new UnsupportedOperation(operation, requestedOperations);
+    throw new UnsupportedOperation(operation, context, requestedOperations);
   }
   return services;
 }
@@ -641,7 +659,7 @@ function filterSpatialSubsettingMatches(
   }
 
   if (services.length === 0) {
-    throw new UnsupportedOperation(operation, requestedOperations);
+    throw new UnsupportedOperation(operation, context, requestedOperations);
   }
   return services;
 }
@@ -670,7 +688,7 @@ function filterReprojectionMatches(
   }
 
   if (services.length === 0) {
-    throw new UnsupportedOperation(operation, requestedOperations);
+    throw new UnsupportedOperation(operation, context, requestedOperations);
   }
   return services;
 }
@@ -699,7 +717,7 @@ function filterShapefileSubsettingMatches(
   }
 
   if (services.length === 0) {
-    throw new UnsupportedOperation(operation, requestedOperations);
+    throw new UnsupportedOperation(operation, context, requestedOperations);
   }
   return services;
 }
@@ -728,7 +746,7 @@ function filterTemporalSubsettingMatches(
   }
 
   if (services.length === 0) {
-    throw new UnsupportedOperation(operation, requestedOperations);
+    throw new UnsupportedOperation(operation, context, requestedOperations);
   }
   return services;
 }
@@ -757,7 +775,7 @@ function filterExtendMatches(
   }
 
   if (services.length === 0) {
-    throw new UnsupportedOperation(operation, requestedOperations);
+    throw new UnsupportedOperation(operation, context, requestedOperations);
   }
   return services;
 }
@@ -786,7 +804,7 @@ function filterDimensionSubsettingMatches(
   }
 
   if (services.length === 0) {
-    throw new UnsupportedOperation(operation, requestedOperations);
+    throw new UnsupportedOperation(operation, context, requestedOperations);
   }
   return services;
 }
@@ -815,7 +833,7 @@ function filterTimeAveragingMatches(
   }
 
   if (services.length === 0) {
-    throw new UnsupportedOperation(operation, requestedOperations);
+    throw new UnsupportedOperation(operation, context, requestedOperations);
   }
   return services;
 }
@@ -844,7 +862,7 @@ function filterAreaAveragingMatches(
   }
 
   if (services.length === 0) {
-    throw new UnsupportedOperation(operation, requestedOperations);
+    throw new UnsupportedOperation(operation, context, requestedOperations);
   }
   return services;
 }
@@ -978,7 +996,7 @@ function requiresStrictCapabilitiesMatching(
   if (
     // Request is only asking for one of temporal or spatial subsetting and
     // is not asking for any other operation, so force making matching strict
-    !requiresVariableSubsetting(operation)
+    !requiresVariableSubsetting(context)
     && !requiresReprojection(operation)
     && !requiresReformatting(operation, context)
     && !requiresConcatenation(operation)
@@ -1009,7 +1027,9 @@ export function chooseServiceConfig(
   let serviceConfig;
   try {
     serviceConfig = filterServiceConfigs(operation, context, configs, allFilterFns);
+    console.log(`CDD - it found a service with strict filtering used (so can't be HyBIG) ${serviceConfig.name}`);
   } catch (e) {
+    console.log(`CDD - bad news - an exception was thrown: ${e.message}`);
     if (e instanceof UnsupportedOperation) {
       if (!requiresStrictCapabilitiesMatching(operation, context)) {
         // if we couldn't find a matching service, make a best effort to find a service that

--- a/services/harmony/app/models/services/index.ts
+++ b/services/harmony/app/models/services/index.ts
@@ -243,9 +243,6 @@ function isCollectionMatch(
   serviceConfig: ServiceConfig<unknown>,
 ): boolean {
   return serviceConfig.capabilities?.all_collections || context.collectionIds.every((collectionId) => {
-    if (serviceConfig.name === 'harmony/service-example') console.log(`CDD Checking matches for ${collectionId} in ${serviceConfig.collections.map((sc) => sc.id)} for service ${serviceConfig.name}`);
-    const allCollections = serviceConfig.collections?.map((sc) => sc.id);
-    if (allCollections.includes(collectionId)) console.log(`Found collection ${collectionId} in ${allCollections}`);
     return serviceConfig.collections?.map((sc) => sc.id).includes(collectionId);
   });
   // return serviceConfig.capabilities?.all_collections || operation.sources.every((source) => {
@@ -339,8 +336,6 @@ function requiresConcatenation(operation: DataOperation): boolean {
  * @returns true if the provided operation requires variable subsetting and false otherwise
  */
 function requiresVariableSubsetting(context: RequestContext): boolean {
-  // console.log(`Context is ${JSON.stringify(context)}`);
-  // console.log(`Requested variables length is : ${context.requestedVariables?.length} and boolean is ${context.requestedVariables?.length > 0}`);
   return context.requestedVariables?.length > 0;
 }
 
@@ -590,9 +585,7 @@ function filterVariableSubsettingMatches(
   let matches = configs;
   if (requiresVariableSubsetting(context)) {
     requestedOperations.push('variable subsetting');
-    console.log(`CDD Before there were ${matches.length} matches: ${matches.map((s) => s.name)}`);
     matches = supportsVariableSubsetting(configs);
-    console.log(`CDD After there were ${matches.length} matches`);
   }
 
   if (matches.length === 0) {
@@ -1027,9 +1020,7 @@ export function chooseServiceConfig(
   let serviceConfig;
   try {
     serviceConfig = filterServiceConfigs(operation, context, configs, allFilterFns);
-    console.log(`CDD - it found a service with strict filtering used (so can't be HyBIG) ${serviceConfig.name}`);
   } catch (e) {
-    console.log(`CDD - bad news - an exception was thrown: ${e.message}`);
     if (e instanceof UnsupportedOperation) {
       if (!requiresStrictCapabilitiesMatching(operation, context)) {
         // if we couldn't find a matching service, make a best effort to find a service that

--- a/services/harmony/app/models/services/index.ts
+++ b/services/harmony/app/models/services/index.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as yaml from 'js-yaml';
-// import _, { get as getIn, partial } from 'lodash';
 import _, { get as getIn } from 'lodash';
 
 import logger from '../../util/log';
@@ -12,9 +11,7 @@ import { addCollectionsToServicesByAssociation } from '../../middleware/service-
 import { listToText, Conjunction, isInteger } from '@harmony/util/string';
 import TurboService from './turbo-service';
 import HttpService from './http-service';
-// import DataOperation, { DataSource } from '../data-operation';
 import DataOperation from '../data-operation';
-// import BaseService, { ServiceCollection, ServiceConfig } from './base-service';
 import BaseService, { ServiceConfig } from './base-service';
 import RequestContext from '../request-context';
 import env from '../../util/env';
@@ -214,21 +211,6 @@ function supportsConcatenation(configs: ServiceConfig<unknown>[]): ServiceConfig
 }
 
 /**
- * Determines whether or not a given ServiceCollection supports a given DataSource, i.e.,
- * the Service Collection has a matching collection id and variables
- *
- * @param source - The DataSource from an operation
- * @param servColl - The ServiceCollection defined in services.yml
- * @returns `true` if the collections are the same and if variables are not defined
- * for the service collection or all the variables in the source are also in the service
- * collection, `false` otherwise
- */
-// function isServiceCollectionMatch(source: DataSource, servColl: ServiceCollection): boolean {
-//   return servColl.id === source.collection &&
-//     (!servColl.variables || source.variables?.every((v) => servColl.variables?.includes(v.id)));
-// }
-
-/**
  * Returns true if all of the collections in the given operation can be operated on by
  * the given service.
  *
@@ -245,10 +227,6 @@ function isCollectionMatch(
   return serviceConfig.capabilities?.all_collections || context.collectionIds.every((collectionId) => {
     return serviceConfig.collections?.map((sc) => sc.id).includes(collectionId);
   });
-  // return serviceConfig.capabilities?.all_collections || operation.sources.every((source) => {
-  //   const rval = serviceConfig.collections?.some(partial(isServiceCollectionMatch, source));
-  //   return rval;
-  // });
 }
 
 /**

--- a/services/harmony/app/routers/router.ts
+++ b/services/harmony/app/routers/router.ts
@@ -45,6 +45,7 @@ import handleLabelParameter from '../middleware/label';
 import { addJobLabels, deleteJobLabels } from '../frontends/labels';
 import handleJobIDParameter from '../middleware/job-id';
 import earthdataLoginSkipped from '../middleware/earthdata-login-skipped';
+import { validateAndSetVariables } from '../util/variables';
 
 export interface RouterConfig {
   PORT?: string | number; // The port to run the frontend server on
@@ -105,7 +106,7 @@ function service(fn: RequestHandler): RequestHandler {
     const child = logger.child({ component: `service.${fn.name}` });
     req.context.logger = child;
     try {
-      if (!req.collections || req.collections.length === 0) {
+      if (!req.context.collections || req.context.collections.length === 0) {
         throw new NotFoundError('Services can only be invoked when a valid collection is supplied in the URL path before the service name.');
       }
       child.info('Running service');
@@ -213,6 +214,12 @@ export default function router({ USE_EDL_CLIENT_APP = 'false' }: RouterConfig): 
   result.use(logged(preServiceConcatenationHandler));
   result.use(logged(chooseService));
   result.use(logged(postServiceConcatenationHandler));
+  result.use(logged(validateAndSetVariables));
+
+  // ogcCoverageApi.addOpenApiRoutes(result);
+  // ogcEdrApi.addOpenApiRoutes(result);
+  // result.use(collectionPrefix('wms'), service(logged(wmsFrontend)));
+
   result.use(logged(cmrUmmCollectionReader));
   result.use(logged(cmrGranuleLocator));
   result.use(logged(addRequestContextToOperation));

--- a/services/harmony/app/routers/router.ts
+++ b/services/harmony/app/routers/router.ts
@@ -46,6 +46,7 @@ import { addJobLabels, deleteJobLabels } from '../frontends/labels';
 import handleJobIDParameter from '../middleware/job-id';
 import earthdataLoginSkipped from '../middleware/earthdata-login-skipped';
 import { validateAndSetVariables } from '../util/variables';
+import validateRestrictedVariables from '../middleware/restricted-variables';
 
 export interface RouterConfig {
   PORT?: string | number; // The port to run the frontend server on
@@ -215,10 +216,7 @@ export default function router({ USE_EDL_CLIENT_APP = 'false' }: RouterConfig): 
   result.use(logged(chooseService));
   result.use(logged(postServiceConcatenationHandler));
   result.use(logged(validateAndSetVariables));
-
-  // ogcCoverageApi.addOpenApiRoutes(result);
-  // ogcEdrApi.addOpenApiRoutes(result);
-  // result.use(collectionPrefix('wms'), service(logged(wmsFrontend)));
+  result.use(logged(validateRestrictedVariables));
 
   result.use(logged(cmrUmmCollectionReader));
   result.use(logged(cmrGranuleLocator));

--- a/services/harmony/app/util/parameter-parsing-helpers.ts
+++ b/services/harmony/app/util/parameter-parsing-helpers.ts
@@ -48,7 +48,7 @@ export function parseNumber(valueStr: string | number): number {
  * @param value - The parameter value to parse (either an array or a string)
  */
 export function parseMultiValueParameter(value: string[] | string): string[] {
-  if (value === null) {
+  if (value === null || value === undefined) {
     return [];
   }
   if (value instanceof Array) {

--- a/services/harmony/app/util/variables.ts
+++ b/services/harmony/app/util/variables.ts
@@ -1,3 +1,5 @@
+import { NextFunction, Response } from 'express';
+import HarmonyRequest from '../models/harmony-request';
 import { CmrCollection, CmrUmmVariable } from './cmr';
 import { RequestValidationError } from './errors';
 import { parseMultiValueParameter } from './parameter-parsing-helpers';
@@ -126,23 +128,56 @@ export function validateVariables(variableIds: string[], queryVars: string | str
 }
 
 /**
- * Given a list of EOSDIS collections and variables parsed from the CMR and an OGC
- * collectionId parameter return the full variables which match.
+ * Creates the variable info objects without looking anything up in CMR. Passes in all of the variables
+ * provided to all of the collections in the request and leaves it up to the service to validate.
  *
  * @param eosdisCollections - An array of collections
+ * @param variableIds - The list of variables
+ * @returns an array of objects with a collectionId and list
+ *   of variables e.g. `[{ collectionId: C123-PROV1, variables: [<Variable object>] }]`
+ */
+function constructVariableInfoWithoutValidation(
+  eosdisCollections: CmrCollection[],
+  variables: string[],
+): VariableInfo[] {
+  console.log(`CDD: I am constructing it without CMR validation: ${JSON.stringify(eosdisCollections)}`);
+  const variableInfo = [];
+
+  // Construct an imitation of what CMR would return from UMM-Var since we are not using variables
+  // from the CMR, but later functions expect the variables in CMR form
+  const imitationCmrVariables = [];
+  for (const variable of variables) {
+    imitationCmrVariables.push({
+      umm: { Name: variable },
+      meta: { 'concept-id': 'unknown' },
+    });
+  }
+  for (const collection of eosdisCollections) {
+    const coordinateVariables = getCoordinateVariables(collection.variables);
+    variableInfo.push({
+      collectionId: collection.id, shortName: collection.short_name,
+      versionId: collection.version_id, variables: imitationCmrVariables,
+      coordinateVariables,
+    });
+  }
+  return variableInfo;
+}
+
+/**
+ * Returns the
+ * collectionId parameter return the full variables which match.
+ *
  * @param collectionIdParam - The OGC collectionId query parameter
  * @param queryVars - A string of comma separated variable names or an array of variable names
  * - taken from the request object via the `variable` parameter
- * @returns an array of objects with a collectionId and list
- *   of variables e.g. `[{ collectionId: C123-PROV1, variables: [<Variable object>] }]`
- * @throws RequestValidationError - if the requested OGC collection ID parameter is not valid
- * based on the variables in the collections
+ * @returns an array of requested variables (either concept IDs or variable names)
+ * @throws RequestValidationError - if the parameter combinations for query parmameters and
+ * route are invalid for specifying variables
  */
 export function parseVariables(
-  eosdisCollections: CmrCollection[],
   collectionIdParam: string,
-  queryVars: string | string[] = null,
-): VariableInfo[] {
+  queryVars: string | string[],
+): string[] {
   // Note that "collectionId" from the Open API spec is an OGC API Collection, which is
   // what we would call a variable (or sometimes a named group of variables).  In the
   // OpenAPI spec doc, a "collection" refers to a UMM-Var variable, and a "CMR collection" refers
@@ -153,52 +188,79 @@ export function parseVariables(
 
   validateVariables(variableIds, queryVars);
 
-  const variableInfo = [];
-  if (variableIds.indexOf('all') !== -1 ||
-    (variableIds.indexOf('parameter_vars') !== -1 &&
-      queryVars &&
-      (queryVars === 'all' ||
-        queryVars[0] === 'all'))) {
-    // If the variable ID is "all" do not subset by variable
-    for (const collection of eosdisCollections) {
-      const coordinateVariables = getCoordinateVariables(collection.variables);
-      variableInfo.push({
-        collectionId: collection.id, shortName: collection.short_name,
-        versionId: collection.version_id, coordinateVariables,
-      });
-    }
-  } else {
-    if (variableIds.indexOf('parameter_vars') !== -1 && queryVars) {
-      variableIds = parseMultiValueParameter(queryVars);
-    }
+  if (variableIds.indexOf('parameter_vars') !== -1 && queryVars) {
+    variableIds = parseMultiValueParameter(queryVars);
+  }
 
-    // Figure out which variables belong to which collections and whether any are missing.
-    // Note that a single variable name may appear in multiple collections
-    const missingVariables = new Set<string>(variableIds);
-    for (const collection of eosdisCollections) {
-      // Get the list of variables configured in services.yml for this collection. If the
-      // returned set is empty then we will ignore it, otherwise we will only add variables
-      // in that set
-      const coordinateVariables = getCoordinateVariables(collection.variables);
-      const variables = [];
-      for (const variableId of variableIds) {
-        const variable = collection.variables.find((v) => doesPathMatch(v, variableId));
-        if (variable) {
-          missingVariables.delete(variableId);
-          // only add the variable to the list if it does not exist.
-          // This is to guard against when variable name mixed with concept id that references the same variable
-          if (variables.find(v => v.meta['concept-id'] === variable.meta['concept-id']) === undefined) {
-            variables.push(variable);
+  // No variables requested to be subset
+  if (variableIds.length === 1 && variableIds[0] === 'all') {
+    variableIds = [];
+  }
+  return variableIds;
+}
+
+/**
+ * Given a list of EOSDIS collections and variables parsed from the CMR and an OGC
+ * collectionId parameter return the full variables which match.
+ *
+ * @param eosdisCollections - An array of collections
+ * @param collectionIdParam - The OGC collectionId query parameter
+ * @param queryVars - A string of comma separated variable names or an array of variable names
+ * - taken from the request object via the `variable` parameter
+ * @param shouldValidateUmmVar - True if we should verify the variables exist in the CMR
+ * @returns an array of objects with a collectionId and list
+ *   of variables e.g. `[{ collectionId: C123-PROV1, variables: [<Variable object>] }]`
+ * @throws RequestValidationError - if the requested OGC collection ID parameter is not valid
+ * based on the variables in the collections
+ */
+export function getVariableInfo(
+  eosdisCollections: CmrCollection[],
+  variableIds: string[],
+  shouldValidateUmmVar: boolean,
+): VariableInfo[] {
+  let variableInfo = [];
+  if (!shouldValidateUmmVar) {
+    variableInfo = constructVariableInfoWithoutValidation(eosdisCollections, variableIds);
+  } else {
+    if (variableIds.length === 0) {
+      // "All" variables or none were requested to be subset, just provide the coordinate variables
+      // Do not provide a list of variables to subset
+      for (const collection of eosdisCollections) {
+        const coordinateVariables = getCoordinateVariables(collection.variables);
+        variableInfo.push({
+          collectionId: collection.id, shortName: collection.short_name,
+          versionId: collection.version_id, coordinateVariables,
+        });
+      }
+    } else {
+      // Figure out which variables belong to which collections and whether any are missing.
+      // Note that a single variable name may appear in multiple collections
+      const missingVariables = new Set<string>(variableIds);
+      for (const collection of eosdisCollections) {
+        // Get the list of variables configured in services.yml for this collection. If the
+        // returned set is empty then we will ignore it, otherwise we will only add variables
+        // in that set
+        const coordinateVariables = getCoordinateVariables(collection.variables);
+        const variables = [];
+        for (const variableId of variableIds) {
+          const variable = collection.variables.find((v) => doesPathMatch(v, variableId));
+          if (variable) {
+            missingVariables.delete(variableId);
+            // only add the variable to the list if it does not exist.
+            // This is to guard against when variable name mixed with concept id that references the same variable
+            if (variables.find(v => v.meta['concept-id'] === variable.meta['concept-id']) === undefined) {
+              variables.push(variable);
+            }
           }
         }
+        variableInfo.push({
+          collectionId: collection.id, shortName: collection.short_name,
+          versionId: collection.version_id, variables, coordinateVariables,
+        });
       }
-      variableInfo.push({
-        collectionId: collection.id, shortName: collection.short_name,
-        versionId: collection.version_id, variables, coordinateVariables,
-      });
-    }
-    if (missingVariables.size > 0) {
-      throw new RequestValidationError(`Coverages were not found for the provided variables: ${Array.from(missingVariables).join(', ')}`);
+      if (missingVariables.size > 0) {
+        throw new RequestValidationError(`Coverages were not found for the provided variables: ${Array.from(missingVariables).join(', ')}`);
+      }
     }
   }
   return variableInfo;
@@ -247,4 +309,41 @@ export function getVariablesForCollection(
     });
   }
   return variableInfo;
+}
+
+/**
+ * Middleware to match the requested variables with CMR UMM-Var records to get
+ * the required variable information
+ * @param req - The client request, containing an operation
+ * @param res - The client response
+ * @param next - The next function in the middleware chain
+ */
+export function validateAndSetVariables(
+  req: HarmonyRequest, _res: Response, next: NextFunction,
+): void {
+  const { operation, context } = req;
+  if (!operation?.sources) {
+    return next();
+  }
+
+  try {
+    const varInfos = getVariableInfo(
+      context.collections,
+      context.requestedVariables,
+      context.serviceConfig.validate_variables !== false,
+    );
+
+    console.log(`Var infos are: ${JSON.stringify(varInfos)}`);
+
+    console.log(`Requested variables were ${context.requestedVariables}`);
+
+    for (const varInfo of varInfos) {
+      operation.addSource(varInfo.collectionId, varInfo.shortName, varInfo.versionId,
+        varInfo.variables, varInfo.coordinateVariables);
+    }
+  } catch (e) {
+    return next(e);
+  }
+
+  return next();
 }

--- a/services/harmony/app/util/variables.ts
+++ b/services/harmony/app/util/variables.ts
@@ -218,6 +218,7 @@ export function getVariableInfo(
   variableIds: string[],
   shouldValidateUmmVar: boolean,
 ): VariableInfo[] {
+  console.log(`CDD: variableIds are (${variableIds}) and the length is ${variableIds.length}`);
   let variableInfo = [];
   if (!shouldValidateUmmVar) {
     variableInfo = constructVariableInfoWithoutValidation(eosdisCollections, variableIds);

--- a/services/harmony/app/util/variables.ts
+++ b/services/harmony/app/util/variables.ts
@@ -140,7 +140,6 @@ function constructVariableInfoWithoutValidation(
   eosdisCollections: CmrCollection[],
   variables: string[],
 ): VariableInfo[] {
-  console.log(`CDD: I am constructing it without CMR validation: ${JSON.stringify(eosdisCollections)}`);
   const variableInfo = [];
 
   // Construct an imitation of what CMR would return from UMM-Var since we are not using variables
@@ -218,7 +217,6 @@ export function getVariableInfo(
   variableIds: string[],
   shouldValidateUmmVar: boolean,
 ): VariableInfo[] {
-  console.log(`CDD: variableIds are (${variableIds}) and the length is ${variableIds.length}`);
   let variableInfo = [];
   if (!shouldValidateUmmVar) {
     variableInfo = constructVariableInfoWithoutValidation(eosdisCollections, variableIds);
@@ -333,10 +331,6 @@ export function validateAndSetVariables(
       context.requestedVariables,
       context.serviceConfig.validate_variables !== false,
     );
-
-    console.log(`Var infos are: ${JSON.stringify(varInfos)}`);
-
-    console.log(`Requested variables were ${context.requestedVariables}`);
 
     for (const varInfo of varInfos) {
       operation.addSource(varInfo.collectionId, varInfo.shortName, varInfo.versionId,

--- a/services/harmony/test/collection-capabilities.ts
+++ b/services/harmony/test/collection-capabilities.ts
@@ -153,7 +153,7 @@ describe('Testing collection capabilities', function () {
       it('returns an error message indicating the collection could not be found', function () {
         expect(JSON.parse(this.res.text)).to.eql({
           code: 'harmony.NotFoundError',
-          description: 'Error: Unable to find collection short name YouCallThatAShortName? in the CMR. Please  make sure the short name is correct and that you have access to the collection.',
+          description: 'Error: Unable to find collection short name YouCallThatAShortName? in the CMR. Please make sure the short name is correct and that you have access to the collection.',
         });
       });
     });

--- a/services/harmony/test/middleware/restricted-variables.ts
+++ b/services/harmony/test/middleware/restricted-variables.ts
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import { hookRangesetRequest } from '../helpers/ogc-api-coverages';
+import hookServersStartStop from '../helpers/servers';
+import { hookServices } from '../helpers/stub-service';
+
+const collectionId = 'C1233800302-EEDTEST';
+const supportedVariable = 'V1233801695-EEDTEST';
+const unsupportedVariable = 'V1233801696-EEDTEST';
+
+describe('testing variables configured directly in services.yml', function () {
+  hookServersStartStop();
+  const serviceConfigs = [
+    {
+      name: 'test-variables',
+      data_operation_version: '0.20.0',
+      type: {
+        name: 'turbo',
+      },
+      collections: [{ id: collectionId, variables: [supportedVariable] }],
+      capabilities: {
+        subsetting: {
+          variable: true,
+        },
+      },
+      steps: [{
+        image: 'foo',
+        is_sequential: true,
+      }],
+    },
+  ];
+  hookServices(serviceConfigs);
+  describe('when submitting a request for a supported variable', function () {
+    hookRangesetRequest('1.0.0', collectionId, supportedVariable, { query: {}, username: 'joe' });
+    it('accepts the request', function () {
+      expect(this.res.status).to.equal(303);
+    });
+  });
+
+  describe('when submitting a request for a supported variable', function () {
+    hookRangesetRequest('1.0.0', collectionId, unsupportedVariable, { query: {}, username: 'joe' });
+
+    it('rejects the request', function () {
+      expect(this.res.status).to.equal(400);
+    });
+
+    it('provides an appropriate error message', function () {
+      expect(JSON.parse(this.res.text)).to.eql({
+        code: 'harmony.RequestValidationError',
+        description: 'Error: Not all variables selected can be subset',
+      });
+    });
+  });
+});
+

--- a/services/harmony/test/middleware/restricted-variables.ts
+++ b/services/harmony/test/middleware/restricted-variables.ts
@@ -36,7 +36,7 @@ describe('testing variables configured directly in services.yml', function () {
     });
   });
 
-  describe('when submitting a request for a supported variable', function () {
+  describe('when submitting a request for an unsupported variable', function () {
     hookRangesetRequest('1.0.0', collectionId, unsupportedVariable, { query: {}, username: 'joe' });
 
     it('rejects the request', function () {

--- a/services/harmony/test/middleware/umm-var-validation.ts
+++ b/services/harmony/test/middleware/umm-var-validation.ts
@@ -51,7 +51,7 @@ describe('UMM variable validation', function () {
     hookServersStartStop();
     const serviceConfigs = [
       {
-        name: 'test-variable-validation-on',
+        name: 'test-variable-validation-disabled',
         data_operation_version: '0.20.0',
         type: {
           name: 'turbo',

--- a/services/harmony/test/middleware/umm-var-validation.ts
+++ b/services/harmony/test/middleware/umm-var-validation.ts
@@ -1,0 +1,82 @@
+import { expect } from 'chai';
+import { hookRangesetRequest } from '../helpers/ogc-api-coverages';
+import hookServersStartStop from '../helpers/servers';
+import { hookServices } from '../helpers/stub-service';
+
+const collectionId = 'C1233800302-EEDTEST';
+const invalidVariable = 'does-not-exist-in-cmr';
+
+describe('UMM variable validation', function () {
+  describe('for a service that validates against CMR variables', function () {
+    hookServersStartStop();
+    const serviceConfigs = [
+      {
+        name: 'test-variable-validation-on',
+        data_operation_version: '0.20.0',
+        type: {
+          name: 'turbo',
+        },
+        collections: [{ id: collectionId }],
+        capabilities: {
+          subsetting: {
+            variable: true,
+          },
+        },
+        validate_variables: true,
+        steps: [{
+          image: 'foo',
+          is_sequential: true,
+        }],
+      },
+    ];
+    hookServices(serviceConfigs);
+
+    describe('when submitting a request for a variable that does not exist in CMR', function () {
+      hookRangesetRequest('1.0.0', collectionId, invalidVariable, { query: {}, username: 'joe' });
+
+      it('rejects the request', function () {
+        expect(this.res.status).to.equal(400);
+      });
+
+      it('provides an appropriate error message', function () {
+        expect(JSON.parse(this.res.text)).to.eql({
+          code: 'harmony.RequestValidationError',
+          description: 'Error: Coverages were not found for the provided variables: does-not-exist-in-cmr',
+        });
+      });
+    });
+  });
+
+  describe('for a service that skips validation against the CMR', function () {
+    hookServersStartStop();
+    const serviceConfigs = [
+      {
+        name: 'test-variable-validation-on',
+        data_operation_version: '0.20.0',
+        type: {
+          name: 'turbo',
+        },
+        collections: [{ id: collectionId }],
+        capabilities: {
+          subsetting: {
+            variable: true,
+          },
+        },
+        validate_variables: false,
+        steps: [{
+          image: 'foo',
+          is_sequential: true,
+        }],
+      },
+    ];
+    hookServices(serviceConfigs);
+
+    describe('when submitting a request for a variable that does not exist in CMR', function () {
+      hookRangesetRequest('1.0.0', collectionId, invalidVariable, { query: {}, username: 'joe' });
+
+      it('accepts the request', function () {
+        expect(this.res.status).to.equal(303);
+      });
+    });
+  });
+});

--- a/services/harmony/test/models/services.ts
+++ b/services/harmony/test/models/services.ts
@@ -12,16 +12,18 @@ import TurboService from '../../app/models/services/turbo-service';
 import { buildOperation } from '../helpers/data-operation';
 import _ from 'lodash';
 
+const defaultCollection = 'C123-TEST';
+const defaultContext = { collectionIds: [defaultCollection] };
+
 describe('services.chooseServiceConfig and services.buildService', function () {
   describe("when the operation's collection is configured for several services", function () {
     beforeEach(function () {
-      const collectionId = 'C123-TEST';
+      const collectionId = defaultCollection;
       const shortName = 'harmony_example';
       const versionId = '1';
       const operation = new DataOperation();
       operation.addSource(collectionId, shortName, versionId);
       this.operation = operation;
-      this.context = { collectionIds: [collectionId] };
       this.config = [
         {
           name: 'should-never-be-picked',
@@ -139,12 +141,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('returns the first service with tiff support for the collection', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('tiff-png-bbox-service');
       });
 
       it('uses the correct service class when building the service', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         const service = buildService(serviceConfig, this.operation);
         expect(service.constructor.name).to.equal('HttpService');
       });
@@ -156,12 +158,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('returns the first service with png support for the collection', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('tiff-png-bbox-service');
       });
 
       it('uses the correct service class when building the service', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         const service = buildService(serviceConfig, this.operation);
         expect(service.constructor.name).to.equal('HttpService');
       });
@@ -173,7 +175,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(this.operation, this.context, this.config))
+        expect(() => chooseServiceConfig(this.operation, defaultContext, this.config))
           .to.throw(UnsupportedOperation, 'the requested combination of operations: reformatting to image/gif on C123-TEST is unsupported');
       });
     });
@@ -184,7 +186,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports spatial subsetting', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('tiff-png-bbox-service');
       });
     });
@@ -195,7 +197,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports dimension extension', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('extend-service');
       });
     });
@@ -206,7 +208,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports area averaging', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('area-averaging-service');
       });
     });
@@ -217,7 +219,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports time averaging', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('time-averaging-service');
       });
     });
@@ -229,12 +231,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports netcdf output, but not spatial subsetting', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('shapefile-tiff-netcdf-service');
       });
 
       it('indicates that it could not clip based on the spatial extent', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.message).to.equal('Data in output files may extend outside the spatial and temporal bounds you requested.');
       });
     });
@@ -246,7 +248,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports temporal subsetting and netcdf-4 format', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('temporal-netcdf-service');
       });
     });
@@ -258,12 +260,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the first service that supports tiff format, but not temporal subsetting since no service can perform both', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('tiff-png-bbox-service');
       });
 
       it('indicates that it could not clip based on the spatial extent', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.message).to.equal('Data in output files may extend outside the spatial and temporal bounds you requested.');
       });
     });
@@ -274,7 +276,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports shapefile subsetting', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('shapefile-tiff-netcdf-service');
       });
     });
@@ -285,7 +287,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports dimension subsetting', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('dimension-service');
       });
     });
@@ -298,12 +300,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('returns the service that supports reprojection, but not temporal or shapefile subsetting', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('tiff-png-reprojection-service');
       });
 
       it('indicates that it could not clip based on the spatial or temporal extents', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.message).to.equal('Data in output files may extend outside the spatial and temporal bounds you requested.');
       });
     });
@@ -314,7 +316,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports reprojection', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('tiff-png-reprojection-service');
       });
     });
@@ -326,7 +328,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(this.operation, this.context, this.config))
+        expect(() => chooseServiceConfig(this.operation, defaultContext, this.config))
           .to.throw(UnsupportedOperation, 'reprojection and reformatting to application/x-netcdf4 on C123-TEST is unsupported');
       });
     });
@@ -339,7 +341,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(this.operation, this.context, this.config))
+        expect(() => chooseServiceConfig(this.operation, defaultContext, this.config))
           .to.throw(UnsupportedOperation, 'reprojection and reformatting to application/x-netcdf4 on C123-TEST is unsupported');
       });
     });
@@ -353,7 +355,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports concatenation and netcdf-4 format', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('netcdf-service');
       });
     });
@@ -382,12 +384,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
     });
 
     it('returns the service configured for the collection', function () {
-      const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+      const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
       expect(serviceConfig.name).to.equal('matching-service');
     });
 
     it('uses the correct service class when building the service', function () {
-      const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
+      const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
       const service = buildService(serviceConfig, this.operation);
       expect(service.constructor.name).to.equal('TurboService');
     });
@@ -426,12 +428,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       operation.outputFormat = 'image/tiff';
 
       it('returns the service configured for variable subsetting', function () {
-        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('variable-subsetter');
       });
 
       it('uses the correct service class when building the service', function () {
-        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(operation, defaultContext, this.config);
         const service = buildService(serviceConfig, operation);
         expect(service.constructor.name).to.equal('TurboService');
       });
@@ -443,7 +445,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       operation.outputFormat = 'application/x-zarr';
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(operation, { requestedVariables: ['the-var'] }, this.config))
+        expect(() => chooseServiceConfig(operation, { requestedVariables: ['the-var'], collectionIds: [defaultCollection] }, this.config))
           .to.throw(UnsupportedOperation, 'variable subsetting and reformatting to application/x-zarr on C123-TEST is unsupported');
       });
     });
@@ -453,7 +455,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       operation.addSource(collectionId, shortName, versionId);
       operation.outputFormat = 'application/x-zarr';
       it('returns the non-variable subsetter service that does support the format', function () {
-        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('non-variable-subsetter');
       });
     });
@@ -488,7 +490,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
     });
 
     it('throws an exception', function () {
-      expect(() => chooseServiceConfig(this.operation, this.context, this.config))
+      expect(() => chooseServiceConfig(this.operation, defaultContext, this.config))
         .to.throw(UnsupportedOperation, 'no operations can be performed on C123-TEST');
     });
   });
@@ -516,7 +518,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(this.operation, this.context, this.config))
+        expect(() => chooseServiceConfig(this.operation, defaultContext, this.config))
           .to.throw(UnsupportedOperation, 'the requested combination of operations: spatial subsetting on C123-TEST is unsupported');
       });
     });
@@ -527,7 +529,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(this.operation, this.context, this.config))
+        expect(() => chooseServiceConfig(this.operation, defaultContext, this.config))
           .to.throw(UnsupportedOperation, 'shapefile subsetting on C123-TEST is unsupported');
       });
     });
@@ -590,7 +592,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
         operation = new DataOperation();
         operation.addSource(collectionId, shortName, versionId, [{ meta: { 'concept-id': variableId }, umm: { Name: 'the-var' } }]);
         operation.outputFormat = 'text/csv';
-        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('variable-based-service');
       });
 
@@ -598,31 +600,9 @@ describe('services.chooseServiceConfig and services.buildService', function () {
         operation = new DataOperation();
         operation.addSource(collectionId, shortName, versionId, [{ meta: { 'concept-id': variableId }, umm: { Name: 'the-var' } }]);
         operation.outputFormat = 'text/csv';
-        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(operation, defaultContext, this.config);
         const service = buildService(serviceConfig, operation);
         expect(service.constructor.name).to.equal('TurboService');
-      });
-    });
-
-    describe('requesting service without variable subsetting', function () {
-      const operation = new DataOperation();
-      operation.addSource(collectionId, shortName, versionId);
-      operation.outputFormat = 'text/csv';
-
-      it('throws an exception', function () {
-        expect(() => chooseServiceConfig(operation, this.context, this.config))
-          .to.throw(UnsupportedOperation, 'no operations can be performed on C123-TEST');
-      });
-    });
-
-    describe('requesting service with no variable matches', function () {
-      const operation = new DataOperation();
-      operation.addSource(collectionId, shortName, versionId, [{ meta: { 'concept-id': 'wrong-variable-Id' }, umm: { Name: 'wrong-var' } }]);
-      operation.outputFormat = 'text/csv';
-
-      it('throws an exception', function () {
-        expect(() => chooseServiceConfig(operation, this.context, this.config))
-          .to.throw(UnsupportedOperation, 'no operations can be performed on C123-TEST');
       });
     });
   });
@@ -631,7 +611,6 @@ describe('services.chooseServiceConfig and services.buildService', function () {
     const collectionId = 'C123-TEST';
     const variableId1 = 'V123-TEST';
     const variableId2 = 'V456-TEST';
-    const variableId3 = 'V789-TEST';
     const shortName = 'harmony_example';
     const versionId = '1';
     beforeEach(function () {
@@ -659,12 +638,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       operation.outputFormat = 'text/csv';
 
       it('returns the service configured for variable-based service', function () {
-        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('variable-based-service');
       });
 
       it('uses the correct service class when building the service', function () {
-        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(operation, defaultContext, this.config);
         const service = buildService(serviceConfig, operation);
         expect(service.constructor.name).to.equal('TurboService');
       });
@@ -677,26 +656,14 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       operation.outputFormat = 'text/csv';
 
       it('returns the service configured for variable-based service', function () {
-        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(operation, defaultContext, this.config);
         expect(serviceConfig.name).to.equal('variable-based-service');
       });
 
       it('uses the correct service class when building the service', function () {
-        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
+        const serviceConfig = chooseServiceConfig(operation, defaultContext, this.config);
         const service = buildService(serviceConfig, operation);
         expect(service.constructor.name).to.equal('TurboService');
-      });
-    });
-
-    describe('requesting service with two variable subsetting and only one matches', function () {
-      const operation = new DataOperation();
-      operation.addSource(collectionId, shortName, versionId,  [{ meta: { 'concept-id': variableId1 }, umm: { Name: 'the-var-1' } },
-        { meta: { 'concept-id': variableId3 }, umm: { Name: 'the-var-3' } }]);
-      operation.outputFormat = 'text/csv';
-
-      it('throws an exception', function () {
-        expect(() => chooseServiceConfig(operation, this.context, this.config))
-          .to.throw(UnsupportedOperation, 'no operations can be performed on C123-TEST');
       });
     });
   });

--- a/services/harmony/test/models/services.ts
+++ b/services/harmony/test/models/services.ts
@@ -21,6 +21,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       const operation = new DataOperation();
       operation.addSource(collectionId, shortName, versionId);
       this.operation = operation;
+      this.context = { collectionIds: [collectionId] };
       this.config = [
         {
           name: 'should-never-be-picked',
@@ -138,12 +139,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('returns the first service with tiff support for the collection', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('tiff-png-bbox-service');
       });
 
       it('uses the correct service class when building the service', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         const service = buildService(serviceConfig, this.operation);
         expect(service.constructor.name).to.equal('HttpService');
       });
@@ -155,12 +156,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('returns the first service with png support for the collection', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('tiff-png-bbox-service');
       });
 
       it('uses the correct service class when building the service', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         const service = buildService(serviceConfig, this.operation);
         expect(service.constructor.name).to.equal('HttpService');
       });
@@ -172,7 +173,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(this.operation, {}, this.config))
+        expect(() => chooseServiceConfig(this.operation, this.context, this.config))
           .to.throw(UnsupportedOperation, 'the requested combination of operations: reformatting to image/gif on C123-TEST is unsupported');
       });
     });
@@ -183,7 +184,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports spatial subsetting', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('tiff-png-bbox-service');
       });
     });
@@ -194,7 +195,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports dimension extension', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('extend-service');
       });
     });
@@ -205,7 +206,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports area averaging', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('area-averaging-service');
       });
     });
@@ -216,7 +217,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports time averaging', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('time-averaging-service');
       });
     });
@@ -228,12 +229,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports netcdf output, but not spatial subsetting', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('shapefile-tiff-netcdf-service');
       });
 
       it('indicates that it could not clip based on the spatial extent', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.message).to.equal('Data in output files may extend outside the spatial and temporal bounds you requested.');
       });
     });
@@ -245,7 +246,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports temporal subsetting and netcdf-4 format', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('temporal-netcdf-service');
       });
     });
@@ -257,12 +258,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the first service that supports tiff format, but not temporal subsetting since no service can perform both', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('tiff-png-bbox-service');
       });
 
       it('indicates that it could not clip based on the spatial extent', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.message).to.equal('Data in output files may extend outside the spatial and temporal bounds you requested.');
       });
     });
@@ -273,7 +274,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports shapefile subsetting', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('shapefile-tiff-netcdf-service');
       });
     });
@@ -284,7 +285,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports dimension subsetting', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('dimension-service');
       });
     });
@@ -297,12 +298,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('returns the service that supports reprojection, but not temporal or shapefile subsetting', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('tiff-png-reprojection-service');
       });
 
       it('indicates that it could not clip based on the spatial or temporal extents', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.message).to.equal('Data in output files may extend outside the spatial and temporal bounds you requested.');
       });
     });
@@ -313,7 +314,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports reprojection', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('tiff-png-reprojection-service');
       });
     });
@@ -325,7 +326,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(this.operation, {}, this.config))
+        expect(() => chooseServiceConfig(this.operation, this.context, this.config))
           .to.throw(UnsupportedOperation, 'reprojection and reformatting to application/x-netcdf4 on C123-TEST is unsupported');
       });
     });
@@ -338,7 +339,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(this.operation, {}, this.config))
+        expect(() => chooseServiceConfig(this.operation, this.context, this.config))
           .to.throw(UnsupportedOperation, 'reprojection and reformatting to application/x-netcdf4 on C123-TEST is unsupported');
       });
     });
@@ -352,7 +353,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('chooses the service that supports concatenation and netcdf-4 format', function () {
-        const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('netcdf-service');
       });
     });
@@ -381,12 +382,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
     });
 
     it('returns the service configured for the collection', function () {
-      const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+      const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
       expect(serviceConfig.name).to.equal('matching-service');
     });
 
     it('uses the correct service class when building the service', function () {
-      const serviceConfig = chooseServiceConfig(this.operation, {}, this.config);
+      const serviceConfig = chooseServiceConfig(this.operation, this.context, this.config);
       const service = buildService(serviceConfig, this.operation);
       expect(service.constructor.name).to.equal('TurboService');
     });
@@ -425,12 +426,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       operation.outputFormat = 'image/tiff';
 
       it('returns the service configured for variable subsetting', function () {
-        const serviceConfig = chooseServiceConfig(operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('variable-subsetter');
       });
 
       it('uses the correct service class when building the service', function () {
-        const serviceConfig = chooseServiceConfig(operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
         const service = buildService(serviceConfig, operation);
         expect(service.constructor.name).to.equal('TurboService');
       });
@@ -442,7 +443,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       operation.outputFormat = 'application/x-zarr';
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(operation, {}, this.config))
+        expect(() => chooseServiceConfig(operation, { requestedVariables: ['the-var'] }, this.config))
           .to.throw(UnsupportedOperation, 'variable subsetting and reformatting to application/x-zarr on C123-TEST is unsupported');
       });
     });
@@ -452,7 +453,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       operation.addSource(collectionId, shortName, versionId);
       operation.outputFormat = 'application/x-zarr';
       it('returns the non-variable subsetter service that does support the format', function () {
-        const serviceConfig = chooseServiceConfig(operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('non-variable-subsetter');
       });
     });
@@ -463,7 +464,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       operation.outputFormat = 'image/foo';
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(operation, {}, this.config))
+        expect(() => chooseServiceConfig(operation, { collectionIds: [collectionId], requestedVariables: ['the-var'] }, this.config))
           .to.throw(UnsupportedOperation, 'variable subsetting and reformatting to image/foo on C123-TEST is unsupported');
       });
     });
@@ -487,7 +488,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
     });
 
     it('throws an exception', function () {
-      expect(() => chooseServiceConfig(this.operation, {}, this.config))
+      expect(() => chooseServiceConfig(this.operation, this.context, this.config))
         .to.throw(UnsupportedOperation, 'no operations can be performed on C123-TEST');
     });
   });
@@ -515,7 +516,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(this.operation, {}, this.config))
+        expect(() => chooseServiceConfig(this.operation, this.context, this.config))
           .to.throw(UnsupportedOperation, 'the requested combination of operations: spatial subsetting on C123-TEST is unsupported');
       });
     });
@@ -526,7 +527,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       });
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(this.operation, {}, this.config))
+        expect(() => chooseServiceConfig(this.operation, this.context, this.config))
           .to.throw(UnsupportedOperation, 'shapefile subsetting on C123-TEST is unsupported');
       });
     });
@@ -589,7 +590,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
         operation = new DataOperation();
         operation.addSource(collectionId, shortName, versionId, [{ meta: { 'concept-id': variableId }, umm: { Name: 'the-var' } }]);
         operation.outputFormat = 'text/csv';
-        const serviceConfig = chooseServiceConfig(operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('variable-based-service');
       });
 
@@ -597,7 +598,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
         operation = new DataOperation();
         operation.addSource(collectionId, shortName, versionId, [{ meta: { 'concept-id': variableId }, umm: { Name: 'the-var' } }]);
         operation.outputFormat = 'text/csv';
-        const serviceConfig = chooseServiceConfig(operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
         const service = buildService(serviceConfig, operation);
         expect(service.constructor.name).to.equal('TurboService');
       });
@@ -609,7 +610,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       operation.outputFormat = 'text/csv';
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(operation, {}, this.config))
+        expect(() => chooseServiceConfig(operation, this.context, this.config))
           .to.throw(UnsupportedOperation, 'no operations can be performed on C123-TEST');
       });
     });
@@ -620,7 +621,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       operation.outputFormat = 'text/csv';
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(operation, {}, this.config))
+        expect(() => chooseServiceConfig(operation, this.context, this.config))
           .to.throw(UnsupportedOperation, 'no operations can be performed on C123-TEST');
       });
     });
@@ -658,12 +659,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       operation.outputFormat = 'text/csv';
 
       it('returns the service configured for variable-based service', function () {
-        const serviceConfig = chooseServiceConfig(operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('variable-based-service');
       });
 
       it('uses the correct service class when building the service', function () {
-        const serviceConfig = chooseServiceConfig(operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
         const service = buildService(serviceConfig, operation);
         expect(service.constructor.name).to.equal('TurboService');
       });
@@ -676,12 +677,12 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       operation.outputFormat = 'text/csv';
 
       it('returns the service configured for variable-based service', function () {
-        const serviceConfig = chooseServiceConfig(operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
         expect(serviceConfig.name).to.equal('variable-based-service');
       });
 
       it('uses the correct service class when building the service', function () {
-        const serviceConfig = chooseServiceConfig(operation, {}, this.config);
+        const serviceConfig = chooseServiceConfig(operation, this.context, this.config);
         const service = buildService(serviceConfig, operation);
         expect(service.constructor.name).to.equal('TurboService');
       });
@@ -694,7 +695,7 @@ describe('services.chooseServiceConfig and services.buildService', function () {
       operation.outputFormat = 'text/csv';
 
       it('throws an exception', function () {
-        expect(() => chooseServiceConfig(operation, {}, this.config))
+        expect(() => chooseServiceConfig(operation, this.context, this.config))
           .to.throw(UnsupportedOperation, 'no operations can be performed on C123-TEST');
       });
     });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1958

## Description
Allows service chains to skip validating variables exist in the CMR. This was requested by the Giovanni team to support their future time and area averaging services.

## Local Test Steps
Since no service chains are currently configured to skip validation you will need to manually modify one of the service chains.

First test without changing services.yml to make sure you get a validation error with something like:
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/bad_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng&subset=time(%222002-09-15T00%3A00%3A00.000Z%22%3A%222022-09-25T00%3A00%3A00Z%22)
```
{
	"code": "harmony.RequestValidationError",
	"description": "Error: Coverages were not found for the provided variables: bad_var"
}
```
Then modify the harmony-service-example chain for UAT and add `validate_variables: false` to the service chain definition. Repeat the request. This time the request should be accepted and you should see it in the workflow-ui. It will fail because the service will not be able to find `bad_var`, but does confirm that the validation is being skipped.


## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)
* [ ] Harmony in a Box tested? (if changes made to microservices)