### PR TITLE
HARMONY-2088: Add dynamic generation of value for reprojection capability documentation

### DIFF
--- a/services/harmony/app/frontends/docs/docs.ts
+++ b/services/harmony/app/frontends/docs/docs.ts
@@ -1,6 +1,5 @@
 import { Response } from 'express';
 import * as fs from 'fs';
-import * as path from 'path';
 import hljs from 'highlight.js';
 import MarkDownIt from 'markdown-it';
 import anchor from 'markdown-it-anchor';
@@ -10,13 +9,15 @@ import inc from 'markdown-it-include';
 import mark from 'markdown-it-mark';
 import replaceLink from 'markdown-it-replace-link';
 import toc from 'markdown-it-toc-done-right';
-import HarmonyRequest from '../../models/harmony-request';
-import { getRequestRoot } from '../../util/url';
-import env from '../../util/env';
-import version from '../../util/version';
+import * as path from 'path';
 import { promisify } from 'util';
-import { generateServicesDocs } from './service-docs-markdown-it-plugin';
+
+import HarmonyRequest from '../../models/harmony-request';
+import env from '../../util/env';
+import { getRequestRoot } from '../../util/url';
+import version from '../../util/version';
 import { interpolate } from './interpolation-markdown-it-plugin';
+import { generateServicesDocs } from './service-docs-markdown-it-plugin';
 
 const readFile = promisify(fs.readFile);
 const readDir = promisify(fs.readdir);
@@ -168,7 +169,6 @@ export async function generateDocumentation(root: string): Promise<string> {
  */
 export default async function docsPage(req: HarmonyRequest, res: Response): Promise<void> {
   const root = getRequestRoot(req);
-  docsHtml = null;
   if (!docsHtml) {
     docsHtml = await generateDocumentation(root);
   }

--- a/services/harmony/app/frontends/docs/service-docs-markdown-it-plugin.ts
+++ b/services/harmony/app/frontends/docs/service-docs-markdown-it-plugin.ts
@@ -1,4 +1,5 @@
 import MarkDownIt from 'markdown-it';
+
 import { ServiceCapabilities } from '../../models/services/base-service';
 import { getServiceConfigs } from '../../models/services/index';
 
@@ -133,6 +134,8 @@ function getServiceTable(md: MarkDownIt, serviceCaps: ServiceCapabilities): unkn
   tableTokens.push(new Token('table_header_close', 'td', -1));
 
   // non-subsetting values
+
+  // concatenation
   itemToken = new Token('table_data_open', 'td', 1);
   itemToken.attrPush(['rowspan', '2']);
   tableTokens.push(itemToken);
@@ -146,14 +149,19 @@ function getServiceTable(md: MarkDownIt, serviceCaps: ServiceCapabilities): unkn
   itemToken.children = [];
   tableTokens.push(itemToken);
   tableTokens.push(new Token('table_data_close', 'td', -1));
+
+  // reprojection
   itemToken = new Token('table_data_open', 'td', 1);
   itemToken.attrPush(['rowspan', '2']);
   tableTokens.push(itemToken);
   itemToken = new Token('inline', '', 0);
-  itemToken.content = 'N';
+  const reprojectSetting = serviceCaps.reprojection ? 'Y' : 'N';
+  itemToken.content = reprojectSetting;
   itemToken.type = 'text';
   itemToken.children = [];
   tableTokens.push(itemToken);
+
+  // output formats
   tableTokens.push(new Token('table_data_close', 'td', -1));
   itemToken = new Token('table_data_open', 'td', 1);
   itemToken.attrPush(['rowspan', '2']);

--- a/services/harmony/test/documentation-page.ts
+++ b/services/harmony/test/documentation-page.ts
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import request from 'supertest';
-import hookServersStartStop from './helpers/servers';
-import { hookRequest } from './helpers/hooks';
+
 import env from '../app/util/env';
 import version from '../app/util/version';
 import { hookDocumentationPage } from './helpers/documentation-page';
+import { hookRequest } from './helpers/hooks';
+import hookServersStartStop from './helpers/servers';
 
 const TEST_PREVIEW_THRESHOLD = 1234;
 


### PR DESCRIPTION


## Jira Issue ID
HARMONY-2088

## Description
Fixes incorrect values for `reprojection` in the online documentation. Also re-enables one-time generation of the documentation so it doesn't get recreated on every request

## Local Test Steps
Load the documentation (http://localhost:3000/docs) and verify that the proper services, e.g., sds/swath-projector, have `Y` under `reprojection` and the other services have `N`

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)