### PR TITLE
HARMONY-2007: Add is_sequential: true where missing for query-cmr in services.yml and validations for same

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -429,6 +429,7 @@ https://cmr.earthdata.nasa.gov:
       reprojection: true
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${HYBIG_IMAGE}
 
   - name: harmony/netcdf-to-zarr
@@ -576,6 +577,7 @@ https://cmr.earthdata.nasa.gov:
       reprojection: true
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${OPERA_RTC_S1_BROWSE_IMAGE}
       - image: !Env ${HYBIG_IMAGE}
 
@@ -1385,5 +1387,6 @@ https://cmr.uat.earthdata.nasa.gov:
       reprojection: true
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${OPERA_RTC_S1_BROWSE_IMAGE}
       - image: !Env ${HYBIG_IMAGE}

--- a/services/harmony/app/models/job.ts
+++ b/services/harmony/app/models/job.ts
@@ -194,7 +194,6 @@ const stateMachine = createMachine(
           active: true,
         },
         on: Object.fromEntries([
-          [JobEvent.COMPLETE, { target: JobStatus.SUCCESSFUL }],
           [JobEvent.COMPLETE_WITH_ERRORS, { target: JobStatus.COMPLETE_WITH_ERRORS }],
           [JobEvent.CANCEL, { target: JobStatus.CANCELED }],
           [JobEvent.FAIL, { target: JobStatus.FAILED }],

--- a/services/harmony/app/models/services/index.ts
+++ b/services/harmony/app/models/services/index.ts
@@ -1,20 +1,21 @@
 import * as fs from 'fs';
-import * as path from 'path';
 import * as yaml from 'js-yaml';
 import _, { get as getIn } from 'lodash';
+import * as path from 'path';
 
-import logger from '../../util/log';
-import { HttpError, NotFoundError, ServerError } from '../../util/errors';
-import { isMimeTypeAccepted, allowsAny } from '../../util/content-negotiation';
-import { CmrCollection } from '../../util/cmr';
+import { Conjunction, isInteger, listToText } from '@harmony/util/string';
+
 import { addCollectionsToServicesByAssociation } from '../../middleware/service-selection';
-import { listToText, Conjunction, isInteger } from '@harmony/util/string';
-import TurboService from './turbo-service';
-import HttpService from './http-service';
-import DataOperation from '../data-operation';
-import BaseService, { ServiceConfig } from './base-service';
-import RequestContext from '../request-context';
+import { CmrCollection } from '../../util/cmr';
+import { allowsAny, isMimeTypeAccepted } from '../../util/content-negotiation';
 import env from '../../util/env';
+import { HttpError, NotFoundError, ServerError } from '../../util/errors';
+import logger from '../../util/log';
+import DataOperation from '../data-operation';
+import RequestContext from '../request-context';
+import BaseService, { ServiceConfig } from './base-service';
+import HttpService from './http-service';
+import TurboService from './turbo-service';
 
 let serviceConfigs: ServiceConfig<unknown>[] = null;
 
@@ -107,6 +108,11 @@ function validateServiceConfigSteps(config: ServiceConfig<unknown>): void {
       if (maxBatchInputs > env.maxGranuleLimit) {
         logger.warn(`Service ${config.name} attempting to allow more than the max allowed granules in a batch. `
           + `Configured to use ${maxBatchInputs}, but will be limited to ${env.maxGranuleLimit}`);
+      }
+    }
+    if (step.image.match(/harmonyservices\/query\-cmr:.*/)) {
+      if (!step.is_sequential) {
+        throw new TypeError(`Invalid is_sequential ${step.is_sequential}. query-cmr steps must always have sequential = true.`);
       }
     }
   }

--- a/services/harmony/app/models/services/index.ts
+++ b/services/harmony/app/models/services/index.ts
@@ -110,10 +110,9 @@ function validateServiceConfigSteps(config: ServiceConfig<unknown>): void {
           + `Configured to use ${maxBatchInputs}, but will be limited to ${env.maxGranuleLimit}`);
       }
     }
