### PR TITLE
HARMONY-2049: Fix behavior of SAMBAH chain when concatenate is not requested

### DIFF
--- a/bin/start-dev-services
+++ b/bin/start-dev-services
@@ -9,61 +9,44 @@ source ".env"
 set +a
 eval "$env_save"
 
-# run harmony
-echo "Starting Harmony server..."
-pushd services/harmony > /dev/null
-export PORT=3000
-export DEBUG_PORT=9200
-npm run start-dev-fast > logs/server.log 2>&1 &
-popd > /dev/null
+wait_for_port() {
+  local port=$1
+  local retries=20
+  while ! nc -z localhost $port; do
+    sleep 1
+    ((retries--))
+    if [ $retries -eq 0 ]; then
+      echo "Error: Service on port $port failed to start."
+      exit 1
+    fi
+  done
+}
 
-sleep 3
+start_service() {
+  local name=$1
+  local dir=$2
+  local port=$3
+  local debug_port=$4
+  local log_file=$5
 
-# create the work scheduler
-echo "Starting the work scheduler..."
-pushd services/work-scheduler > /dev/null
-export PORT=5006
-export DEBUG_PORT=9206
-npm run start-dev-fast > logs/work-scheduler.log 2>&1 &
-popd > /dev/null
+  echo "Starting $name..."
+  pushd "$dir" > /dev/null
+  export PORT=$port
+  export DEBUG_PORT=$debug_port
+  npm run start-dev-fast > "$log_file" 2>&1 &
+  popd > /dev/null
 
-sleep 3
+  wait_for_port $port
+}
 
-# create the work updaters
+start_service "Harmony server" "services/harmony" 3000 9200 "logs/server.log"
+start_service "Work scheduler" "services/work-scheduler" 5006 9206 "logs/work-scheduler.log"
+
 if [ "$KUBE_CONTEXT" != "colima" ]; then
   export LOCALSTACK_HOST=localhost
 fi
 
-echo "Starting the large job work updater..."
-pushd services/work-updater > /dev/null
-export PORT=5002
-export DEBUG_PORT=9202
-export WORK_ITEM_UPDATE_QUEUE_TYPE=large
-npm run start-dev-fast > logs/work-update-large.log 2>&1 &
-
-sleep 3
-
-echo "Starting the small job work updater..."
-export PORT=5003
-export DEBUG_PORT=9203
-export WORK_ITEM_UPDATE_QUEUE_TYPE=small
-npm run start-dev-fast > logs/work-update-small.log 2>&1 &
-popd > /dev/null
-
-sleep 3
-
-echo "Starting the cron service..."
-pushd services/cron-service > /dev/null
-export PORT=5004
-export DEBUG_PORT=9204
-npm run start-dev-fast > logs/cron-service.log 2>&1 &
-popd > /dev/null
-
-sleep 3
-
-echo "Starting the work failer..."
-pushd services/work-failer > /dev/null
-export PORT=5005
-export DEBUG_PORT=9205
-npm run start-dev-fast > logs/work-failer.log 2>&1 &
-popd > /dev/null
+WORK_ITEM_UPDATE_QUEUE_TYPE=large start_service "Large job work updater" "services/work-updater" 5002 9202 "logs/work-update-large.log"
+WORK_ITEM_UPDATE_QUEUE_TYPE=small start_service "Small job work updater" "services/work-updater" 5003 9203 "logs/work-update-small.log"
+start_service "Cron service" "services/cron-service" 5004 9204 "logs/cron-service.log"
+start_service "Work failer" "services/work-failer" 5005 9205 "logs/work-failer.log"

--- a/config/services.yml
+++ b/config/services.yml
@@ -136,6 +136,7 @@ https://cmr.earthdata.nasa.gov:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
       - image: !Env ${PODAAC_CONCISE_IMAGE}
+        always_wait_for_prior_step: true
         is_batched: true
         operations: ['concatenate']
 
