### PR TITLE
Harmony 2052 - Rework service-runner to be more responsive to termination requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @indiejames @chris-durbin @ygliuvt

--- a/docs/guides/configuring-harmony-service.ipynb
+++ b/docs/guides/configuring-harmony-service.ipynb
@@ -492,7 +492,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "harmony-py-notebooks",
    "language": "python",
    "name": "python3"
   },
@@ -506,7 +506,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/services/harmony/package.json
+++ b/services/harmony/package.json
@@ -227,6 +227,6 @@
     "braces": "^3.0.3",
     "fast-xml-parser": "4.4.1",
     "jsonpath-plus": "^10.0.7",
-    "cross-spawn": "7.0.5"  
+    "cross-spawn": "7.0.5"
   }
 }

--- a/services/harmony/test/aggregation-workflows.ts
+++ b/services/harmony/test/aggregation-workflows.ts
@@ -475,3 +475,5 @@ describe('When a workflow has an aggregating step in the middle and end and star
   });
 
 });
+
+

--- a/services/service-runner/app/util/axios-clients.ts
+++ b/services/service-runner/app/util/axios-clients.ts
@@ -1,7 +1,8 @@
-import logger from '../../../harmony/app/util/log';
+import Agent from 'agentkeepalive';
 import axios, { AxiosError, AxiosInstance } from 'axios';
 import axiosRetry, { exponentialDelay, isNetworkOrIdempotentRequestError } from 'axios-retry';
-import Agent from 'agentkeepalive';
+
+import logger from '../../../harmony/app/util/log';
 
 /**
  * Default Axios client timeout (also used by keepAliveAgent).
@@ -32,7 +33,7 @@ enum AxiosErrorCode {
  * @param maxDelayMs - sets an upper limit on the calculated delay
  * @returns - delay in ms
  */
