### PR TITLE
HARMONY-2055: Make cronjob logging more consistent with info statements for when each job starts running.

### DIFF
--- a/services/cron-service/app/cronjobs/restart-prometheus.ts
+++ b/services/cron-service/app/cronjobs/restart-prometheus.ts
@@ -65,7 +65,7 @@ async function restartPrometheusIfBroken(ctx: Context): Promise<void> {
 export class RestartPrometheus extends CronJob {
   static async run(ctx: Context): Promise<void> {
     const { logger } = ctx;
-    logger.debug('Running');
+    logger.info('Started restart Prometheus cron job');
     try {
       await restartPrometheusIfBroken(ctx);
     } catch (e) {

--- a/services/cron-service/app/cronjobs/work-reaper.ts
+++ b/services/cron-service/app/cronjobs/work-reaper.ts
@@ -101,7 +101,7 @@ export class WorkReaper extends CronJob {
 
   static async run(ctx: Context): Promise<void> {
     const { logger } = ctx;
-    logger.debug('Running');
+    logger.info('Started work reaper cron job');
     try {
       const updatedAtCutoff = subMinutes(new Date(), env.reapableWorkAgeMinutes);
       await deleteTerminalWorkItems(

--- a/services/cron-service/app/util/env.ts
+++ b/services/cron-service/app/util/env.ts
@@ -12,31 +12,33 @@ import { IsCrontab } from './cron-validation';
 
 class CronServiceHarmonyEnv extends HarmonyEnv {
 
-  // work reaper specific vars
+  // Begin work reaper variables
   @IsCrontab()
   workReaperCron: string;
 
   @IsInt()
   @Min(1)
   workReaperBatchSize: number;
-  // end work reaper specific vars
 
   @IsInt()
   @Min(1)
   reapableWorkAgeMinutes: number;
+  // End work reaper variables
 
-  // Restart prometheus
+
+  // Begin restart prometheus variables
   @IsCrontab()
   restartPrometheusCron: string;
+  // End restart prometheus variables
 
-  // user-work update specific vars
+  // Begin user work update variables
   @IsCrontab()
   userWorkUpdaterCron: string;
 
   @IsInt()
   @Min(1)
   userWorkExpirationMinutes: number;
-  // end user-work update specific vars
+  // End user work update variables
 }
 
 const localPath = path.resolve(__dirname, '../../env-defaults');

--- a/services/cron-service/env-defaults
+++ b/services/cron-service/env-defaults
@@ -13,8 +13,8 @@ WORK_REAPER_BATCH_SIZE=2000
 # The cron schedule for restarting Prometheus if it is down
 RESTART_PROMETHEUS_CRON="*/10 * * * *" # every 10 minutes
 
-# The cron schedule for the user-work updater
+# The cron schedule for the user work updater
 USER_WORK_UPDATER_CRON="*/30 * * * *" # every thirty minutes
 
-# Rows in user-work older than this will cause the user-work for a job to be recalculated
+# Rows in user_work older than this will cause the ready and running counts for a job to be recalculated
 USER_WORK_EXPIRATION_MINUTES=60

--- a/services/cron-service/test/restart-prometheus.ts
+++ b/services/cron-service/test/restart-prometheus.ts
@@ -10,7 +10,6 @@ import { Context } from '../app/util/context';
 describe('RestartPrometheus', () => {
   let ctx: Context;
   let loggerStub: {
-    debug: sinon.SinonStub;
     info: sinon.SinonStub;
     warn: sinon.SinonStub;
     error: sinon.SinonStub;
@@ -21,7 +20,6 @@ describe('RestartPrometheus', () => {
 
   beforeEach(() => {
     loggerStub = {
-      debug: sinon.stub(),
       info: sinon.stub(),
       warn: sinon.stub(),
       error: sinon.stub(),
@@ -76,11 +74,11 @@ describe('RestartPrometheus', () => {
       });
     });
 
-    it('should log debug and call restartPrometheusIfBroken', async () => {
+    it('should log starting and call restartPrometheusIfBroken', async () => {
       await RestartPrometheus.run(ctx);
-      expect(loggerStub.debug.calledOnceWith('Running')).to.be.true;
+      expect(loggerStub.info.calledWith('Started restart Prometheus cron job')).to.be.true;
       expect(hpaApiStub.listNamespacedHorizontalPodAutoscaler.calledOnceWith({ namespace: 'harmony' })).to.be.true;
-      expect(loggerStub.info.calledOnceWith('All 1 HPAs are collecting metrics, Prometheus working as expected.')).to.be.true;
+      expect(loggerStub.info.calledWith('All 1 HPAs are collecting metrics, Prometheus working as expected.')).to.be.true;
     });
 
     it('should catch and log any errors', async () => {
@@ -88,7 +86,7 @@ describe('RestartPrometheus', () => {
       hpaApiStub.listNamespacedHorizontalPodAutoscaler.rejects(error);
       await RestartPrometheus.run(ctx);
 
-      expect(loggerStub.debug.calledOnceWith('Running')).to.be.true;
+      expect(loggerStub.info.calledWith('Started restart Prometheus cron job')).to.be.true;
       expect(loggerStub.error.calledWith('Failed to monitor and restart Prometheus')).to.be.true;
       expect(loggerStub.error.calledWith(error)).to.be.true;
     });

--- a/services/cron-service/test/update-user-work.ts
+++ b/services/cron-service/test/update-user-work.ts
@@ -14,7 +14,6 @@ import { buildJob } from './helpers/jobs';
 describe('UserWorkUpdater', () => {
   let ctx: Context;
   let loggerInfoStub: sinon.SinonStub;
-  let loggerDebugStub: sinon.SinonStub;
   let loggerErrorStub: sinon.SinonStub;
   let loggerWarnStub: sinon.SinonStub;
   let recalculateCountsStub: sinon.SinonStub;
@@ -24,7 +23,6 @@ describe('UserWorkUpdater', () => {
     await truncateAll();
     // Set up logger stubs
     loggerInfoStub = sinon.stub();
-    loggerDebugStub = sinon.stub();
     loggerErrorStub = sinon.stub();
     loggerWarnStub = sinon.stub();
 
@@ -32,7 +30,6 @@ describe('UserWorkUpdater', () => {
     ctx = {
       logger: {
         info: loggerInfoStub,
-        debug: loggerDebugStub,
         error: loggerErrorStub,
         warn: loggerWarnStub,
       },
@@ -56,10 +53,9 @@ describe('UserWorkUpdater', () => {
   });
 
   describe('UserWorkUpdater.run', () => {
-    it('should call logger.debug and execute updateUserWork', async () => {
+    it('should call logger.info and execute updateUserWork', async () => {
       await updateUserWorkMod.UserWorkUpdater.run(ctx);
-
-      expect(loggerDebugStub.calledOnceWith('Running')).to.be.true;
+      expect(loggerInfoStub.calledWith('Started user work updater cron job')).to.be.true;
     });
 
     let trxStub: SinonStub;
@@ -75,7 +71,7 @@ describe('UserWorkUpdater', () => {
 
       } finally {
         expect(loggerErrorStub.called).to.be.true;
-        expect(loggerErrorStub.calledWith('User work udpater failed to update user_work table')).to.be.true;
+        expect(loggerErrorStub.calledWith('User work updater failed to update user_work table')).to.be.true;
         expect(loggerErrorStub.secondCall.args[0]).to.equal(error);
         trxStub.restore();
       }


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2055

## Description
Ensures each cron job logs the start of execution at info level.

## Local Test Steps

Set the cron interval to every minute to avoid having to wait up to 30 minutes to verify.

```
WORK_REAPER_CRON="*/1 * * * *"
RESTART_PROMETHEUS_CRON="*/1 * * * *"
USER_WORK_UPDATER_CRON="*/1 * * * *"
```

Verify there is an info level log statement for each of the 3 jobs stating when they start executing.

Run `npm run build` for the cron service to make sure there are no issues creating the docker image.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)