### PR TITLE
HARMONY-2008: Fix query-cmr granule size parsing logic

### DIFF
--- a/services/harmony/test/geojson-normalizer.ts
+++ b/services/harmony/test/geojson-normalizer.ts
@@ -511,12 +511,12 @@ describe('convertPointsToPolygons', () => {
   ];
 
   for (const [testGeoJson, expectedOutputFile] of pointTestCases) {
-    const expectedOutputJson = fs.readFileSync(path.resolve(__dirname, `resources/${expectedOutputFile}.geojson`), 'utf8');
+    const expectedOutputJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, `resources/${expectedOutputFile}.geojson`), 'utf8'));
 
     const normalizedGeoJson = convertPointsToPolygons(testGeoJson);
     it('should convert Points to Polygons', function () {
       expect(normalizedGeoJson.features[0].geometry.type).to.equal('Polygon');
-      expect(JSON.stringify(normalizedGeoJson, null, 2)).to.eql(expectedOutputJson);
+      expect(normalizedGeoJson).to.eql(expectedOutputJson);
     });
   }
 
@@ -526,12 +526,12 @@ describe('convertPointsToPolygons', () => {
   ];
 
   for (const [testGeoJson, expectedOutputFile] of multiPointTestCases) {
-    const expectedOutputJson = fs.readFileSync(path.resolve(__dirname, `resources/${expectedOutputFile}.geojson`), 'utf8');
+    const expectedOutputJson = JSON.parse(fs.readFileSync(path.resolve(__dirname, `resources/${expectedOutputFile}.geojson`), 'utf8'));
 
     const normalizedGeoJson = convertPointsToPolygons(testGeoJson);
     it('should convert MultiPoints to MultiPolygons', function () {
       expect(normalizedGeoJson.features[0].geometry.type).to.equal('MultiPolygon');
-      expect(JSON.stringify(normalizedGeoJson, null, 2)).to.eql(expectedOutputJson);
+      expect(normalizedGeoJson).to.eql(expectedOutputJson);
     });
   }
 

--- a/services/query-cmr/test/query.ts
+++ b/services/query-cmr/test/query.ts
@@ -1,0 +1,54 @@
+
+
+import { expect } from 'chai';
+
+import logger from '../../harmony/app/util/log';
+import { getGranuleSizeInBytes } from '../app/query';
+
+describe('#getGranuleSizeInBytes', () => {
+  it('should return 0 for undefined archiveInfo', () => {
+    expect(getGranuleSizeInBytes(logger, undefined)).to.equal(0);
+  });
+
+  it('should return 0 for null archiveInfo', () => {
+    expect(getGranuleSizeInBytes(logger, null)).to.equal(0);
+  });
+
+  it('should return 0 for empty archiveInfo array', () => {
+    expect(getGranuleSizeInBytes(logger, [])).to.equal(0);
+  });
+
+  it('should correctly handle a single entry with SizeInBytes', () => {
+    expect(getGranuleSizeInBytes(logger, [{ SizeInBytes: 5000 }])).to.equal(5000);
+  });
+
+  it('should correctly handle a single entry with Size and SizeUnit', () => {
+    expect(getGranuleSizeInBytes(logger, [{ Size: 2, SizeUnit: 'MB' }])).to.equal(2 * 1024 * 1024);
+  });
+
+  it('should correctly sum multiple entries with different units', () => {
+    const archiveInfo = [
+      { SizeInBytes: 5000 },
+      { Size: 1, SizeUnit: 'KB' },
+      { Size: 2, SizeUnit: 'MB' },
+      { Size: 3, SizeUnit: 'GB' },
+      { Size: 4, SizeUnit: 'TB' },
+    ];
+    const expectedSize =
+      5000 +
+      1 * 1024 +
+      2 * 1024 * 1024 +
+      3 * 1024 * 1024 * 1024 +
+      4 * 1024 * 1024 * 1024 * 1024;
+    expect(getGranuleSizeInBytes(logger, archiveInfo)).to.equal(expectedSize);
+  });
+
+  it('should treat an entry with an unknown SizeUnit as 0', () => {
+    expect(getGranuleSizeInBytes(logger, [{ Size: 10, SizeUnit: 'NA' }])).to.equal(0);
+  });
+
+  it('should use SizeInBytes when all fields are present', () => {
+    const archiveInfo = [{ Size: 2, SizeUnit: 'MB', SizeInBytes: 5000000 }];
+    expect(getGranuleSizeInBytes(logger, archiveInfo)).to.equal(5000000);
+  });
+});


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2008

## Description
Some providers use Size and SizeUnits in their CMR UMM-G metadata and others user SizeInBytes to specify the size of the granule files. This changes it to be able to correctly pull the size from either field. The UMM schema provides guidance that all providers should use SizeInBytes going forward, so if both are provided we use the SizeInBytes field.

## Local Test Steps
1. `npm run build` in `services/query-cmr`
2. `bin/restart-services`
3. Submit a request and verify it works as expected

I performed performance testing in my sandbox - a 110K granule request took 10 minutes to complete all of the query-cmr tasks and populate all of the work items.

I then redeployed my sandbox pointing to production metadata and issued the original request for this ticket. Each query-cmr work item took between 11 and 28 seconds to populate 2000 work items. Previously each query-cmr work item was taking at least 3 minutes and as long as 30 minutes.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested? (if changes made to microservices or new dependencies added)