### PR TITLE
HARMONY-2044: Add validtion of exists conditions and operations for steps in services.yml

### DIFF
--- a/services/harmony/app/models/services/base-service.ts
+++ b/services/harmony/app/models/services/base-service.ts
@@ -122,7 +122,7 @@ function serviceImageToId(image: string): string {
   return image;
 }
 
-const conditionToOperationField = {
+export const conditionToOperationField = {
   concatenate: 'shouldConcatenate',
   dimensionSubset: 'shouldDimensionSubset',
   extend: 'shouldExtend',

--- a/services/harmony/app/models/services/base-service.ts
+++ b/services/harmony/app/models/services/base-service.ts
@@ -25,6 +25,7 @@ export interface ServiceCapabilities {
   concatenation?: boolean;
   concatenate_by_default?: boolean;
   subsetting?: {
+    dimension?: boolean;
     bbox?: boolean;
     shape?: boolean;
     temporal?: boolean;

--- a/services/harmony/app/models/services/index.ts
+++ b/services/harmony/app/models/services/index.ts
@@ -13,7 +13,7 @@ import { HttpError, NotFoundError, ServerError } from '../../util/errors';
 import logger from '../../util/log';
 import DataOperation from '../data-operation';
 import RequestContext from '../request-context';
-import BaseService, { conditionToOperationField, ServiceConfig } from './base-service';
+import BaseService, { conditionToOperationField, ServiceConfig, ServiceStep } from './base-service';
 import HttpService from './http-service';
 import TurboService from './turbo-service';
 
@@ -91,6 +91,58 @@ export function loadServiceConfigs(cmrEndpoint: string): ServiceConfig<unknown>[
 }
 
 /**
+ * Validate step operations
+ *
+ * @param config - The service configuration to validate
+ * @param stepIndex - The step number
+ */
+export function validateStepOperations(config: ServiceConfig<unknown>, step: ServiceStep): string {
+  if (step.operations) {
+    for (const op of step.operations) {
+      // validate that the `capabilities` section includes the operation and that the operation
+      // is one of the known operations
+      let shouldThrow = false;
+      switch (op) {
+        case 'concatenate':
+          shouldThrow = !config.capabilities?.concatenation;
+          break;
+        case 'dimensionSubset':
+          shouldThrow = !config.capabilities?.subsetting?.dimension;
+          break;
+        case 'extend':
+          shouldThrow = !config.capabilities?.extend;
+          break;
+        case 'reformat':
+          // reformat is checked elsewhere
+          break;
+        case 'reproject':
+          shouldThrow = !config.capabilities?.reprojection;
+          break;
+        case 'shapefileSubset':
+          shouldThrow = !config.capabilities?.subsetting?.shape;
+          break;
+        case 'spatialSubset':
+          shouldThrow = !config.capabilities?.subsetting?.bbox;
+          break;
+        case 'temporalSubset':
+          shouldThrow = !config.capabilities?.subsetting?.temporal;
+          break;
+        case 'variableSubset':
+          shouldThrow = !config.capabilities?.subsetting?.variable;
+          break;
+        default:
+          return `Service ${config.name} step with image ${step.image} has invalid operation '${op}'.`;
+      }
+      if (shouldThrow) {
+        return `Service ${config.name} step with image ${step.image} has operation '${op}' which is not included in capabilities.`;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
  * Throws an error if the steps configuration is invalid. Logs a warning if configuration will be ignored.
  * @param config - The service configuration to validate
  */
@@ -115,13 +167,10 @@ function validateServiceConfigSteps(config: ServiceConfig<unknown>): void {
       throw new TypeError(`Invalid is_sequential ${step.is_sequential}. query-cmr steps must always have sequential = true.`);
     }
 
-    // validate operations
-    if (step.operations) {
-      for (const op of step.operations) {
-        if (!conditionToOperationField[op]) {
-          throw new TypeError(`Service ${config.name} step with image ${step.image} has invalid operation '${op}'.`);
-        }
-      }
+    // validate that the operations included in the step are listed in capabilities
+    const errMsg = validateStepOperations(config, step);
+    if (errMsg) {
+      throw new TypeError(errMsg);
     }
 
     // all operations except 'reformat' can be used in 'exists' conditions
@@ -138,11 +187,12 @@ function validateServiceConfigSteps(config: ServiceConfig<unknown>): void {
     // validate that the conditional format is actually supported by the service chain
     if (step.conditional?.format) {
       for (const fmt of step.conditional.format) {
-        if (!(config.capabilities.output_formats && config.capabilities.output_formats.includes(fmt))) {
+        if (!(config.capabilities?.output_formats && config.capabilities.output_formats.includes(fmt))) {
           throw new TypeError(`Service ${config.name} step with image ${step.image} has format conditional '${fmt}' which is not included in capabilities.`);
         }
       }
     }
+
   }
 }
 

--- a/services/harmony/test/models/index.ts
+++ b/services/harmony/test/models/index.ts
@@ -105,4 +105,25 @@ describe('Services.yml validation', function () {
       expect(() => configs.forEach(validateServiceConfig)).to.throw(/Invalid is_sequential false. query-cmr steps must always have sequential = true./);
     });
   });
+
+  describe('services.yml with service step with invalid operation is invalid', function () {
+    it('throws an exception', function () {
+      const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_invalid_step_operations.yml');
+      expect(() => configs.forEach(validateServiceConfig)).to.throw(/Service with-invalid-step-operation step with image .*? has invalid operation 'foo'./);
+    });
+  });
+
+  describe('services.yml with service step with invalid exists conditional is invalid', function () {
+    it('throws an exception', function () {
+      const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_invalid_exists_condition.yml');
+      expect(() => configs.forEach(validateServiceConfig)).to.throw(/Service with-invalid-exists-condition step with image .*? has invalid exists conditional 'reformat'./);
+    });
+  });
+
+  describe('services.yml with service step with invalid format conditional is invalid', function () {
+    it('throws an exception', function () {
+      const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_invalid_format_condition.yml');
+      expect(() => configs.forEach(validateServiceConfig)).to.throw(/Service with-invalid-format-condition step with image .*? has format conditional 'image\/png' which is not included in capabilities./);
+    });
+  });
 });

--- a/services/harmony/test/models/index.ts
+++ b/services/harmony/test/models/index.ts
@@ -1,14 +1,165 @@
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
 import _ from 'lodash';
 
 import {
   getServiceConfigs, loadServiceConfigs, loadServiceConfigsFromFile, validateServiceConfig,
+  validateStepOperations,
 } from '../../app/models/services';
+
+// print out full objects instead of truncated ones when a test fails
+chai.config.truncateThreshold = 0;
 
 const cmrEndpoints = {
   'uat': 'https://cmr.uat.earthdata.nasa.gov',
   'prod': 'https://cmr.earthdata.nasa.gov',
 };
+
+describe('validateStepOperations', function () {
+
+  describe('when the step config conatins the concatenate operation', function () {
+    const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_unsupported_step_operation.yml');
+    const testConfig = configs[0];
+    testConfig.steps[1].operations = ['concatenate'];
+    describe('and the capabilites do not', function () {
+      testConfig.capabilities = {};
+      it('returns an error message', function () {
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-step-operation step with image ghcr.io/podaac/l2ss-py:sit has operation \'concatenate\' which is not included in capabilities.');
+      });
+    });
+    describe('and the capabilites do as well', function () {
+      it('does not return an error message', function () {
+        testConfig.capabilities.concatenation = true;
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
+      });
+    });
+  });
+
+  describe('when the step config conatins the dimensionSubset operation', function () {
+    const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_unsupported_step_operation.yml');
+    const testConfig = configs[0];
+    testConfig.steps[1].operations = ['dimensionSubset'];
+    describe('and the capabilites do not', function () {
+      testConfig.capabilities = {};
+      it('returns an error message', function () {
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-step-operation step with image ghcr.io/podaac/l2ss-py:sit has operation \'dimensionSubset\' which is not included in capabilities.');
+      });
+    });
+    describe('and the capabilites do as well', function () {
+      it('does not return an error message', function () {
+        testConfig.capabilities.subsetting = { dimension: true };
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
+      });
+    });
+  });
+
+  describe('when the step config conatins the extend operation', function () {
+    const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_unsupported_step_operation.yml');
+    const testConfig = configs[0];
+    testConfig.steps[1].operations = ['extend'];
+    describe('and the capabilites do not', function () {
+      testConfig.capabilities = {};
+      it('returns an error message', function () {
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-step-operation step with image ghcr.io/podaac/l2ss-py:sit has operation \'extend\' which is not included in capabilities.');
+      });
+    });
+    describe('and the capabilites do as well', function () {
+      it('does not return an error message', function () {
+        testConfig.capabilities.extend = true;
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
+      });
+    });
+  });
+
+  describe('when the step config conatins the reproject operation', function () {
+    const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_unsupported_step_operation.yml');
+    const testConfig = configs[0];
+    testConfig.steps[1].operations = ['reproject'];
+    describe('and the capabilites do not', function () {
+      testConfig.capabilities = {};
+      it('returns an error message', function () {
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-step-operation step with image ghcr.io/podaac/l2ss-py:sit has operation \'reproject\' which is not included in capabilities.');
+      });
+    });
+    describe('and the capabilites do as well', function () {
+      it('does not return an error message', function () {
+        testConfig.capabilities.reprojection = true;
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
+      });
+    });
+  });
+
+  describe('when the step config conatins the shapefileSubset operation', function () {
+    const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_unsupported_step_operation.yml');
+    const testConfig = configs[0];
+    testConfig.steps[1].operations = ['shapefileSubset'];
+    describe('and the capabilites do not', function () {
+      testConfig.capabilities = {};
+      it('returns an error message', function () {
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-step-operation step with image ghcr.io/podaac/l2ss-py:sit has operation \'shapefileSubset\' which is not included in capabilities.');
+      });
+    });
+    describe('and the capabilites do as well', function () {
+      it('does not return an error message', function () {
+        testConfig.capabilities.subsetting = { shape: true };
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
+      });
+    });
+  });
+
+  describe('when the step config conatins the spatialSubset operation', function () {
+    const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_unsupported_step_operation.yml');
+    const testConfig = configs[0];
+    testConfig.steps[1].operations = ['spatialSubset'];
+    describe('and the capabilites do not', function () {
+      testConfig.capabilities = {};
+      it('returns an error message', function () {
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-step-operation step with image ghcr.io/podaac/l2ss-py:sit has operation \'spatialSubset\' which is not included in capabilities.');
+      });
+    });
+    describe('and the capabilites do as well', function () {
+      it('does not return an error message', function () {
+        testConfig.capabilities.subsetting = { bbox: true };
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
+      });
+    });
+  });
+
+  describe('when the step config conatins the temporalSubset operation', function () {
+    const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_unsupported_step_operation.yml');
+    const testConfig = configs[0];
+    testConfig.steps[1].operations = ['temporalSubset'];
+    describe('and the capabilites do not', function () {
+      testConfig.capabilities = {};
+      it('returns an error message', function () {
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-step-operation step with image ghcr.io/podaac/l2ss-py:sit has operation \'temporalSubset\' which is not included in capabilities.');
+      });
+    });
+    describe('and the capabilites do as well', function () {
+      it('does not return an error message', function () {
+        testConfig.capabilities.subsetting = { temporal: true };
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
+      });
+    });
+  });
+
+  describe('when the step config conatins the variableSubset operation', function () {
+    const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_unsupported_step_operation.yml');
+    const testConfig = configs[0];
+    testConfig.steps[1].operations = ['variableSubset'];
+    describe('and the capabilites do not', function () {
+      testConfig.capabilities = {};
+      it('returns an error message', function () {
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-step-operation step with image ghcr.io/podaac/l2ss-py:sit has operation \'variableSubset\' which is not included in capabilities.');
+      });
+    });
+    describe('and the capabilites do as well', function () {
+      it('does not return an error message', function () {
+        testConfig.capabilities.subsetting = { variable: true };
+        expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
+      });
+    });
+  });
+});
 
 describe('Services.yml validation', function () {
 
@@ -124,6 +275,13 @@ describe('Services.yml validation', function () {
     it('throws an exception', function () {
       const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_invalid_format_condition.yml');
       expect(() => configs.forEach(validateServiceConfig)).to.throw(/Service with-invalid-format-condition step with image .*? has format conditional 'image\/png' which is not included in capabilities./);
+    });
+  });
+
+  describe('services.yml with service step with unsupported step operation is invalid', function () {
+    it('throws an exception', function () {
+      const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, '../../../test/resources/services_with_unsupported_step_operation.yml');
+      expect(() => configs.forEach(validateServiceConfig)).to.throw(/Service with-unsupported-step-operation step with image .*? has operation 'variableSubset' which is not included in capabilities./);
     });
   });
 });

