### PR TITLE
HARMONY-2018: Move reformatting services to the bottom of services.yml

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -343,31 +343,6 @@ https://cmr.earthdata.nasa.gov:
         is_sequential: true
       - image: !Env ${GEOLOCO_IMAGE}
 
-  - name: net2cog
-    description: |
-      Converts NetCDF files to COG. Includes extension for running in NASA Harmony. https://github.com/podaac/net2cog
-    data_operation_version: '0.20.0'
-    type:
-      <<: *default-turbo-config
-      params:
-        <<: *default-turbo-params
-        env:
-          <<: *default-turbo-env
-          STAGING_PATH: public/harmony/net2cog
-    umm_s: S3177988677-POCLOUD
-    capabilities:
-      subsetting:
-        variable: true
-      output_formats:
-        # According to https://github.com/opengeospatial/CloudOptimizedGeoTIFF/issues/1 "image/tiff; application=geotiff; profile=cloud-optimized" is the media type that should be used for COG.
-        # pystac agrees https://pystac.readthedocs.io/en/stable/api/media_type.html
-        # Harmony only matches on the part before the first semi-colon
-        - image/tiff
-    steps:
-      - image: !Env ${QUERY_CMR_IMAGE}
-        is_sequential: true
-      - image: !Env ${NET2COG_IMAGE}
-
   - name: nasa/harmony-gdal-adapter
     description: |
       Service translating Harmony operations to GDAL commands.
@@ -526,10 +501,9 @@ https://cmr.earthdata.nasa.gov:
         conditional:
           exists: ['concatenate']
 
-  - name: harmony/service-example
+  - name: net2cog
     description: |
-      Reference service that can be used to perform most operations supported by Harmony.
-      Useful for testing new API features end-to-end on example data but not meant for production use.
+      Converts NetCDF files to COG. Includes extension for running in NASA Harmony. https://github.com/podaac/net2cog
     data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
@@ -537,22 +511,20 @@ https://cmr.earthdata.nasa.gov:
         <<: *default-turbo-params
         env:
           <<: *default-turbo-env
-          STAGING_PATH: public/harmony/service-example
-    umm_s: S2685815868-XYZ_PROV
+          STAGING_PATH: public/harmony/net2cog
+    umm_s: S3177988677-POCLOUD
     capabilities:
       subsetting:
-        bbox: true
         variable: true
-        multiple_variable: true
       output_formats:
+        # According to https://github.com/opengeospatial/CloudOptimizedGeoTIFF/issues/1 "image/tiff; application=geotiff; profile=cloud-optimized" is the media type that should be used for COG.
+        # pystac agrees https://pystac.readthedocs.io/en/stable/api/media_type.html
+        # Harmony only matches on the part before the first semi-colon
         - image/tiff
-        - image/png
-        - image/gif
-      reprojection: true
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
-      - image: !Env ${HARMONY_SERVICE_EXAMPLE_IMAGE}
+      - image: !Env ${NET2COG_IMAGE}
 
   - name: asf/opera-rtc-s1-browse
     description: Service that generates GIBS-compliant browse imagery for the OPERA_L2_RTC-S1 collection
@@ -580,6 +552,34 @@ https://cmr.earthdata.nasa.gov:
         is_sequential: true
       - image: !Env ${OPERA_RTC_S1_BROWSE_IMAGE}
       - image: !Env ${HYBIG_IMAGE}
+
+  - name: harmony/service-example
+    description: |
+      Reference service that can be used to perform most operations supported by Harmony.
+      Useful for testing new API features end-to-end on example data but not meant for production use.
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/harmony/service-example
+    umm_s: S2685815868-XYZ_PROV
+    capabilities:
+      subsetting:
+        bbox: true
+        variable: true
+        multiple_variable: true
+      output_formats:
+        - image/tiff
+        - image/png
+        - image/gif
+      reprojection: true
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${HARMONY_SERVICE_EXAMPLE_IMAGE}
 
 https://cmr.uat.earthdata.nasa.gov:
 
@@ -935,53 +935,6 @@ https://cmr.uat.earthdata.nasa.gov:
       - image: !Env ${TRAJECTORY_SUBSETTER_IMAGE}
         operations: ['variableSubset', 'spatialSubset', 'shapefileSubset', 'temporalSubset']
 
