### PR TITLE
HARMONY-2090: Fix for images variables not being populated in the harmony-env configmap which are needed when creating workflow steps.

### DIFF
--- a/bin/create-k8s-config-maps-and-secrets
+++ b/bin/create-k8s-config-maps-and-secrets
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 # check if the input string is a service specific variable name, e.g.
-# BATCHEE_IMAGE. note that variable names that end in QUEUE_URLS are not service
+# BATCHEE_IMAGE. note that variable names that end in QUEUE_URLS or IMAGE are not service
 # specific variables - they are used by harmony itself.
 # returns 0 if the string is the name of a service specific variable name, 1 otherwise
 is_service_var() {
-   if [[ "$1" == *"QUEUE_URLS" ]]; then
-    return 1 # we need to include QUEUE_URLS env vars in the main config map
+  if [[ "$1" == *"QUEUE_URLS" || "$1" == *"IMAGE" ]]; then
+    return 1 # we need to include QUEUE_URLS or IMAGE env vars in the main config map
   fi
 
   for service in ${LOCALLY_DEPLOYED_SERVICES//,/ }


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2090

## Description
While testing a new service image and chain locally with harmony in a box we found that the work item for the new service was populated with a blank string instead of the image name when submitting a request. The issue was the image environment variable is not being created in the harmony configmap. You will only see this issue when testing with harmony in a box which uses a configmap for the harmony environment variables.

## Local Test Steps
Use harmony in a box. Add a new service chain and service image.

e.g. in `services/harmony/env-defaults`

```
FILTERING_IMAGE=harmony/filtering:latest
FILTERING_REQUESTS_MEMORY=128Mi
FILTERING_LIMITS_MEMORY=512Mi
FILTERING_INVOCATION_ARGS='python -m filtering'
FILTERING_SERVICE_QUEUE_URLS='["harmony/filtering:latest,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/filtering.fifo"]'
```
in `config/services-uat.yml` - as the first chain (above harmony/download)
```
  - name: asdc/filtering
    description: Harmony service to filter netCDF based on user specified filtering criteria (spatial, min/max, glamping, and variable).
    data_operation_version: '0.21.0'
    type:
      <<: *default-turbo-config
      params:
        <<: *default-turbo-params
        env:
          <<: *default-turbo-env
          STAGING_PATH: public/harmony/filtering
    umm_s: 'S1273163940-LARC_CLOUD'
    capabilities:
      concatenation: false
      subsetting:
        bbox: false
        variable: false
        temporal: false
      output_formats:
        - application/netcdf4
      reprojection: false
    steps:
      - image: !Env ${QUERY_CMR_IMAGE}
        is_sequential: true
      - image: !Env ${FILTERING_IMAGE}
```

Then submit a request:
http://localhost:3000/TEMPO_NO2_L2/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=1&forceAsync=true

Verify via the workflow-ui that the 2nd work item is created with `harmony/filtering:latest` as the service ID

Note the work item will not be picked up since you do not have that service docker image.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [X] Harmony in a Box tested (if changes made to microservices or new dependencies added)