-    if (step.image.match(/harmonyservices\/query\-cmr:.*/)) {
-      if (!step.is_sequential) {
-        throw new TypeError(`Invalid is_sequential ${step.is_sequential}. query-cmr steps must always have sequential = true.`);
-      }
+    if (step.image.match(/harmonyservices\/query\-cmr:.*/) && !step.is_sequential) {
+
+      throw new TypeError(`Invalid is_sequential ${step.is_sequential}. query-cmr steps must always have sequential = true.`);
     }
   }
 }

--- a/services/harmony/test/models/index.ts
+++ b/services/harmony/test/models/index.ts
@@ -1,6 +1,9 @@
 import { expect } from 'chai';
-import { loadServiceConfigs, loadServiceConfigsFromFile, getServiceConfigs, validateServiceConfig } from '../../app/models/services';
 import _ from 'lodash';
+
+import {
+  getServiceConfigs, loadServiceConfigs, loadServiceConfigsFromFile, validateServiceConfig,
+} from '../../app/models/services';
 
 const cmrEndpoints = {
   'uat': 'https://cmr.uat.earthdata.nasa.gov',
@@ -72,6 +75,34 @@ describe('Services.yml validation', function () {
     it('throws an exception', function () {
       const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_colls_prod.yml');
       expect(() => configs.forEach(validateServiceConfig)).to.throw(/Collections cannot be configured for harmony service: with-collections, use umm_s instead./);
+    });
+  });
+
+  describe('services.yml with unset is_sequential for query-cmr in UAT is invalid', function () {
+    it('throws an exception', function () {
+      const configs = loadServiceConfigsFromFile(cmrEndpoints.uat, '../../../test/resources/services_with_unset_is_sequential_query_cmr_uat.yml');
+      expect(() => configs.forEach(validateServiceConfig)).to.throw(/Invalid is_sequential undefined. query-cmr steps must always have sequential = true./);
+    });
+  });
+
+  describe('services.yml with unset is_sequential for query-cmr in PROD is invalid', function () {
+    it('throws an exception', function () {
+      const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_unset_is_sequential_query_cmr_prod.yml');
+      expect(() => configs.forEach(validateServiceConfig)).to.throw(/Invalid is_sequential undefined. query-cmr steps must always have sequential = true./);
+    });
+  });
+
+  describe('services.yml with false is_sequential for query-cmr in UAT is invalid', function () {
+    it('throws an exception', function () {
+      const configs = loadServiceConfigsFromFile(cmrEndpoints.uat, '../../../test/resources/services_with_false_is_sequential_query_cmr_uat.yml');
+      expect(() => configs.forEach(validateServiceConfig)).to.throw(/Invalid is_sequential false. query-cmr steps must always have sequential = true./);
+    });
+  });
+
+  describe('services.yml with false is_sequential for query-cmr in PROD is invalid', function () {
+    it('throws an exception', function () {
+      const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_false_is_sequential_query_cmr_prod.yml');
+      expect(() => configs.forEach(validateServiceConfig)).to.throw(/Invalid is_sequential false. query-cmr steps must always have sequential = true./);
     });
   });
 });

--- a/services/harmony/test/resources/services_no_umm_s_prod.yml
+++ b/services/harmony/test/resources/services_no_umm_s_prod.yml
@@ -52,6 +52,7 @@ https://cmr.earthdata.nasa.gov:
         - application/x-netcdf4
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
 
 
@@ -76,4 +77,5 @@ https://cmr.earthdata.nasa.gov:
         - application/x-netcdf4
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}

--- a/services/harmony/test/resources/services_no_umm_s_uat.yml
+++ b/services/harmony/test/resources/services_no_umm_s_uat.yml
@@ -44,6 +44,7 @@ https://cmr.uat.earthdata.nasa.gov:
         - application/x-netcdf4
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
 
   - name: podaac/l2-subsetter
@@ -75,5 +76,6 @@ https://cmr.uat.earthdata.nasa.gov:
         - application/x-netcdf4
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
 

--- a/services/harmony/test/resources/services_umm_s_not_string_prod.yml
+++ b/services/harmony/test/resources/services_umm_s_not_string_prod.yml
@@ -52,6 +52,7 @@ https://cmr.earthdata.nasa.gov:
         - application/x-netcdf4
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
 
   - name: umm_s_not_string
