### PR TITLE
HARMONY-2030: Make successful service deployment logs available via Harmony deployment logs endpoint.

### DIFF
--- a/docs/guides/managing-existing-services.md
+++ b/docs/guides/managing-existing-services.md
@@ -109,7 +109,7 @@ curl -XGET -Ln -bj https://harmony.uat.earthdata.nasa.gov/service-deployment/<de
 ```
 **Example 8** - Get service image tag update status
 
-The returned JSON response has the fields indicating the current status of the service image deployment.
+The returned JSON response has the fields indicating the current status of the service image deployment. The service deployment log can be viewed via the link provided in `message` once the deployment is complete.
 
 ```JSON
 {
@@ -119,7 +119,7 @@ The returned JSON response has the fields indicating the current status of the s
   "tag": "new-version",
   "regressionTestVersion": "1.0.0",
   "status": "successful",
-  "message": "Deployment successful",
+  "message": "Deployment successful. See details at: https://harmony.uat.earthdata.nasa.gov/deployment-logs/befb50e0-e467-4776-86c8-e7218f1123cc",
   "createdAt": "2024-03-29T14:56:29.151Z",
   "updatedAt": "2024-03-29T14:56:29.273Z"
 }


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2030

## Description
Make successful service deployment logs available via Harmony deployment logs endpoint.

## Local Test Steps
Tested in Sandbox. Now, there is a deployment log link in the message field of a successful deployment status page which leads to the log of the service deployment. See:

https://internal-harmony-yliu10-frontend-569546241.us-west-2.elb.amazonaws.com/service-deployment/9fc2fec7-8a2d-43fc-90a5-9d209eafe6df

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)