### PR TITLE
HARMONY-2070: As a harmony user, I want my EDL bearer token cached so that I can submit many simultaneous requests

### DIFF
--- a/services/harmony/app/frontends/health.ts
+++ b/services/harmony/app/frontends/health.ts
@@ -56,7 +56,6 @@ async function getGeneralHealth(context: RequestContext): Promise<HealthInfo> {
   ]);
 
   const { healthy: cmrHealthy, message: cmrMessage } = cmrResult;
-
   const cmrHealth = cmrHealthy
     ? { name: 'cmr', status: HealthStatus.UP }
     : { name: 'cmr', status: HealthStatus.DOWN, message: cmrMessage };

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -563,6 +563,8 @@ export async function updateServiceImageTag(
 
   const deployment = new ServiceDeployment({
     deployment_id: deploymentId,
+    // This will happen when deploying service with cookie_secret
+    // The only formal use case of this is harmony-service-example deployment in Bamboo
     username: req.user || 'cookie_secret',
     service: service,
     tag: tag,

--- a/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
+++ b/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
@@ -1,9 +1,41 @@
 import { RequestHandler } from 'express';
 
 import HarmonyRequest from '../models/harmony-request';
+import RequestContext from '../models/request-context';
 import { getUserIdRequest } from '../util/edl-api';
 
 const BEARER_TOKEN_REGEX = new RegExp('^Bearer ([-a-zA-Z0-9._~+/]+)$', 'i');
+
+/**
+ * Builds Express.js middleware for authenticating an EDL token and extracting the username.
+ * Only used for routes that require authentication. If no token is passed in then the
+ * middleware does nothing and forces the user through the oauth workflow.
+ *
+ * @param paths - Paths that require authentication
+ * @returns Express.js middleware for doing EDL token authentication
+ */
+function makeCachedGetUserIdRequest(ttlMs: number) {
+  const cache = new Map<string, { promise: Promise<string>; expires: number }>();
+
+  return async (context: RequestContext, token: string): Promise<string> => {
+    const now = Date.now();
+    const cached = cache.get(token);
+
+    if (cached && cached.expires > now) {
+      return cached.promise;
+    }
+
+    const promise = getUserIdRequest(context, token).catch((err) => {
+      cache.delete(token);
+      throw err;
+    });
+
+    cache.set(token, { promise, expires: now + ttlMs });
+    return promise;
+  };
+}
+
+export const cachedGetUserIdRequest = makeCachedGetUserIdRequest(5 * 60 * 1000); // 5 min TTL
 
 /**
  * Builds Express.js middleware for authenticating an EDL token and extracting the username.
@@ -24,13 +56,13 @@ export default function buildEdlAuthorizer(paths: Array<string | RegExp> = []): 
       if (match) {
         const userToken = match[1];
         try {
-          // Get the username for the provided token from EDL
-          const username = await getUserIdRequest(req.context, userToken);
+          // Use the cached version
+          const username = await cachedGetUserIdRequest(req.context, userToken);
           req.user = username;
           req.accessToken = userToken;
           req.authorized = true;
         } catch (e) {
-          next(e);
+          return next(e); // don't forget return here!
         }
       }
     }

--- a/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
+++ b/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
@@ -2,13 +2,14 @@ import { RequestHandler } from 'express';
 
 import HarmonyRequest from '../models/harmony-request';
 import { getUserIdRequest } from '../util/edl-api';
+import env from '../util/env';
 import { MemoryCache } from '../util/cache/memory-cache';
 
 const BEARER_TOKEN_REGEX = new RegExp('^Bearer ([-a-zA-Z0-9._~+/]+)$', 'i');
 
 // In memory cache with 5 min TTL for EDL token to username.
 // The token is valid if it exists in the cache.
-export const tokenCache = new MemoryCache(getUserIdRequest, { ttl: 5 * 60 * 1000 });
+export const tokenCache = new MemoryCache(getUserIdRequest, { ttl: env.tokenCacheTtl });
 
 /**
  * Builds Express.js middleware for authenticating an EDL token and extracting the username.

--- a/services/harmony/app/util/cache/memory-cache.ts
+++ b/services/harmony/app/util/cache/memory-cache.ts
@@ -4,27 +4,43 @@ import env from '../env';
 
 // Simple implementation of a string cache backed by an in-memory
 // least-recently-used (LRU) cache
-export class MemoryCache extends Cache {
-  data: LRUCache<string, string>;
 
-  constructor(fetchMethod: (k: string) => Promise<string>) {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type FetchMethod = (key: string, context?: any) => Promise<string>;
+
+interface MemoryCacheOptions {
+  ttl?: number; // Optional TTL in milliseconds
+  maxSize?: number; // Optional max size override
+}
+
+export class MemoryCache extends Cache {
+  private data: LRUCache<string, string>;
+
+  private fetchMethod: FetchMethod;
+
+  constructor(fetchMethod: FetchMethod, options?: MemoryCacheOptions) {
     super();
-    const options = {
-      maxSize: env.maxDataOperationCacheSize,
-      sizeCalculation: (v: string): number => {
-        return v.length;
-      },
-      fetchMethod,
-    };
-    this.data = new LRUCache(options);
+    this.fetchMethod = fetchMethod;
+
+    this.data = new LRUCache<string, string>({
+      maxSize: options?.maxSize ?? env.maxDataOperationCacheSize,
+      ttl: options?.ttl, // Will be undefined if not passed (no expiration)
+      sizeCalculation: (value: string): number => value.length,
+    });
   }
 
-  async get(key: string): Promise<string> {
+  async get(key: string): Promise<string | undefined> {
     return this.data.get(key);
   }
 
-  async fetch(key: string): Promise<string> {
-    return this.data.fetch(key);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async fetch(key: string, context?: any): Promise<string> {
+    let value = this.data.get(key);
+    if (value !== undefined) return value;
+
+    value = await this.fetchMethod(key, context);
+    this.data.set(key, value);
+    return value;
   }
 
   async set(key: string, value: string): Promise<void> {

--- a/services/harmony/app/util/cache/memory-cache.ts
+++ b/services/harmony/app/util/cache/memory-cache.ts
@@ -18,13 +18,15 @@ export class MemoryCache extends Cache {
 
   private fetchMethod: FetchMethod;
 
+  private pending: Map<string, Promise<string>> = new Map();
+
   constructor(fetchMethod: FetchMethod, options?: MemoryCacheOptions) {
     super();
     this.fetchMethod = fetchMethod;
 
     this.data = new LRUCache<string, string>({
       maxSize: options?.maxSize ?? env.maxDataOperationCacheSize,
-      ttl: options?.ttl, // Will be undefined if not passed (no expiration)
+      ttl: options?.ttl, // No expiration if undefined
       sizeCalculation: (value: string): number => value.length,
     });
   }
@@ -35,12 +37,29 @@ export class MemoryCache extends Cache {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async fetch(key: string, context?: any): Promise<string> {
-    let value = this.data.get(key);
-    if (value !== undefined) return value;
+    const cached = this.data.get(key);
+    if (cached !== undefined) return cached;
 
-    value = await this.fetchMethod(key, context);
-    this.data.set(key, value);
-    return value;
+    // Check for in-progress fetch
+    const existingPromise = this.pending.get(key);
+    if (existingPromise) return existingPromise;
+
+    // Initiate fetch and store the promise
+    const fetchPromise = this.fetchMethod(key, context)
+      .then((result) => {
+        if (result !== undefined) {
+          this.data.set(key, result);
+        }
+        this.pending.delete(key);
+        return result;
+      })
+      .catch((err) => {
+        this.pending.delete(key);
+        throw err;
+      });
+
+    this.pending.set(key, fetchPromise);
+    return fetchPromise;
   }
 
   async set(key: string, value: string): Promise<void> {

--- a/services/harmony/app/util/edl-api.ts
+++ b/services/harmony/app/util/edl-api.ts
@@ -43,12 +43,12 @@ export async function getClientCredentialsToken(logger: Logger): Promise<string>
  * Makes a request to the EDL users endpoint to validate a token and return the user ID
  * associated with that token.
  *
- * @param context - Information related to the user's request
  * @param userToken - The user's token
+ * @param context - Information related to the user's request
  * @returns the username associated with the token
  * @throws ForbiddenError if the token is invalid
  */
-export async function getUserIdRequest(context: RequestContext, userToken: string)
+export async function getUserIdRequest(userToken: string, context: RequestContext)
   : Promise<string> {
   const { logger } = context;
   try {

--- a/services/harmony/app/util/env.ts
+++ b/services/harmony/app/util/env.ts
@@ -105,6 +105,10 @@ class HarmonyServerEnv extends HarmonyEnv {
   @Min(1)
   maxDataOperationCacheSize: number;
 
+  @IsInt()
+  @Min(1)
+  tokenCacheTtl: number;
+
   @IsPositive()
   wktPrecision: number;
 

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -132,6 +132,9 @@ MAX_POST_FILE_PARTS=100
 # Maximum size (in bytes) of the cache for data operations
 MAX_DATA_OPERATION_CACHE_SIZE=512000000
 
+# Token Cache TTL in milliseconds
+TOKEN_CACHE_TTL=300000
+
 # WKT POINT/LINESTRING to POLYGON conversion side length, 0.0001 is about 11 meters in precision
 WKT_PRECISION=0.0001
 

--- a/services/harmony/fixtures/uat.urs.earthdata.nasa.gov-443/174542564007893935
+++ b/services/harmony/fixtures/uat.urs.earthdata.nasa.gov-443/174542564007893935
@@ -1,0 +1,25 @@
+POST /oauth/tokens/user?client_id=foo&token=my-bearer-token
+accept: application/json, text/plain, */*
+content-type: application/x-www-form-urlencoded
+authorization: Bearer fake_access
+accept-encoding: gzip, compress, deflate, br
+
+HTTP/1.1 403 Forbidden
+server: nginx/1.22.1
+date: Wed, 23 Apr 2025 16:27:24 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: keep-alive
+x-frame-options: SAMEORIGIN
+x-xss-protection: 0
+x-content-type-options: nosniff
+x-permitted-cross-domain-policies: none
+referrer-policy: strict-origin-when-cross-origin
+cache-control: no-store
+pragma: no-cache
+expires: Fri, 01 Jan 1990 00:00:00 GMT
+x-request-id: 2cd71efe-3658-41a1-8d0e-2e00697bb48e
+x-runtime: 0.011115
+strict-transport-security: max-age=31536000
+
+{"error":"invalid_client_id","error_description":"This Client ID is not valid for this token"}

--- a/services/harmony/test/helpers/stub-edl-token.ts
+++ b/services/harmony/test/helpers/stub-edl-token.ts
@@ -12,16 +12,16 @@ import * as edlAuth from '../../app/middleware/earthdata-login-token-authorizer'
  */
 export function hookEdlTokenAuthentication(username: string): void {
   let clientCredentialsStub;
-  let userIdRequestStub;
+  let tokenCacheStub;
   before(async function () {
     clientCredentialsStub = sinon.stub(edl, 'getClientCredentialsToken')
       .callsFake(async () => 'client-token');
-    userIdRequestStub = sinon.stub(edl, 'getUserIdRequest')
+    tokenCacheStub = sinon.stub(edlAuth.tokenCache, 'fetch')
       .callsFake(async () => username);
   });
   after(async function () {
     if (clientCredentialsStub.restore) clientCredentialsStub.restore();
-    if (userIdRequestStub.restore) userIdRequestStub.restore();
+    if (tokenCacheStub.restore) tokenCacheStub.restore();
   });
 }
 
@@ -31,16 +31,16 @@ export function hookEdlTokenAuthentication(username: string): void {
  */
 export function hookEdlTokenAuthenticationError(): void {
   let clientCredentialsStub;
-  let cachedRequestStub;
+  let tokenCacheStub;
 
   before(async function () {
     const error = new ForbiddenError();
     clientCredentialsStub = sinon.stub(edl, 'getClientCredentialsToken').throws(error);
-    cachedRequestStub = sinon.stub(edlAuth, 'cachedGetUserIdRequest').throws(error);
+    tokenCacheStub = sinon.stub(edlAuth.tokenCache, 'fetch').throws(error);
   });
 
   after(async function () {
     if (clientCredentialsStub.restore) clientCredentialsStub.restore();
-    if (cachedRequestStub.restore) cachedRequestStub.restore();
+    if (tokenCacheStub.restore) tokenCacheStub.restore();
   });
 }

--- a/services/harmony/test/helpers/stub-edl-token.ts
+++ b/services/harmony/test/helpers/stub-edl-token.ts
@@ -2,6 +2,7 @@ import { before, after } from 'mocha';
 import * as sinon from 'sinon';
 import { ForbiddenError } from '../../app/util/errors';
 import * as edl from '../../app/util/edl-api';
+import * as edlAuth from '../../app/middleware/earthdata-login-token-authorizer';
 
 /**
  * Adds before / after hooks in mocha to replace calls to EDL token interaction
@@ -30,14 +31,16 @@ export function hookEdlTokenAuthentication(username: string): void {
  */
 export function hookEdlTokenAuthenticationError(): void {
   let clientCredentialsStub;
-  let userIdRequestStub;
+  let cachedRequestStub;
+
   before(async function () {
     const error = new ForbiddenError();
     clientCredentialsStub = sinon.stub(edl, 'getClientCredentialsToken').throws(error);
-    userIdRequestStub = sinon.stub(edl, 'getUserIdRequest').throws(error);
+    cachedRequestStub = sinon.stub(edlAuth, 'cachedGetUserIdRequest').throws(error);
   });
+
   after(async function () {
     if (clientCredentialsStub.restore) clientCredentialsStub.restore();
-    if (userIdRequestStub.restore) userIdRequestStub.restore();
+    if (cachedRequestStub.restore) cachedRequestStub.restore();
   });
 }


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2070

## Description
Cache EDL bearer token lookup to improve performance.

## Local Test Steps
Add the following line to line 54 of services/harmony/app/util/edl-api.ts to facilitate the testing:
console.log(`calling getUserIdRequest with token: ${userToken}`);

Use the following curl to submit an example harmony request with EDL bearer token:
curl -i -H "Authorization: Bearer $HARMONY_UAT_TOKEN" "http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng"

Verify the `getUserIdRequest` function is called for only the first request, not the subsequent ones.
Verify after 5 minutes (the cache will expire), the `getUserIdRequest` function is called again to repopulate the cache and then skipped for the subsequent requests.

Verify the following request (invalid token) will return a 403 status code with proper error message:
curl -i -H "Authorization: Bearer HARMONY_UAT_TOKEN" "http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng"

Add `TOKEN_CACHE_TTL=60000` to .env, restart server, repeat the tests above and verify the EDL token lookup is called after a minute.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)