-function calculateExponentialDelay(
+export function calculateExponentialDelay(
   retryNumber: number,
   exponentialOffset = 0,
   maxDelayMs = Infinity,
@@ -78,22 +79,22 @@ export function isRetryable(error: AxiosError): boolean {
  * @returns AxiosInstance
  */
 export default function createAxiosClientWithRetry(
-  retries = Infinity,
-  maxDelayMs = Infinity,
-  exponentialOffset = 0,
-  retryCondition = isRetryable,
+  _retries = Infinity,
+  _maxDelayMs = Infinity,
+  _exponentialOffset = 0,
+  _retryCondition = isRetryable,
   timeoutMs = axiosTimeoutMs,
   httpAgent = keepAliveAgent,
 ): AxiosInstance {
-  if (process.env.NODE_ENV === 'test') {
-    retries = 2;
-  }
+  // if (process.env.NODE_ENV === 'test') {
+  //   retries = 2;
+  // }
   const axiosClient = axios.create({ httpAgent, timeout: timeoutMs });
-  axiosRetry(axiosClient, {
-    retryDelay: (retryNumber) =>
-      calculateExponentialDelay(retryNumber, exponentialOffset, maxDelayMs),
-    retryCondition,
-    shouldResetTimeout: true,
-    retries });
+  // axiosRetry(axiosClient, {
+  //   retryDelay: (retryNumber) =>
+  //     calculateExponentialDelay(retryNumber, exponentialOffset, maxDelayMs),
+  //   retryCondition,
+  //   shouldResetTimeout: true,
+  //   retries });
   return axiosClient;
 }

--- a/services/service-runner/app/util/axios-clients.ts
+++ b/services/service-runner/app/util/axios-clients.ts
@@ -79,22 +79,22 @@ export function isRetryable(error: AxiosError): boolean {
  * @returns AxiosInstance
  */
 export default function createAxiosClientWithRetry(
-  _retries = Infinity,
-  _maxDelayMs = Infinity,
-  _exponentialOffset = 0,
-  _retryCondition = isRetryable,
+  retries = Infinity,
+  maxDelayMs = Infinity,
+  exponentialOffset = 0,
+  retryCondition = isRetryable,
   timeoutMs = axiosTimeoutMs,
   httpAgent = keepAliveAgent,
 ): AxiosInstance {
-  // if (process.env.NODE_ENV === 'test') {
-  //   retries = 2;
-  // }
+  if (process.env.NODE_ENV === 'test') {
+    retries = 2;
+  }
   const axiosClient = axios.create({ httpAgent, timeout: timeoutMs });
-  // axiosRetry(axiosClient, {
-  //   retryDelay: (retryNumber) =>
-  //     calculateExponentialDelay(retryNumber, exponentialOffset, maxDelayMs),
-  //   retryCondition,
-  //   shouldResetTimeout: true,
-  //   retries });
+  axiosRetry(axiosClient, {
+    retryDelay: (retryNumber) =>
+      calculateExponentialDelay(retryNumber, exponentialOffset, maxDelayMs),
+    retryCondition,
+    shouldResetTimeout: true,
+    retries });
   return axiosClient;
 }

--- a/services/service-runner/app/util/sleep-check.ts
+++ b/services/service-runner/app/util/sleep-check.ts
@@ -1,8 +1,8 @@
 /**
- * Sleeps for a duration, checking a condition at 1-second intervals
+ * Sleeps for a duration, checking a condition at periodic intervals
  * @param duration - Maximum sleep duration in milliseconds
  * @param check - Function that returns true when the sleep should be interrupted
- * @param interval - How often in milliseconds to check the sleep condition
+ * @param interval - How often in milliseconds to check the sleep condition - default 1000
  * @returns Promise that resolves when either the check passes or duration expires
  */
 export async function sleepCheck(duration: number, check: () => boolean, interval = 1000): Promise<void> {
@@ -10,15 +10,9 @@ export async function sleepCheck(duration: number, check: () => boolean, interva
   const endTime = Date.now() + duration;
 
   // Loop until either the check passes or we exceed the duration
-  while (Date.now() < endTime) {
+  while (Date.now() < endTime && !check()) {
     // Sleep for `interval` msec or the remaining duration, whichever is smaller
     const sleepTime = Math.min(interval, endTime - Date.now());
     await new Promise(resolve => setTimeout(resolve, sleepTime));
-
-    // Check if the condition is true
-    if (check()) {
-      // Condition passed, exit early
-      return;
-    }
   }
 }

--- a/services/service-runner/app/util/sleep-check.ts
+++ b/services/service-runner/app/util/sleep-check.ts
@@ -1,0 +1,24 @@
+/**
+ * Sleeps for a duration, checking a condition at 1-second intervals
+ * @param duration - Maximum sleep duration in milliseconds
+ * @param check - Function that returns true when the sleep should be interrupted
+ * @param interval - How often in milliseconds to check the sleep condition
+ * @returns Promise that resolves when either the check passes or duration expires
+ */
+export async function sleepCheck(duration: number, check: () => boolean, interval = 1000): Promise<void> {
+  // Calculate the end time
+  const endTime = Date.now() + duration;
+
+  // Loop until either the check passes or we exceed the duration
+  while (Date.now() < endTime) {
+    // Sleep for `interval` msec or the remaining duration, whichever is smaller
+    const sleepTime = Math.min(interval, endTime - Date.now());
+    await new Promise(resolve => setTimeout(resolve, sleepTime));
+
+    // Check if the condition is true
+    if (check()) {
+      // Condition passed, exit early
+      return;
+    }
+  }
+}

--- a/services/service-runner/app/workers/pull-worker.ts
+++ b/services/service-runner/app/workers/pull-worker.ts
@@ -112,10 +112,11 @@ async function _pullWork(): Promise<{ item?: WorkItemRecord; status?: number; er
       // 404s are expected when no work is available
       if (response.status === 404) {
         result = { status: response.status };
+      } else {
+        const item = response.data.workItem;
+        result = { item, maxCmrGranules: response.data.maxCmrGranules, status: response.status };
       }
 
-      const item = response.data.workItem;
-      result = { item, maxCmrGranules: response.data.maxCmrGranules, status: response.status };
     } catch (err) {
       if (!isRetryable(err) || !retryUnlessTerminating(err) || retries > maxGetWorkRetries) {
         if (err.response) {

--- a/services/service-runner/test/sleep-check.ts
+++ b/services/service-runner/test/sleep-check.ts
@@ -40,12 +40,12 @@ describe('sleepCheck', () => {
 
     const promise = sleepCheck(5000, checkStub);
 
-    // Advance time by 1 second
-    await clock.tickAsync(1000);
+    // Advance time by 1/2 second
+    await clock.tickAsync(500);
     expect(checkStub.calledOnce).to.be.true;
 
-    // Advance time by another second
-    await clock.tickAsync(1000);
+    // Advance time by another 1/2 second
+    await clock.tickAsync(500);
     expect(checkStub.calledTwice).to.be.true;
 
     // Advance time by another second, which should trigger the third call
@@ -95,8 +95,8 @@ describe('sleepCheck', () => {
     // Advance a tiny bit of time to allow promises to resolve
     await clock.tickAsync(10);
 
-    // Check function should still be called once
-    expect(checkStub.calledOnce).to.be.true;
+    // Check function should not be called
+    expect(checkStub.called).to.be.false;
 
     // Wait for the promise to resolve
     await promise;

--- a/services/service-runner/test/sleep-check.ts
+++ b/services/service-runner/test/sleep-check.ts
@@ -1,0 +1,104 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+
+// Import the function to test (adjust import path as needed)
+// Assuming the sleepCheck function is in a file called sleepUtils.ts
+import { sleepCheck } from '../app/util/sleep-check';
+
+describe('sleepCheck', () => {
+  // Use fake timers to control time in tests
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    // Setup fake timer before each test
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // Restore real timers after each test
+    clock.restore();
+  });
+
+  it('should resolve immediately if check function returns true initially', async () => {
+    const checkStub = sinon.stub().returns(true);
+
+    await sleepCheck(5000, checkStub);
+
+    // Advance time by a small amount to allow any pending promises to resolve
+    await clock.tickAsync(10);
+
+    // Check function should have been called once
+    expect(checkStub.calledOnce).to.be.true;
+  });
+
+  it('should wait for check function to return true', async () => {
+    // Create a stub that returns false twice, then true
+    const checkStub = sinon.stub();
+    checkStub.onCall(0).returns(false);
+    checkStub.onCall(1).returns(false);
+    checkStub.onCall(2).returns(true);
+
+    const promise = sleepCheck(5000, checkStub);
+
+    // Advance time by 1 second
+    await clock.tickAsync(1000);
+    expect(checkStub.calledOnce).to.be.true;
+
+    // Advance time by another second
+    await clock.tickAsync(1000);
+    expect(checkStub.calledTwice).to.be.true;
+
+    // Advance time by another second, which should trigger the third call
+    // and resolve the promise
+    await clock.tickAsync(1000);
+    expect(checkStub.calledThrice).to.be.true;
+
+    // Wait for the promise to resolve
+    await promise;
+  });
+
+  it('should timeout after specified duration if check never passes', async () => {
+    const checkStub = sinon.stub().returns(false);
+
+    const promise = sleepCheck(3500, checkStub);
+
+    // Advance clock by slightly more than the total duration
+    await clock.tickAsync(3600);
+
+    // Check that the function was called 4 times (at ~1s, ~2s, ~3s, and at the end)
+    expect(checkStub.callCount).to.equal(4);
+
+    // Wait for the promise to resolve
+    await promise;
+  });
+
+  it('should handle durations less than 1 second', async () => {
+    const checkStub = sinon.stub().returns(false);
+
+    const promise = sleepCheck(500, checkStub);
+
+    // Advance time just beyond the duration
+    await clock.tickAsync(510);
+
+    // Check that the function was called just once at the end
+    expect(checkStub.calledOnce).to.be.true;
+
+    // Wait for the promise to resolve
+    await promise;
+  });
+
+  it('should handle zero duration', async () => {
+    const checkStub = sinon.stub().returns(false);
+
+    const promise = sleepCheck(0, checkStub);
+
+    // Advance a tiny bit of time to allow promises to resolve
+    await clock.tickAsync(10);
+
+    // Check function should still be called once
+    expect(checkStub.calledOnce).to.be.true;
+
+    // Wait for the promise to resolve
+    await promise;
+  });
+});


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2052

## Description
Changes to make service-runner check for termination requests while doing exponential backoff when getting work

## Local Test Steps
* Make sure queries still work
* try ./bin/stop-harmony-and-services to see pods shut down relatively quickly. 
* try stopping harmony and restarting to make sure pods start polling for work again

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] ~Documentation updated (if needed)~
* [x] Harmony in a Box tested (if changes made to microservices or new dependencies added)