### PR TITLE
HARMONY-1986: As a Harmony operator I want the Harmony health endpoint to provide more detailed and fine-grained information

### DIFF
--- a/services/harmony/app/frontends/health.ts
+++ b/services/harmony/app/frontends/health.ts
@@ -72,7 +72,7 @@ async function getGeneralHealth(context: RequestContext): Promise<HealthStatus> 
   } : {
     name: 'cmr',
     status: DOWN,
-    message: `CMR is down. ${cmrMessage}`,
+    message: cmrMessage,
   };
 
   const edlHealthy = await isEdlHealthy(context);

--- a/services/harmony/app/frontends/health.ts
+++ b/services/harmony/app/frontends/health.ts
@@ -1,5 +1,5 @@
 import { Response, NextFunction } from 'express';
-import { cmrApiConfig, isCmrHealthy } from '../util/cmr';
+import { isCmrHealthy } from '../util/cmr';
 import { isEdlHealthy } from '../util/edl-api';
 import HarmonyRequest from '../models/harmony-request';
 import { Job } from '../models/job';
@@ -65,14 +65,14 @@ async function getDbHealth(): Promise<DependencyStatus> {
 async function getGeneralHealth(context: RequestContext): Promise<HealthStatus> {
   const dbHealth = await getDbHealth();
 
-  const cmrHealthy = await isCmrHealthy();
+  const { healthy: cmrHealthy, message: cmrMessage } = await isCmrHealthy();
   const cmrHealth = cmrHealthy ? {
     name: 'cmr',
     status: UP,
   } : {
     name: 'cmr',
     status: DOWN,
-    message: `CMR is down. For details see: ${cmrApiConfig.baseURL}/search/health`,
+    message: `CMR is down. ${cmrMessage}`,
   };
 
   const edlHealthy = await isEdlHealthy(context);

--- a/services/harmony/app/util/cmr.ts
+++ b/services/harmony/app/util/cmr.ts
@@ -1095,29 +1095,20 @@ export function filterGranuleLinks(
 /**
  * Returns CMR health information
  *
- * @returns a promise resolving to the DependencyStatus of CMR
+ * @returns A Promise containing `true` if CMR is up
  */
-export async function getCmrHealth(): Promise<object> {
+export async function isCmrHealthy(): Promise<boolean> {
   try {
     const response: CmrResponse = await fetch(`${cmrApiConfig.baseURL}/search/health`);
     response.data = await response.json();
     if (response.status === 200) {
-      return {
-        name: 'cmr',
-        status: 'up',
-      };
+      return true;
     } else {
-      return {
-        name: 'cmr',
-        status: 'down',
-        message: `${JSON.stringify(response.data)}`,
-      };
+      return false;
     }
-  } catch (error) {
-    return {
-      name: 'cmr',
-      status: 'down',
-      message: 'Unable to get CMR health info',
-    };
+  } catch (e) {
+    logger.error('Unable to get CMR health info');
+    logger.error(e);
+    return false;
   }
 }

--- a/services/harmony/app/util/cmr.ts
+++ b/services/harmony/app/util/cmr.ts
@@ -1098,12 +1098,12 @@ export function filterGranuleLinks(
  *
  * @returns A Promise with healthy and message indicating the CMR health info
  */
-export async function getCmrHealth(): Promise<{ healthy: boolean; message: string }> {
+export async function getCmrHealth(): Promise<{ healthy: boolean; message?: string }> {
   try {
     const response: CmrResponse = await fetch(`${cmrApiConfig.baseURL}/search/health`);
 
     if (response.status === 200) {
-      return { healthy: true, message: '' };
+      return { healthy: true };
     } else {
       const contentType = response.headers.get('content-type');
       const message = contentType?.includes('application/json')

--- a/services/harmony/app/util/cmr.ts
+++ b/services/harmony/app/util/cmr.ts
@@ -1091,3 +1091,33 @@ export function filterGranuleLinks(
   return granule.links.filter((g) => (g.rel.endsWith('/data#') || g.rel.endsWith('/service#'))
     && !g.inherited);
 }
+
+/**
+ * Returns CMR health information
+ *
+ * @returns a promise resolving to the DependencyStatus of CMR
+ */
+export async function getCmrHealth(): Promise<object> {
+  try {
+    const response: CmrResponse = await fetch(`${cmrApiConfig.baseURL}/search/health`);
+    response.data = await response.json();
+    if (response.status === 200) {
+      return {
+        name: 'cmr',
+        status: 'up',
+      };
+    } else {
+      return {
+        name: 'cmr',
+        status: 'down',
+        message: `${JSON.stringify(response.data)}`,
+      };
+    }
+  } catch (error) {
+    return {
+      name: 'cmr',
+      status: 'down',
+      message: 'Unable to get CMR health info',
+    };
+  }
+}

--- a/services/harmony/app/util/cmr.ts
+++ b/services/harmony/app/util/cmr.ts
@@ -1098,7 +1098,7 @@ export function filterGranuleLinks(
  *
  * @returns A Promise with healthy and message indicating the CMR health info
  */
-export async function isCmrHealthy(): Promise<{ healthy: boolean; message: string }> {
+export async function getCmrHealth(): Promise<{ healthy: boolean; message: string }> {
   try {
     const response: CmrResponse = await fetch(`${cmrApiConfig.baseURL}/search/health`);
 

--- a/services/harmony/app/util/edl-api.ts
+++ b/services/harmony/app/util/edl-api.ts
@@ -215,3 +215,22 @@ export async function validateUserIsInCoreGroup(
 
   return true;
 }
+
+/**
+ * Returns true if EDL is up
+ *
+ * @param context - Information related to the user's request
+ * @param username - The EDL username
+ * @returns the groups to which the user belongs
+ */
+export async function isEdlHealthy(context: RequestContext): Promise<boolean> {
+  const { logger } = context;
+  try {
+    const response = await axios.default.get(`${env.oauthHost}/home`);
+    return response.status === 200;
+  } catch (e) {
+    logger.error('Failed to access EDL home page.');
+    logger.error(e);
+    return false;
+  }
+}

--- a/services/harmony/app/util/edl-api.ts
+++ b/services/harmony/app/util/edl-api.ts
@@ -219,9 +219,8 @@ export async function validateUserIsInCoreGroup(
 /**
  * Returns true if EDL is up
  *
- * @param context - Information related to the user's request
- * @param username - The EDL username
- * @returns the groups to which the user belongs
+ * @param context - request context
+ * @returns A Promise containing `true` if EDL is up
  */
 export async function isEdlHealthy(context: RequestContext): Promise<boolean> {
   const { logger } = context;

--- a/services/harmony/test/health.ts
+++ b/services/harmony/test/health.ts
@@ -39,6 +39,10 @@ const databaseDownHealthResponse = {
   }],
 };
 
+const cmrUpStatus = { healthy: true, message: '' };
+const cmrDownMessage = '{"indexer":{"ok?":false,"dependencies":{"elastic_search":{"ok?":false},"metadata-db":{"ok?":true,"dependencies":{"oracle":{"ok?":true}}}}}}';
+const cmrDownStatus = { healthy: false, message: cmrDownMessage };
+
 const dependenciesDownHealthResponse = {
   status: 'down',
   message: 'Harmony is currently down.',
@@ -50,7 +54,7 @@ const dependenciesDownHealthResponse = {
   {
     name: 'cmr',
     status: 'down',
-    message: 'CMR is down. For details see: https://cmr.uat.earthdata.nasa.gov/search/health',
+    message: `CMR is down. ${cmrDownMessage}`,
   },
   {
     name: 'edl',
@@ -65,7 +69,7 @@ describe('Health endpoints', function () {
   describe('When calling /health', function () {
     describe('When not authenticated', function () {
       describe('When the system is healthy', function () {
-        hookCmrEdlHealthCheck(true, true);
+        hookCmrEdlHealthCheck(cmrUpStatus, true);
         hookGetHealth();
         it('returns a 200 status code', function () {
           expect(this.res.statusCode).to.equal(200);
@@ -76,7 +80,7 @@ describe('Health endpoints', function () {
         });
       });
       describe('When the database catches fire', function () {
-        hookCmrEdlHealthCheck(true, true);
+        hookCmrEdlHealthCheck(cmrUpStatus, true);
         hookDatabaseFailure();
         hookGetHealth();
         it('returns a 503 status code', function () {
@@ -88,7 +92,7 @@ describe('Health endpoints', function () {
         });
       });
       describe('When multiple dependency errors', function () {
-        hookCmrEdlHealthCheck(false, false);
+        hookCmrEdlHealthCheck(cmrDownStatus, false);
         hookDatabaseFailure();
         hookGetHealth();
         it('returns a 503 status code', function () {
@@ -125,7 +129,7 @@ describe('Health endpoints', function () {
 
   describe('When authenticated as an admin user', function () {
     describe('When the system is healthy', function () {
-      hookCmrEdlHealthCheck(true, true);
+      hookCmrEdlHealthCheck(cmrUpStatus, true);
       hookGetAdminHealth({ username: 'adam' });
       it('returns a 200 status code', function () {
         expect(this.res.statusCode).to.equal(200);
@@ -136,7 +140,7 @@ describe('Health endpoints', function () {
       });
     });
     describe('When the database catches fire', function () {
-      hookCmrEdlHealthCheck(true, true);
+      hookCmrEdlHealthCheck(cmrUpStatus, true);
       hookDatabaseFailure();
       hookGetAdminHealth({ username: 'adam' });
       it('returns a 503 status code', function () {
@@ -148,7 +152,7 @@ describe('Health endpoints', function () {
       });
     });
     describe('When multiple dependency errors', function () {
-      hookCmrEdlHealthCheck(false, false);
+      hookCmrEdlHealthCheck(cmrDownStatus, false);
       hookDatabaseFailure();
       hookGetAdminHealth({ username: 'adam' });
       it('returns a 503 status code', function () {

--- a/services/harmony/test/health.ts
+++ b/services/harmony/test/health.ts
@@ -39,7 +39,7 @@ const databaseDownHealthResponse = {
   }],
 };
 
-const cmrUpStatus = { healthy: true, message: '' };
+const cmrUpStatus = { healthy: true };
 const cmrDownMessage = 'CMR is down. {"indexer":{"ok?":false,"dependencies":{"elastic_search":{"ok?":false},"metadata-db":{"ok?":true,"dependencies":{"oracle":{"ok?":true}}}}}}';
 const cmrDownStatus = { healthy: false, message: cmrDownMessage };
 

--- a/services/harmony/test/health.ts
+++ b/services/harmony/test/health.ts
@@ -50,7 +50,7 @@ const dependenciesDownHealthResponse = {
   {
     name: 'cmr',
     status: 'down',
-    message: 'cmr is down',
+    message: 'CMR is down. For details see: https://cmr.uat.earthdata.nasa.gov/search/health',
   },
   {
     name: 'edl',
@@ -65,7 +65,7 @@ describe('Health endpoints', function () {
   describe('When calling /health', function () {
     describe('When not authenticated', function () {
       describe('When the system is healthy', function () {
-        hookCmrEdlHealthCheck({ name: 'cmr', status: 'up' }, true);
+        hookCmrEdlHealthCheck(true, true);
         hookGetHealth();
         it('returns a 200 status code', function () {
           expect(this.res.statusCode).to.equal(200);
@@ -76,7 +76,7 @@ describe('Health endpoints', function () {
         });
       });
       describe('When the database catches fire', function () {
-        hookCmrEdlHealthCheck({ name: 'cmr', status: 'up' }, true);
+        hookCmrEdlHealthCheck(true, true);
         hookDatabaseFailure();
         hookGetHealth();
         it('returns a 503 status code', function () {
@@ -88,7 +88,7 @@ describe('Health endpoints', function () {
         });
       });
       describe('When multiple dependency errors', function () {
-        hookCmrEdlHealthCheck({ name: 'cmr', status: 'down', message: 'cmr is down' }, false);
+        hookCmrEdlHealthCheck(false, false);
         hookDatabaseFailure();
         hookGetHealth();
         it('returns a 503 status code', function () {
@@ -125,7 +125,7 @@ describe('Health endpoints', function () {
 
   describe('When authenticated as an admin user', function () {
     describe('When the system is healthy', function () {
-      hookCmrEdlHealthCheck({ name: 'cmr', status: 'up' }, true);
+      hookCmrEdlHealthCheck(true, true);
       hookGetAdminHealth({ username: 'adam' });
       it('returns a 200 status code', function () {
         expect(this.res.statusCode).to.equal(200);
@@ -136,7 +136,7 @@ describe('Health endpoints', function () {
       });
     });
     describe('When the database catches fire', function () {
-      hookCmrEdlHealthCheck({ name: 'cmr', status: 'up' }, true);
+      hookCmrEdlHealthCheck(true, true);
       hookDatabaseFailure();
       hookGetAdminHealth({ username: 'adam' });
       it('returns a 503 status code', function () {
@@ -148,7 +148,7 @@ describe('Health endpoints', function () {
       });
     });
     describe('When multiple dependency errors', function () {
-      hookCmrEdlHealthCheck({ name: 'cmr', status: 'down', message: 'cmr is down' }, false);
+      hookCmrEdlHealthCheck(false, false);
       hookDatabaseFailure();
       hookGetAdminHealth({ username: 'adam' });
       it('returns a 503 status code', function () {

--- a/services/harmony/test/health.ts
+++ b/services/harmony/test/health.ts
@@ -40,7 +40,7 @@ const databaseDownHealthResponse = {
 };
 
 const cmrUpStatus = { healthy: true, message: '' };
-const cmrDownMessage = '{"indexer":{"ok?":false,"dependencies":{"elastic_search":{"ok?":false},"metadata-db":{"ok?":true,"dependencies":{"oracle":{"ok?":true}}}}}}';
+const cmrDownMessage = 'CMR is down. {"indexer":{"ok?":false,"dependencies":{"elastic_search":{"ok?":false},"metadata-db":{"ok?":true,"dependencies":{"oracle":{"ok?":true}}}}}}';
 const cmrDownStatus = { healthy: false, message: cmrDownMessage };
 
 const dependenciesDownHealthResponse = {
@@ -54,7 +54,7 @@ const dependenciesDownHealthResponse = {
   {
     name: 'cmr',
     status: 'down',
-    message: `CMR is down. ${cmrDownMessage}`,
+    message: cmrDownMessage,
   },
   {
     name: 'edl',

--- a/services/harmony/test/helpers/health.ts
+++ b/services/harmony/test/helpers/health.ts
@@ -7,12 +7,12 @@ import * as edl from '../../app/util/edl-api';
 /**
  * Hooks to stub CMR and EDL health checks for specific tests.
  */
-export function hookCmrEdlHealthCheck(cmrStatus: object, edlStatus: boolean): void {
+export function hookCmrEdlHealthCheck(cmrStatus: boolean, edlStatus: boolean): void {
   let cmrStub;
   let edlStub;
 
   before(function () {
-    cmrStub = sinon.stub(cmr, 'getCmrHealth').callsFake(async () => cmrStatus);
+    cmrStub = sinon.stub(cmr, 'isCmrHealthy').callsFake(async () => cmrStatus);
     edlStub = sinon.stub(edl, 'isEdlHealthy').callsFake(async () => edlStatus);
   });
 

--- a/services/harmony/test/helpers/health.ts
+++ b/services/harmony/test/helpers/health.ts
@@ -7,7 +7,9 @@ import * as edl from '../../app/util/edl-api';
 /**
  * Hooks to stub CMR and EDL health checks for specific tests.
  */
-export function hookCmrEdlHealthCheck(cmrStatus: boolean, edlStatus: boolean): void {
+export function hookCmrEdlHealthCheck(
+  cmrStatus: { healthy: boolean, message: string },
+  edlStatus: boolean): void {
   let cmrStub;
   let edlStub;
 

--- a/services/harmony/test/helpers/health.ts
+++ b/services/harmony/test/helpers/health.ts
@@ -8,7 +8,7 @@ import * as edl from '../../app/util/edl-api';
  * Hooks to stub CMR and EDL health checks for specific tests.
  */
 export function hookCmrEdlHealthCheck(
-  cmrStatus: { healthy: boolean, message: string },
+  cmrStatus: { healthy: boolean, message?: string },
   edlStatus: boolean): void {
   let cmrStub;
   let edlStub;

--- a/services/harmony/test/helpers/health.ts
+++ b/services/harmony/test/helpers/health.ts
@@ -14,7 +14,7 @@ export function hookCmrEdlHealthCheck(
   let edlStub;
 
   before(function () {
-    cmrStub = sinon.stub(cmr, 'isCmrHealthy').callsFake(async () => cmrStatus);
+    cmrStub = sinon.stub(cmr, 'getCmrHealth').callsFake(async () => cmrStatus);
     edlStub = sinon.stub(edl, 'isEdlHealthy').callsFake(async () => edlStatus);
   });
 

--- a/services/harmony/test/helpers/health.ts
+++ b/services/harmony/test/helpers/health.ts
@@ -1,5 +1,26 @@
+import sinon from 'sinon';
 import request from 'supertest';
 import { hookRequest } from './hooks';
+import * as cmr from '../../app/util/cmr';
+import * as edl from '../../app/util/edl-api';
+
+/**
+ * Hooks to stub CMR and EDL health checks for specific tests.
+ */
+export function hookCmrEdlHealthCheck(cmrStatus: object, edlStatus: boolean): void {
+  let cmrStub;
+  let edlStub;
+
+  before(function () {
+    cmrStub = sinon.stub(cmr, 'getCmrHealth').callsFake(async () => cmrStatus);
+    edlStub = sinon.stub(edl, 'isEdlHealthy').callsFake(async () => edlStatus);
+  });
+
+  after(function () {
+    cmrStub.restore();
+    edlStub.restore();
+  });
+}
 
 /**
  * Makes a /admin/health request


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1986

## Description
Add CMR and EDL dependencies to health check.

## Local Test Steps
http://localhost:3000/health now shows the CMR and EDL status in addition to db status:
```
{
  status: "up",
  message: "Harmony is operating normally.",
  dependencies: [
    {
      name: "db",
      status: "up"
    },
    {
      name: "cmr",
      status: "up"
    },
    {
      name: "edl",
      status: "up"
    }
  ]
}
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)