### PR TITLE
HARMONY-2085: Add caching for CMR collections/variables/services/grids and EDL queries.

### DIFF
--- a/packages/util/env-defaults
+++ b/packages/util/env-defaults
@@ -166,3 +166,21 @@ BACKEND_HOST=harmony
 # MAX_PUT_WORK_RETRIES should be high enough to allow a work item update to succeed
 # even when a deployment is happening (~25 min max currently)
 MAX_PUT_WORK_RETRIES=30
+
+# Maximum size (in bytes) of the token cache, 50MB
+TOKEN_CACHE_SIZE=50000000
+
+# Token Cache TTL in milliseconds
+TOKEN_CACHE_TTL=300000
+
+# Maximum size (in bytes) of the cache for EDL searches, 50MB
+EDL_CACHE_SIZE=50000000
+
+# EDL Cache TTL in milliseconds
+EDL_CACHE_TTL=600000
+
+# Maximum size (in bytes) of the cache for CMR searches, 256MB
+CMR_CACHE_SIZE=256000000
+
+# CMR Cache TTL in milliseconds
+CMR_CACHE_TTL=600000

--- a/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
+++ b/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
@@ -23,7 +23,7 @@ async function fetchUserId(token: string, _sv: string, { context }): Promise<str
 // A token is valid if it exists in the cache.
 export const tokenCache = new LRUCache({
   ttl: env.tokenCacheTtl,
-  maxSize: env.maxDataOperationCacheSize,
+  maxSize: env.tokenCacheSize,
   sizeCalculation: (value: string): number => value.length,
   fetchMethod: fetchUserId,
 });

--- a/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
+++ b/services/harmony/app/middleware/earthdata-login-token-authorizer.ts
@@ -1,9 +1,32 @@
 import { RequestHandler } from 'express';
+import { LRUCache } from 'lru-cache';
 
 import HarmonyRequest from '../models/harmony-request';
 import { getUserIdRequest } from '../util/edl-api';
+import env from '../util/env';
 
 const BEARER_TOKEN_REGEX = new RegExp('^Bearer ([-a-zA-Z0-9._~+/]+)$', 'i');
+
+/**
+ * Wrapper function of getUserIdRequest to be set to fetchMethod of LRUCache.
+ *
+ * @param token - EDL bearer token
+ * @param _sv - stale value parameter of LRUCache fetchMethod, unused here
+ * @param options - options parameter of LRUCache fetchMethod, carries the request context
+ * @returns Promise of user name associated with the EDL token
+ */
+async function fetchUserId(token: string, _sv: string, { context }): Promise<string> {
+  return getUserIdRequest(context, token);
+}
+
+// In memory cache for EDL bearer token to username.
+// A token is valid if it exists in the cache.
+export const tokenCache = new LRUCache({
+  ttl: env.tokenCacheTtl,
+  maxSize: env.maxDataOperationCacheSize,
+  sizeCalculation: (value: string): number => value.length,
+  fetchMethod: fetchUserId,
+});
 
 /**
  * Builds Express.js middleware for authenticating an EDL token and extracting the username.
@@ -25,7 +48,7 @@ export default function buildEdlAuthorizer(paths: Array<string | RegExp> = []): 
         const userToken = match[1];
         try {
           // Get the username for the provided token from EDL
-          const username = await getUserIdRequest(req.context, userToken);
+          const username = await tokenCache.fetch(userToken, { context: req.context });
           req.user = username;
           req.accessToken = userToken;
           req.authorized = true;

--- a/services/harmony/app/util/cmr.ts
+++ b/services/harmony/app/util/cmr.ts
@@ -670,7 +670,7 @@ async function _cmrPostBody(
  * @param token - Access token for user request
  * @returns The variable search results
  */
