### PR TITLE
HARMONY-2070: As a harmony user, I want my EDL bearer token cached so that I can submit many simultaneous requests.

### DIFF
--- a/services/harmony/app/frontends/health.ts
+++ b/services/harmony/app/frontends/health.ts
@@ -56,7 +56,6 @@ async function getGeneralHealth(context: RequestContext): Promise<HealthInfo> {
   ]);
 
   const { healthy: cmrHealthy, message: cmrMessage } = cmrResult;
-
   const cmrHealth = cmrHealthy
     ? { name: 'cmr', status: HealthStatus.UP }
     : { name: 'cmr', status: HealthStatus.DOWN, message: cmrMessage };

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -563,6 +563,8 @@ export async function updateServiceImageTag(
 
   const deployment = new ServiceDeployment({
     deployment_id: deploymentId,
+    // This will happen when deploying service with cookie_secret
+    // The only formal use case of this is harmony-service-example deployment in Bamboo
     username: req.user || 'cookie_secret',
     service: service,
     tag: tag,

--- a/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
+++ b/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
@@ -1,9 +1,32 @@
 import { RequestHandler } from 'express';
+import { LRUCache } from 'lru-cache';
 
 import HarmonyRequest from '../models/harmony-request';
 import { getUserIdRequest } from '../util/edl-api';
+import env from '../util/env';
 
 const BEARER_TOKEN_REGEX = new RegExp('^Bearer ([-a-zA-Z0-9._~+/]+)$', 'i');
+
+/**
+ * Wrapper function of getUserIdRequest to be set to fetchMethod of LRUCache.
+ *
+ * @param token - EDL bearer token
+ * @param _sv - default value parameter of LRUCache fetchMethod, unused here
+ * @param options - options parameter of LRUCache fetchMethod, carries the request context
+ * @returns Promise of user name associated with the EDL token
+ */
+async function fetchUserId(token: string, _sv: string, { context }): Promise<string> {
+  return getUserIdRequest(context, token);
+}
+
+// In memory cache with 5 min TTL for EDL token to username.
+// The token is valid if it exists in the cache.
+export const tokenCache = new LRUCache({
+  maxSize: env.maxDataOperationCacheSize,
+  ttl: env.tokenCacheTtl,
+  sizeCalculation: (value: string): number => value.length,
+  fetchMethod: fetchUserId,
+});
 
 /**
  * Builds Express.js middleware for authenticating an EDL token and extracting the username.
@@ -25,7 +48,7 @@ export default function buildEdlAuthorizer(paths: Array<string | RegExp> = []): 
         const userToken = match[1];
         try {
           // Get the username for the provided token from EDL
-          const username = await getUserIdRequest(req.context, userToken);
+          const username = await tokenCache.fetch(userToken, { context: req.context });
           req.user = username;
           req.accessToken = userToken;
           req.authorized = true;

--- a/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
+++ b/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
@@ -11,7 +11,7 @@ const BEARER_TOKEN_REGEX = new RegExp('^Bearer ([-a-zA-Z0-9._~+/]+)$', 'i');
  * Wrapper function of getUserIdRequest to be set to fetchMethod of LRUCache.
  *
  * @param token - EDL bearer token
- * @param _sv - default value parameter of LRUCache fetchMethod, unused here
+ * @param _sv - stale value parameter of LRUCache fetchMethod, unused here
  * @param options - options parameter of LRUCache fetchMethod, carries the request context
  * @returns Promise of user name associated with the EDL token
  */

--- a/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
+++ b/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
@@ -19,11 +19,11 @@ async function fetchUserId(token: string, _sv: string, { context }): Promise<str
   return getUserIdRequest(context, token);
 }
 
-// In memory cache with 5 min TTL for EDL token to username.
-// The token is valid if it exists in the cache.
+// In memory cache for EDL bearer token to username.
+// A token is valid if it exists in the cache.
 export const tokenCache = new LRUCache({
-  maxSize: env.maxDataOperationCacheSize,
   ttl: env.tokenCacheTtl,
+  maxSize: env.maxDataOperationCacheSize,
   sizeCalculation: (value: string): number => value.length,
   fetchMethod: fetchUserId,
 });

--- a/services/harmony/app/util/env.ts
+++ b/services/harmony/app/util/env.ts
@@ -105,6 +105,10 @@ class HarmonyServerEnv extends HarmonyEnv {
   @Min(1)
   maxDataOperationCacheSize: number;
 
+  @IsInt()
+  @Min(1)
+  tokenCacheTtl: number;
+
   @IsPositive()
   wktPrecision: number;
 

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -132,6 +132,9 @@ MAX_POST_FILE_PARTS=100
 # Maximum size (in bytes) of the cache for data operations
 MAX_DATA_OPERATION_CACHE_SIZE=512000000
 
+# Token Cache TTL in milliseconds
+TOKEN_CACHE_TTL=300000
+
 # WKT POINT/LINESTRING to POLYGON conversion side length, 0.0001 is about 11 meters in precision
 WKT_PRECISION=0.0001
 

--- a/services/harmony/test/helpers/stub-edl-token.ts
+++ b/services/harmony/test/helpers/stub-edl-token.ts
@@ -2,6 +2,7 @@ import { before, after } from 'mocha';
 import * as sinon from 'sinon';
 import { ForbiddenError } from '../../app/util/errors';
 import * as edl from '../../app/util/edl-api';
+import * as edlAuth from '../../app/middleware/earthdata-login-token-authorizer';
 
 /**
  * Adds before / after hooks in mocha to replace calls to EDL token interaction
@@ -11,16 +12,16 @@ import * as edl from '../../app/util/edl-api';
  */
 export function hookEdlTokenAuthentication(username: string): void {
   let clientCredentialsStub;
-  let userIdRequestStub;
+  let tokenCacheStub;
   before(async function () {
     clientCredentialsStub = sinon.stub(edl, 'getClientCredentialsToken')
       .callsFake(async () => 'client-token');
-    userIdRequestStub = sinon.stub(edl, 'getUserIdRequest')
+    tokenCacheStub = sinon.stub(edlAuth.tokenCache, 'fetch')
       .callsFake(async () => username);
   });
   after(async function () {
     if (clientCredentialsStub.restore) clientCredentialsStub.restore();
-    if (userIdRequestStub.restore) userIdRequestStub.restore();
+    if (tokenCacheStub.restore) tokenCacheStub.restore();
   });
 }
 
@@ -30,14 +31,16 @@ export function hookEdlTokenAuthentication(username: string): void {
  */
 export function hookEdlTokenAuthenticationError(): void {
   let clientCredentialsStub;
-  let userIdRequestStub;
+  let tokenCacheStub;
+
   before(async function () {
     const error = new ForbiddenError();
     clientCredentialsStub = sinon.stub(edl, 'getClientCredentialsToken').throws(error);
-    userIdRequestStub = sinon.stub(edl, 'getUserIdRequest').throws(error);
+    tokenCacheStub = sinon.stub(edlAuth.tokenCache, 'fetch').throws(error);
   });
+
   after(async function () {
     if (clientCredentialsStub.restore) clientCredentialsStub.restore();
-    if (userIdRequestStub.restore) userIdRequestStub.restore();
+    if (tokenCacheStub.restore) tokenCacheStub.restore();
   });
 }


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2070

## Description
Here is a new approach that abandons the reuse of MemoryCache and just use LRUCache directly. I think it is much cleaner than the previous implementation.

## Local Test Steps
Add the following line to line 54 of services/harmony/app/util/edl-api.ts to facilitate the testing:
console.log(`calling getUserIdRequest with token: ${userToken}`);

Use the following curl to submit an example harmony request with EDL bearer token:
curl -i -H "Authorization: Bearer $HARMONY_UAT_TOKEN" "http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng"

Verify the `getUserIdRequest` function is called for only the first request, not the subsequent ones.
Verify after 5 minutes (the cache will expire), the `getUserIdRequest` function is called again to repopulate the cache and then skipped for the subsequent requests.

Verify the following request (invalid token) will return a 403 status code with proper error message:
curl -i -H "Authorization: Bearer HARMONY_UAT_TOKEN" "http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng"

Add `TOKEN_CACHE_TTL=60000` to .env, restart server, repeat the tests above and verify the EDL token lookup is called after a minute.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)