### PR TITLE
HARMONY-2051: Do not fail a job immediately if a work item does not provide outputs

### DIFF
--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -696,7 +696,7 @@ export async function processWorkItem(
       return;
     }
 
-    const hasOutput = results?.length > 0;
+    const hasOutput = results && results.length > 0;
     if (status === WorkItemStatus.SUCCESSFUL && !hasOutput) {
       // To return no output the status needs to be a warning, otherwise we treat it as an error
       logger.error('The work item update should have contained results, but it did not.');

--- a/services/harmony/test/workflow-orchestration.ts
+++ b/services/harmony/test/workflow-orchestration.ts
@@ -150,7 +150,7 @@ describe('when a work item callback request does not return the results to const
         const jobs = await Job.forUser(db, 'anonymous');
         const job = jobs.data[0];
         expect(job.status).to.equal('failed');
-        expect(job.message).to.equal('Harmony internal failure: service did not return any outputs.');
+        expect(job.message).to.equal('WorkItem failed: Service did not return any outputs.');
       });
     });
   });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2051

## Description
We've started seeing an error in production and reproduced in sandbox where work items are returning a successful status but without any output results. I'm not sure of the root cause yet, but this PR will change the error to be retried and only considered as a work item error as opposed to immediately failing the job.

## Local Test Steps
Since I've been unable to figure out the exact root cause I'm just testing in the sandbox environment with an updated work-item-updater image. I'm finding that during an initial scale up I'm seeing the problem occur for quite a few work items and then the issues stopped. In looking at the pods I found some errors like the following (though could be unrelated):

```
{"env_name":"harmony-cdd-sandbox","level":"debug","message":"SIDECAR STATUS: {\n  \"metadata\": {},\n  \"status\": \"Failure\",\n  \"message\": \"Internal error occurred: unable to upgrade connection: rpc error: code = Unavailable desc = connection error: desc = \\\"transport: Error while dialing: dial unix /run/containerd/containerd.sock: connect: no such file or directory\\\"\",\n  \"reason\": \"InternalError\",\n  \"details\": {\n    \"causes\": [\n      {\n        \"message\": \"unable to upgrade connection: rpc error: code = Unavailable desc = connection error: desc = \\\"transport: Error while dialing: dial unix /run/containerd/containerd.sock: connect: no such file or directory\\\"\"\n      }\n    ]\n  },\n  \"code\": 500\n}","timestamp":"2025-04-02T20:25:19.728Z","workItemId":116800}
```

In my testing I'm finding some work items failing 5 times and being marked as failed, but this change will at least be a first step to prevent jobs from immediately failing.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)