### PR TITLE
HARMONY-2053: Roll back the service-runner base docker image

### DIFF
--- a/services/service-runner/Dockerfile
+++ b/services/service-runner/Dockerfile
@@ -1,7 +1,6 @@
-FROM node:22.14.0
+FROM node:22.5.1-alpine
 
-RUN apt-get update
-RUN apt-get install -y vim
+RUN apk add bash vim curl git
 RUN git config --global url."https://".insteadOf ssh://
 
 RUN mkdir -p /service-runner/services/service-runner


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2053

## Description
Rolling back the service-runner base docker image change to node 22.14 in order to workaround issues with service-runner returning empty results to harmony and causing failures.

## Local Test Steps

Build the service-runner image locally and then restart your services and make sure requests continue to work.

I've tested in sandbox - previously every 110K granule request I submitted would run into multiple work items failing during the run and usually near the beginning as nodes were scaling up. This time there have been no failures.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)