### PR TITLE
Harmony 2025 - Add support for custom environment variables for services

### DIFF
--- a/bin/create-k8s-config-maps-and-secrets
+++ b/bin/create-k8s-config-maps-and-secrets
@@ -1,5 +1,25 @@
 #!/bin/bash
 
+# check if the input string is a service specific variable name, e.g.
+# BATCHEE_IMAGE. note that variable names that end in QUEUE_URLS are not service
+# specific variables - they are used by harmony itself.
+# returns 0 if the string is the name of a service specific variable name, 1 otherwise
+is_service_var() {
+   if [[ "$1" == *"QUEUE_URLS" ]]; then
+    return 1 # we need to include QUEUE_URLS env vars in the main config map
+  fi
+
+  for service in ${LOCALLY_DEPLOYED_SERVICES//,/ }
+  do
+    local var_prefix=`echo $service | tr 'a-z' 'A-Z' | tr '-' '_'`
+    if [[ $1 == "$var_prefix"* ]]; then
+      return 0 # is a service variable
+    fi
+  done
+
+  return 1 # not a service variable
+}
+
 declare -a secrets=("OAUTH_UID" "OAUTH_CLIENT_ID" "OAUTH_PASSWORD" "SHARED_SECRET_KEY" "COOKIE_SECRET" "DATABASE_URL" "NB_EDL_PASSWORD")
 declare -a applications=("work-scheduler" "work-updater" "cron-service" "work-failer" "harmony")
 
@@ -42,10 +62,10 @@ EOF
 
   # Harmony-specific variables
   if [[ "$app" == "harmony" ]]; then
-    if [[ "$CMR_ENDPOINT" == "https://cmr.earthdata.nasa.gov" ]]; then
-      SERVICES_YML=$(< config/services-prod.yml)
-    else
+    if [[ "$CMR_ENDPOINT" == "https://cmr.uat.earthdata.nasa.gov" ]]; then
       SERVICES_YML=$(< config/services-uat.yml)
+    else
+      SERVICES_YML=$(< config/services-prod.yml)
     fi
     echo "  STAGING_PATH: \"${STAGING_PATH}\"" >> "$config_map_file"
     echo "  SERVICES_YML: $(echo -n "${SERVICES_YML}" | base64 | tr -d "\n")" >> "$config_map_file"
@@ -62,6 +82,7 @@ EOF
       while IFS='=' read -r name _; do
         [[ $name =~ ^\#.* ]] && continue  # Skip comments
         name=$(echo -n "$name" | xargs)   # Trim whitespace
+        $(is_service_var "$name") && continue # skip service specific variables
 
         # if the named variable exists in the environment and is not a secret, add it to
         # the config map

--- a/bin/create-k8s-config-maps-and-secrets
+++ b/bin/create-k8s-config-maps-and-secrets
@@ -63,6 +63,8 @@ EOF
         [[ $name =~ ^\#.* ]] && continue  # Skip comments
         name=$(echo -n "$name" | xargs)   # Trim whitespace
 
+        # if the named variable exists in the environment and is not a secret, add it to
+        # the config map
         if [[ -n "${!name}" && ! " ${secrets[@]} " =~ " ${name} " ]]; then
           escaped_value=$(echo "${!name}" | sed 's/"/\\\"/g')
           echo "  ${name}: \"${escaped_value}\"" >> "$config_map_file"

--- a/bin/deploy-services
+++ b/bin/deploy-services
@@ -95,7 +95,7 @@ fi
 file="services/service-runner/config/service-template.yaml"
 for service in ${LOCALLY_DEPLOYED_SERVICES//,/ }
 do
-  # set up enviornment variables for service
+  # set up environment variables for service
   export SERVICE_NAME=${service}
   var_prefix=`echo $service | tr 'a-z' 'A-Z' | tr '-' '_'`
   declare ${var_prefix}_IMAGE
@@ -119,6 +119,36 @@ do
   declare ${var_prefix}_INVOCATION_ARGS
   varname=${var_prefix}_INVOCATION_ARGS
   export SERVICE_INVOCATION_ARGS=${!varname}
+
+  vars_to_exclude=("${var_prefix}_IMAGE" "${var_prefix}_REQUESTS_CPU" "${var_prefix}_REQUESTS_MEMORY" "${var_prefix}_LIMITS_CPU" "${var_prefix}_LIMITS_MEMORY" "${var_prefix}_WORKING_DIR" "${var_prefix}_INVOCATION_ARGS" "${var_prefix}_SERVICE_QUEUE_URLS")
+
+  # create an env: entry in the service template for env vars specific to this service
+  SERVICE_SPECIFIC_ENV=""
+
+  # Get all environment variables that start with $service prefix
+  matching_vars=$(env | grep "^$var_prefix" || true)
+
+  # Only add the env: section if we have matching variables
+  if [ -n "$matching_vars" ]; then
+    # Process each matching environment variable.
+    while IFS='=' read -r name value; do
+      if [[ ! " ${vars_to_exclude[*]} " =~ [[:space:]]${name}[[:space:]] ]]; then
+        # Escape any double quotes in the value
+        escaped_value=$(echo "$value" | sed 's/"/\\"/g')
+
+        # Append the env entry to the variable
+        SERVICE_SPECIFIC_ENV+=$'\n'"            - name: \"$name\""
+        SERVICE_SPECIFIC_ENV+=$'\n'"              value: \"$escaped_value\""
+      fi
+    done < <(echo "$matching_vars")
+  fi
+
+  if [ -n "$SERVICE_SPECIFIC_ENV" ]; then
+    # Start with the env section header
+    SERVICE_SPECIFIC_ENV="env:${SERVICE_SPECIFIC_ENV}"
+  fi
+
+  export SERVICE_SPECIFIC_ENV
 
   envsubst < $file | kubectl apply -f - -n harmony
 

--- a/docs/guides/adapting-new-services.md
+++ b/docs/guides/adapting-new-services.md
@@ -90,7 +90,7 @@ HARMONY_SERVICE_EXAMPLE_LIMITS_MEMORY=512Mi
 HARMONY_SERVICE_EXAMPLE_INVOCATION_ARGS='python -m harmony_service_example'
 ```
 
-Be sure to prefix the entries with the name of your service. Set the value for the `INVOCATION_ARGS` environment variable. This should be how you would run your service from the command line. For example, if you had a python module named `my-service` in the working directory, then you would run the service using:
+**Important** Be sure to prefix the entries with the name of your service. Set the value for the `INVOCATION_ARGS` environment variable. This should be how you would run your service from the command line. For example, if you had a python module named `my-service` in the working directory, then you would run the service using:
   ```bash
   python -m my-service
   ```

--- a/services/service-runner/config/service-template.yaml
+++ b/services/service-runner/config/service-template.yaml
@@ -28,6 +28,7 @@ spec:
               memory: $SERVICE_LIMITS_MEMORY
             requests:
               memory: $SERVICE_REQUESTS_MEMORY
+          $SERVICE_SPECIFIC_ENV
           envFrom:
           - configMapRef:
               name: harmony-env


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2052

## Description
This PR moves service specific environment variables out of the `harmony_env` config map and into the yaml template file for the service, so that services can't see environment variables for other services.

## Local Test Steps
* add s service specific variable, e.g.,` BATCHEE_FOO=bar`, to your `.env` file and another one to `services/harmony/env-defaults` for one of the services in your `LOCALLY_DEPLOYED_SERVICES`.
* run ./bin/deploy and make sure queries still work. 
* use `kubectl` or `k9s` to describe the pod for the service
* verify that the environment variables are defined
* (optional) ssh into the worker container for the pod and `echo` the variables to make sure they are correct 

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)
* [x] Harmony in a Box tested (if changes made to microservices or new dependencies added)