--- a/services/harmony/test/resources/services_with_invalid_exists_condition.yml
+++ b/services/harmony/test/resources/services_with_invalid_exists_condition.yml
@@ -1,0 +1,82 @@
+# Order for each CMR endpoint in this file will reflect precedence of the service when
+# multiple services handle a collection
+
+# Default turbo configuration
+x-turbo-config: &default-turbo-config
+  name: turbo
+  params: &default-turbo-params
+    env: &default-turbo-env
+      USE_LOCALSTACK: !Env ${USE_LOCALSTACK}
+      LOCALSTACK_HOST: !Env ${BACKEND_HOST}
+      AWS_DEFAULT_REGION: us-west-2
+      STAGING_BUCKET: !Env ${STAGING_BUCKET}
+      TEXT_LOGGER: !Env ${TEXT_LOGGER}
+      BACKEND_HOST: !Env ${BACKEND_HOST}
+      OAUTH_UID: !Env ${OAUTH_UID}
+      OAUTH_PASSWORD: !Env ${OAUTH_PASSWORD}
+      OAUTH_HOST: !Env ${OAUTH_HOST}
+      OAUTH_CLIENT_ID: !Env ${OAUTH_CLIENT_ID}
+      OAUTH_REDIRECT_URI: !Env ${OAUTH_REDIRECT_URI}
+
+https://cmr.earthdata.nasa.gov:
+
+  - name: with-invalid-exists-condition
+    description: |
+      testing service configuration with invalid step operation
+    data_operation_version: '0.17.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/somewhere
+    umm_s: S23456789-EXAMPLE
+    capabilities:
+      subsetting:
+        temporal: true
+        bbox: true
+        variable: true
+        shape: true
+      output_formats:
+        - application/x-netcdf4
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
+        conditional:
+          exists: ['reformat']
+
+
+  - name: podaac/l2-subsetter
+    description: |
+      Implementation of the L2 swath subsetter based on python, xarray and netcdf4.
+
+      * Works with Trajectory (1D) and Along track/across track data.
+      * Works with NetCDF and HDF5 inputfiles
+      * Variable subsetting supported
+      * works with hierarchical groups
+      Outputs netcdf4.
+    data_operation_version: '0.17.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/podaac/l2-subsetter
+    umm_s: S1234899453-POCLOUD
+    capabilities:
+      subsetting:
+        temporal: true
+        bbox: true
+        variable: true
+        shape: true
+      output_formats:
+        - application/netcdf # Incorrect mime-type, remove when no longer needed
+        - application/x-netcdf4
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
+