-  # This is an example service and backend from example/http-backend.js mounted by
-  # the frontend callback server.
-  # EOSS Example: curl -Lnbj 'http://localhost:3000/C1104-PVC_TS2/eoss/0.2.0/items/G1216319051-PVC_TS2'
-  - name: harmony/example
-    description: |
-      An example service for testing harmony http service integration. This service isn't docker-based or make GDAL calls - it does not actually do anything with the data files.
-    data_operation_version: '0.20.0'
-    enabled: !Env ${EXAMPLE_SERVICES}
-    type:
-      name: http
-      params:
-        url: http://127.0.0.1:4000/example/harmony
-    umm_s: S1233603903-EEDTEST
-    capabilities:
-      subsetting:
-        variable: true
-        bbox: true
-      output_formats:
-        - image/tiff
-      reprojection: true
-
-  - name: net2cog
-    description: |
-      Converts NetCDF files to COG. Includes extension for running in NASA Harmony. https://github.com/podaac/net2cog
-    data_operation_version: '0.20.0'
-    type:
-      <<: *default-turbo-config
-      params:
-        <<: *default-turbo-params
-        env:
-          <<: *default-turbo-env
-          STAGING_PATH: public/harmony/net2cog
-    umm_s: S1268612173-POCLOUD
-    capabilities:
-      subsetting:
-        variable: true
-      output_formats:
-        # According to https://github.com/opengeospatial/CloudOptimizedGeoTIFF/issues/1 "image/tiff; application=geotiff; profile=cloud-optimized" is the media type that should be used for COG.
-        # pystac agrees https://pystac.readthedocs.io/en/stable/api/media_type.html
-        # Harmony only matches on the part before the first semi-colon
-        - image/tiff
-    steps:
-      - image: !Env ${QUERY_CMR_IMAGE}
-        is_sequential: true
-      - image: !Env ${NET2COG_IMAGE}
-
-
   - name: nasa/harmony-gdal-adapter
     description: |
       Service translating Harmony operations to GDAL commands.
@@ -1072,7 +1025,6 @@ https://cmr.uat.earthdata.nasa.gov:
         is_sequential: true
       - image: !Env ${HARMONY_SMAP_L2_GRIDDER_IMAGE}
 
-  # CHAINED SERVICES BELOW HERE
   - name: sds/HOSS-geographic
     description: |
       A service that currently supports L3/L4 geographically gridded collections, offering variable, temporal, named dimension, bounding box spatial and shape file spatial subsetting.
@@ -1267,10 +1219,8 @@ https://cmr.uat.earthdata.nasa.gov:
         conditional:
           format: ['application/x-zarr']
 
-  - name: harmony/service-example
-    description: |
-      Reference service that can be used to perform most operations supported by Harmony.
-      Useful for testing new API features end-to-end on example data but not meant for production use.
+  - name: asf/opera-rtc-s1-browse
+    description: Service that generates GIBS-compliant browse imagery for the OPERA_L2_RTC-S1 collection
     data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
@@ -1278,25 +1228,23 @@ https://cmr.uat.earthdata.nasa.gov:
         <<: *default-turbo-params
         env:
           <<: *default-turbo-env
-          STAGING_PATH: public/harmony/service-example
-    umm_s: S1257851197-EEDTEST
-    collections:
-      - id: C1243747507-EEDTEST
-        granule_limit: 100 # added to test collection granule limits for HARMONY-795
+          STAGING_PATH: public/asf/opera-rtc-s1-browse
+    umm_s: S1271728813-ASF
+    maximum_sync_granules: 0
     capabilities:
+      concatenation: false
       subsetting:
-        bbox: true
-        variable: true
-        multiple_variable: true
+        bbox: false
+        variable: false
+        temporal: false
       output_formats:
-        - image/tiff
         - image/png
-        - image/gif
       reprojection: true
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
-      - image: !Env ${HARMONY_SERVICE_EXAMPLE_IMAGE}
+      - image: !Env ${OPERA_RTC_S1_BROWSE_IMAGE}
+      - image: !Env ${HYBIG_IMAGE}
 
   - name: l2-subsetter-batchee-stitchee-concise
     description: |
@@ -1364,8 +1312,9 @@ https://cmr.uat.earthdata.nasa.gov:
         conditional:
           exists: ['concatenate']
 
-  - name: asf/opera-rtc-s1-browse
-    description: Service that generates GIBS-compliant browse imagery for the OPERA_L2_RTC-S1 collection
+  - name: net2cog
+    description: |
+      Converts NetCDF files to COG. Includes extension for running in NASA Harmony. https://github.com/podaac/net2cog
     data_operation_version: '0.20.0'
     type:
       <<: *default-turbo-config
@@ -1373,20 +1322,69 @@ https://cmr.uat.earthdata.nasa.gov:
         <<: *default-turbo-params
         env:
           <<: *default-turbo-env
-          STAGING_PATH: public/asf/opera-rtc-s1-browse
-    umm_s: S1271728813-ASF
-    maximum_sync_granules: 0
+          STAGING_PATH: public/harmony/net2cog
+    umm_s: S1268612173-POCLOUD
     capabilities:
-      concatenation: false
       subsetting:
-        bbox: false
-        variable: false
-        temporal: false
+        variable: true
       output_formats:
+        # According to https://github.com/opengeospatial/CloudOptimizedGeoTIFF/issues/1 "image/tiff; application=geotiff; profile=cloud-optimized" is the media type that should be used for COG.
+        # pystac agrees https://pystac.readthedocs.io/en/stable/api/media_type.html
+        # Harmony only matches on the part before the first semi-colon
+        - image/tiff
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${NET2COG_IMAGE}
+
+  - name: harmony/service-example
+    description: |
+      Reference service that can be used to perform most operations supported by Harmony.
+      Useful for testing new API features end-to-end on example data but not meant for production use.
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/harmony/service-example
+    umm_s: S1257851197-EEDTEST
+    collections:
+      - id: C1243747507-EEDTEST
+        granule_limit: 100 # added to test collection granule limits for HARMONY-795
+    capabilities:
+      subsetting:
+        bbox: true
+        variable: true
+        multiple_variable: true
+      output_formats:
+        - image/tiff
         - image/png
+        - image/gif
       reprojection: true
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
-      - image: !Env ${OPERA_RTC_S1_BROWSE_IMAGE}
-      - image: !Env ${HYBIG_IMAGE}
+      - image: !Env ${HARMONY_SERVICE_EXAMPLE_IMAGE}
+
+  # This is an example service and backend from example/http-backend.js mounted by
+  # the frontend callback server.
+  # EOSS Example: curl -Lnbj 'http://localhost:3000/C1104-PVC_TS2/eoss/0.2.0/items/G1216319051-PVC_TS2'
+  - name: harmony/example
+    description: |
+      An example service for testing harmony http service integration. This service isn't docker-based or make GDAL calls - it does not actually do anything with the data files.
+    data_operation_version: '0.20.0'
+    enabled: !Env ${EXAMPLE_SERVICES}
+    type:
+      name: http
+      params:
+        url: http://127.0.0.1:4000/example/harmony
+    umm_s: S1233603903-EEDTEST
+    capabilities:
+      subsetting:
+        variable: true
+        bbox: true
+      output_formats:
+        - image/tiff
+      reprojection: true

--- a/config/services.yml
+++ b/config/services.yml
@@ -343,38 +343,6 @@ https://cmr.earthdata.nasa.gov:
         is_sequential: true
       - image: !Env ${GEOLOCO_IMAGE}
 
-  - name: nasa/harmony-gdal-adapter
-    description: |
-      Service translating Harmony operations to GDAL commands.
-      Supports spatial bounding box, temporal, variable, and shapefile, reprojection,
-      and output to NetCDF4 or COG.
-      Operates on input file types supported by GDAL (most EOSDIS data).
-      Most operations assume L3 data, though it is likely that some work on L2.
-    data_operation_version: '0.20.0'
-    type:
-      <<: *default-turbo-config
-      params:
-        <<: *default-turbo-params
-        env:
-          <<: *default-turbo-env
-          STAGING_PATH: public/nasa/harmony-gdal-adapter
-    umm_s: S2606110201-XYZ_PROV
-    capabilities:
-      subsetting:
-        temporal: true
-        shape: true
-        bbox: true
-        variable: true
-        multiple_variable: true
-      output_formats:
-        - application/x-netcdf4
-        - image/tiff
-      reprojection: true
-    steps:
-      - image: !Env ${QUERY_CMR_IMAGE}
-        is_sequential: true
-      - image: !Env ${HARMONY_GDAL_ADAPTER_IMAGE}
-
   - name: sds/HyBIG
     description: |
       The Harmony Browse Image Generator (HyBIG) supports the conversion of
@@ -553,6 +521,38 @@ https://cmr.earthdata.nasa.gov:
         is_sequential: true
       - image: !Env ${OPERA_RTC_S1_BROWSE_IMAGE}
       - image: !Env ${HYBIG_IMAGE}
+
+  - name: nasa/harmony-gdal-adapter
+    description: |
+      Service translating Harmony operations to GDAL commands.
+      Supports spatial bounding box, temporal, variable, and shapefile, reprojection,
+      and output to NetCDF4 or COG.
+      Operates on input file types supported by GDAL (most EOSDIS data).
+      Most operations assume L3 data, though it is likely that some work on L2.
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/nasa/harmony-gdal-adapter
+    umm_s: S2606110201-XYZ_PROV
+    capabilities:
+      subsetting:
+        temporal: true
+        shape: true
+        bbox: true
+        variable: true
+        multiple_variable: true
+      output_formats:
+        - application/x-netcdf4
+        - image/tiff
+      reprojection: true
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${HARMONY_GDAL_ADAPTER_IMAGE}
 
   - name: harmony/service-example
     description: |
@@ -936,38 +936,6 @@ https://cmr.uat.earthdata.nasa.gov:
       - image: !Env ${TRAJECTORY_SUBSETTER_IMAGE}
         operations: ['variableSubset', 'spatialSubset', 'shapefileSubset', 'temporalSubset']
 