@@ -77,4 +78,5 @@ https://cmr.earthdata.nasa.gov:
         - application/x-netcdf4
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}

--- a/services/harmony/test/resources/services_umm_s_not_string_uat.yml
+++ b/services/harmony/test/resources/services_umm_s_not_string_uat.yml
@@ -46,6 +46,7 @@ https://cmr.uat.earthdata.nasa.gov:
         - application/x-netcdf4
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
 
   - name: podaac/l2-subsetter
@@ -77,5 +78,6 @@ https://cmr.uat.earthdata.nasa.gov:
         - application/x-netcdf4
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
 

--- a/services/harmony/test/resources/services_with_colls_prod.yml
+++ b/services/harmony/test/resources/services_with_colls_prod.yml
@@ -47,6 +47,7 @@ https://cmr.earthdata.nasa.gov:
         - application/x-netcdf4
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
 
   - name: podaac/l2-subsetter
@@ -78,5 +79,6 @@ https://cmr.earthdata.nasa.gov:
         - application/x-netcdf4
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
 

--- a/services/harmony/test/resources/services_with_colls_uat.yml
+++ b/services/harmony/test/resources/services_with_colls_uat.yml
@@ -47,6 +47,7 @@ https://cmr.uat.earthdata.nasa.gov:
         - application/x-netcdf4
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
 
   - name: podaac/l2-subsetter
@@ -78,5 +79,6 @@ https://cmr.uat.earthdata.nasa.gov:
         - application/x-netcdf4
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
 

--- a/services/harmony/test/resources/services_with_false_is_sequential_query_cmr_prod.yml
+++ b/services/harmony/test/resources/services_with_false_is_sequential_query_cmr_prod.yml
@@ -1,0 +1,52 @@
+# Order for each CMR endpoint in this file will reflect precedence of the service when
+# multiple services handle a collection
+
+# Default turbo configuration
+x-turbo-config: &default-turbo-config
+  name: turbo
+  params: &default-turbo-params
+    env: &default-turbo-env
+      USE_LOCALSTACK: !Env ${USE_LOCALSTACK}
+      LOCALSTACK_HOST: !Env ${BACKEND_HOST}
+      AWS_DEFAULT_REGION: us-west-2
+      STAGING_BUCKET: !Env ${STAGING_BUCKET}
+      TEXT_LOGGER: !Env ${TEXT_LOGGER}
+      BACKEND_HOST: !Env ${BACKEND_HOST}
+      EDL_USERNAME: !Env ${EDL_USERNAME}
+      EDL_PASSWORD: !Env ${EDL_PASSWORD}
+      OAUTH_UID: !Env ${OAUTH_UID}
+      OAUTH_PASSWORD: !Env ${OAUTH_PASSWORD}
+      OAUTH_HOST: !Env ${OAUTH_HOST}
+      OAUTH_CLIENT_ID: !Env ${OAUTH_CLIENT_ID}
+      OAUTH_REDIRECT_URI: !Env ${OAUTH_REDIRECT_URI}
+      FALLBACK_AUTHN_ENABLED: !Env ${FALLBACK_AUTHN_ENABLED}
+
+https://cmr.earthdata.nasa.gov:
+
+  - name: non-sequential-query-cmr
+    description: |
+      testing service configuration with query-cmr with no is_sequential:
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/asf/opera-rtc-s1-browse
+    umm_s: S1271728813-ASF
+    maximum_sync_granules: 0
+    capabilities:
+      concatenation: false
+      subsetting:
+        bbox: false
+        variable: false
+        temporal: false
+      output_formats:
+        - image/png
+      reprojection: true
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: false
+      - image: !Env ${OPERA_RTC_S1_BROWSE_IMAGE}
+      - image: !Env ${HYBIG_IMAGE}