@@ -180,6 +181,7 @@ https://cmr.earthdata.nasa.gov:
         conditional:
           exists: ['spatialSubset', 'variableSubset', 'temporalSubset']
       - image: !Env ${PODAAC_CONCISE_IMAGE}
+        always_wait_for_prior_step: true
         is_batched: true
         operations: ['concatenate']
         conditional:
@@ -430,6 +432,7 @@ https://cmr.earthdata.nasa.gov:
         extra_args:
           cut: false
       - image: !Env ${BATCHEE_IMAGE}
+        always_wait_for_prior_step: true
         operations: ['concatenate']
         conditional:
           exists: ['concatenate', 'extend']
@@ -438,6 +441,7 @@ https://cmr.earthdata.nasa.gov:
         conditional:
           exists: ['concatenate', 'extend']
       - image: !Env ${PODAAC_CONCISE_IMAGE}
+        always_wait_for_prior_step: true
         is_batched: true
         operations: ['concatenate']
         conditional:
@@ -760,6 +764,7 @@ https://cmr.uat.earthdata.nasa.gov:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
       - image: !Env ${PODAAC_CONCISE_IMAGE}
+        always_wait_for_prior_step: true
         is_batched: true
         operations: ['concatenate']
 
@@ -804,6 +809,7 @@ https://cmr.uat.earthdata.nasa.gov:
         conditional:
           exists: ['spatialSubset', 'variableSubset', 'temporalSubset']
       - image: !Env ${PODAAC_CONCISE_IMAGE}
+        always_wait_for_prior_step: true
         is_batched: true
         operations: ['concatenate']
         conditional:
@@ -1123,6 +1129,7 @@ https://cmr.uat.earthdata.nasa.gov:
         extra_args:
           cut: false
       - image: !Env ${BATCHEE_IMAGE}
+        always_wait_for_prior_step: true
         operations: ['concatenate']
         conditional:
           exists: ['concatenate', 'extend']
@@ -1131,6 +1138,7 @@ https://cmr.uat.earthdata.nasa.gov:
         conditional:
           exists: ['concatenate', 'extend']
       - image: !Env ${PODAAC_CONCISE_IMAGE}
+        always_wait_for_prior_step: true
         is_batched: true
         operations: ['concatenate']
         conditional:

