### PR TITLE
HARMONY-2048: Add a feature toggle to allow a user to specify the service chain to use in test environments.

### DIFF
--- a/services/harmony/app/schemas/ogc-api-coverages/1.0.0/ogc-api-coverages-v1.0.0.yml
+++ b/services/harmony/app/schemas/ogc-api-coverages/1.0.0/ogc-api-coverages-v1.0.0.yml
@@ -335,6 +335,7 @@ paths:
         - $ref: "#/components/parameters/height"
         - $ref: "#/components/parameters/format"
         - $ref: "#/components/parameters/forceAsync"
+        - $ref: "#/components/parameters/serviceId"
         - $ref: "#/components/parameters/maxResults"
         - $ref: "#/components/parameters/skipPreview"
         - $ref: "#/components/parameters/ignoreErrors"
@@ -379,6 +380,7 @@ paths:
         - $ref: "#/components/parameters/height"
         - $ref: "#/components/parameters/format"
         - $ref: "#/components/parameters/forceAsync"
+        - $ref: "#/components/parameters/serviceId"
         - $ref: "#/components/parameters/maxResults"
         - $ref: "#/components/parameters/skipPreview"
         - $ref: "#/components/parameters/ignoreErrors"
@@ -902,6 +904,15 @@ components:
       in: query
       description: if "true", override the default API behavior and always treat the request as asynchronous
       required: false
+      schema:
+        type: string
+    serviceId:
+      name: serviceId
+      in: query
+      description: Either the CMR concept ID or the name in services.yml for the UMM-S service chain to invoke. Useful for testing a service chain against a collection not yet configured for use with that service chain.
+      required: false
+      style: form
+      explode: true
       schema:
         type: string
     maxResults:

--- a/services/harmony/app/schemas/ogc-api-edr/1.1.0/ogc-api-edr-v1.1.0.yml
+++ b/services/harmony/app/schemas/ogc-api-edr/1.1.0/ogc-api-edr-v1.1.0.yml
@@ -165,6 +165,7 @@ paths:
         - $ref: "#/components/parameters/width"
         - $ref: "#/components/parameters/height"
         - $ref: "#/components/parameters/forceAsync"
+        - $ref: "#/components/parameters/serviceId"
         - $ref: "#/components/parameters/maxResults"
         - $ref: "#/components/parameters/skipPreview"
         - $ref: "#/components/parameters/ignoreErrors"
@@ -245,6 +246,8 @@ paths:
                   type: integer
                 forceAsync:
                   type: string
+                serviceId:
+                  type: string
                 maxResults:
                   type: integer
                 skipPreview:
@@ -308,6 +311,7 @@ paths:
         - $ref: "#/components/parameters/width"
         - $ref: "#/components/parameters/height"
         - $ref: "#/components/parameters/forceAsync"
+        - $ref: "#/components/parameters/serviceId"
         - $ref: "#/components/parameters/maxResults"
         - $ref: "#/components/parameters/skipPreview"
         - $ref: "#/components/parameters/ignoreErrors"
@@ -394,6 +398,8 @@ paths:
                   type: integer
                 forceAsync:
                   type: string
+                serviceId:
+                  type: string
                 maxResults:
                   type: integer
                 skipPreview:
@@ -457,6 +463,7 @@ paths:
         - $ref: "#/components/parameters/width"
         - $ref: "#/components/parameters/height"
         - $ref: "#/components/parameters/forceAsync"
+        - $ref: "#/components/parameters/serviceId"
         - $ref: "#/components/parameters/maxResults"
         - $ref: "#/components/parameters/skipPreview"
         - $ref: "#/components/parameters/ignoreErrors"
@@ -541,6 +548,8 @@ paths:
                   type: integer
                 forceAsync:
                   type: string
+                serviceId:
+                  type: string
                 maxResults:
                   type: integer
                 skipPreview:
@@ -602,6 +611,7 @@ paths:
         - $ref: "#/components/parameters/width"
         - $ref: "#/components/parameters/height"
         - $ref: "#/components/parameters/forceAsync"
+        - $ref: "#/components/parameters/serviceId"
         - $ref: "#/components/parameters/maxResults"
         - $ref: "#/components/parameters/skipPreview"
         - $ref: "#/components/parameters/ignoreErrors"
@@ -681,6 +691,8 @@ paths:
                   type: integer
                 forceAsync:
                   type: string
+                serviceId:
+                  type: string
                 maxResults:
                   type: integer
                 skipPreview:
@@ -742,6 +754,7 @@ paths:
         - $ref: "#/components/parameters/width"
         - $ref: "#/components/parameters/height"
         - $ref: "#/components/parameters/forceAsync"
+        - $ref: "#/components/parameters/serviceId"
         - $ref: "#/components/parameters/maxResults"
         - $ref: "#/components/parameters/skipPreview"
         - $ref: "#/components/parameters/ignoreErrors"
@@ -822,6 +835,8 @@ paths:
                   type: integer
                 forceAsync:
                   type: string
+                serviceId:
+                  type: string
                 maxResults:
                   type: integer
                 skipPreview:
@@ -889,6 +904,7 @@ paths:
         - $ref: "#/components/parameters/width"
         - $ref: "#/components/parameters/height"
         - $ref: "#/components/parameters/forceAsync"
+        - $ref: "#/components/parameters/serviceId"
         - $ref: "#/components/parameters/maxResults"
         - $ref: "#/components/parameters/skipPreview"
         - $ref: "#/components/parameters/ignoreErrors"
@@ -984,6 +1000,8 @@ paths:
                 height:
                   type: integer
                 forceAsync:
+                  type: string
+                serviceId:
                   type: string
                 maxResults:
                   type: integer
@@ -1634,6 +1652,13 @@ components:
       name: forceAsync
       in: query
       description: if "true", override the default API behavior and always treat the request as asynchronous
+      required: false
+      schema:
+        type: string
+    serviceId:
+      name: serviceId
+      in: query
+      description: Either the CMR concept ID or the name in services.yml for the UMM-S service chain to invoke. Useful for testing a service chain against a collection not yet configured for use with that service chain.
       required: false
       schema:
         type: string

--- a/services/harmony/app/util/env.ts
+++ b/services/harmony/app/util/env.ts
@@ -1,7 +1,8 @@
 import { IsBoolean, IsInt, IsNotEmpty, IsPositive, Matches, Min } from 'class-validator';
-import { HarmonyEnv, memorySizeRegex } from '@harmony/util/env';
 import _ from 'lodash';
 import * as path from 'path';
+
+import { HarmonyEnv, memorySizeRegex } from '@harmony/util/env';
 
 //
 // harmony env module
@@ -130,6 +131,9 @@ class HarmonyServerEnv extends HarmonyEnv {
   useEdlClientApp: boolean;
 
   edlToken: string;
+
+  @IsBoolean()
+  allowServiceSelection: boolean;
 }
 
 const localPath = path.resolve(__dirname, '../../env-defaults');

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -255,6 +255,10 @@ LOCALSTACK_K8S_HOST=localstack
 # Toggle whether the labeling dropdown should be enabled in the workflow ui
 UI_LABELING=true
 
+# Toggle whether users can explicitly choose the service chain to call for
+# their request using the serviceId query parameter
+ALLOW_SERVICE_SELECTION=true
+
 ###########################################################################
 #                             Prometheus Config                           #
 #                                                                         #

--- a/services/harmony/test/middleware/service-selection.ts
+++ b/services/harmony/test/middleware/service-selection.ts
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import { NextFunction, Response } from 'express';
+import sinon from 'sinon';
+
+import chooseService from '../../app/middleware/service-selection';
+import DataOperation from '../../app/models/data-operation';
+import HarmonyRequest from '../../app/models/harmony-request';
+import * as serviceUtils from '../../app/models/services';
+import env from '../../app/util/env';
+
+describe('chooseService middleware', () => {
+  let req: Partial<HarmonyRequest>;
+  let res: Partial<Response>;
+  let nextFunction: sinon.SinonSpy;
+  let allowServiceSelectionStub: sinon.SinonStub;
+  let getServiceConfigsStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    req = {
+      query: {},
+      operation: { sources: [] } as unknown as DataOperation,
+      context: { collections: [], collectionIds: [] },
+    };
+    res = {};
+    nextFunction = sinon.spy();
+    allowServiceSelectionStub = sinon.stub(env, 'allowServiceSelection');
+    getServiceConfigsStub = sinon.stub(serviceUtils, 'getServiceConfigs');
+  });
+
+  afterEach(() => {
+    allowServiceSelectionStub.restore();
+    getServiceConfigsStub.restore();
+  });
+
+  it('should call next() if operation.sources is not defined', () => {
+    chooseService(req as HarmonyRequest, res as Response, nextFunction as NextFunction);
+    expect(nextFunction.calledOnce).to.be.true;
+    expect(nextFunction.firstCall.args).to.have.lengthOf(0);
+  });
+
+  it('should choose a service config when serviceId is provided', () => {
+    req.query = { serviceid: 'TestServiceId' };
+    const mockServiceConfig = { name: 'TestService', umm_s: 'TestServiceId', collections: [] };
+    allowServiceSelectionStub.value(true);
+    getServiceConfigsStub.returns([mockServiceConfig]);
+
+    chooseService(req as HarmonyRequest, res as Response, nextFunction as NextFunction);
+    expect(req.context.serviceConfig).to.equal(mockServiceConfig);
+    expect(nextFunction.calledOnce).to.be.true;
+    expect(nextFunction.firstCall.args).to.have.lengthOf(0);
+  });
+
+  it('should throw an error when service selection is disabled', () => {
+    req.query = { serviceid: 'TestServiceId' };
+    allowServiceSelectionStub.value(false);
+
+    chooseService(req as HarmonyRequest, res as Response, nextFunction as NextFunction);
+    expect(nextFunction.calledOnce).to.be.true;
+    expect(nextFunction.firstCall.args[0]).to.be.an.instanceOf(Error);
+    expect(nextFunction.firstCall.args[0].message).to.equal('Requesting a service chain using serviceId is disabled in this environment.');
+  });
+
+  it('should throw an error when serviceId is not found', () => {
+    req.query = { serviceid: 'NonexistentServiceId' };
+    allowServiceSelectionStub.value(true);
+    getServiceConfigsStub.returns([]);
+
+    chooseService(req as HarmonyRequest, res as Response, nextFunction as NextFunction);
+    expect(nextFunction.calledOnce).to.be.true;
+    expect(nextFunction.firstCall.args[0]).to.be.an.instanceOf(Error);
+    expect(nextFunction.firstCall.args[0].message).to.equal('Could not find a service chain that matched the provided serviceId. Ensure the provided serviceId is either a CMR concept ID or the name of the chain in services.yml');
+  });
+
+  it('should add collections to the service config when serviceId is provided', () => {
+    req.query = { serviceid: 'TestServiceId' };
+    req.context.collectionIds = ['collection1', 'collection2'];
+    const mockServiceConfig = { name: 'TestService', umm_s: 'TestServiceId', collections: [] };
+    allowServiceSelectionStub.value(true);
+    getServiceConfigsStub.returns([mockServiceConfig]);
+
+    chooseService(req as HarmonyRequest, res as Response, nextFunction as NextFunction);
+    expect(req.context.serviceConfig.collections).to.have.lengthOf(2);
+    expect(req.context.serviceConfig.collections[0].id).to.equal('collection1');
+    expect(req.context.serviceConfig.collections[1].id).to.equal('collection2');
+  });
+});


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2048

