### PR TITLE
DAS-2313 - Create a service chain for SMAP L2 GeoTIFF reformatting

### DIFF
--- a/config/services-prod.yml
+++ b/config/services-prod.yml
@@ -215,6 +215,34 @@ https://cmr.earthdata.nasa.gov:
       - image: !Env ${TRAJECTORY_SUBSETTER_IMAGE}
         operations: ['variableSubset', 'spatialSubset', 'shapefileSubset', 'temporalSubset']
 
+  - name: sds/trajectory-smap-l2-geotiff-reformatter
+    description: |
+      A processing service chain for that Harmony Trajectory Subsetter dedicated to performing GeoTIFF reformatting of SMAP L2 Data. The service chain calls the Trajectory Subsetter, then calls the SMAP L2 Gridder to convert the trajectory/swath data to gridded NetCDF4 output, which in turn calls the Net2COG service to reformat the output to cloud-optimized GeoTIFF.
+    data_operation_version: '0.21.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/sds/trajectory-subsetter
+    umm_s: S1273345267-EEDTEST
+    capabilities:
+      subsetting:
+        temporal: false
+        bbox: true
+        shape: true
+        variable: true
+      output_formats:
+        - application/x-netcdf4
+        - image/tiff
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${TRAJECTORY_SUBSETTER_IMAGE}
+        operations: ['variableSubset', 'spatialSubset', 'shapefileSubset']
+      - image: !Env ${HARMONY_SMAP_L2_GRIDDER_IMAGE}
+
   - name: sds/HOSS-geographic
     description: |
       A service that currently supports L3/L4 geographically gridded collections, offering variable, temporal, named dimension, bounding box spatial and shape file spatial subsetting.

--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -374,6 +374,34 @@ https://cmr.uat.earthdata.nasa.gov:
       - image: !Env ${TRAJECTORY_SUBSETTER_IMAGE}
         operations: ['variableSubset', 'spatialSubset', 'shapefileSubset', 'temporalSubset']
 
+  - name: sds/trajectory-smap-l2-geotiff-reformatter
+    description: |
+      A processing service chain for that Harmony Trajectory Subsetter dedicated to performing GeoTIFF reformatting of SMAP L2 Data. The service chain calls the Trajectory Subsetter, then calls the SMAP L2 Gridder to convert the trajectory/swath data to gridded NetCDF4 output, which in turn calls the Net2COG service to reformat the output to cloud-optimized GeoTIFF.
+    data_operation_version: '0.21.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/sds/trajectory-subsetter
+    umm_s: S1273345267-EEDTEST
+    capabilities:
+      subsetting:
+        temporal: false
+        bbox: true
+        shape: true
+        variable: true
+      output_formats:
+        - application/x-netcdf4
+        - image/tiff
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${TRAJECTORY_SUBSETTER_IMAGE}
+        operations: ['variableSubset', 'spatialSubset', 'shapefileSubset']
+      - image: !Env ${HARMONY_SMAP_L2_GRIDDER_IMAGE}
+
   - name: sds/HyBIG
     description: |
       The Harmony Browse Image Generator (HyBIG) supports the conversion of


### PR DESCRIPTION
## Jira Issue ID
[DAS-2313](https://bugs.earthdata.nasa.gov/browse/DAS-2313)

## Description
This PR creates a new Harmony service chain for reformatting SMAP L2 Trajectory Subsetter output to GeoTIFF (new UMM-S record [S1273345267-EEDTEST](https://mmt.uat.earthdata.nasa.gov/services/S1273345267-EEDTEST)). This service chain is not yet complete since Net2COG currently does not work with SMAP L2 data, so the purpose of this ticket is to test if the service chain works up to calling the SMAP L2 Gridder. This chain will be completed and service associations officially updated in MMT in [DAS-2354](https://bugs.earthdata.nasa.gov/browse/DAS-2354). 

The end goal chain will be:
Trajectory Subsetter -> SMAP L2 Gridder -> Net2COG

## Local Test Steps
First, review the new UMM-S service record: [S1273345267-EEDTEST](https://mmt.uat.earthdata.nasa.gov/services/S1273345267-EEDTEST)

Next, run two requests locally in a Harmony URL: one request using the current service association, and a second request using the new service chain.

- Open Docker Desktop.
- Re-build the Harmony image:
```
npm run build
```
- Pull this Harmony branch.
- Place the following in your `.env` file (you’ll want to comment this out when you’re not directly editing Harmony):
```
HARMONY_IMAGE=harmonyservices/harmony:latest 
```
Bootstrap Harmony:
```
./bin/bootstrap-harmony
```
Restart Harmony:
```
./bin/restart-services
```
- Execute two spatial subset requests for SPL2SMA. One request uses the current service association, while the second request uses the new service association. Observe the invoked service chains in http://localhost:3000/workflow-ui. 

**Request 1: Using the current UMM-S service association.** 

http://localhost:3000/C1268429729-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&subset=lat(-25.0%3A-18.0)&subset=lon(130.0%3A135.0)&granuleId=G1268429738-EEDTEST

- The service chain shown in the workflow-ui should be `sds/trajectory-subsetter` with the steps listed in the image below.
- Observe that the output is HDF5 formatted. 
<img width="819" alt="image" src="https://github.com/user-attachments/assets/e8f2a08e-866b-4aec-aa71-e5b55dd6aaed" />

**Request 2: Using the new trial UMM-S service association.** 

http://localhost:3000/C1268429729-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&subset=lat(-25.0%3A-18.0)&subset=lon(130.0%3A135.0)&granuleId=G1268429738-EEDTEST&serviceId=S1273345267-EEDTEST 

- The service chain shown in the workflow-ui should be `sds/trajectory-smap-l2-geotiff-reformatter` with the steps listed in the image below.
- Observe that the output is NetCDF4 formatted.
<img width="819" alt="image" src="https://github.com/user-attachments/assets/13e23e8f-96f1-42fb-a883-aa24b7e45653" />

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [NA] Tests added/updated (if needed) and passing
* [NA] Documentation updated (if needed)
* [X] Harmony in a Box tested (if changes made to microservices or new dependencies added)