--- a/services/harmony/test/resources/services_with_false_is_sequential_query_cmr_uat.yml
+++ b/services/harmony/test/resources/services_with_false_is_sequential_query_cmr_uat.yml
@@ -1,0 +1,52 @@
+# Order for each CMR endpoint in this file will reflect precedence of the service when
+# multiple services handle a collection
+
+# Default turbo configuration
+x-turbo-config: &default-turbo-config
+  name: turbo
+  params: &default-turbo-params
+    env: &default-turbo-env
+      USE_LOCALSTACK: !Env ${USE_LOCALSTACK}
+      LOCALSTACK_HOST: !Env ${BACKEND_HOST}
+      AWS_DEFAULT_REGION: us-west-2
+      STAGING_BUCKET: !Env ${STAGING_BUCKET}
+      TEXT_LOGGER: !Env ${TEXT_LOGGER}
+      BACKEND_HOST: !Env ${BACKEND_HOST}
+      EDL_USERNAME: !Env ${EDL_USERNAME}
+      EDL_PASSWORD: !Env ${EDL_PASSWORD}
+      OAUTH_UID: !Env ${OAUTH_UID}
+      OAUTH_PASSWORD: !Env ${OAUTH_PASSWORD}
+      OAUTH_HOST: !Env ${OAUTH_HOST}
+      OAUTH_CLIENT_ID: !Env ${OAUTH_CLIENT_ID}
+      OAUTH_REDIRECT_URI: !Env ${OAUTH_REDIRECT_URI}
+      FALLBACK_AUTHN_ENABLED: !Env ${FALLBACK_AUTHN_ENABLED}
+
+https://cmr.uat.earthdata.nasa.gov:
+
+  - name: non-sequential-query-cmr
+    description: |
+      testing service configuration with query-cmr with no is_sequential:
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/asf/opera-rtc-s1-browse
+    umm_s: S1271728813-ASF
+    maximum_sync_granules: 0
+    capabilities:
+      concatenation: false
+      subsetting:
+        bbox: false
+        variable: false
+        temporal: false
+      output_formats:
+        - image/png
+      reprojection: true
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: false
+      - image: !Env ${OPERA_RTC_S1_BROWSE_IMAGE}
+      - image: !Env ${HYBIG_IMAGE}

--- a/services/harmony/test/resources/services_with_unset_is_sequential_query_cmr_prod.yml
+++ b/services/harmony/test/resources/services_with_unset_is_sequential_query_cmr_prod.yml
@@ -1,0 +1,51 @@
+# Order for each CMR endpoint in this file will reflect precedence of the service when
+# multiple services handle a collection
+
+# Default turbo configuration
+x-turbo-config: &default-turbo-config
+  name: turbo
+  params: &default-turbo-params
+    env: &default-turbo-env
+      USE_LOCALSTACK: !Env ${USE_LOCALSTACK}
+      LOCALSTACK_HOST: !Env ${BACKEND_HOST}
+      AWS_DEFAULT_REGION: us-west-2
+      STAGING_BUCKET: !Env ${STAGING_BUCKET}
+      TEXT_LOGGER: !Env ${TEXT_LOGGER}
+      BACKEND_HOST: !Env ${BACKEND_HOST}
+      EDL_USERNAME: !Env ${EDL_USERNAME}
+      EDL_PASSWORD: !Env ${EDL_PASSWORD}
+      OAUTH_UID: !Env ${OAUTH_UID}
+      OAUTH_PASSWORD: !Env ${OAUTH_PASSWORD}
+      OAUTH_HOST: !Env ${OAUTH_HOST}
+      OAUTH_CLIENT_ID: !Env ${OAUTH_CLIENT_ID}
+      OAUTH_REDIRECT_URI: !Env ${OAUTH_REDIRECT_URI}
+      FALLBACK_AUTHN_ENABLED: !Env ${FALLBACK_AUTHN_ENABLED}
+
+https://cmr.earthdata.nasa.gov:
+
+  - name: non-sequential-query-cmr
+    description: |
+      testing service configuration with query-cmr with no is_sequential:
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/asf/opera-rtc-s1-browse
+    umm_s: S1271728813-ASF
+    maximum_sync_granules: 0
+    capabilities:
+      concatenation: false
+      subsetting:
+        bbox: false
+        variable: false
+        temporal: false
+      output_formats:
+        - image/png
+      reprojection: true
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+      - image: !Env ${OPERA_RTC_S1_BROWSE_IMAGE}
+      - image: !Env ${HYBIG_IMAGE}

