### PR TITLE
HARMONY-2024: As a harmony client, I want boolean parameters on transformation routes be validated against true/false

### DIFF
--- a/services/harmony/app/frontends/ogc-edr/get-data-common.ts
+++ b/services/harmony/app/frontends/ogc-edr/get-data-common.ts
@@ -1,7 +1,11 @@
 import DataOperation from '../../models/data-operation';
 import HarmonyRequest from '../../models/harmony-request';
 import wrap from '../../util/array';
-import { handleAveragingType, handleCrs, handleExtend, handleFormat, handleGranuleIds, handleGranuleNames, handleScaleExtent, handleScaleSize } from '../../util/parameter-parsers';
+import {
+  validateBooleanParameters, handleAveragingType, handleCrs, handleExtend, handleFormat,
+  handleGranuleIds, handleGranuleNames, handleScaleExtent, handleScaleSize, handleForceAsync,
+  handleIgnoreErrors, handlePixelSubset,
+} from '../../util/parameter-parsers';
 import { createDecrypter, createEncrypter } from '../../util/crypto';
 import env from '../../util/env';
 import { RequestValidationError } from '../../util/errors';
@@ -22,6 +26,7 @@ export function getDataCommon(
   req: HarmonyRequest,
 ): void {
   req.context.frontend = 'ogcEdr';
+  validateBooleanParameters(req.query);
   const query = keysToLowerCase(req.query);
 
   const encrypter = createEncrypter(env.sharedSecretKey);
@@ -36,20 +41,14 @@ export function getDataCommon(
   handleScaleExtent(operation, query);
   handleScaleSize(operation, query);
   handleAveragingType(operation, query);
+  handleForceAsync(operation, query);
+  handleIgnoreErrors(operation, query);
+  handlePixelSubset(operation, query);
 
   operation.interpolationMethod = query.interpolation;
   operation.outputWidth = query.width;
   operation.outputHeight = query.height;
-  if (query.forceasync) {
-    operation.isSynchronous = false;
-  }
-
-  operation.ignoreErrors = query.ignoreerrors === false ? false : true;
   operation.destinationUrl = query.destinationurl;
-
-  if (query.pixelsubset !== undefined) {
-    operation.pixelSubset = query.pixelsubset;
-  }
 
   try {
     const subset = parseSubsetParams(wrap(query.subset));

--- a/services/harmony/app/schemas/ogc-api-coverages/1.0.0/ogc-api-coverages-v1.0.0.yml
+++ b/services/harmony/app/schemas/ogc-api-coverages/1.0.0/ogc-api-coverages-v1.0.0.yml
@@ -903,7 +903,7 @@ components:
       description: if "true", override the default API behavior and always treat the request as asynchronous
       required: false
       schema:
-        type: boolean
+        type: string
     maxResults:
       name: maxResults
       in: query
@@ -925,7 +925,7 @@ components:
       description: if "true", override the default API behavior and never auto-pause jobs
       required: false
       schema:
-        type: boolean
+        type: string
     ignoreErrors:
       name: ignoreErrors
       in: query
@@ -934,7 +934,7 @@ components:
         immediately fail the request on the first failure. Defaults to true.
       required: false
       schema:
-        type: boolean
+        type: string
     destinationUrl:
       name: destinationUrl
       in: query
@@ -1017,4 +1017,4 @@ components:
       description: if "true", pixel subset will be performed by the service
       required: false
       schema:
-        type: boolean
+        type: string

--- a/services/harmony/app/schemas/ogc-api-edr/1.1.0/ogc-api-edr-v1.1.0.yml
+++ b/services/harmony/app/schemas/ogc-api-edr/1.1.0/ogc-api-edr-v1.1.0.yml
@@ -244,13 +244,13 @@ paths:
                 height:
                   type: integer
                 forceAsync:
-                  type: boolean
+                  type: string
                 maxResults:
                   type: integer
                 skipPreview:
-                  type: boolean
+                  type: string
                 ignoreErrors:
-                  type: boolean
+                  type: string
                 destinationUrl:
                   type: string
                 granuleName:
@@ -268,7 +268,7 @@ paths:
                 average:
                   type: string
                 pixelSubset:
-                  type: boolean
+                  type: string
       responses:
         "200":
           description: A collection's EDR.
@@ -393,13 +393,13 @@ paths:
                 height:
                   type: integer
                 forceAsync:
-                  type: boolean
+                  type: string
                 maxResults:
                   type: integer
                 skipPreview:
-                  type: boolean
+                  type: string
                 ignoreErrors:
-                  type: boolean
+                  type: string
                 destinationUrl:
                   type: string
                 granuleName:
@@ -417,7 +417,7 @@ paths:
                 average:
                   type: string
                 pixelSubset:
-                  type: boolean
+                  type: string
       responses:
         "200":
           description: A collection's EDR.
@@ -540,13 +540,13 @@ paths:
                 height:
                   type: integer
                 forceAsync:
-                  type: boolean
+                  type: string
                 maxResults:
                   type: integer
                 skipPreview:
-                  type: boolean
+                  type: string
                 ignoreErrors:
-                  type: boolean
+                  type: string
                 destinationUrl:
                   type: string
                 granuleName:
@@ -564,7 +564,7 @@ paths:
                 average:
                   type: string
                 pixelSubset:
-                  type: boolean
+                  type: string
       responses:
         "200":
           description: A edr description.
@@ -680,13 +680,13 @@ paths:
                 height:
                   type: integer
                 forceAsync:
-                  type: boolean
+                  type: string
                 maxResults:
                   type: integer
                 skipPreview:
-                  type: boolean
+                  type: string
                 ignoreErrors:
-                  type: boolean
+                  type: string
                 destinationUrl:
                   type: string
                 granuleName:
@@ -704,7 +704,7 @@ paths:
                 average:
                   type: string
                 pixelSubset:
-                  type: boolean
+                  type: string
       responses:
         "200":
           description: A collection's EDR.
@@ -821,13 +821,13 @@ paths:
                 height:
                   type: integer
                 forceAsync:
-                  type: boolean
+                  type: string
                 maxResults:
                   type: integer
                 skipPreview:
-                  type: boolean
+                  type: string
                 ignoreErrors:
-                  type: boolean
+                  type: string
                 destinationUrl:
                   type: string
                 granuleName:
@@ -845,7 +845,7 @@ paths:
                 average:
                   type: string
                 pixelSubset:
-                  type: boolean
+                  type: string
       responses:
         "200":
           description: A collection's EDR.
@@ -984,13 +984,13 @@ paths:
                 height:
                   type: integer
                 forceAsync:
-                  type: boolean
+                  type: string
                 maxResults:
                   type: integer
                 skipPreview:
-                  type: boolean
+                  type: string
                 ignoreErrors:
-                  type: boolean
+                  type: string
                 destinationUrl:
                   type: string
                 granuleName:
@@ -1008,7 +1008,7 @@ paths:
                 average:
                   type: string
                 pixelSubset:
-                  type: boolean
+                  type: string
       responses:
         "200":
           description: A collection's EDR.
@@ -1636,7 +1636,7 @@ components:
       description: if "true", override the default API behavior and always treat the request as asynchronous
       required: false
       schema:
-        type: boolean
+        type: string
     maxResults:
       name: maxResults
       in: query
@@ -1658,7 +1658,7 @@ components:
       description: if "true", override the default API behavior and never auto-pause jobs
       required: false
       schema:
-        type: boolean
+        type: string
     ignoreErrors:
       name: ignoreErrors
       in: query
@@ -1667,7 +1667,7 @@ components:
         immediately fail the request on the first failure. Defaults to true.
       required: false
       schema:
-        type: boolean
+        type: string
     destinationUrl:
       name: destinationUrl
       in: query
@@ -1738,4 +1738,4 @@ components:
         if "true", pixel subset will be performed by the service
       required: false
       schema:
-        type: boolean
+        type: string

--- a/services/harmony/app/util/cmr.ts
+++ b/services/harmony/app/util/cmr.ts
@@ -492,8 +492,8 @@ async function processGeoJson(geoJsonOrUri: string, formData: FormData): Promise
     });
     return tempFile;
   } else {
-    logger.error('GEOJSON :');
-    logger.error(geoJsonOrUri);
+    logger.info('GEOJSON :');
+    logger.info(geoJsonOrUri);
     const buf = Buffer.from(geoJsonOrUri);
     formData.append('shapefile', buf, {
       contentType: 'application/geo+json',

--- a/services/harmony/test/ignore-errors.ts
+++ b/services/harmony/test/ignore-errors.ts
@@ -22,14 +22,14 @@ const reprojectAndZarrQuery = {
   scaleExtent: '0,2500000.3,1500000,3300000',
   scaleSize: '1.1,2',
   format: 'application/x-zarr',
-  concatenate: 'false',
+  concatenate: false,
 };
 
 const l2ssAndConciseQuery = {
   subset: 'lat(0:90)',
-  concatenate: 'false',
+  concatenate: false,
   maxResults: 1,
-  ignoreErrors: 'true',
+  ignoreErrors: true,
 };
 
 const collection = 'C1233800302-EEDTEST';
@@ -1549,7 +1549,7 @@ describe('ignoreErrors', function () {
 
   describe('when setting ignoreErrors=false', function () {
     describe('when making a request for 3 granules and one fails while in progress', function () {
-      hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery, ...{ maxResults: 3, ignoreErrors: 'false' } } });
+      hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery, ...{ maxResults: 3, ignoreErrors: false } } });
       hookRedirect('joe');
 
       before(async function () {

--- a/services/harmony/test/ignore-errors.ts
+++ b/services/harmony/test/ignore-errors.ts
@@ -22,14 +22,14 @@ const reprojectAndZarrQuery = {
   scaleExtent: '0,2500000.3,1500000,3300000',
   scaleSize: '1.1,2',
   format: 'application/x-zarr',
-  concatenate: false,
+  concatenate: 'false',
 };
 
 const l2ssAndConciseQuery = {
   subset: 'lat(0:90)',
-  concatenate: false,
+  concatenate: 'false',
   maxResults: 1,
-  ignoreErrors: true,
+  ignoreErrors: 'true',
 };
 
 const collection = 'C1233800302-EEDTEST';
@@ -1549,7 +1549,7 @@ describe('ignoreErrors', function () {
 
   describe('when setting ignoreErrors=false', function () {
     describe('when making a request for 3 granules and one fails while in progress', function () {
-      hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery, ...{ maxResults: 3, ignoreErrors: false } } });
+      hookRangesetRequest('1.0.0', collection, 'all', { query: { ...reprojectAndZarrQuery, ...{ maxResults: 3, ignoreErrors: 'false' } } });
       hookRedirect('joe');
 
       before(async function () {

--- a/services/harmony/test/ogc-api-coverages/get-coverage-rangeset.ts
+++ b/services/harmony/test/ogc-api-coverages/get-coverage-rangeset.ts
@@ -535,7 +535,7 @@ describe('OGC API Coverages - getCoverageRangeset', function () {
     StubService.hook({ params: { redirect: 'http://example.com' } });
 
     describe('set to "true"', function () {
-      const forceAsync = true;
+      const forceAsync = 'true';
 
       describe('and making a request would otherwise be synchronous', function () {
         hookRangesetRequest(version, collection, variableName,
@@ -556,7 +556,7 @@ describe('OGC API Coverages - getCoverageRangeset', function () {
     });
 
     describe('set to "false"', function () {
-      const forceAsync = false;
+      const forceAsync = 'false';
 
       describe('and making a request would otherwise be synchronous', function () {
         hookRangesetRequest(version, collection, variableName,

--- a/services/harmony/test/ogc-api-edr/get-data-for-area.ts
+++ b/services/harmony/test/ogc-api-edr/get-data-for-area.ts
@@ -51,8 +51,8 @@ describe('OGC API EDR - getEdrArea', function () {
           height: 500,
           width: 1000,
           f: 'image/png',
-          skipPreview: true,
-          pixelSubset: true,
+          skipPreview: 'true',
+          pixelSubset: 'true',
           // extend: 'lat,lon', TODO: HARMONY-1569 support extend
         };
 
@@ -397,7 +397,7 @@ describe('OGC API EDR - getEdrArea', function () {
     StubService.hook({ params: { redirect: 'http://example.com' } });
 
     describe('set to "true"', function () {
-      const forceAsync = true;
+      const forceAsync = 'true';
 
       describe('and making a request would otherwise be synchronous', function () {
         hookEdrRequest('area', version, collection,
@@ -418,7 +418,7 @@ describe('OGC API EDR - getEdrArea', function () {
     });
 
     describe('set to "false"', function () {
-      const forceAsync = false;
+      const forceAsync = 'false';
 
       describe('and making a request would otherwise be synchronous', function () {
         hookEdrRequest('area', version, collection,

--- a/services/harmony/test/ogc-api-edr/get-data-for-cube.ts
+++ b/services/harmony/test/ogc-api-edr/get-data-for-cube.ts
@@ -49,7 +49,7 @@ describe('OGC API EDR - getEdrCube', function () {
           height: 500,
           width: 1000,
           f: 'image/png',
-          skipPreview: true,
+          skipPreview: 'true',
           // extend: 'lat,lon', TODO: HARMONY-1569 support extend
         };
 
@@ -418,7 +418,7 @@ describe('OGC API EDR - getEdrCube', function () {
     StubService.hook({ params: { redirect: 'http://example.com' } });
 
     describe('set to "true"', function () {
-      const forceAsync = true;
+      const forceAsync = 'true';
 
       describe('and making a request would otherwise be synchronous', function () {
         hookEdrRequest('cube', version, collection,
@@ -439,7 +439,7 @@ describe('OGC API EDR - getEdrCube', function () {
     });
 
     describe('set to "false"', function () {
-      const forceAsync = false;
+      const forceAsync = 'false';
 
       describe('and making a request would otherwise be synchronous', function () {
         hookEdrRequest('cube', version, collection,

--- a/services/harmony/test/ogc-api-edr/get-data-for-point.ts
+++ b/services/harmony/test/ogc-api-edr/get-data-for-point.ts
@@ -107,7 +107,7 @@ describe('OGC API EDR - getEdrPosition', function () {
           height: 500,
           width: 1000,
           f: 'image/png',
-          skipPreview: true,
+          skipPreview: 'true',
           // extend: 'lat,lon', TODO: HARMONY-1569 support extend
         };
 
@@ -448,7 +448,7 @@ describe('OGC API EDR - getEdrPosition', function () {
     StubService.hook({ params: { redirect: 'http://example.com' } });
 
     describe('set to "true"', function () {
-      const forceAsync = true;
+      const forceAsync = 'true';
 
       describe('and making a request would otherwise be synchronous', function () {
         hookEdrRequest('position', version, collection,
@@ -469,7 +469,7 @@ describe('OGC API EDR - getEdrPosition', function () {
     });
 
     describe('set to "false"', function () {
-      const forceAsync = false;
+      const forceAsync = 'false';
 
       describe('and making a request would otherwise be synchronous', function () {
         hookEdrRequest('position', version, collection,

--- a/services/harmony/test/ogc-api-edr/get-data-for-trajectory.ts
+++ b/services/harmony/test/ogc-api-edr/get-data-for-trajectory.ts
@@ -141,7 +141,7 @@ describe('OGC API EDR - getEdrTrajectory', function () {
           height: 500,
           width: 1000,
           f: 'image/png',
-          skipPreview: true,
+          skipPreview: 'true',
           // extend: 'lat,lon', TODO: HARMONY-1569 support extend
         };
 

--- a/services/harmony/test/parameters/concatenation.ts
+++ b/services/harmony/test/parameters/concatenation.ts
@@ -105,7 +105,7 @@ describe('testing concatenation', function () {
           expect(this.res.statusCode).to.equal(400);
           expect(this.res.body).to.eql({
             code: 'harmony.RequestValidationError',
-            description: 'Error: query parameter "concatenate" \'random\' must be \'false\' or \'true\'',
+            description: 'Error: query parameter \"concatenate\" must be either true or false',
           });
         });
       });

--- a/services/harmony/test/util/parameter-parser.ts
+++ b/services/harmony/test/util/parameter-parser.ts
@@ -1,0 +1,142 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+
+import DataOperation from '../../app/models/data-operation';
+import { validateBooleanField, handleForceAsync, handleIgnoreErrors, handlePixelSubset } from '../../app/util/parameter-parsers';
+import { RequestValidationError } from '../../app/util/errors';
+import { buildOperation } from '../helpers/data-operation';
+
+describe('validateBooleanField', () => {
+  it('should not throw an error for "true" string', () => {
+    expect(() => validateBooleanField('testField', 'true')).to.not.throw();
+  });
+
+  it('should not throw an error for "false" string', () => {
+    expect(() => validateBooleanField('testField', 'false')).to.not.throw();
+  });
+
+  it('should not throw an error for mixed case "TrUe" string', () => {
+    expect(() => validateBooleanField('testField', 'TrUe')).to.not.throw();
+  });
+
+  it('should not throw an error for mixed case "FaLsE" string', () => {
+    expect(() => validateBooleanField('testField', 'FaLsE')).to.not.throw();
+  });
+
+  it('should throw RequestValidationError for invalid string', () => {
+    expect(() => validateBooleanField('testField', 'invalid')).to.throw(RequestValidationError, 'query parameter "testField" must be either true or false');
+  });
+
+  it('should throw RequestValidationError for numbers', () => {
+    expect(() => validateBooleanField('testField', 123 as unknown as string)).to.throw(RequestValidationError, 'query parameter "testField" must be either true or false');
+  });
+
+  it('should throw RequestValidationError for empty string', () => {
+    expect(() => validateBooleanField('testField', '')).to.throw(RequestValidationError, 'query parameter "testField" must be either true or false');
+  });
+
+  it('should not throw an error if value is undefined', () => {
+    expect(() => validateBooleanField('testField', undefined as unknown as string)).to.not.throw();
+  });
+});
+
+describe('handleForceAsync', () => {
+  let operation: DataOperation;
+
+  beforeEach(() => {
+    operation = buildOperation(undefined);
+  });
+
+  it('should not modify operation when query.forceasync is undefined', () => {
+    handleForceAsync(operation, {});
+    expect(operation.isSynchronous).to.be.undefined;
+  });
+
+  it('should set isSynchronous to false when query.forceasync is string "true"', () => {
+    handleForceAsync(operation, { forceasync: 'true' });
+    expect(operation.isSynchronous).to.be.false;
+  });
+
+  it('should set isSynchronous to undefined when query.forceasync is string "false"', () => {
+    handleForceAsync(operation, { forceasync: 'false' });
+    expect(operation.isSynchronous).to.be.undefined;
+  });
+
+  it('should set isSynchronous to false when query.forceasync is mixed case "TrUe"', () => {
+    handleForceAsync(operation, { forceasync: 'TrUe' });
+    expect(operation.isSynchronous).to.be.false;
+  });
+
+  it('should set isSynchronous to undefined when query.forceasync is mixed case "FaLsE"', () => {
+    handleForceAsync(operation, { forceasync: 'FaLsE' });
+    expect(operation.isSynchronous).to.be.undefined;
+  });
+});
+
+describe('handleIgnoreErrors', () => {
+  let operation: DataOperation;
+
+  beforeEach(() => {
+    operation = buildOperation(undefined);
+  });
+
+  it('should set ignoreErrors to true when query.ignoreerrors is undefined', () => {
+    handleIgnoreErrors(operation, {});
+    expect(operation.ignoreErrors).to.be.true;
+  });
+
+  it('should set ignoreErrors to true when query.ignoreerrors is string "true"', () => {
+    handleIgnoreErrors(operation, { ignoreerrors: 'true' });
+    expect(operation.ignoreErrors).to.be.true;
+  });
+
+  it('should set ignoreErrors to false when query.ignoreerrors is string "false"', () => {
+    handleIgnoreErrors(operation, { ignoreerrors: 'false' });
+    expect(operation.ignoreErrors).to.be.false;
+  });
+
+  it('should set ignoreErrors to true when query.ignoreerrors is mixed case "TrUe"', () => {
+    handleIgnoreErrors(operation, { ignoreerrors: 'TrUe' });
+    expect(operation.ignoreErrors).to.be.true;
+  });
+
+  it('should set ignoreErrors to false when query.ignoreerrors is mixed case "FaLsE"', () => {
+    handleIgnoreErrors(operation, { ignoreerrors: 'FaLsE' });
+    expect(operation.ignoreErrors).to.be.false;
+  });
+
+});
+
+describe('handlePixelSubset', () => {
+  let operation: DataOperation;
+
+  beforeEach(() => {
+    operation = buildOperation(undefined);
+  });
+
+  it('should not modify operation when query.pixelsubset is undefined', () => {
+    handlePixelSubset(operation, {});
+    expect(operation.pixelSubset).to.be.undefined;
+  });
+
+  it('should set pixelSubset to true when query.pixelsubset is string "true"', () => {
+    handlePixelSubset(operation, { pixelsubset: 'true' });
+    expect(operation.pixelSubset).to.be.true;
+  });
+
+  it('should set pixelSubset to false when query.pixelsubset is string "false"', () => {
+    handlePixelSubset(operation, { pixelsubset: 'false' });
+    expect(operation.pixelSubset).to.be.false;
+  });
+
+  it('should set pixelSubset to true when query.pixelsubset is mixed case "TrUe"', () => {
+    handlePixelSubset(operation, { pixelsubset: 'TrUe' });
+    expect(operation.pixelSubset).to.be.true;
+  });
+
+  it('should set pixelSubset to false when query.pixelsubset is mixed case "FaLsE"', () => {
+    handlePixelSubset(operation, { pixelsubset: 'FaLsE' });
+    expect(operation.pixelSubset).to.be.false;
+  });
+});
+

--- a/services/harmony/test/util/parameter-parsing-helpers.ts
+++ b/services/harmony/test/util/parameter-parsing-helpers.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'mocha';
 import { expect } from 'chai';
 import { ParameterParseError, parseBoolean, parseMultiValueParameter, parseNumber, parseWkt } from '../../app/util/parameter-parsing-helpers';
 
-describe('util/parameter-parsing', function () {
+describe('util/parameter-parsing-helpers', function () {
   describe('#parseMultiValueParameter', function () {
     it('returns an array unchanged when it receives an array', function () {
       expect(parseMultiValueParameter(['foo', 'bar'])).to.eql(['foo', 'bar']);


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2024

## Description
As a harmony client, I want boolean parameters on transformation routes be validated against true/false

## Local Test Steps
Submit OGC rangeset and EDR requests with different values for boolean parameters, e.g. 
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&subset=lat(20%3A60)&subset=lon(-140%3A-50)&label=harmony-py&outputcrs=EPSG%3A31975&granuleId=G1233800343-EEDTEST&format=image%2Fpng&variable=blue_var&pixelSubset=xyz

http://localhost:3000/ogc-api-edr/1.1.0/collections/C1233800302-EEDTEST/area?forceAsync=true&coords=POLYGON((-140%2020%2C%20-50%2020%2C%20-50%2060%2C%20-140%2060%2C%20-140%2020))&datetime=1980-01-01T00%3A00%3A00Z%2F2020-12-30T00%3A00%3A00Z&label=harmony-py&crs=EPSG%3A31975&granuleId=C1233800302-EEDTEST&f=image%2Fpng&maxResults=1&parameter-name=blue_var&pixelSubset=tru

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)