-  - name: nasa/harmony-gdal-adapter
-    description: |
-      Service translating Harmony operations to GDAL commands.
-      Supports spatial bounding box, temporal, variable, and shapefile, reprojection,
-      and output to NetCDF4 or COG.
-      Operates on input file types supported by GDAL (most EOSDIS data).
-      Most operations assume L3 data, though it is likely that some work on L2.
-    data_operation_version: '0.20.0'
-    type:
-      <<: *default-turbo-config
-      params:
-        <<: *default-turbo-params
-        env:
-          <<: *default-turbo-env
-          STAGING_PATH: public/nasa/harmony-gdal-adapter
-    umm_s: S1245787332-EEDTEST
-    capabilities:
-      subsetting:
-        temporal: true
-        shape: true
-        bbox: true
-        variable: true
-        multiple_variable: true
-      output_formats:
-        - application/x-netcdf4
-        - image/tiff
-      reprojection: true
-    steps:
-      - image: !Env ${QUERY_CMR_IMAGE}
-        is_sequential: true
-      - image: !Env ${HARMONY_GDAL_ADAPTER_IMAGE}
-
   - name: sds/HyBIG
     description: |
       The Harmony Browse Image Generator (HyBIG) supports the conversion of
@@ -1338,6 +1306,38 @@ https://cmr.uat.earthdata.nasa.gov:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
       - image: !Env ${NET2COG_IMAGE}
+
+  - name: nasa/harmony-gdal-adapter
+    description: |
+      Service translating Harmony operations to GDAL commands.
+      Supports spatial bounding box, temporal, variable, and shapefile, reprojection,
+      and output to NetCDF4 or COG.
+      Operates on input file types supported by GDAL (most EOSDIS data).
+      Most operations assume L3 data, though it is likely that some work on L2.
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/nasa/harmony-gdal-adapter
+    umm_s: S1245787332-EEDTEST
+    capabilities:
+      subsetting:
+        temporal: true
+        shape: true
+        bbox: true
+        variable: true
+        multiple_variable: true
+      output_formats:
+        - application/x-netcdf4
+        - image/tiff
+      reprojection: true
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${HARMONY_GDAL_ADAPTER_IMAGE}
 
   - name: harmony/service-example
     description: |

--- a/config/services.yml
+++ b/config/services.yml
@@ -407,34 +407,6 @@ https://cmr.earthdata.nasa.gov:
         is_sequential: true
       - image: !Env ${HYBIG_IMAGE}
 
-  - name: harmony/netcdf-to-zarr
-    description: |
-      Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
-      The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
-    data_operation_version: '0.20.0'
-    type:
-      <<: *default-turbo-config
-      params:
-        <<: *default-turbo-params
-        env:
-          <<: *default-turbo-env
-          STAGING_PATH: public/harmony/netcdf-to-zarr
-    umm_s: S2839491596-XYZ_PROV
-    maximum_sync_granules: 0
-    capabilities:
-      concatenation: true
-      concatenate_by_default: false
-      subsetting:
-        variable: false
-      output_formats:
-        - application/x-zarr
-    steps:
-      - image: !Env ${QUERY_CMR_IMAGE}
-        is_sequential: true
-      - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
-        is_batched: false
-        operations: ['reformat', 'concatenate']
-
   - name: l2-subsetter-batchee-stitchee-concise
     description: |
       ### Subsetter And Multi-dimensional Batched Aggregation in Harmony (SAMBAH)
@@ -500,6 +472,35 @@ https://cmr.earthdata.nasa.gov:
         operations: ['concatenate']
         conditional:
           exists: ['concatenate']
+
+  # Reformatting services below. Any other transformation service should be added above.
+  - name: harmony/netcdf-to-zarr
+    description: |
+      Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
+      The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/harmony/netcdf-to-zarr
+    umm_s: S2839491596-XYZ_PROV
+    maximum_sync_granules: 0
+    capabilities:
+      concatenation: true
+      concatenate_by_default: false
+      subsetting:
+        variable: false
+      output_formats:
+        - application/x-zarr
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
+        is_batched: false
+        operations: ['reformat', 'concatenate']
 
   - name: net2cog
     description: |
@@ -1099,6 +1100,73 @@ https://cmr.uat.earthdata.nasa.gov:
         conditional:
           exists: ['shapefileSubset', 'spatialSubset']
 