--- a/services/harmony/test/resources/services_with_invalid_format_condition.yml
+++ b/services/harmony/test/resources/services_with_invalid_format_condition.yml
@@ -22,7 +22,7 @@ https://cmr.earthdata.nasa.gov:
 
   - name: with-invalid-format-condition
     description: |
-      testing service configuration with invalid step operation
+      testing service configuration with invalid step format condition
     data_operation_version: '0.17.0'
     type:
       <<: *default-turbo-config

--- a/services/harmony/test/resources/services_with_invalid_format_condition.yml
+++ b/services/harmony/test/resources/services_with_invalid_format_condition.yml
@@ -1,0 +1,82 @@
+# Order for each CMR endpoint in this file will reflect precedence of the service when
+# multiple services handle a collection
+
+# Default turbo configuration
+x-turbo-config: &default-turbo-config
+  name: turbo
+  params: &default-turbo-params
+    env: &default-turbo-env
+      USE_LOCALSTACK: !Env ${USE_LOCALSTACK}
+      LOCALSTACK_HOST: !Env ${BACKEND_HOST}
+      AWS_DEFAULT_REGION: us-west-2
+      STAGING_BUCKET: !Env ${STAGING_BUCKET}
+      TEXT_LOGGER: !Env ${TEXT_LOGGER}
+      BACKEND_HOST: !Env ${BACKEND_HOST}
+      OAUTH_UID: !Env ${OAUTH_UID}
+      OAUTH_PASSWORD: !Env ${OAUTH_PASSWORD}
+      OAUTH_HOST: !Env ${OAUTH_HOST}
+      OAUTH_CLIENT_ID: !Env ${OAUTH_CLIENT_ID}
+      OAUTH_REDIRECT_URI: !Env ${OAUTH_REDIRECT_URI}
+
+https://cmr.earthdata.nasa.gov:
+
+  - name: with-invalid-format-condition
+    description: |
+      testing service configuration with invalid step operation
+    data_operation_version: '0.17.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/somewhere
+    umm_s: S23456789-EXAMPLE
+    capabilities:
+      subsetting:
+        temporal: true
+        bbox: true
+        variable: true
+        shape: true
+      output_formats:
+        - application/x-netcdf4
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
+        conditional:
+          format: ['image/png']
+
+
+  - name: podaac/l2-subsetter
+    description: |
+      Implementation of the L2 swath subsetter based on python, xarray and netcdf4.
+
+      * Works with Trajectory (1D) and Along track/across track data.
+      * Works with NetCDF and HDF5 inputfiles
+      * Variable subsetting supported
+      * works with hierarchical groups
+      Outputs netcdf4.
+    data_operation_version: '0.17.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/podaac/l2-subsetter
+    umm_s: S1234899453-POCLOUD
+    capabilities:
+      subsetting:
+        temporal: true
+        bbox: true
+        variable: true
+        shape: true
+      output_formats:
+        - application/netcdf # Incorrect mime-type, remove when no longer needed
+        - application/x-netcdf4
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
+

