### PR TITLE
HARMONY-2013: Check if a job is in a terminal state prior to attempting to process the STAC catalog for a work item update.

### DIFF
--- a/services/harmony/app/models/job.ts
+++ b/services/harmony/app/models/job.ts
@@ -10,7 +10,7 @@ import { createPublicPermalink } from '../frontends/service-results';
 import {
   CmrPermission, CmrPermissionsMap, CmrTagKeys, getCollectionsByIds, getPermissions,
 } from '../util/cmr';
-import { Transaction } from '../util/db';
+import db, { Transaction } from '../util/db';
 import env from '../util/env';
 import { ConflictError } from '../util/errors';
 import { removeEmptyProperties } from '../util/object';
@@ -335,6 +335,21 @@ async function getUniqueProviderIds(tx: Transaction): Promise<string[]> {
     .whereNotNull('provider_id')
     .distinct('provider_id');
   return results.map((job) => job.provider_id);
+}
+
+/**
+ * Get the job status for the given job ID
+ *
+ * @param jobID - the job ID
+ * @returns the job status for the given job ID
+ */
+export async function getJobStatusForJobID(jobID: string): Promise<JobStatus> {
+  return (
+    await db('jobs')
+      .select('status')
+      .where({ jobID })
+      .first()
+  )?.status;
 }
 
 /**


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2013

## Description
Fixes a bug we're seeing in UAT right now where a work item that takes more than 30 seconds to process is not getting cleaned up. This changes things to check the job status prior to doing any work for the work item and skips reading the STAC catalog and items if the job is already in a terminal state.

## Local Test Steps
I reproduced the problem in my sandbox and then built and pushed the work-updater image. With the new image I verified it skipped reading the catalog and the SQS message was successfully deleted from the queue.

I've also verified with a 110K granule request that performance is not impacted by the extra DB call to get the job status.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested? (if changes made to microservices or new dependencies added)