### PR TITLE
DAS-2293: nudge memory limit from 20Gi to 24Gi for smap-l2-gridder

### DIFF
--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -547,6 +547,6 @@ OPERA_RTC_S1_BROWSE_SERVICE_QUEUE_URLS='["ghcr.io/asfhyp3/opera-rtc-s1-browse:la
 
 HARMONY_SMAP_L2_GRIDDER_IMAGE=ghcr.io/nasa/harmony-smap-l2-gridder:latest
 HARMONY_SMAP_L2_GRIDDER_REQUESTS_MEMORY=128Mi
-HARMONY_SMAP_L2_GRIDDER_LIMITS_MEMORY=16Gi
+HARMONY_SMAP_L2_GRIDDER_LIMITS_MEMORY=24Gi
 HARMONY_SMAP_L2_GRIDDER_INVOCATION_ARGS='python -m harmony_service'
 HARMONY_SMAP_L2_GRIDDER_SERVICE_QUEUE_URLS='["ghcr.io/nasa/harmony-smap-l2-gridder:latest,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/harmony-smap-l2-gridder.fifo"]'


### PR DESCRIPTION
The SPL2SMA is a 3km grid with almost 70 variables which requires a lot of memory to process.

## Jira Issue ID

DAS-2293

## Description

In testing the SPL2SMA collection against the smap-l2-gridder with Harmony-In-A-Box I found I was just nosing over 20Gi, this memory setting  should suffice for testing Harmony-In-A-Box.


## Local Test Steps


- Ensure your resources for your docker desktop / k8 cluster have more than 24Gi available. 
- Build the smap-l2-gridder service image from [the development branch](https://github.com/nasa/harmony-SMAP-L2-gridding-service/tree/mhs/DAS-2293/add-SPL2SMA)
- Bootstrap Harmony-In-A-Box with this branch.

Run a request that will trigger the smap-l2-gridder for the SPL2SMA collection and ensure it completes:

http://localhost:3000/C1268429729-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&outputcrs=EPSG%3A4326&granuleId=G1268429743-EEDTEST&format=application%2Fx-netcdf4&variable=all

(or you can just merge it since it's just changing an environmental variable) 

## PR Acceptance Checklist
* [N/A] Acceptance criteria met
* [N/A] Tests added/updated (if needed) and passing
* [N/A] Documentation updated (if needed)
* [X] Harmony in a Box tested? (if changes made to microservices)
