### PR TITLE
HARMONY-2016: Fix race condition in work reaper.

### DIFF
--- a/services/cron-service/test/work-reaper.ts
+++ b/services/cron-service/test/work-reaper.ts
@@ -1,5 +1,6 @@
 import { describe, it } from 'mocha';
 import { expect } from 'chai';
+import { subMinutes } from 'date-fns';
 import MockDate from 'mockdate';
 import { buildJob } from './helpers/jobs';
 import { buildWorkflowStep } from './helpers/workflow-steps';
@@ -53,10 +54,11 @@ describe('WorkReaper-related functions', function () {
   describe('.getWorkItemIdsByJobUpdateAgeAndStatus', function () {
     it('returns the work items and steps of jobs that have not been updated for n minutes', async function () {
       MockDate.set(newDate);
+      const updatedAtCutoff = subMinutes(new Date(), 60);
 
       const itemIds = await getWorkItemIdsByJobUpdateAgeAndStatus(
         this.trx,
-        60,
+        updatedAtCutoff,
         [JobStatus.CANCELED, JobStatus.SUCCESSFUL, JobStatus.FAILED],
       );
       expect(itemIds.length).to.eql(3);
@@ -64,7 +66,7 @@ describe('WorkReaper-related functions', function () {
 
       const stepIds = await getWorkflowStepIdsByJobUpdateAgeAndStatus(
         this.trx,
-        60,
+        updatedAtCutoff,
         [JobStatus.CANCELED, JobStatus.SUCCESSFUL, JobStatus.FAILED],
       );
       expect(stepIds.length).to.eql(3);
@@ -75,17 +77,18 @@ describe('WorkReaper-related functions', function () {
 
     it('returns no work items / steps when they were created recently', async function () {
       MockDate.set(oldDate);
+      const updatedAtCutoff = subMinutes(new Date(), 60);
 
       const itemIds = await getWorkItemIdsByJobUpdateAgeAndStatus(
         this.trx,
-        60,
+        updatedAtCutoff,
         [JobStatus.CANCELED, JobStatus.SUCCESSFUL],
       );
       expect(itemIds.length).to.eql(0);
 
       const stepIds = await getWorkflowStepIdsByJobUpdateAgeAndStatus(
         this.trx,
-        60,
+        updatedAtCutoff,
         [JobStatus.CANCELED, JobStatus.SUCCESSFUL],
       );
       expect(stepIds.length).to.eql(0);
@@ -96,11 +99,12 @@ describe('WorkReaper-related functions', function () {
   describe('.deleteWorkItemsById', function () {
     it('deletes work items and steps by id', async function () {
       MockDate.set(newDate);
+      const updatedAtCutoff = subMinutes(new Date(), 60);
 
       // get the old work items
       const beforeDeletionItemIds = await getWorkItemIdsByJobUpdateAgeAndStatus(
         this.trx,
-        60,
+        updatedAtCutoff,
         [JobStatus.CANCELED, JobStatus.SUCCESSFUL, JobStatus.FAILED],
       );
       expect(beforeDeletionItemIds.length).to.eql(3);
@@ -110,7 +114,7 @@ describe('WorkReaper-related functions', function () {
       await deleteWorkItemsById(this.trx, beforeDeletionItemIds);
       const afterDeletionItemIds = await getWorkItemIdsByJobUpdateAgeAndStatus(
         this.trx,
-        60,
+        updatedAtCutoff,
         [JobStatus.CANCELED, JobStatus.SUCCESSFUL, JobStatus.FAILED],
       );
       expect(afterDeletionItemIds.length).to.eql(0);
@@ -118,7 +122,7 @@ describe('WorkReaper-related functions', function () {
       // get the old steps
       const beforeDeletionStepIds = await getWorkflowStepIdsByJobUpdateAgeAndStatus(
         this.trx,
-        60,
+        updatedAtCutoff,
         [JobStatus.CANCELED, JobStatus.SUCCESSFUL, JobStatus.FAILED],
       );
       expect(beforeDeletionStepIds.length).to.eql(3);
@@ -128,7 +132,7 @@ describe('WorkReaper-related functions', function () {
       await deleteWorkflowStepsById(this.trx, beforeDeletionItemIds);
       const afterDeletionStepIds = await getWorkflowStepIdsByJobUpdateAgeAndStatus(
         this.trx,
-        60,
+        updatedAtCutoff,
         [JobStatus.CANCELED, JobStatus.SUCCESSFUL, JobStatus.FAILED],
       );
       expect(afterDeletionStepIds.length).to.eql(0);


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2016

## Description
I think the issue is caused by the race condition between old work items cleanup and old workflow steps cleanup. Currently, work reaper uses the current time minus the `reapableWorkAgeMinutes` configuration value to find and cleanup old work items and old workflow steps, but because it takes time to run old work items cleanup, by the time it gets to workflow steps cleanup, there might be more work items that are eligible for cleanup based on the current time, thus causes the error documented in this ticket. 

The fix is to pre-calculate the cutoff time before executing the work items cleanup and the workflow steps cleanup to avoid the race condition.

## Local Test Steps
npm run test

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)