### PR TITLE
HARMONY-2043: Skip dimension subsetting based on  user request

### DIFF
--- a/services/harmony/app/models/services/base-service.ts
+++ b/services/harmony/app/models/services/base-service.ts
@@ -124,6 +124,7 @@ function serviceImageToId(image: string): string {
 
 const conditionToOperationField = {
   concatenate: 'shouldConcatenate',
+  dimensionSubset: 'shouldDimensionSubset',
   extend: 'shouldExtend',
   reformat: 'outputFormat',
   reproject: 'crs',
@@ -154,9 +155,7 @@ export function stepUsesMultipleInputCatalogs(step: ServiceStep, operation: Data
 
   // check to see if the user has actually requested any of the multi-catalog operations
   for (const op of multiCatOps) {
-    const upperCaseOp = op.charAt(0).toUpperCase() + op.slice(1);
-    const should = `should${upperCaseOp}`;
-
+    const should = conditionToOperationField[op];
     if (operation[should]) {
       return true;
     }
@@ -179,7 +178,7 @@ export function stepUsesMultipleInputCatalogs(step: ServiceStep, operation: Data
  *
  * @returns true if the workflow step is required
  */
-function stepRequired(step: ServiceStep, operation: DataOperation): boolean {
+export function stepRequired(step: ServiceStep, operation: DataOperation): boolean {
   let required = true;
   if (step.conditional?.exists?.length > 0) {
     required = false;


### PR DESCRIPTION

## Jira Issue ID
HARMONY-2043

## Description
Add support for skipping a step in a service chain based on whether or not the user asked for dimension subsetting

## Local Test Steps
Issue the following query
```
https://internal-harmony-jn-frontend-1954287425.us-west-2.elb.amazonaws.com/C1378227407-LAADS/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&subset=lat(24.6%3A29.9)&subset=lon(-84.6%3A-79.1)&subset=bands(6%3A10)&label=harmony-py&outputcrs=%2Ba%3D6378137.0%20%2Bb%3D6356752.3142451793%20%2Bno_defs%20%2Bproj%3Dlatlong&interpolation=NN&scaleSize=0.018,0.018&granuleId=G3455129607-LAADS&variable=all
```
The geoloco service will fail to download geolocation file it needs - not sure why this is happening, for some reason it pulls it from the LAADS uat environment. Apparently there is not much staged there - will work with Christine to figure out a query that pulls a geolocation file that actually exists. This is not relevant to this ticket, however.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [x] Harmony in a Box tested (if changes made to microservices or new dependencies added)