+  - name: l2-subsetter-batchee-stitchee-concise
+    description: |
+      ### Subsetter And Multi-dimensional Batched Aggregation in Harmony (SAMBAH)
+      Chained Service of the L2-subsetter, Batchee, STITCHEE, and CONCISE services.
+      Additional documentation [here](https://stitchee.readthedocs.io/en/latest/sambah_readme/).
+      #### L2 swath subsetter (L2-subsetter)
+      * Works with trajectory (1D) and along track/across track data.
+      * Works with netCDF and HDF5 input files.
+      * Supports variable subsetting.
+      * Supports temporal subsetting.
+      * Supports shape subsetting
+      * Works with hierarchical groups.
+      * Outputs netCDF4.
+      #### Batchee
+      * Service groups together filenames so that further operations (such as concatenation) can be performed separately on each group of files.
+      #### STITCH by Extending a dimEnsion (Stitchee)
+      * Service concatenates a group of netCDF data files along an existing dimension.
+      #### CONCatenation SErvice (CONCISE)
+      * Service capable of "concatenating" multiple netCDF files into a single netCDF file.
+      The resulting file has an extra dimension with size equal to the number of input files, where each slice in that dimension corresponds to the data from one of the input files.
+      The resulting file has an extra dimension with size equal to the number of input files, where each slice in that dimension corresponds to the data from one of the input files.
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/asdc-trade/l2-subsetter-batchee-stitchee-concise
+    umm_s: S1262025641-LARC_CLOUD
+    capabilities:
+      concatenation: true
+      concatenate_by_default: false
+      extend: true
+      default_extend_dimensions: ['mirror_step']
+      subsetting:
+        bbox: true
+        variable: true
+        temporal: true
+        shape: true
+      output_formats:
+        - application/netcdf4
+      reprojection: false
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
+        operations: ['spatialSubset', 'shapefileSubset', 'variableSubset', 'temporalSubset']
+        conditional:
+          exists: ['spatialSubset', 'shapefileSubset', 'variableSubset', 'temporalSubset']
+        extra_args:
+          cut: false
+      - image: !Env ${BATCHEE_IMAGE}
+        operations: ['concatenate']
+        conditional:
+          exists: ['concatenate', 'extend']
+      - image: !Env ${STITCHEE_IMAGE}
+        operations: ['extend']
+        conditional:
+          exists: ['concatenate', 'extend']
+      - image: !Env ${PODAAC_CONCISE_IMAGE}
+        is_batched: true
+        operations: ['concatenate']
+        conditional:
+          exists: ['concatenate']
+
+  # Reformatting services below. Any other transformation service should be added above.
   - name: harmony/netcdf-to-zarr
     description: |
       Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
@@ -1245,72 +1313,6 @@ https://cmr.uat.earthdata.nasa.gov:
         is_sequential: true
       - image: !Env ${OPERA_RTC_S1_BROWSE_IMAGE}
       - image: !Env ${HYBIG_IMAGE}
-
-  - name: l2-subsetter-batchee-stitchee-concise
-    description: |
-      ### Subsetter And Multi-dimensional Batched Aggregation in Harmony (SAMBAH)
-      Chained Service of the L2-subsetter, Batchee, STITCHEE, and CONCISE services.
-      Additional documentation [here](https://stitchee.readthedocs.io/en/latest/sambah_readme/).
-      #### L2 swath subsetter (L2-subsetter)
-      * Works with trajectory (1D) and along track/across track data.
-      * Works with netCDF and HDF5 input files.
-      * Supports variable subsetting.
-      * Supports temporal subsetting.
-      * Supports shape subsetting
-      * Works with hierarchical groups.
-      * Outputs netCDF4.
-      #### Batchee
-      * Service groups together filenames so that further operations (such as concatenation) can be performed separately on each group of files.
-      #### STITCH by Extending a dimEnsion (Stitchee)
-      * Service concatenates a group of netCDF data files along an existing dimension.
-      #### CONCatenation SErvice (CONCISE)
-      * Service capable of "concatenating" multiple netCDF files into a single netCDF file.
-      The resulting file has an extra dimension with size equal to the number of input files, where each slice in that dimension corresponds to the data from one of the input files.
-      The resulting file has an extra dimension with size equal to the number of input files, where each slice in that dimension corresponds to the data from one of the input files.
-    data_operation_version: '0.20.0'
-    type:
-      <<: *default-turbo-config
-      params:
-        <<: *default-turbo-params
-        env:
-          <<: *default-turbo-env
-          STAGING_PATH: public/asdc-trade/l2-subsetter-batchee-stitchee-concise
-    umm_s: S1262025641-LARC_CLOUD
-    capabilities:
-      concatenation: true
-      concatenate_by_default: false
-      extend: true
-      default_extend_dimensions: ['mirror_step']
-      subsetting:
-        bbox: true
-        variable: true
-        temporal: true
-        shape: true
-      output_formats:
-        - application/netcdf4
-      reprojection: false
-    steps:
-      - image: !Env ${QUERY_CMR_IMAGE}
-        is_sequential: true
-      - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
-        operations: ['spatialSubset', 'shapefileSubset', 'variableSubset', 'temporalSubset']
-        conditional:
-          exists: ['spatialSubset', 'shapefileSubset', 'variableSubset', 'temporalSubset']
-        extra_args:
-          cut: false
-      - image: !Env ${BATCHEE_IMAGE}
-        operations: ['concatenate']
-        conditional:
-          exists: ['concatenate', 'extend']
-      - image: !Env ${STITCHEE_IMAGE}
-        operations: ['extend']
-        conditional:
-          exists: ['concatenate', 'extend']
-      - image: !Env ${PODAAC_CONCISE_IMAGE}
-        is_batched: true
-        operations: ['concatenate']
-        conditional:
-          exists: ['concatenate']
 
   - name: net2cog
     description: |

--- a/config/services.yml
+++ b/config/services.yml
@@ -442,34 +442,6 @@ https://cmr.earthdata.nasa.gov:
           exists: ['concatenate']
 
   # Reformatting services below. Any other transformation service should be added above.
-  - name: harmony/netcdf-to-zarr
-    description: |
-      Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
-      The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
-    data_operation_version: '0.20.0'
-    type:
-      <<: *default-turbo-config
-      params:
-        <<: *default-turbo-params
-        env:
-          <<: *default-turbo-env
-          STAGING_PATH: public/harmony/netcdf-to-zarr
-    umm_s: S2839491596-XYZ_PROV
-    maximum_sync_granules: 0
-    capabilities:
-      concatenation: true
-      concatenate_by_default: false
-      subsetting:
-        variable: false
-      output_formats:
-        - application/x-zarr
-    steps:
-      - image: !Env ${QUERY_CMR_IMAGE}
-        is_sequential: true
-      - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
-        is_batched: false
-        operations: ['reformat', 'concatenate']
-
   - name: net2cog
     description: |
       Converts NetCDF files to COG. Includes extension for running in NASA Harmony. https://github.com/podaac/net2cog
@@ -553,6 +525,34 @@ https://cmr.earthdata.nasa.gov:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
       - image: !Env ${HARMONY_GDAL_ADAPTER_IMAGE}
+
+  - name: harmony/netcdf-to-zarr
+    description: |
+      Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
+      The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/harmony/netcdf-to-zarr
+    umm_s: S2839491596-XYZ_PROV
+    maximum_sync_granules: 0
+    capabilities:
+      concatenation: true
+      concatenate_by_default: false
+      subsetting:
+        variable: false
+      output_formats:
+        - application/x-zarr
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
+        is_batched: false
+        operations: ['reformat', 'concatenate']
 
   - name: harmony/service-example
     description: |
@@ -1135,34 +1135,6 @@ https://cmr.uat.earthdata.nasa.gov:
           exists: ['concatenate']
 
   # Reformatting services below. Any other transformation service should be added above.
-  - name: harmony/netcdf-to-zarr
-    description: |
-      Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
-      The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
-    data_operation_version: '0.20.0'
-    type:
-      <<: *default-turbo-config
-      params:
-        <<: *default-turbo-params
-        env:
-          <<: *default-turbo-env
-          STAGING_PATH: public/harmony/netcdf-to-zarr
-    umm_s: S1237980031-EEDTEST
-    maximum_sync_granules: 0
-    capabilities:
-      concatenation: true
-      concatenate_by_default: false
-      subsetting:
-        variable: false
-      output_formats:
-        - application/x-zarr
-    steps:
-      - image: !Env ${QUERY_CMR_IMAGE}
-        is_sequential: true
-      - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
-        is_batched: false
-        operations: ['reformat', 'concatenate']
-
   - name: harmony/podaac-l2-subsetter-netcdf-to-zarr
     description: |
       ### Chained Service of the PODAAC L2 swath subsetter and Harmony netcdf-to-zarr services.
@@ -1338,6 +1310,34 @@ https://cmr.uat.earthdata.nasa.gov:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
       - image: !Env ${HARMONY_GDAL_ADAPTER_IMAGE}
+
+  - name: harmony/netcdf-to-zarr
+    description: |
+      Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
+      The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/harmony/netcdf-to-zarr
+    umm_s: S1237980031-EEDTEST
+    maximum_sync_granules: 0
+    capabilities:
+      concatenation: true
+      concatenate_by_default: false
+      subsetting:
+        variable: false
+      output_formats:
+        - application/x-zarr
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
+        is_batched: false
+        operations: ['reformat', 'concatenate']
 
   - name: harmony/service-example
     description: |

--- a/config/services.yml
+++ b/config/services.yml
@@ -1135,98 +1135,6 @@ https://cmr.uat.earthdata.nasa.gov:
           exists: ['concatenate']
 
   # Reformatting services below. Any other transformation service should be added above.
-  - name: harmony/podaac-l2-subsetter-netcdf-to-zarr
-    description: |
-      ### Chained Service of the PODAAC L2 swath subsetter and Harmony netcdf-to-zarr services.
-
-      #### PODAAC L2 swath subsetter
-      * Works with Trajectory (1D) and Along track/across track data.
-      * Works with NetCDF and HDF5 inputfiles
-      * Variable subsetting supported
-      * works with hierarchical groups
-      Outputs netcdf4.
-
-      #### Harmony netcdf-to-zarr service
-      Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
-      The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
-    data_operation_version: '0.20.0'
-    type:
-      <<: *default-turbo-config
-      params:
-        <<: *default-turbo-params
-        env:
-          <<: *default-turbo-env
-          STAGING_PATH: public/harmony/podaac-l2-subsetter-netcdf-to-zarr
-    maximum_sync_granules: 0
-    umm_s: S1239265626-EEDTEST
-    capabilities:
-      concatenation: true
-      concatenate_by_default: false
-      subsetting:
-        temporal: true
-        bbox: true
-        variable: true
-      output_formats:
-        - application/x-zarr
-    steps:
-      - image: !Env ${QUERY_CMR_IMAGE}
-        is_sequential: true
-      - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
-        operations: ['spatialSubset', 'variableSubset', 'temporalSubset']
-        conditional:
-          exists: ['spatialSubset', 'variableSubset', 'temporalSubset']
-      - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
-        is_batched: false
-        operations: ['reformat', 'concatenate']
-        conditional:
-          format: ['application/x-zarr']
-
-  - name: harmony/swath-projector-netcdf-to-zarr
-    description: |
-      ### Chained Service of the SDS Swath Projection and Harmony netcdf-to-zarr services.
-
-      #### SDS Swath Projector service
-      Takes NetCDF-4 input files and projects input swath variables to an output grid.
-      Target CRS, output grid dimensions, extents and/or resolutions can be specified in the Harmony request.
-
-      #### Harmony netcdf-to-zarr service
-      Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
-      The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
-
-    data_operation_version: '0.20.0'
-    type:
-      <<: *default-turbo-config
-      params:
-        <<: *default-turbo-params
-        env:
-          <<: *default-turbo-env
-          STAGING_PATH: public/harmony/swath-projector-netcdf-to-zarr
-    umm_s: S1240999847-EEDTEST
-    maximum_sync_granules: 0
-    capabilities:
-      concatenation: true
-      concatenate_by_default: false
-      subsetting:
-        bbox: false
-        variable: false
-      output_formats:
-        - application/netcdf # Incorrect mime-type, remove when no longer needed
-        - application/x-netcdf4
-        - application/x-zarr
-      reprojection: true
-    steps:
-      - image: !Env ${QUERY_CMR_IMAGE}
-        is_sequential: true
-      - image: !Env ${SWATH_PROJECTOR_IMAGE}
-        operations: ['reproject']
-        conditional:
-          exists: ['reproject']
-      - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
-        is_batched: false
-        operations: ['reformat', 'concatenate']
-        conditional:
-          format: ['application/x-zarr']
-
   - name: asf/opera-rtc-s1-browse
     description: Service that generates GIBS-compliant browse imagery for the OPERA_L2_RTC-S1 collection
     data_operation_version: '0.20.0'
@@ -1338,6 +1246,98 @@ https://cmr.uat.earthdata.nasa.gov:
       - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
         is_batched: false
         operations: ['reformat', 'concatenate']
+
+  - name: harmony/podaac-l2-subsetter-netcdf-to-zarr
+    description: |
+      ### Chained Service of the PODAAC L2 swath subsetter and Harmony netcdf-to-zarr services.
+
+      #### PODAAC L2 swath subsetter
+      * Works with Trajectory (1D) and Along track/across track data.
+      * Works with NetCDF and HDF5 inputfiles
+      * Variable subsetting supported
+      * works with hierarchical groups
+      Outputs netcdf4.
+
+      #### Harmony netcdf-to-zarr service
+      Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
+      The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/harmony/podaac-l2-subsetter-netcdf-to-zarr
+    maximum_sync_granules: 0
+    umm_s: S1239265626-EEDTEST
+    capabilities:
+      concatenation: true
+      concatenate_by_default: false
+      subsetting:
+        temporal: true
+        bbox: true
+        variable: true
+      output_formats:
+        - application/x-zarr
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
+        operations: ['spatialSubset', 'variableSubset', 'temporalSubset']
+        conditional:
+          exists: ['spatialSubset', 'variableSubset', 'temporalSubset']
+      - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
+        is_batched: false
+        operations: ['reformat', 'concatenate']
+        conditional:
+          format: ['application/x-zarr']
+
+  - name: harmony/swath-projector-netcdf-to-zarr
+    description: |
+      ### Chained Service of the SDS Swath Projection and Harmony netcdf-to-zarr services.
+
+      #### SDS Swath Projector service
+      Takes NetCDF-4 input files and projects input swath variables to an output grid.
+      Target CRS, output grid dimensions, extents and/or resolutions can be specified in the Harmony request.
+
+      #### Harmony netcdf-to-zarr service
+      Converts NetCDF4 files to the Zarr format as faithfully as possible, preserving metadata.
+      The service attempts to optimize chunking in both time and space via heuristic algorithm in the output Zarr store.
+
+    data_operation_version: '0.20.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/harmony/swath-projector-netcdf-to-zarr
+    umm_s: S1240999847-EEDTEST
+    maximum_sync_granules: 0
+    capabilities:
+      concatenation: true
+      concatenate_by_default: false
+      subsetting:
+        bbox: false
+        variable: false
+      output_formats:
+        - application/netcdf # Incorrect mime-type, remove when no longer needed
+        - application/x-netcdf4
+        - application/x-zarr
+      reprojection: true
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${SWATH_PROJECTOR_IMAGE}
+        operations: ['reproject']
+        conditional:
+          exists: ['reproject']
+      - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
+        is_batched: false
+        operations: ['reformat', 'concatenate']
+        conditional:
+          format: ['application/x-zarr']
 
   - name: harmony/service-example
     description: |

--- a/services/harmony/test/versions.ts
+++ b/services/harmony/test/versions.ts
@@ -35,7 +35,6 @@ describe('Versions endpoint', function () {
           'sds/variable-subsetter',
           'sds/maskfill',
           'sds/trajectory-subsetter',
-          'nasa/harmony-gdal-adapter',
           'sds/HyBIG',
           'sds/harmony-smap-l2-gridder',
           'sds/HOSS-geographic',
@@ -46,6 +45,7 @@ describe('Versions endpoint', function () {
           'harmony/swath-projector-netcdf-to-zarr',
           'asf/opera-rtc-s1-browse',
           'net2cog',
+          'nasa/harmony-gdal-adapter',
           'harmony/service-example',
         ]);
       });

--- a/services/harmony/test/versions.ts
+++ b/services/harmony/test/versions.ts
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
+
+import hookDescribeImage from './helpers/container-registry';
 import hookServersStartStop from './helpers/servers';
 import { hookServices } from './helpers/stub-service';
 import { hookVersions } from './helpers/versions';
-import hookDescribeImage from './helpers/container-registry';
 
 describe('Versions endpoint', function () {
   hookServersStartStop();
@@ -34,18 +35,18 @@ describe('Versions endpoint', function () {
           'sds/variable-subsetter',
           'sds/maskfill',
           'sds/trajectory-subsetter',
-          'net2cog',
           'nasa/harmony-gdal-adapter',
           'sds/HyBIG',
-	  'sds/harmony-smap-l2-gridder',
+          'sds/harmony-smap-l2-gridder',
           'sds/HOSS-geographic',
           'sds/HOSS-projection-gridded',
           'harmony/netcdf-to-zarr',
           'harmony/podaac-l2-subsetter-netcdf-to-zarr',
           'harmony/swath-projector-netcdf-to-zarr',
-          'harmony/service-example',
-          'l2-subsetter-batchee-stitchee-concise',
           'asf/opera-rtc-s1-browse',
+          'l2-subsetter-batchee-stitchee-concise',
+          'net2cog',
+          'harmony/service-example',
         ]);
       });
 

--- a/services/harmony/test/versions.ts
+++ b/services/harmony/test/versions.ts
@@ -40,12 +40,12 @@ describe('Versions endpoint', function () {
           'sds/HOSS-geographic',
           'sds/HOSS-projection-gridded',
           'l2-subsetter-batchee-stitchee-concise',
-          'harmony/netcdf-to-zarr',
           'harmony/podaac-l2-subsetter-netcdf-to-zarr',
           'harmony/swath-projector-netcdf-to-zarr',
           'asf/opera-rtc-s1-browse',
           'net2cog',
           'nasa/harmony-gdal-adapter',
+          'harmony/netcdf-to-zarr',
           'harmony/service-example',
         ]);
       });