## Description
Add a feature toggle to allow a user to specify the service chain to use in test environments.

## Local Test Steps
### Verify that specifying a service chain is controlled by a feature toggle.

Set `ALLOW_SERVICE_SELECTION=false` in your .env
Verify that http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&outputCrs=EPSG%3A31975&format=image%2Fpng&maxResults=1&subset=time(%222002-09-15T00%3A00%3A00.000Z%22%3A%222022-09-25T00%3A00%3A00Z%22)&serviceId=harmony%2Fdownload

returns a 400 validation error with the message "Requesting a service chain using serviceId is disabled in this environment."

For the remaining tests make sure to remove `ALLOW_SERVICE_SELECTION=false` from your .env and restart harmony.

### Verify that a UMM-S concept ID can be specified as the chain
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&outputCrs=EPSG%3A31975&format=image%2Fpng&maxResults=1&subset=time(%222002-09-15T00%3A00%3A00.000Z%22%3A%222022-09-25T00%3A00%3A00Z%22)&serviceId=S1262025641-LARC_CLOUD

Verify using the workflow-ui that the service is sent to the l2-subsetter-batchee-stitchee-concise (SAMBAH) chain.

### Verify that the name of a service chain from services.yml can be specified as the chain (URL encoded)

http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&outputCrs=EPSG%3A31975&format=image%2Fpng&maxResults=1&subset=time(%222002-09-15T00%3A00%3A00.000Z%22%3A%222022-09-25T00%3A00%3A00Z%22)&serviceId=harmony%2Fdownload

Verify using the workflow-ui that the service is sent to the harmony/download service chain.

### Verify that an invalid service ID returns an error
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&outputCrs=EPSG%3A31975&format=image%2Fpng&maxResults=1&subset=time(%222002-09-15T00%3A00%3A00.000Z%22%3A%222022-09-25T00%3A00%3A00Z%22)&serviceId=bad_id

```
{
	"code": "harmony.RequestValidationError",
	"description": "Error: Could not find a service chain that matched the provided serviceId. Ensure the provided serviceId is either a CMR concept ID or the name of the chain in services.yml"
}
```

### Verify that EDR routes allow specifying the serviceId the same way as the OGC coverages route
All of these requests should be sent to the `harmony/download` service chain.

http://localhost:3000/ogc-api-edr/1.1.0/collections/C1233800302-EEDTEST/cube?bbox=-140,20,-50,60&granuleId=G1233800343-EEDTEST&crs=EPSG%3A31975&f=image%2Fpng&datetime=1975-01-02T00%3A00%3A00Z%2F2020-01-01T01%3A00%3A00Z&parameter-name=blue_var&label=foo&ignoreErrors=true&pixelSubset=true&skipPreview=false&forceAsync=false&serviceId=harmony%2Fdownload

http://localhost:3000/ogc-api-edr/1.1.0/collections/C1233800302-EEDTEST/area?granuleId=G1233800343-EEDTEST&crs=EPSG%3A31975&f=image%2Fpng&datetime=1975-01-02T00%3A00%3A00Z%2F2020-01-01T01%3A00%3A00Z&parameter-name=blue_var&coords=POLYGON((-65.390625%20-13.239945,%20-29.882813%20-50.958427,%2017.929688%2030.145127,%20-65.390625%20-13.239945))&serviceId=harmony%2Fdownload

http://localhost:3000/ogc-api-edr/1.1.0/collections/C1238548013-EEDTEST/trajectory?granuleId=G1245558551-EEDTEST&parameter-name=%2FAnalysis_Data%2Fsurface_temp_analysis&coords=MULTILINESTRING%20((-40%2010,%2030%2010),(10%201,%2010%2030))&forceAsync=true&serviceId=harmony%2Fdownload

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)