### PR TITLE
HARMONY-2070: Add logging.

### DIFF
--- a/services/harmony/app/util/edl-api.ts
+++ b/services/harmony/app/util/edl-api.ts
@@ -51,6 +51,7 @@ export async function getClientCredentialsToken(logger: Logger): Promise<string>
 export async function getUserIdRequest(context: RequestContext, userToken: string)
   : Promise<string> {
   const { logger } = context;
+  logger.debug('Calling EDL to validate bearer token');
   try {
     const clientToken = await getClientCredentialsToken(context.logger);
     const response = await axios.default.post(
@@ -64,7 +65,9 @@ export async function getUserIdRequest(context: RequestContext, userToken: strin
         headers: { authorization: `Bearer ${clientToken}`, 'X-Request-Id': context.id },
       },
     );
-    return response.data.uid;
+    const userId = response.data.uid;
+    logger.debug(`Successfully validated bearer token for user: ${userId}`);
+    return userId;
   } catch (e) {
     logger.error('Failed to validate passed in bearer token.');
     logger.error(e);


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2070

## Description
This only adds some logging messages to make monitoring possible.

## Local Test Steps
Run:
```
for i in {1..10}; do curl -i -H "Authorization: Bearer $HARMONY_UAT_TOKEN" "http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng&forceAsync=true"&; done
```
and verify the logging messages `Calling EDL to validate bearer token` and `Successfully validated bearer token for user: ......` only show up in log once.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)