### PR TITLE
HARMONY-2042: Update all the default ports to 3000

### DIFF
--- a/services/cron-service/env-defaults
+++ b/services/cron-service/env-defaults
@@ -1,5 +1,5 @@
 # Port the health check server listens on
-PORT=5000
+PORT=3000
 
 # The cron schedule for the work reaper service
 WORK_REAPER_CRON="*/6 * * * *" # every 6 minutes

--- a/services/service-runner/env-defaults
+++ b/services/service-runner/env-defaults
@@ -1,5 +1,5 @@
 # port on which the express server listens
-PORT=5000
+PORT=3000
 # The port on which a worker container listens for work from the manager container
 WORKER_PORT=5001
 HARMONY_SERVICE="harmonyservices/query-cmr:stable"

--- a/services/work-failer/env-defaults
+++ b/services/work-failer/env-defaults
@@ -1,5 +1,5 @@
 # Port the health check server listens on
-PORT=5000
+PORT=3000
 
 # The time (in seconds) between invocations of the work failer service
 WORK_FAILER_PERIOD_SEC=300

--- a/services/work-scheduler/env-defaults
+++ b/services/work-scheduler/env-defaults
@@ -1,5 +1,5 @@
 # Port the health check server listens on
-PORT=5000
+PORT=3000
 
 WORKING_DIR=/tmp
 # SQS queue used to request scheduling of work items for a service

--- a/services/work-updater/env-defaults
+++ b/services/work-updater/env-defaults
@@ -1,5 +1,5 @@
 # Port the health check server listens on
-PORT=5000
+PORT=3000
 
 # maximum number of items to pull from the queue at once for the large item queue (to avoid visibility timeouts)
 # if this is set to greater than 10 (the SQS max) then 10 will be used instead


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2042

## Description
Fixes the issue that during deployments where app ports and liveness checks were sometimes out of sync between ports 3000 and 5000.

## Local Test Steps
Run harmony locally using `bin/start-dev-services` and verify that all of the applications start up correctly and listen on different ports.

Run harmony in a box and verify requests work as expected.

I also tested in sandbox and verified requests worked as expected during deployments and all of the services and health checks were using port 3000.

You can check the configuration maps to make sure they are always using port 3000 with:
`kubectl get configmaps -n harmony -o yaml | grep PORT | grep -v WORKER_PORT | grep -v BACKEND`

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [X] Harmony in a Box tested (if changes made to microservices or new dependencies added)