### PR TITLE
DAS-2295: Add harmony-smap-l2-gridder to production configuration.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -494,6 +494,32 @@ https://cmr.earthdata.nasa.gov:
       - image: !Env ${OPERA_RTC_S1_BROWSE_IMAGE}
       - image: !Env ${HYBIG_IMAGE}
 
+  - name: sds/harmony-smap-l2-gridder
+    description: |
+      Harmony SMAP L2 Gridding Service. Takes L2G trajectories and reformats the data into the appropriate gridded output.
+    data_operation_version: '0.21.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/sds/harmony-smap-l2-gridder
+    umm_s: S3435625172-XYZ_PROV
+    capabilities:
+      concatenation: false
+      subsetting:
+        bbox: false
+        variable: false
+        temporal: false
+      output_formats:
+        - application/x-netcdf4
+      reprojection: true
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${HARMONY_SMAP_L2_GRIDDER_IMAGE}
+
   - name: nasa/harmony-gdal-adapter
     description: |
       Service translating Harmony operations to GDAL commands.


### PR DESCRIPTION
## Jira Issue ID

[DAS-2295](https://bugs.earthdata.nasa.gov/browse/DAS-2295)

## Description

This PR updates the Harmony services.yml with the information for harmony prod. It mimics the initial Harmony record for [smap-l2-gridder in UAT](https://github.com/nasa/harmony/pull/667/files#diff-9f2aab6054ac5cdd28c879e2e3c7ebfa25f39d24b40313e3148b4c940fb970d8).

It points to the correct UMM-S service record. Harmony SMAP-L2-Gridder [UMM-S Service record in production](https://mmt.earthdata.nasa.gov/services/S3435625172-XYZ_PROV)



## Local Test Steps

Probably to validate that the service image is built in production.  


## PR Acceptance Checklist
* [X] Acceptance criteria met
* [N/A] Tests added/updated (if needed) and passing
* [N/A] Documentation updated (if needed)
* [X] Harmony in a Box tested (if changes made to microservices or new dependencies added)