### PR TITLE
HARMONY-2079: Fix issue with worker container not being ready

### DIFF
--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -721,7 +721,7 @@ export async function processWorkItem(
         return;
       } else {
         logger.warn(`Retry limit of ${env.workItemRetryLimit} exceeded`);
-        logger.warn(`Updating work item for ${workItemID} to ${status} with message ${message}`);
+        logger.warn(`Updating work item for ${workItemID} to ${status} with message ${message}`, { workFailureMessage: message, serviceId: workItem.serviceID });
       }
     }
 

--- a/services/service-runner/app/server.ts
+++ b/services/service-runner/app/server.ts
@@ -1,21 +1,50 @@
+/* eslint-disable no-process-exit */
 import express from 'express';
-import env from './util/env';
+import { Server } from 'http';
+
 import log from '../../harmony/app/util/log';
 import router from './routers/router';
+import env from './util/env';
+import { isContainerRunning } from './util/k8s';
 import PullWorker from './workers/pull-worker';
-import { Server } from 'http';
 
 /**
  *
  * @param config - The configuration Record from the environment variables
  * @returns An object containing the running components
  */
-export default function start(_config: Record<string, string>): Server {
+export default async function start(_config: Record<string, string>): Promise<Server> {
   // trap SIGTERM so we can shut down gracefully via the PreStop hook
   process.on('SIGTERM', function () {
-    // eslint-disable-next-line no-process-exit
     process.exit(0);
   });
+
+  // Wait for the worker container to be ready
+  const startTime = Date.now();
+  const timeout = 180_000;
+  const sleepDelay = 3_000;
+
+  log.info('Waiting for the worker container to start up');
+
+  while (true) {
+    const running = await isContainerRunning('worker');
+    if (running) {
+      log.info('Worker container is running.');
+      break;
+    } else {
+      log.info('Worker container not yet running.');
+    }
+
+    const elapsed = Date.now() - startTime;
+    if (elapsed >= timeout) {
+      log.error('Timeout waiting for the worker container to be running.');
+      throw new Error('Worker container did not start in time');
+    }
+
+    log.info(`Worker container not yet running, retrying in ${sleepDelay / 1000} seconds`);
+    await new Promise((resolve) => setTimeout(resolve, sleepDelay));
+  }
+
   // start the puller
   const pullWorker = new PullWorker();
   pullWorker.start().catch((e) => {
@@ -34,5 +63,12 @@ export default function start(_config: Record<string, string>): Server {
 }
 
 if (require.main === module) {
-  start(process.env);
+  void (async (): Promise<void> => {
+    try {
+      await start(process.env);
+    } catch (err) {
+      console.error('Failed to start server:', err);
+      process.exit(1);
+    }
+  })();
 }

--- a/services/service-runner/app/service/service-runner.ts
+++ b/services/service-runner/app/service/service-runner.ts
@@ -404,9 +404,9 @@ export async function runServiceFromPull(
       });
 
       if ('retryable' in result) {
-        workItemLogger.debug(`Retryable error encountered (attempt ${retryCount + 1} of ${maxRetries})`);
-        await waitForContainerToStart('worker');
         retryCount += 1;
+        workItemLogger.debug(`Retryable error encountered (attempt ${retryCount} of ${maxRetries})`);
+        await waitForContainerToStart('worker');
       } else {
         return result;
       }

--- a/services/service-runner/app/service/service-runner.ts
+++ b/services/service-runner/app/service/service-runner.ts
@@ -315,7 +315,7 @@ export async function runServiceFromPull(
       '--harmony-sources',
       stacCatalogLocation,
       '--harmony-metadata-dir',
-      `${catalogDir}`,
+      catalogDir,
     ];
 
     let retryCount = 0;

--- a/services/service-runner/app/service/service-runner.ts
+++ b/services/service-runner/app/service/service-runner.ts
@@ -348,8 +348,10 @@ export async function runServiceFromPull(
 
             try {
               const retryMessage = `${new Date().toISOString()} Start of service execution (retryCount=${workItem.retryCount}, workItemId=${workItem.id})`;
-              const redactedcommandAndArgs = commandAndArgs[0].replace(
-                /"accessToken":"[^"]*"/,
+
+              const fullCommand = commandAndArgs.join(' ');
+              const redactedcommandAndArgs = fullCommand.replace(
+                /"accessToken"\s*:\s*"[^"]*"/g,
                 '"accessToken":"<redacted>"',
               );
 
@@ -357,10 +359,15 @@ export async function runServiceFromPull(
                 `${new Date().toISOString()} ${sidecarMessage}`,
                 `COMMAND: ${redactedcommandAndArgs}`,
                 `POD: ${env.myPodName}`,
-                `STATUS REASON: ${String(status.reason)}`,
-                `STATUS MESSAGE: ${String(status.message)}`,
-                `STATUS CODE: ${String(status.code)}`,
               ];
+
+              if (status.code || status.reason || status.message) {
+                debugInfo.push(
+                  `STATUS REASON: ${String(status.reason)}`,
+                  `STATUS MESSAGE: ${String(status.message)}`,
+                  `STATUS CODE: ${String(status.code)}`,
+                );
+              }
 
               await uploadLogs(workItem, [retryMessage, debugInfo, ...stdOut.logStrArr]);
 

--- a/services/service-runner/app/service/service-runner.ts
+++ b/services/service-runner/app/service/service-runner.ts
@@ -240,12 +240,6 @@ export async function uploadLogs(
   workItem: WorkItemRecord, logs: (string | object)[],
 ): Promise<object> {
   let newFileContent = logs;
-  // const retryMessage = `${new Date().toISOString()} Start of service execution (retryCount=${workItem.retryCount}, id=${workItem.id})`;
-  // if (logs.length > 0 && (typeof logs[0] === 'string' || logs[0] instanceof String)) {
-  //   newFileContent = [retryMessage, ...logs];
-  // } else {
-  //   newFileContent = [{ message: retryMessage }, ...logs];
-  // }
   const s3 = objectStoreForProtocol('s3');
   const logsLocation = getItemLogsLocation(workItem);
   if (await s3.objectExists(logsLocation)) { // append to existing logs

--- a/services/service-runner/app/util/k8s.ts
+++ b/services/service-runner/app/util/k8s.ts
@@ -1,0 +1,28 @@
+import * as k8s from '@kubernetes/client-node';
+
+import log from '../../../harmony/app/util/log';
+import env from './env';
+
+const kc = new k8s.KubeConfig();
+kc.loadFromDefault();
+const k8sApi = kc.makeApiClient(k8s.CoreV1Api);
+
+/**
+ * Resolves to true if the worker container is running
+ *
+ * @param containerName - the name of the container to check e.g. worker or manager
+ * @returns a promise resolving to true if the worker container is running and false otherwise
+ */
+export async function isContainerRunning(containerName: string): Promise<boolean> {
+  const podName = env.myPodName;
+  const namespace = 'harmony';
+
+  const pod = await k8sApi.readNamespacedPod(podName, namespace);
+  const workerContainer = pod.body.status?.containerStatuses?.find(
+    (status) => status.name === containerName,
+  );
+
+  log.info(`Worker container: ${JSON.stringify(workerContainer)}`);
+
+  return workerContainer?.state?.running !== undefined;
+}

--- a/services/service-runner/app/util/k8s.ts
+++ b/services/service-runner/app/util/k8s.ts
@@ -18,11 +18,51 @@ export async function isContainerRunning(containerName: string): Promise<boolean
   const namespace = 'harmony';
 
   const pod = await k8sApi.readNamespacedPod(podName, namespace);
-  const workerContainer = pod.body.status?.containerStatuses?.find(
+  const container = pod.body.status?.containerStatuses?.find(
     (status) => status.name === containerName,
   );
 
-  log.info(`Worker container: ${JSON.stringify(workerContainer)}`);
+  log.info(`Container: ${JSON.stringify(container)}`);
 
-  return workerContainer?.state?.running !== undefined;
+  return container?.state?.running !== undefined;
+}
+
+/**
+ * Waits up to the timeout interval for the given container to be ready
+ *
+ * @param containerName - the name of the container to check e.g. worker or manager
+ * @param timeout - how long to wait before giving up (ms)
+ * @param checkInterval - how long to sleep (ms) between checks to see if the container is running
+ * @returns a promise resolving to true if the worker container is running and false otherwise
+ * @throws an error if the container does not start within the timeout period
+ */
+export async function waitForContainerToStart(
+  containerName: string, timeout = 180_000, checkInterval = 3_000,
+): Promise<boolean> {
+  let running = false;
+
+  const startTime = Date.now();
+
+  log.info(`Waiting for the ${containerName} container to start up`);
+
+  while (!running) {
+    running = await isContainerRunning(containerName);
+    if (running) {
+      log.info(`${containerName} container is running.`);
+      break;
+    } else {
+      log.info(`${containerName} container not yet running.`);
+    }
+
+    const elapsed = Date.now() - startTime;
+    if (elapsed >= timeout) {
+      log.error(`Timeout waiting for the ${containerName} container to be running.`);
+      throw new Error(`${containerName} container did not start in time`);
+    }
+
+    log.warn(`${containerName} container not yet running, retrying in ${checkInterval / 1000} seconds`);
+    await new Promise((resolve) => setTimeout(resolve, checkInterval));
+  }
+
+  return running;
 }

--- a/services/service-runner/app/workers/pull-worker.ts
+++ b/services/service-runner/app/workers/pull-worker.ts
@@ -219,8 +219,8 @@ async function _pullAndDoWork(repeat = true): Promise<void> {
     }
 
     pullCounter += 1;
-    logger.debug('Polling for work');
     if (pullCounter === pullLogPeriod) {
+      logger.debug('Polling for work');
       pullCounter = 0;
     }
 

--- a/services/service-runner/app/workers/pull-worker.ts
+++ b/services/service-runner/app/workers/pull-worker.ts
@@ -50,10 +50,6 @@ const axiosGetWork = createAxiosClientWithRetry(
 );
 const axiosUpdateWork = createAxiosClientWithRetry(maxPutWorkRetries, maxDelayMs, exponentialOffset);
 
-let pullCounter = 0;
-// how many pulls to execute before logging - used to keep log message count reasonable
-const pullLogPeriod = 10;
-
 // this debug statement works around a test failure in Bamboo
 console.log(`NODE_ENV = ${process.env.NODE_ENV}`);
 // retry twice for tests and 1200 (2 minutes) for real
@@ -218,11 +214,7 @@ async function _pullAndDoWork(repeat = true): Promise<void> {
       // expected if file does not exist
     }
 
-    pullCounter += 1;
-    if (pullCounter === pullLogPeriod) {
-      logger.debug('Polling for work');
-      pullCounter = 0;
-    }
+    logger.debug('Polling for work');
 
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     const work = await exportedForTesting._pullWork();

--- a/services/service-runner/test/pull-worker.ts
+++ b/services/service-runner/test/pull-worker.ts
@@ -1,16 +1,15 @@
 import { expect } from 'chai';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { describe, it } from 'mocha';
 import * as sinon from 'sinon';
-import { SinonStub } from 'sinon';
-import env from '../app/util/env';
+
 import WorkItem from '../../harmony/app/models/work-item';
-import { hookGetWorkRequest } from './helpers/pull-worker';
-import * as pullWorker from '../app/workers/pull-worker';
-import PullWorker from '../app/workers/pull-worker';
-import * as serviceRunner from '../app/service/service-runner';
-import { existsSync, writeFileSync, mkdirSync } from 'fs';
 import { WorkItemRecord } from '../../harmony/app/models/work-item-interface';
 import { buildOperation } from '../../harmony/test/helpers/data-operation';
+import * as serviceRunner from '../app/service/service-runner';
+import env from '../app/util/env';
+import PullWorker, * as pullWorker from '../app/workers/pull-worker';
+import { hookGetWorkRequest } from './helpers/pull-worker';
 
 const {
   _pullWork,
@@ -50,8 +49,8 @@ describe('Pull Worker', async function () {
   });
 
   describe('on start with primer errors', async function () {
-    let serviceStub: SinonStub;
-    let exitStub: SinonStub;
+    let serviceStub: sinon.SinonStub;
+    let exitStub: sinon.SinonStub;
     const { harmonyService } = env;
 
     beforeEach(async function () {
@@ -208,9 +207,9 @@ describe('Pull Worker', async function () {
     });
 
     describe('when _pullWork runs', async function () {
-      let pullStub: SinonStub;
-      let doWorkStub: SinonStub;
-      let axiosStub: SinonStub;
+      let pullStub: sinon.SinonStub;
+      let doWorkStub: sinon.SinonStub;
+      let axiosStub: sinon.SinonStub;
       const dir = `${env.workingDir}/abc123`;
       const fakeOperation = buildOperation('foo');
       fakeOperation.sources = [
@@ -277,8 +276,8 @@ describe('Pull Worker', async function () {
     });
 
     describe('when _pullWork throws an exception', async function () {
-      let pullStub: SinonStub;
-      let doWorkStub: SinonStub;
+      let pullStub: sinon.SinonStub;
+      let doWorkStub: sinon.SinonStub;
       beforeEach(function () {
         pullStub = sinon.stub(pullWorker.exportedForTesting, '_pullWork').callsFake(async function () {
           throw new Error('something bad happened');
@@ -304,8 +303,8 @@ describe('Pull Worker', async function () {
     });
 
     describe('when _doWork throws an exception', async function () {
-      let pullStub: SinonStub;
-      let doWorkStub: SinonStub;
+      let pullStub: sinon.SinonStub;
+      let doWorkStub: sinon.SinonStub;
       beforeEach(function () {
         pullStub = sinon.stub(pullWorker.exportedForTesting, '_pullWork').callsFake(async function (): Promise<{ item?: WorkItem; status?: number; error?: string }> {
           return {};

--- a/services/service-runner/test/service-runner.ts
+++ b/services/service-runner/test/service-runner.ts
@@ -1,18 +1,19 @@
+import axios from 'axios';
 /* eslint-disable @typescript-eslint/no-throw-literal */
 import { expect } from 'chai';
-import * as k8s from '@kubernetes/client-node';
+import { readFileSync } from 'fs';
 import { describe, it } from 'mocha';
-import env from '../app/util/env';
+import sinon from 'sinon';
+
+import * as k8s from '@kubernetes/client-node';
+
 import WorkItem from '../../harmony/app/models/work-item';
+import { getItemLogsLocation, WorkItemRecord } from '../../harmony/app/models/work-item-interface';
 import { objectStoreForProtocol } from '../../harmony/app/util/object-store';
-import * as serviceRunner from '../app/service/service-runner';
 import { resolve } from '../../harmony/app/util/url';
 import { createLoggerForTest } from '../../harmony/test/helpers/log';
-import { getItemLogsLocation, WorkItemRecord } from '../../harmony/app/models/work-item-interface';
-import { uploadLogs } from '../app/service/service-runner';
-import sinon from 'sinon';
-import axios from 'axios';
-import { readFileSync } from 'fs';
+import * as serviceRunner from '../app/service/service-runner';
+import env from '../app/util/env';
 
 const { _getErrorInfo: _getErrorInfo, _getStacCatalogs } = serviceRunner.exportedForTesting;
 
@@ -203,7 +204,7 @@ describe('Service Runner', function () {
     });
   });
 
-  describe('uploadLogs', function () {
+  describe('serviceRunner.uploadLogs', function () {
     describe('with text logs', function () {
       const itemRecord0: WorkItemRecord = {
         id: 0, jobID: '123', serviceID: '', sortIndex: 0,
@@ -215,10 +216,10 @@ describe('Service Runner', function () {
       };
       before(async function () {
         // One of the items will have its log file written to twice
-        await uploadLogs(itemRecord0, ['the old logs']);
+        await serviceRunner.uploadLogs(itemRecord0, ['the old logs']);
         itemRecord0.retryCount = 1; // simulate a retry
-        await uploadLogs(itemRecord0, ['the new logs']);
-        await uploadLogs(itemRecord1, ['the only logs']);
+        await serviceRunner.uploadLogs(itemRecord0, ['the new logs']);
+        await serviceRunner.uploadLogs(itemRecord1, ['the only logs']);
       });
       describe('when there is a logs file already associated with the WorkItem', async function () {
         it('appends the new logs to the old ones', async function () {
@@ -226,9 +227,7 @@ describe('Service Runner', function () {
           const s3 = objectStoreForProtocol('s3');
           const logs = await s3.getObjectJson(logsLocation0);
           expect(logs).to.deep.equal([
-            'Start of service execution (retryCount=0, id=0)',
             'the old logs',
-            'Start of service execution (retryCount=1, id=0)',
             'the new logs',
           ]);
         });
@@ -239,7 +238,6 @@ describe('Service Runner', function () {
           const s3 = objectStoreForProtocol('s3');
           const logs = await s3.getObjectJson(logsLocation1);
           expect(logs).to.deep.equal([
-            'Start of service execution (retryCount=0, id=1)',
             'the only logs',
           ]);
         });
@@ -256,11 +254,11 @@ describe('Service Runner', function () {
       };
       before(async function () {
         // One of the items will have its log file written to twice
-        await uploadLogs(itemRecord0, [{ message: 'the old logs' }]);
+        await serviceRunner.uploadLogs(itemRecord0, [{ message: 'the old logs' }]);
         itemRecord0.retryCount = 1; // simulate a retry
-        await uploadLogs(itemRecord0, [{ message: 'the new logs' }]);
+        await serviceRunner.uploadLogs(itemRecord0, [{ message: 'the new logs' }]);
 
-        await uploadLogs(itemRecord1, [{ message: 'the only logs' }]);
+        await serviceRunner.uploadLogs(itemRecord1, [{ message: 'the only logs' }]);
       });
       describe('when there is a logs file already associated with the WorkItem', async function () {
         it('appends the new logs to the old ones', async function () {
@@ -268,9 +266,7 @@ describe('Service Runner', function () {
           const s3 = objectStoreForProtocol('s3');
           const logs = await s3.getObjectJson(logsLocation0);
           expect(logs).to.deep.equal([
-            { message: 'Start of service execution (retryCount=0, id=2)' },
             { message: 'the old logs' },
-            { message: 'Start of service execution (retryCount=1, id=2)' },
             { message: 'the new logs' },
           ]);
         });
@@ -281,7 +277,6 @@ describe('Service Runner', function () {
           const s3 = objectStoreForProtocol('s3');
           const logs = await s3.getObjectJson(logsLocation1);
           expect(logs).to.deep.equal([
-            { message: 'Start of service execution (retryCount=0, id=3)' },
             { message: 'the only logs' },
           ]);
         });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2079

## Description
Fixes a bug where the service-runner was attempting to make a request to the worker container but an error was being returned indicating the worker container was not ready.

I made a few changes to get more logging information saved in the work item logs we push to S3 in addition to changing the service runner to first make a k8s call to check if the worker is in a running state. It seems like that change to check fixed the problem altogether despite not finding any evidence that the check failed. I also changed the service runner to not immediately return an error to harmony if there was a k8s issue with the exec call (not the worker container returning a non zero exit code which is still handled in the same way). If there is a k8s issue it will check to make sure the worker container is running and then perform up to 5 internal retries before finally giving up and sending an "Internal server error" back to harmony.

## Local Test Steps
Build the service-runner image and submit requests - verify that requests work as expected and you can see additional log information about the pod that the request ran on and details about the command line that was run (by looking at the logs through the workflow-ui).

In sandbox build and push the service-runner image and submit a request for 110K granules. Verify that only the 4 expected failures happen for the request.

I've submitted several 110K granule requests as part of my sandbox testing and in every case only the 4 expected failures occurred.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [X] Harmony in a Box tested (if changes made to microservices or new dependencies added)