### PR TITLE
HARMONY-1969: Add support to deploy service with cookie secret.

### DIFF
--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -257,6 +257,19 @@ async function validateUserIsInDeployerOrCoreGroup(
 }
 
 /**
+ * Validate that the cookie secret is provided in the request or
+ * the user is in the deployers or the core permissions group
+ * @param req - The request object
+ * @param res  - The response object - will be used to send an error if the validation fails
+ * @returns A Promise containing `true` if cookie secret is present or the user is in either group, `false` otherwise
+ */
+async function validateCookieSecretOrUserIsInDeployerOrCoreGroup(
+  req: HarmonyRequest, res: Response,
+): Promise<boolean> {
+  return hasCookieSecret(req) || await validateUserIsInDeployerOrCoreGroup(req, res);
+}
+
+/**
  * Returns an error message if a tag does not have the correct form.
  * See https://docs.docker.com/engine/reference/commandline/image_tag/
  *
@@ -519,7 +532,7 @@ export async function updateServiceImageTag(
 ): Promise<void> {
 
   const validations = [
-    validateUserIsInDeployerOrCoreGroup,
+    validateCookieSecretOrUserIsInDeployerOrCoreGroup,
     validateServiceDeploymentIsEnabled,
     validateTagPresent,
     validateRequestParams,
@@ -550,7 +563,7 @@ export async function updateServiceImageTag(
 
   const deployment = new ServiceDeployment({
     deployment_id: deploymentId,
-    username: req.user,
+    username: req.user || 'cookie_secret',
     service: service,
     tag: tag,
     regression_test_version: regressionTestVersion,


### PR DESCRIPTION
## Jira Issue ID
HARMONY-1969

## Description
This is the Harmony part of the change to add support to deploy service with cookie secret. There will be a separate PR in harmony-service-example that will use this feature to deploy harmony-serivce-example as part of the Bamboo deployment.

## Local Test Steps
Tested in Sandbox: 

curl -XPUT --insecure --socks5 localhost:8080 -H "COOKIE-SECRET: $bamboo_COOKIE_SECRET" -H 'Content-type: application/json' https://internal-harmony-yliu10-frontend-2063572707.us-west-2.elb.amazonaws.com/service-image-tag/harmony-service-example -d '{"tag": "latest"}'

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)