### PR TITLE
HARMONY-1824: Add route for viewing service deployment error logs.

### DIFF
--- a/services/harmony/app/routers/router.ts
+++ b/services/harmony/app/routers/router.ts
@@ -29,7 +29,7 @@ import { setLogLevel } from '../frontends/configuration';
 import getVersions from '../frontends/versions';
 import serviceInvoker from '../backends/service-invoker';
 import HarmonyRequest, { addRequestContextToOperation } from '../models/harmony-request';
-import { getServiceImageTag, getServiceImageTags, updateServiceImageTag, getServiceDeploymentsState, setServiceDeploymentsState, getServiceDeployment, getServiceDeployments } from '../frontends/service-image-tags';
+import { getServiceImageTag, getServiceImageTags, updateServiceImageTag, getServiceDeploymentsState, setServiceDeploymentsState, getServiceDeployment, getServiceDeployments, getDeploymentLogs } from '../frontends/service-image-tags';
 import cmrCollectionReader = require('../middleware/cmr-collection-reader');
 import cmrUmmCollectionReader = require('../middleware/cmr-umm-collection-reader');
 import env from '../util/env';
@@ -143,6 +143,7 @@ const authorizedRoutes = [
   '/configuration*',
   '/jobs*',
   '/logs*',
+  '/deployment-logs*',
   '/service-results/*',
   '/workflow-ui*',
   '/service-image*',
@@ -294,6 +295,7 @@ export default function router({ USE_EDL_CLIENT_APP = 'false' }: RouterConfig): 
   result.post('/admin/workflow-ui/jobs', jsonParser, asyncHandler(getJobsTable));
 
   result.get('/logs/:jobID/:id', asyncHandler(getWorkItemLogs));
+  result.get('/deployment-logs/:deploymentId', asyncHandler(getDeploymentLogs));
 
   result.get('/staging-bucket-policy', asyncHandler(getStagingBucketPolicy));
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1824

## Description
Save the deployment log when service deployment fails.
Add route to allow authorized users to view the log through Harmony frontend.
Provide link to the service deployment log in the message of failed service deployment status page.

## Local Test Steps
Tested in my Sandbox with a modified `deploy-service` script that will fail with a message. 
Verified that the service deployment status page provide a link to the deployment logs. See below:
![Screenshot 2025-02-07 at 2 36 24 PM](https://github.com/user-attachments/assets/b4786af6-f4b0-48d4-ae8f-36c7bed4f8f1)

Follow the link, I can see the logs of service deployment.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested? (if changes made to microservices or new dependencies added)