--- a/services/harmony/test/resources/services_with_invalid_step_operations.yml
+++ b/services/harmony/test/resources/services_with_invalid_step_operations.yml
@@ -1,0 +1,81 @@
+# Order for each CMR endpoint in this file will reflect precedence of the service when
+# multiple services handle a collection
+
+# Default turbo configuration
+x-turbo-config: &default-turbo-config
+  name: turbo
+  params: &default-turbo-params
+    env: &default-turbo-env
+      USE_LOCALSTACK: !Env ${USE_LOCALSTACK}
+      LOCALSTACK_HOST: !Env ${BACKEND_HOST}
+      AWS_DEFAULT_REGION: us-west-2
+      STAGING_BUCKET: !Env ${STAGING_BUCKET}
+      TEXT_LOGGER: !Env ${TEXT_LOGGER}
+      BACKEND_HOST: !Env ${BACKEND_HOST}
+      OAUTH_UID: !Env ${OAUTH_UID}
+      OAUTH_PASSWORD: !Env ${OAUTH_PASSWORD}
+      OAUTH_HOST: !Env ${OAUTH_HOST}
+      OAUTH_CLIENT_ID: !Env ${OAUTH_CLIENT_ID}
+      OAUTH_REDIRECT_URI: !Env ${OAUTH_REDIRECT_URI}
+
+https://cmr.earthdata.nasa.gov:
+
+  - name: with-invalid-step-operation
+    description: |
+      testing service configuration with invalid step operation
+    data_operation_version: '0.17.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/somewhere
+    umm_s: S23456789-EXAMPLE
+    capabilities:
+      subsetting:
+        temporal: true
+        bbox: true
+        variable: true
+        shape: true
+      output_formats:
+        - application/x-netcdf4
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
+        operations: ['foo']
+
+
+  - name: podaac/l2-subsetter
+    description: |
+      Implementation of the L2 swath subsetter based on python, xarray and netcdf4.
+
+      * Works with Trajectory (1D) and Along track/across track data.
+      * Works with NetCDF and HDF5 inputfiles
+      * Variable subsetting supported
+      * works with hierarchical groups
+      Outputs netcdf4.
+    data_operation_version: '0.17.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/podaac/l2-subsetter
+    umm_s: S1234899453-POCLOUD
+    capabilities:
+      subsetting:
+        temporal: true
+        bbox: true
+        variable: true
+        shape: true
+      output_formats:
+        - application/netcdf # Incorrect mime-type, remove when no longer needed
+        - application/x-netcdf4
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
+