-export async function _getAllVariables(
+async function _getAllVariables(
   context: RequestContext, query: CmrQuery, token: string,
 ): Promise<Array<CmrUmmVariable>> {
   logger.debug('Calling CMR to fetch variables');
@@ -706,7 +706,7 @@ export async function _getAllVariables(
  * @param token - Access token for user request
  * @returns The services search results
  */
-export async function _getAllServices(
+async function _getAllServices(
   context: RequestContext, query: CmrQuery, token: string,
 ): Promise<Array<CmrUmmService>> {
   logger.debug('Calling CMR to fetch services');

--- a/services/harmony/app/util/edl-api.ts
+++ b/services/harmony/app/util/edl-api.ts
@@ -1,13 +1,17 @@
 import * as axios from 'axios';
-import { hasCookieSecret } from './cookie-secret';
-import { ForbiddenError } from './errors';
+import { createHash } from 'crypto';
 import { Response } from 'express';
-import env from './env';
-import HarmonyRequest from '../models/harmony-request';
-import { oauthOptions } from '../middleware/earthdata-login-oauth-authorizer';
+import { LRUCache } from 'lru-cache';
 import { ClientCredentials, AccessToken } from 'simple-oauth2';
-import RequestContext from '../models/request-context';
 import { Logger } from 'winston';
+
+import { hasCookieSecret } from './cookie-secret';
+import env from './env';
+import { ForbiddenError } from './errors';
+import theLogger from './log';
+import { oauthOptions } from '../middleware/earthdata-login-oauth-authorizer';
+import HarmonyRequest from '../models/harmony-request';
+import RequestContext from '../models/request-context';
 
 const edlUserRequestUrl = `${env.oauthHost}/oauth/tokens/user`;
 const edlUserGroupsBaseUrl = `${env.oauthHost}/api/user_groups/groups_for_user`;
@@ -48,7 +52,7 @@ export async function getClientCredentialsToken(logger: Logger): Promise<string>
  * @returns the username associated with the token
  * @throws ForbiddenError if the token is invalid
  */
-export async function getUserIdRequest(context: RequestContext, userToken: string)
+export async function _getUserIdRequest(context: RequestContext, userToken: string)
   : Promise<string> {
   const { logger } = context;
   logger.debug('Calling EDL to validate bearer token');
@@ -114,8 +118,10 @@ export interface EdlGroupMembership {
  * @returns A promise which resolves to info about whether the user is an admin, log viewer or service deployer,
  * and has core permissions (e.g. allowing user to access server configuration endpoints)
  */
-export async function getEdlGroupInformation(context: RequestContext, username: string)
+export async function _getEdlGroupInformation(context: RequestContext, username: string)
   : Promise<EdlGroupMembership> {
+  const { logger } = context;
+  logger.debug(`Get EDL group info for user: ${username}`);
 
   if (!env.useEdlClientApp) {
     return { isAdmin: false, isLogViewer: false, isServiceDeployer: false, hasCorePermissions: false };
@@ -146,24 +152,6 @@ export async function getEdlGroupInformation(context: RequestContext, username: 
 }
 
 /**
- * Helper function which returns true if the request is from an admin user
- * @param req - the harmony request
- */
-export async function isAdminUser(req: HarmonyRequest): Promise<boolean> {
-  if (!env.useEdlClientApp) return false;
-
-  const isAdmin = req.context.isAdminAccess ||
-    (await getEdlGroupInformation(req.context, req.user)).isAdmin;
-  return isAdmin;
-}
-
-export interface EdlUserEulaInfo {
-  statusCode: number;
-  error?: string;
-  acceptEulaUrl?: string;
-}
-
-/**
  * Check whether the user has accepted a EULA.
  *
  * @param context - Information related to the user's request
@@ -172,11 +160,13 @@ export interface EdlUserEulaInfo {
  * @returns A promise which resolves to info about whether the user has accepted a EULA,
  * and if not, where they can go to accept it
  */
-export async function verifyUserEula(context: RequestContext, username: string, eulaId: string)
+export async function _verifyUserEula(context: RequestContext, username: string, eulaId: string)
   : Promise<EdlUserEulaInfo> {
   let statusCode: number;
   let eulaResponse: { msg: string, error: string, accept_eula_url: string };
   try {
+    const { logger } = context;
+    logger.debug(`Verify user Eula, user: ${username}, eulaId: ${eulaId}`);
     const clientToken = await getClientCredentialsToken(context.logger);
     const response = await axios.default.get(
       edlVerifyUserEulaUrl(username, eulaId), { headers: { Authorization: `Bearer ${clientToken}`, 'X-Request-Id': context.id } },
@@ -192,6 +182,117 @@ export async function verifyUserEula(context: RequestContext, username: string, 
     error: eulaResponse.error,
     acceptEulaUrl: eulaResponse.accept_eula_url,
   };
+}
+
+// type of EDL query results
+type EdlResults = EdlUserEulaInfo | EdlGroupMembership | string;
+
+// Enum defining supported types of edl requests
+export enum edlQueryType {
+  EULA = 'EULA',
+  GROUP = 'GROUP',
+  USERID = 'USERID',
+}
+
+/**
+ * Wrapper function for EDL queries.
+ * Designed to be used as the `fetchMethod` in an LRUCache.
+ *
+ * @param key - The cache key (usually a hash of query parameters)
+ * @param _sv - The "stale value" from LRUCache; unused in this implementation
+ * @param options - Contains `context` used to submit EDL query request
+ * @returns A Promise resolving to a EdlResults object from the appropriate source
+ */
+async function fetchFromEdl(
+  key: string,
+  _sv: EdlResults,
+  { context: fetchContext })
+  : Promise<EdlResults> {
+  const { type, context, username, eulaId } = fetchContext;
+  if (type === edlQueryType.EULA) {
+    return _verifyUserEula(context, username, eulaId);
+  } else if (type === edlQueryType.GROUP) {
+    return _getEdlGroupInformation(context, key);
+  } else if (type === edlQueryType.USERID) {
+    return _getUserIdRequest(context, key);
+  } else {
+    throw new Error(`Invalid EDL query type: ${type}`);
+  }
+}
+
+// In memory cache for EDL query results.
+export const edlCache = new LRUCache<string, EdlResults>({
+  ttl: env.edlCacheTtl,
+  maxSize: env.edlCacheSize,
+  sizeCalculation: (result, _key): number => {
+    try {
+      // Serialize to JSON and measure byte size
+      const size = Buffer.byteLength(JSON.stringify(result), 'utf8');
+      theLogger.debug(`Cached EDL result size: ${size}`);
+      return size;
+    } catch {
+      // Fallback if serialization fails
+      theLogger.error('Failed to serialize EDL result in Cache');
+      return 1000;
+    }
+  },
+  fetchMethod: fetchFromEdl,
+});
+
+/**
+ * Retrieve the user EULA verification result.
+ * Perform the verification if cache miss.
+ *
+ * @param context - Information related to the user's request
+ * @param username - The EDL username
+ * @param eulaId - The id of the EULA (from the collection metadata)
+ * @returns A promise which resolves to info about whether the user has accepted a EULA,
+ * and if not, where they can go to accept it
+ */
+export async function verifyUserEula(context: RequestContext, username: string, eulaId: string)
+  : Promise<EdlUserEulaInfo> {
+  const type = edlQueryType.EULA;
+  const inputString = JSON.stringify({
+    username,
+    eulaId,
+  });
+
+  // Compute MD5 hash
+  const key = createHash('md5').update(inputString).digest('hex');
+  const result = await edlCache.fetch(key, { context: { type, context, username, eulaId } });
+  return result as EdlUserEulaInfo;
+}
+
+/**
+ * Retrieve the harmony relevant group information for a user with two keys isAdmin and isLogViewer.
+ * Perform the EDL query if cache miss.
+ *
+ * @param context - Information related to the user's request
+ * @param username - The EDL username
+ * @returns A promise which resolves to info about whether the user is an admin, log viewer or service deployer,
+ * and has core permissions (e.g. allowing user to access server configuration endpoints)
+ */
+export async function getEdlGroupInformation(context: RequestContext, username: string)
+  : Promise<EdlGroupMembership> {
+  const type = edlQueryType.GROUP;
+  const result = await edlCache.fetch(username, { context: { type, context } });
+  return result as EdlGroupMembership;
+}
+
+/**
+ * Makes a request to the EDL users endpoint to validate a token and return the user ID
+ * associated with that token.
+ *
+ * @param context - Information related to the user's request
+ * @param userToken - The user's token
+ * @returns the username associated with the token
+ * @throws ForbiddenError if the token is invalid
+ */
+export async function getUserIdRequest(context: RequestContext, userToken: string)
+  : Promise<string> {
+  const type = edlQueryType.USERID;
+  const result = await edlCache.fetch(userToken, { context: { type, context } });
+  return result as string;
 }
 
 /**
@@ -217,6 +318,24 @@ export async function validateUserIsInCoreGroup(
   }
 
   return true;
+}
+
+/**
+ * Helper function which returns true if the request is from an admin user
+ * @param req - the harmony request
+ */
+export async function isAdminUser(req: HarmonyRequest): Promise<boolean> {
+  if (!env.useEdlClientApp) return false;
+
+  const isAdmin = req.context.isAdminAccess ||
+    (await getEdlGroupInformation(req.context, req.user)).isAdmin;
+  return isAdmin;
+}
+
+export interface EdlUserEulaInfo {
+  statusCode: number;
+  error?: string;
+  acceptEulaUrl?: string;
 }
 
 /**

--- a/services/harmony/app/util/edl-api.ts
+++ b/services/harmony/app/util/edl-api.ts
@@ -110,6 +110,12 @@ export interface EdlGroupMembership {
   hasCorePermissions: boolean;
 }
 
+export interface EdlUserEulaInfo {
+  statusCode: number;
+  error?: string;
+  acceptEulaUrl?: string;
+}
+
 /**
  * Returns the harmony relevant group information for a user with two keys isAdmin and isLogViewer.
  *
@@ -311,12 +317,6 @@ export async function isAdminUser(req: HarmonyRequest): Promise<boolean> {
   const isAdmin = req.context.isAdminAccess ||
     (await getEdlGroupInformation(req.context, req.user)).isAdmin;
   return isAdmin;
-}
-
-export interface EdlUserEulaInfo {
-  statusCode: number;
-  error?: string;
-  acceptEulaUrl?: string;
 }
 
 /**

--- a/services/harmony/app/util/edl-api.ts
+++ b/services/harmony/app/util/edl-api.ts
@@ -124,7 +124,7 @@ export interface EdlUserEulaInfo {
  * @returns A promise which resolves to info about whether the user is an admin, log viewer or service deployer,
  * and has core permissions (e.g. allowing user to access server configuration endpoints)
  */
-export async function _getEdlGroupInformation(context: RequestContext, username: string)
+async function _getEdlGroupInformation(context: RequestContext, username: string)
   : Promise<EdlGroupMembership> {
   const { logger } = context;
   logger.debug(`Get EDL group info for user: ${username}`);
@@ -166,7 +166,7 @@ export async function _getEdlGroupInformation(context: RequestContext, username:
  * @returns A promise which resolves to info about whether the user has accepted a EULA,
  * and if not, where they can go to accept it
  */
-export async function _verifyUserEula(context: RequestContext, username: string, eulaId: string)
+async function _verifyUserEula(context: RequestContext, username: string, eulaId: string)
   : Promise<EdlUserEulaInfo> {
   let statusCode: number;
   let eulaResponse: { msg: string, error: string, accept_eula_url: string };

--- a/services/harmony/app/util/edl-api.ts
+++ b/services/harmony/app/util/edl-api.ts
@@ -117,7 +117,7 @@ export interface EdlUserEulaInfo {
 }
 
 /**
- * Returns the harmony relevant group information for a user with two keys isAdmin and isLogViewer.
+ * Returns the harmony relevant group information for a user
  *
  * @param context - Information related to the user's request
  * @param username - The EDL username
@@ -267,7 +267,7 @@ export async function verifyUserEula(context: RequestContext, username: string, 
 }
 
 /**
- * Retrieve the harmony relevant group information for a user with two keys isAdmin and isLogViewer.
+ * Retrieve the harmony relevant group information for a user
  * Perform the EDL query if cache miss.
  *
  * @param context - Information related to the user's request

--- a/services/harmony/app/util/edl-api.ts
+++ b/services/harmony/app/util/edl-api.ts
@@ -52,7 +52,7 @@ export async function getClientCredentialsToken(logger: Logger): Promise<string>
  * @returns the username associated with the token
  * @throws ForbiddenError if the token is invalid
  */
-export async function _getUserIdRequest(context: RequestContext, userToken: string)
+export async function getUserIdRequest(context: RequestContext, userToken: string)
   : Promise<string> {
   const { logger } = context;
   logger.debug('Calling EDL to validate bearer token');
@@ -185,13 +185,12 @@ export async function _verifyUserEula(context: RequestContext, username: string,
 }
 
 // type of EDL query results
-type EdlResults = EdlUserEulaInfo | EdlGroupMembership | string;
+type EdlResults = EdlUserEulaInfo | EdlGroupMembership;
 
 // Enum defining supported types of edl requests
 export enum edlQueryType {
   EULA = 'EULA',
   GROUP = 'GROUP',
-  USERID = 'USERID',
 }
 
 /**
@@ -213,8 +212,6 @@ async function fetchFromEdl(
     return _verifyUserEula(context, username, eulaId);
   } else if (type === edlQueryType.GROUP) {
     return _getEdlGroupInformation(context, key);
-  } else if (type === edlQueryType.USERID) {
-    return _getUserIdRequest(context, key);
   } else {
     throw new Error(`Invalid EDL query type: ${type}`);
   }
@@ -277,22 +274,6 @@ export async function getEdlGroupInformation(context: RequestContext, username: 
   const type = edlQueryType.GROUP;
   const result = await edlCache.fetch(username, { context: { type, context } });
   return result as EdlGroupMembership;
-}
-
-/**
- * Makes a request to the EDL users endpoint to validate a token and return the user ID
- * associated with that token.
- *
- * @param context - Information related to the user's request
- * @param userToken - The user's token
- * @returns the username associated with the token
- * @throws ForbiddenError if the token is invalid
- */
-export async function getUserIdRequest(context: RequestContext, userToken: string)
-  : Promise<string> {
-  const type = edlQueryType.USERID;
-  const result = await edlCache.fetch(userToken, { context: { type, context } });
-  return result as string;
 }
 
 /**

--- a/services/harmony/app/util/env.ts
+++ b/services/harmony/app/util/env.ts
@@ -107,7 +107,19 @@ class HarmonyServerEnv extends HarmonyEnv {
 
   @IsInt()
   @Min(1)
-  tokenCacheTtl: number;
+  edlCacheSize: number;
+
+  @IsInt()
+  @Min(1)
+  edlCacheTtl: number;
+
+  @IsInt()
+  @Min(1)
+  cmrCacheSize: number;
+
+  @IsInt()
+  @Min(1)
+  cmrCacheTtl: number;
 
   @IsPositive()
   wktPrecision: number;

--- a/services/harmony/app/util/env.ts
+++ b/services/harmony/app/util/env.ts
@@ -107,6 +107,10 @@ class HarmonyServerEnv extends HarmonyEnv {
 
   @IsInt()
   @Min(1)
+  tokenCacheSize: number;
+
+  @IsInt()
+  @Min(1)
   tokenCacheTtl: number;
 
   @IsInt()

--- a/services/harmony/app/util/env.ts
+++ b/services/harmony/app/util/env.ts
@@ -107,6 +107,10 @@ class HarmonyServerEnv extends HarmonyEnv {
 
   @IsInt()
   @Min(1)
+  tokenCacheTtl: number;
+
+  @IsInt()
+  @Min(1)
   edlCacheSize: number;
 
   @IsInt()

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -132,24 +132,6 @@ MAX_POST_FILE_PARTS=100
 # Maximum size (in bytes) of the cache for data operations, 512MB
 MAX_DATA_OPERATION_CACHE_SIZE=512000000
 
-# Maximum size (in bytes) of the token cache, 50MB
-TOKEN_CACHE_SIZE=50000000
-
-# Token Cache TTL in milliseconds
-TOKEN_CACHE_TTL=300000
-
-# Maximum size (in bytes) of the cache for EDL searches, 50MB
-EDL_CACHE_SIZE=50000000
-
-# EDL Cache TTL in milliseconds
-EDL_CACHE_TTL=600000
-
-# Maximum size (in bytes) of the cache for CMR searches, 256MB
-CMR_CACHE_SIZE=256000000
-
-# CMR Cache TTL in milliseconds
-CMR_CACHE_TTL=600000
-
 # WKT POINT/LINESTRING to POLYGON conversion side length, 0.0001 is about 11 meters in precision
 WKT_PRECISION=0.0001
 

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -132,8 +132,17 @@ MAX_POST_FILE_PARTS=100
 # Maximum size (in bytes) of the cache for data operations
 MAX_DATA_OPERATION_CACHE_SIZE=512000000
 
-# Token Cache TTL in milliseconds
-TOKEN_CACHE_TTL=300000
+# Maximum size (in bytes) of the cache for CMR searches
+EDL_CACHE_SIZE=256000000
+
+# EDL Cache TTL in milliseconds
+EDL_CACHE_TTL=300000
+
+# Maximum size (in bytes) of the cache for CMR searches
+CMR_CACHE_SIZE=1024000000
+
+# CMR Cache TTL in milliseconds
+CMR_CACHE_TTL=600000
 
 # WKT POINT/LINESTRING to POLYGON conversion side length, 0.0001 is about 11 meters in precision
 WKT_PRECISION=0.0001

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -132,17 +132,20 @@ MAX_POST_FILE_PARTS=100
 # Maximum size (in bytes) of the cache for data operations
 MAX_DATA_OPERATION_CACHE_SIZE=512000000
 
+# Maximum size (in bytes) of the token cache
+TOKEN_CACHE_SIZE=50000000
+
 # Token Cache TTL in milliseconds
 TOKEN_CACHE_TTL=300000
 
-# Maximum size (in bytes) of the cache for CMR searches
-EDL_CACHE_SIZE=256000000
+# Maximum size (in bytes) of the cache for EDL searches
+EDL_CACHE_SIZE=50000000
 
 # EDL Cache TTL in milliseconds
 EDL_CACHE_TTL=600000
 
 # Maximum size (in bytes) of the cache for CMR searches
-CMR_CACHE_SIZE=1024000000
+CMR_CACHE_SIZE=256000000
 
 # CMR Cache TTL in milliseconds
 CMR_CACHE_TTL=600000

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -132,11 +132,14 @@ MAX_POST_FILE_PARTS=100
 # Maximum size (in bytes) of the cache for data operations
 MAX_DATA_OPERATION_CACHE_SIZE=512000000
 
+# Token Cache TTL in milliseconds
+TOKEN_CACHE_TTL=300000
+
 # Maximum size (in bytes) of the cache for CMR searches
 EDL_CACHE_SIZE=256000000
 
 # EDL Cache TTL in milliseconds
-EDL_CACHE_TTL=300000
+EDL_CACHE_TTL=600000
 
 # Maximum size (in bytes) of the cache for CMR searches
 CMR_CACHE_SIZE=1024000000

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -129,22 +129,22 @@ MAX_POST_FILE_SIZE=2000000000
 # Maximum number of multipart parts to accept when providing a shapefile
 MAX_POST_FILE_PARTS=100
 
-# Maximum size (in bytes) of the cache for data operations
+# Maximum size (in bytes) of the cache for data operations, 512MB
 MAX_DATA_OPERATION_CACHE_SIZE=512000000
 
-# Maximum size (in bytes) of the token cache
+# Maximum size (in bytes) of the token cache, 50MB
 TOKEN_CACHE_SIZE=50000000
 
 # Token Cache TTL in milliseconds
 TOKEN_CACHE_TTL=300000
 
-# Maximum size (in bytes) of the cache for EDL searches
+# Maximum size (in bytes) of the cache for EDL searches, 50MB
 EDL_CACHE_SIZE=50000000
 
 # EDL Cache TTL in milliseconds
 EDL_CACHE_TTL=600000
 
-# Maximum size (in bytes) of the cache for CMR searches
+# Maximum size (in bytes) of the cache for CMR searches, 256MB
 CMR_CACHE_SIZE=256000000
 
 # CMR Cache TTL in milliseconds

--- a/services/harmony/test/helpers/stub-edl-token.ts
+++ b/services/harmony/test/helpers/stub-edl-token.ts
@@ -2,6 +2,7 @@ import { before, after } from 'mocha';
 import * as sinon from 'sinon';
 import { ForbiddenError } from '../../app/util/errors';
 import * as edl from '../../app/util/edl-api';
+import * as edlAuth from '../../app/middleware/earthdata-login-token-authorizer';
 
 /**
  * Adds before / after hooks in mocha to replace calls to EDL token interaction
@@ -11,16 +12,16 @@ import * as edl from '../../app/util/edl-api';
  */
 export function hookEdlTokenAuthentication(username: string): void {
   let clientCredentialsStub;
-  let userIdRequestStub;
+  let tokenCacheStub;
   before(async function () {
     clientCredentialsStub = sinon.stub(edl, 'getClientCredentialsToken')
       .callsFake(async () => 'client-token');
-    userIdRequestStub = sinon.stub(edl, 'getUserIdRequest')
+    tokenCacheStub = sinon.stub(edlAuth.tokenCache, 'fetch')
       .callsFake(async () => username);
   });
   after(async function () {
     if (clientCredentialsStub.restore) clientCredentialsStub.restore();
-    if (userIdRequestStub.restore) userIdRequestStub.restore();
+    if (tokenCacheStub.restore) tokenCacheStub.restore();
   });
 }
 
@@ -30,14 +31,16 @@ export function hookEdlTokenAuthentication(username: string): void {
  */
 export function hookEdlTokenAuthenticationError(): void {
   let clientCredentialsStub;
-  let userIdRequestStub;
+  let tokenCacheStub;
+
   before(async function () {
     const error = new ForbiddenError();
     clientCredentialsStub = sinon.stub(edl, 'getClientCredentialsToken').throws(error);
-    userIdRequestStub = sinon.stub(edl, 'getUserIdRequest').throws(error);
+    tokenCacheStub = sinon.stub(edlAuth.tokenCache, 'fetch').throws(error);
   });
+
   after(async function () {
     if (clientCredentialsStub.restore) clientCredentialsStub.restore();
-    if (userIdRequestStub.restore) userIdRequestStub.restore();
+    if (tokenCacheStub.restore) tokenCacheStub.restore();
   });
 }

--- a/services/harmony/test/helpers/stub-edl-token.ts
+++ b/services/harmony/test/helpers/stub-edl-token.ts
@@ -2,7 +2,6 @@ import { before, after } from 'mocha';
 import * as sinon from 'sinon';
 import { ForbiddenError } from '../../app/util/errors';
 import * as edl from '../../app/util/edl-api';
-import * as edlAuth from '../../app/middleware/earthdata-login-token-authorizer';
 
 /**
  * Adds before / after hooks in mocha to replace calls to EDL token interaction
@@ -12,16 +11,16 @@ import * as edlAuth from '../../app/middleware/earthdata-login-token-authorizer'
  */
 export function hookEdlTokenAuthentication(username: string): void {
   let clientCredentialsStub;
-  let tokenCacheStub;
+  let userIdRequestStub;
   before(async function () {
     clientCredentialsStub = sinon.stub(edl, 'getClientCredentialsToken')
       .callsFake(async () => 'client-token');
-    tokenCacheStub = sinon.stub(edlAuth.tokenCache, 'fetch')
+    userIdRequestStub = sinon.stub(edl, 'getUserIdRequest')
       .callsFake(async () => username);
   });
   after(async function () {
     if (clientCredentialsStub.restore) clientCredentialsStub.restore();
-    if (tokenCacheStub.restore) tokenCacheStub.restore();
+    if (userIdRequestStub.restore) userIdRequestStub.restore();
   });
 }
 
@@ -31,16 +30,14 @@ export function hookEdlTokenAuthentication(username: string): void {
  */
 export function hookEdlTokenAuthenticationError(): void {
   let clientCredentialsStub;
-  let tokenCacheStub;
-
+  let userIdRequestStub;
   before(async function () {
     const error = new ForbiddenError();
     clientCredentialsStub = sinon.stub(edl, 'getClientCredentialsToken').throws(error);
-    tokenCacheStub = sinon.stub(edlAuth.tokenCache, 'fetch').throws(error);
+    userIdRequestStub = sinon.stub(edl, 'getUserIdRequest').throws(error);
   });
-
   after(async function () {
     if (clientCredentialsStub.restore) clientCredentialsStub.restore();
-    if (tokenCacheStub.restore) tokenCacheStub.restore();
+    if (userIdRequestStub.restore) userIdRequestStub.restore();
   });
 }

--- a/services/query-cmr/package-lock.json
+++ b/services/query-cmr/package-lock.json
@@ -33,6 +33,7 @@
         "geojson-antimeridian-cut": "^0.1.0",
         "lodash": "^4.17.21",
         "lodash.camelcase": "^4.3.0",
+        "lru-cache": "^11.0.2",
         "node-fetch": ">=2.7.0 <3.0.0",
         "shpjs": ">=4.0.4 <5.0.0",
         "tmp": "^0.2.1",
@@ -2006,6 +2007,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -7659,13 +7670,12 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-      "dev": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.1.0.tgz",
+      "integrity": "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==",
       "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/make-dir": {
@@ -8989,16 +8999,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/lru-cache": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/rimraf/node_modules/minimatch": {

--- a/services/query-cmr/package.json
+++ b/services/query-cmr/package.json
@@ -64,6 +64,7 @@
     "geojson-antimeridian-cut": "^0.1.0",
     "lodash": "^4.17.21",
     "lodash.camelcase": "^4.3.0",
+    "lru-cache": "^11.0.2",
     "node-fetch": ">=2.7.0 <3.0.0",
     "shpjs": ">=4.0.4 <5.0.0",
     "tmp": "^0.2.1",


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2085

## Description
This PR adds caching for CMR collections/variables/services/grids and EDL queries such as EDL user group search, Eula verification.

## Local Test Steps
Add the following configuration in `.env` to make testing easier:
```
TOKEN_CACHE_TTL=60000
EDL_CACHE_TTL=60000
CMR_CACHE_TTL=60000
```
Modify the `services-uat.yml` `harmony/service-example` service section to the following to test out the UMM collection caching:
```
- name: harmony/service-example
    description: |
      Reference service that can be used to perform most operations supported by Harmony.
      Useful for testing new API features end-to-end on example data but not meant for production use.
    data_operation_version: '0.21.0'
    type:
      <<: *default-turbo-config
      params:
        <<: *default-turbo-params
        env:
          <<: *default-turbo-env
          STAGING_PATH: public/harmony/service-example
    umm_s: S1257851197-EEDTEST
    collections:
      - id: C1243747507-EEDTEST
        granule_limit: 100 # added to test collection granule limits for HARMONY-795
    capabilities:
      subsetting:
        bbox: true
        variable: true
        multiple_variable: true
      output_formats:
        - image/tiff
        - image/png
        - image/gif
      reprojection: true
    steps:
      - image: !Env ${QUERY_CMR_IMAGE}
        is_sequential: true
      - image: !Env ${HARMONY_NETCDF_TO_ZARR_IMAGE}
        conditional:
          umm_c:
            native_format: ['netcdf-4']
      - image: !Env ${HARMONY_SERVICE_EXAMPLE_IMAGE}
```
Submit concurrent service-example requests to test out EDL token and CMR collection, UMM collection and variables caching, e.g.
```
for i in {1..10}; do curl -i -H "Authorization: Bearer $HARMONY_UAT_TOKEN" "http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng&forceAsync=true"&; done
```
Verify `Calling CMR to fetch` for collections, variables, UMM collections only happens once.
Submit a request to test EULA verification, e.g. 
```
for i in {1..10}; do curl -i -H "Authorization: Bearer $HARMONY_UAT_TOKEN" "http://localhost:3000/C1258839703-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&outputCrs=EPSG%3A31975&format=image%2Fpng&maxResults=1"&; done
```
Similarly verify that the `Verify user Eula, user: ...` only happens once.
Similarly, you can use the following request to verify grid caching:
```
curl -i -H "Authorization: Bearer $HARMONY_UAT_TOKEN" "http://localhost:3000/C1233860183-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?granuleId=G1233860486-EEDTEST&interpolation=near&grid=LambertDurbin"
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)