--- a/services/harmony/test/resources/services_with_unset_is_sequential_query_cmr_uat.yml
+++ b/services/harmony/test/resources/services_with_unset_is_sequential_query_cmr_uat.yml
@@ -1,0 +1,51 @@
+# Order for each CMR endpoint in this file will reflect precedence of the service when
+# multiple services handle a collection
+
+# Default turbo configuration
+x-turbo-config: &default-turbo-config
+  name: turbo
+  params: &default-turbo-params
+    env: &default-turbo-env
+      USE_LOCALSTACK: !Env ${USE_LOCALSTACK}
+      LOCALSTACK_HOST: !Env ${BACKEND_HOST}
+      AWS_DEFAULT_REGION: us-west-2
+      STAGING_BUCKET: !Env ${STAGING_BUCKET}
+      TEXT_LOGGER: !Env ${TEXT_LOGGER}
+      BACKEND_HOST: !Env ${BACKEND_HOST}
+      EDL_USERNAME: !Env ${EDL_USERNAME}
+      EDL_PASSWORD: !Env ${EDL_PASSWORD}
+      OAUTH_UID: !Env ${OAUTH_UID}
+      OAUTH_PASSWORD: !Env ${OAUTH_PASSWORD}
+      OAUTH_HOST: !Env ${OAUTH_HOST}
+      OAUTH_CLIENT_ID: !Env ${OAUTH_CLIENT_ID}
+      OAUTH_REDIRECT_URI: !Env ${OAUTH_REDIRECT_URI}
+      FALLBACK_AUTHN_ENABLED: !Env ${FALLBACK_AUTHN_ENABLED}
+
+https://cmr.uat.earthdata.nasa.gov:
+
+  - name: non-sequential-query-cmr
+    description: |
+      testing service configuration with query-cmr with no is_sequential:
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/asf/opera-rtc-s1-browse
+    umm_s: S1271728813-ASF
+    maximum_sync_granules: 0
+    capabilities:
+      concatenation: false
+      subsetting:
+        bbox: false
+        variable: false
+        temporal: false
+      output_formats:
+        - image/png
+      reprojection: true
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+      - image: !Env ${OPERA_RTC_S1_BROWSE_IMAGE}
+      - image: !Env ${HYBIG_IMAGE}


### PR DESCRIPTION
Add is_sequential: true where missing for query-cmr in services.yml and validation for same

## Jira Issue ID
HARMONY-2007

## Description
This fixes a configuration error where some query-cmr steps did not have `sequential: true`. This was causing jobs to move from `RUNNING_WITH_ERRORS` to `COMPLETED_WITH_ERRORS` prematurely. It also adds a validation for this setting and tests for the validation.

## Local Test Steps
1. Do a deployment configured to point to production CMR/EDL. Or use my sandbox deployment here https://internal-harmony-jn-frontend-13863418.us-west-2.elb.amazonaws.com
2. Run the following query
```
http://localhost:3000/OPERA_L2_RTC-S1_V1/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&subset=time(%222025-01-01T00%3A00%3A00%22%3A%222025-01-02T00%3A00%3A00%22)&destinationUrl=s3%3A%2F%2Fcdd-harmony-sandbox-staging%2Fopera-browse-test&format=image%2Fpng&skipPreview=true&variable=all
```
This job will run very slowly due to issues with getting file sizes from S3 when updating work-items from query-cmr. Eventually it should move to `RUNNING_WITH_ERRORS`, and then after about an hour `COMPLETED_WITH_ERRORS`. 
3. Use the workflow-ui to verify that there are no running work-items. Or check the database.
You should see something like this if you set a `status: running` filter (no work-items runniing)
![image](https://github.com/user-attachments/assets/fac91212-38f5-4d6a-a41f-e58c2547fc77)



## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [x] Harmony in a Box tested? (if changes made to microservices or new dependencies added)