--- a/services/harmony/test/resources/services_with_unsupported_step_operation.yml
+++ b/services/harmony/test/resources/services_with_unsupported_step_operation.yml
@@ -20,9 +20,9 @@ x-turbo-config: &default-turbo-config
 
 https://cmr.earthdata.nasa.gov:
 
-  - name: with-invalid-exists-condition
+  - name: with-unsupported-step-operation
     description: |
-      testing service configuration with invalid step exists condition
+      testing service configuration with unsupported step operation 'variableSubset'
     data_operation_version: '0.17.0'
     type:
       <<: *default-turbo-config
@@ -36,7 +36,6 @@ https://cmr.earthdata.nasa.gov:
       subsetting:
         temporal: true
         bbox: true
-        variable: true
         shape: true
       output_formats:
         - application/x-netcdf4
@@ -44,8 +43,7 @@ https://cmr.earthdata.nasa.gov:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
       - image: !Env ${PODAAC_L2_SUBSETTER_IMAGE}
-        conditional:
-          exists: ['reformat']
+        operations: ['variableSubset']
 
 
   - name: podaac/l2-subsetter


### PR DESCRIPTION

## Jira Issue ID
HARMONY-2044

## Description
Adds some extra validation for service configs in services.yml

## Local Test Steps
1. Add and invalid operation to a step in a service chain in services.yml on line 1407
```
operations: ['foo']
```
2. start harmony and see the following
```
TypeError: Service harmony/service-example step with image harmonyservices/service-example:latest has invalid operation 'foo'.
```
3. Remove the change to services.yml then add an invalid `conditional/exists` operation on line 1407
```
conditional:
          exists: ['reformat']
```
4. start harmony and see the following error:
```
TypeError: Service harmony/service-example step with image harmonyservices/service-example:latest has invalid exists conditional 'reformat'.
```
5. Remove the changes to services.yml then add an unsupported output format on line 1407
```
conditional:
          format: ['application/x-zarr']
```
6. start harmony and see the following error:
```
TypeError: Service harmony/service-example step with image harmonyservices/service-example:latest has format conditional 'application/x-zarr' which is not included in capabilities.
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)