--- a/services/harmony/test/versions.ts
+++ b/services/harmony/test/versions.ts
@@ -40,11 +40,11 @@ describe('Versions endpoint', function () {
           'sds/harmony-smap-l2-gridder',
           'sds/HOSS-geographic',
           'sds/HOSS-projection-gridded',
+          'l2-subsetter-batchee-stitchee-concise',
           'harmony/netcdf-to-zarr',
           'harmony/podaac-l2-subsetter-netcdf-to-zarr',
           'harmony/swath-projector-netcdf-to-zarr',
           'asf/opera-rtc-s1-browse',
-          'l2-subsetter-batchee-stitchee-concise',
           'net2cog',
           'harmony/service-example',
         ]);

--- a/services/harmony/test/versions.ts
+++ b/services/harmony/test/versions.ts
@@ -40,12 +40,12 @@ describe('Versions endpoint', function () {
           'sds/HOSS-geographic',
           'sds/HOSS-projection-gridded',
           'l2-subsetter-batchee-stitchee-concise',
-          'harmony/podaac-l2-subsetter-netcdf-to-zarr',
-          'harmony/swath-projector-netcdf-to-zarr',
           'asf/opera-rtc-s1-browse',
           'net2cog',
           'nasa/harmony-gdal-adapter',
           'harmony/netcdf-to-zarr',
+          'harmony/podaac-l2-subsetter-netcdf-to-zarr',
+          'harmony/swath-projector-netcdf-to-zarr',
           'harmony/service-example',
         ]);
       });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2018

## Description
Moves reformatting services to the bottom of services.yml to ensure they are matched last in tiebreaker scenarios. This fixes an issue where requests were being sent to `net2cog` when they should instead be sent to `sds/HOSS-projection-gridded`.

## Local Test Steps
Verify that http://localhost:3000/C1240150677-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&granuleId=G1245558662-EEDTEST&variable=%2FGPP%2Fgpp_mean&skipPreview=true is sent to `sds/HOSS-projection-gridded` (by checking http://localhost:3000/workflow-ui).

You can verify that in SIT and UAT the same request is currently going to `net2cog` which is not desired - https://harmony.uat.earthdata.nasa.gov/C1240150677-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&granuleId=G1245558662-EEDTEST&variable=%2FGPP%2Fgpp_mean&skipPreview=true

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested? (if changes made to microservices or new dependencies added)