--- a/db/db.sql
+++ b/db/db.sql
@@ -114,6 +114,7 @@ CREATE TABLE `workflow_steps` (
   `isBatched` boolean not null default false,
   `is_complete` boolean not null default false,
   `is_sequential` boolean not null default false,
+  `always_wait_for_prior_step` boolean not null default false,
   `maxBatchInputs` integer,
   `maxBatchSizeInBytes` integer,
   `operation` text not null,

--- a/db/migrations/20250331143557_add_always_wait_for_prior_step_to_workflow_steps.js
+++ b/db/migrations/20250331143557_add_always_wait_for_prior_step_to_workflow_steps.js
@@ -1,0 +1,13 @@
+exports.up = function(knex) {
+  return knex.schema
+    .alterTable('workflow_steps', (t) => {
+      t.boolean('always_wait_for_prior_step').defaultTo(false).notNullable();
+    });
+  };
+
+exports.down = function(knex) {
+  return knex.schema
+    .alterTable('workflow_steps', (t) => {
+      t.dropColumn('always_wait_for_prior_step');
+    });
+};

--- a/docs/guides/adapting-new-services.md
+++ b/docs/guides/adapting-new-services.md
@@ -190,9 +190,8 @@ An example of this is the query-cmr service. Each invocation of the query-cmr se
 For most services `is_sequential: true` is not necessary.
 
 ### Aggregation Steps
-Services that provide aggregation, e.g., concatenation for CONCISE, require that all inputs are
-available when they are run. Harmony infers this from the `operations` field in the associated step.
-Currently the only supported aggregation operation is `concatenate`.
+Services that provide aggregation, e.g., concatenation for CONCISE, require that all inputs are available when they are run. There are cases when a service such as netcdf-to-zarr can concatenate, but based on the user request will instead work on one granule at a time. For aggregation services that should always wait for the prior step inputs set `always_wait_for_prior_step` to true. Otherwise harmony will infer whether to wait based on the `operations` field in the associated step and whether the user requested some type of aggregation.
+The currently supported aggregation operations are `concatenate` and `extend`.
 
 There are limits to the number of files an aggregating service can process as well as the total number
 of bytes of all combined input files. To support larger aggregations Harmony can partition the output
@@ -209,6 +208,7 @@ steps:
   - image: !Env ${QUERY_CMR_IMAGE}
     is_sequential: true
   - image: !Env ${EXAMPLE_AGGREGATING_SERVICE_IMAGE}
+    always_wait_for_prior_step: true
     is_batched: true
     max_batch_inputs: 100
     max_batch_size_in_bytes: 2000000000

--- a/services/harmony/app/models/workflow-steps.ts
+++ b/services/harmony/app/models/workflow-steps.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/dot-notation */
-import env from '../util/env';
 import _ from 'lodash';
+
 import { Transaction } from '../util/db';
+import env from '../util/env';
 import { Job, JobStatus } from './job';
 import Record from './record';
 import WorkItem, { workItemCountForStep } from './work-item';
@@ -59,6 +60,9 @@ export interface WorkflowStepRecord {
 
   // Relative contribution of this step to the overall job progress calculation
   progress_weight: number;
+
+  // Whether the step needs to wait for all of the work items from the prior step to complete prior to starting
+  always_wait_for_prior_step: boolean;
 }
 
 /**
@@ -111,6 +115,9 @@ export default class WorkflowStep extends Record implements WorkflowStepRecord {
 
   // Relative contribution of this step to the overall job progress calculation
   progress_weight: number;
+
+  // Whether the step needs to wait for all of the work items from the prior step to complete prior to starting
+  always_wait_for_prior_step: boolean;
 
   /**
  * Get the collections that are the sources for the given operation

--- a/services/harmony/package-lock.json
+++ b/services/harmony/package-lock.json
@@ -23345,7 +23345,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2049

## Description
Fixes a bug where multiple batchee items were created when concatenate is not requested. You should be able to reproduce the problem with:
https://harmony.uat.earthdata.nasa.gov/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-70%3A30)&subset=lon(-157.5%3A-10)&extend=foo,bar&granuleId=G1261454424-LARC_CLOUD&granuleId=G1261454434-LARC_CLOUD&granuleId=G1261454423-LARC_CLOUD&granuleId=G1261454429-LARC_CLOUD&label=all-but-concise

I also fixed an issue with starting up dev services intermittently failing.

## Local Test Steps
In order to test you will first need to be setup to run the services for the SAMBAH chain locally.
* Add `batchee,stitchee,podaac-l2-subsetter,podaac-concise` to your `LOCALLY_DEPLOYED_SERVICES` in .env
* Add the following to your .env:
```
BATCHEE_IMAGE=ghcr.io/nasa/batchee:1.3.0
STITCHEE_IMAGE=ghcr.io/nasa/stitchee:1.6.1
PODAAC_L2_SUBSETTER_IMAGE=ghcr.io/podaac/l2ss-py:2.13.0
BATCHEE_SERVICE_QUEUE_URLS='["ghcr.io/nasa/batchee:1.3.0,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/batchee.fifo"]'
STITCHEE_SERVICE_QUEUE_URLS='["ghcr.io/nasa/stitchee:1.6.1,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/stitchee.fifo"]'
PODAAC_L2_SUBSETTER_SERVICE_QUEUE_URLS='["ghcr.io/podaac/l2ss-py:2.13.0,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/podaac-l2-subsetter.fifo"]'
```

Issue the following requests and verify the behavior matches expectations. The label for each request will help to verify which services should be called for that request.

Every request is for 4 granules. Batchee should find that there are 2 groups with 2 granules in each. So for the steps you should see the following when that step is executed for the request:
* 1 query-cmr
* 4 l2ss-py
* 1 batchee
* 2 STITCHEE
* 1 Concise

### Request list

1. Custom dimensions, concatenate true - runs all services: http://localhost:3000/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-70%3A30)&subset=lon(-157.5%3A-10)&concatenate=true&extend=foo,bar&granuleId=G1261454424-LARC_CLOUD&granuleId=G1261454434-LARC_CLOUD&granuleId=G1261454423-LARC_CLOUD&granuleId=G1261454429-LARC_CLOUD&label=all-services

2. Custom dimensions, no concatenation - skips Concise: http://localhost:3000/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-70%3A30)&subset=lon(-157.5%3A-10)&extend=foo,bar&granuleId=G1261454424-LARC_CLOUD&granuleId=G1261454434-LARC_CLOUD&granuleId=G1261454423-LARC_CLOUD&granuleId=G1261454429-LARC_CLOUD&label=all-but-concise

3. No extend, only concatenation - runs all services: http://localhost:3000/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-70%3A30)&subset=lon(-157.5%3A-10)&concatenate=true&granuleId=G1261454424-LARC_CLOUD&granuleId=G1261454434-LARC_CLOUD&granuleId=G1261454423-LARC_CLOUD&granuleId=G1261454429-LARC_CLOUD&label=all-services

4. No extend, no concatenation - only runs l2ss-py: http://localhost:3000/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-70%3A30)&subset=lon(-157.5%3A-10)&granuleId=G1261454424-LARC_CLOUD&granuleId=G1261454434-LARC_CLOUD&granuleId=G1261454423-LARC_CLOUD&granuleId=G1261454429-LARC_CLOUD&label=only-l2ss-py

5. Extend true, no concatenation - skips Concise, uses default extendDimensions (will need to look at the operation in the database or print out the operation in the code): http://localhost:3000/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-70%3A30)&subset=lon(-157.5%3A-10)&granuleId=G1261454424-LARC_CLOUD&granuleId=G1261454434-LARC_CLOUD&granuleId=G1261454423-LARC_CLOUD&granuleId=G1261454429-LARC_CLOUD&extend=true&label=all-but-concise

6. Extend false, no concatenation - only runs l2ss-py: http://localhost:3000/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-70%3A30)&subset=lon(-157.5%3A-10)&granuleId=G1261454424-LARC_CLOUD&granuleId=G1261454434-LARC_CLOUD&granuleId=G1261454423-LARC_CLOUD&granuleId=G1261454429-LARC_CLOUD&extend=false&label=only-l2ss-py

7. Extend true, no concatenation, no subsetting - only batchee and stitchee
http://localhost:3000/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?granuleId=G1261454424-LARC_CLOUD&granuleId=G1261454434-LARC_CLOUD&granuleId=G1261454423-LARC_CLOUD&granuleId=G1261454429-LARC_CLOUD&extend=true&label=only-batchee-and-stitchee

8. Concatenate true, no subsetting - all but l2ss-py
http://localhost:3000/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?granuleId=G1261454424-LARC_CLOUD&granuleId=G1261454434-LARC_CLOUD&granuleId=G1261454423-LARC_CLOUD&granuleId=G1261454429-LARC_CLOUD&concatenate=true&label=all-but-l2ss-py

9. Extend false, concatenate true - only runs l2ss-py and concise: http://localhost:3000/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-70%3A30)&subset=lon(-157.5%3A-10)&granuleId=G1261454424-LARC_CLOUD&granuleId=G1261454434-LARC_CLOUD&granuleId=G1261454423-LARC_CLOUD&granuleId=G1261454429-LARC_CLOUD&extend=false&concatenate=true&label=l2ss-py-and-concise


## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)