### PR TITLE
HARMONY-2054: Do not include OPeNDAP links as outputs when the harmony/download service chain is used.

### DIFF
--- a/config/services-prod.yml
+++ b/config/services-prod.yml
@@ -45,6 +45,8 @@ https://cmr.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
+        extra_args:
+          include_opendap_links: false
 
   - name: giovanni-time-series-adapter
     description: |

--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -45,6 +45,8 @@ https://cmr.uat.earthdata.nasa.gov:
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
+        extra_args:
+          include_opendap_links: false
 
   - name: ldds/subset-band-name
     description: |

--- a/services/harmony/app/models/data-operation.ts
+++ b/services/harmony/app/models/data-operation.ts
@@ -1,13 +1,14 @@
-import * as fs from 'fs';
-import * as path from 'path';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
+import * as fs from 'fs';
 import _ from 'lodash';
-import logger from '../util/log';
+import * as path from 'path';
+
 import { CmrUmmCollection, CmrUmmVariable } from '../util/cmr';
-import { Encrypter, Decrypter } from '../util/crypto';
-import { cmrVarToHarmonyVar, HarmonyVariable } from '../util/variables';
+import { Decrypter, Encrypter } from '../util/crypto';
+import logger from '../util/log';
 import { isValidUri } from '../util/url';
+import { cmrVarToHarmonyVar, HarmonyVariable } from '../util/variables';
 
 export const CURRENT_SCHEMA_VERSION = '0.21.0';
 
@@ -959,7 +960,7 @@ export default class DataOperation {
    *
    * @returns The extra arguments that will be passed to service worker
    */
-  get extraArgs(): object {
+  get extraArgs(): Record<string, unknown> {
     return this.model.extraArgs;
   }
 
@@ -968,7 +969,7 @@ export default class DataOperation {
    *
    * @param extraArgs - The extra arguments that will be passed to service worker
    */
-  set extraArgs(extraArgs: object) {
+  set extraArgs(extraArgs: Record<string, unknown>) {
     this.model.extraArgs = extraArgs;
   }
 

--- a/services/query-cmr/test/cmr-to-stac.ts
+++ b/services/query-cmr/test/cmr-to-stac.ts
@@ -1,7 +1,95 @@
-import { StacAsset, StacItem } from '../app/stac/types';
 import { expect } from 'chai';
 import _ from 'lodash';
+
+import logger from '../../harmony/app/util/log';
 import CmrCatalog, { bboxToGeometry } from '../app/stac/cmr-catalog';
+import { StacItem } from '../app/stac/types';
+
+const cmrUmmGranules = [{
+  meta: {
+    'concept-id': 'G0_TEST',
+    'collection-concept-id': 'C0-TEST',
+  },
+  umm: {
+    TemporalExtent: {
+      RangeDateTime: {
+        BeginningDateTime: '2019-01-01T00:00:00Z',
+        EndingDateTime: '2019-01-02T00:00:00Z',
+      },
+    },
+    GranuleUR: 'g0',
+    RelatedUrls: [{
+      URL: './g0_0.nc4',
+      Type: 'GET DATA',
+      Description: 'Data 0',
+      MimeType: 'application/x-netcdf4',
+    },
+    {
+      URL: './g0_1.nc4',
+      Type: 'GET DATA',
+      Description: 'Data 1',
+      MimeType: 'application/x-netcdf4',
+    },
+    {
+      URL: './g0_3.json',
+      Type: 'EXTENDED METADATA',
+      Description: 'Metadata 3',
+      MimeType: 'application/json',
+    },
+    {
+      URL: './g0_4.nc4',
+      Type: 'USE SERVICE API',
+      Description: 'OPeNDAP Data 4',
+      MimeType: 'application/x-netcdf4',
+    },
+    {
+      URL: './g0_5.nc4',
+      Type: 'USE SERVICE API',
+      Description: 'OPeNDAP Data 5',
+      MimeType: 'application/x-netcdf4',
+    },
+    {
+      URL: 'https://gesdisc.nasa.gov/opendap/Aqua_AIRS_Level3/AIR222P5.006/2002/AIRS.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf',
+      Type: 'USE SERVICE API',
+      Description: 'OPeNDAP request URL (GET DATA : OPENDAP DATA)',
+      MimeType: 'application/x-hdf',
+    },
+    {
+      URL: 'https://gesdisc.nasa.gov/opentrap/Aqua_AIRS_Level3/AIR222P5.006/2002/abcd.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf',
+      Type: 'USE SERVICE API',
+      Description: 'OPeNTRAP request URL',
+      MimeType: 'application/x-hdf',
+    },
+    {
+      URL: 'https://gesdisc.nasa.gov/opendap/Aqua_AIRS_Level3/AIR222P5.006/2002/123.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf',
+      Type: 'GET DATA',
+      Description: 'OPeNDAP request URL (GET DATA : OPENDAP DATA)',
+      MimeType: 'application/x-hdf',
+    },
+    {
+      URL: 'https://archive.gesdisc.nasa.gov/Aqua_AIRS_Level3/AIR222P5.006/browse_source.zip',
+      Type: 'GET DATA',
+      Description: 'Download browse_source.zip',
+      Subtype: 'BROWSE IMAGE SOURCE',
+    },
+    ],
+  },
+},
+{
+  meta: {
+    'concept-id': 'G1_TEST',
+    'collection-concept-id': 'C0-TEST',
+  },
+  umm: {
+    TemporalExtent: {
+      RangeDateTime: {
+        BeginningDateTime: '2019-01-01T00:00:00Z',
+        EndingDateTime: '2019-01-02T00:00:00Z',
+      },
+    },
+    GranuleUR: 'g1',
+  },
+}];
 
 describe('bboxToGeometry conversion', function () {
   it('provides a single polygon for bboxes that do not cross the antimeridian', function () {
@@ -26,187 +114,162 @@ describe('bboxToGeometry conversion', function () {
 
 describe('addCmrUmmGranules to catalog', function () {
   describe('asset extraction', function () {
-    let catalog: CmrCatalog;
-    let assets: { [name: string]: StacAsset };
-    let properties: { [name: string]: StacAsset };
-    before(function () {
-      catalog = new CmrCatalog({ description: 'test' });
-      catalog.addCmrUmmGranules([{
-        meta: {
-          'concept-id': 'G0_TEST',
-          'collection-concept-id': 'C0-TEST',
-        },
-        umm: {
-          TemporalExtent: {
-            RangeDateTime: {
-              BeginningDateTime: '2019-01-01T00:00:00Z',
-              EndingDateTime: '2019-01-02T00:00:00Z',
-            },
-          },
-          GranuleUR: 'g0',
-          RelatedUrls: [{
-            URL: './g0_0.nc4',
-            Type: 'GET DATA',
-            Description: 'Data 0',
-            MimeType: 'application/x-netcdf4',
-          },
-          {
-            URL: './g0_1.nc4',
-            Type: 'GET DATA',
-            Description: 'Data 1',
-            MimeType: 'application/x-netcdf4',
-          },
-          {
-            URL: './g0_3.json',
-            Type: 'EXTENDED METADATA',
-            Description: 'Metadata 3',
-            MimeType: 'application/json',
-          },
-          {
-            URL: './g0_4.nc4',
-            Type: 'USE SERVICE API',
-            Description: 'OPeNDAP Data 4',
-            MimeType: 'application/x-netcdf4',
-          },
-          {
-            URL: './g0_5.nc4',
-            Type: 'USE SERVICE API',
-            Description: 'OPeNDAP Data 5',
-            MimeType: 'application/x-netcdf4',
-          },
-          {
-            URL: 'https://gesdisc.nasa.gov/opendap/Aqua_AIRS_Level3/AIR222P5.006/2002/AIRS.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf',
-            Type: 'USE SERVICE API',
-            Description: 'OPeNDAP request URL (GET DATA : OPENDAP DATA)',
-            MimeType: 'application/x-hdf',
-          },
-          {
-            URL: 'https://gesdisc.nasa.gov/opentrap/Aqua_AIRS_Level3/AIR222P5.006/2002/abcd.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf',
-            Type: 'USE SERVICE API',
-            Description: 'OPeNTRAP request URL',
-            MimeType: 'application/x-hdf',
-          },
-          {
-            URL: 'https://gesdisc.nasa.gov/opendap/Aqua_AIRS_Level3/AIR222P5.006/2002/123.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf',
-            Type: 'GET DATA',
-            Description: 'OPeNDAP request URL (GET DATA : OPENDAP DATA)',
-            MimeType: 'application/x-hdf',
-          },
-          {
-            URL: 'https://archive.gesdisc.nasa.gov/Aqua_AIRS_Level3/AIR222P5.006/browse_source.zip',
-            Type: 'GET DATA',
-            Description: 'Download browse_source.zip',
-            Subtype: 'BROWSE IMAGE SOURCE',
-          },
-          ],
-        },
-      },
-      {
-        meta: {
-          'concept-id': 'G1_TEST',
-          'collection-concept-id': 'C0-TEST',
-        },
-        umm: {
-          TemporalExtent: {
-            RangeDateTime: {
-              BeginningDateTime: '2019-01-01T00:00:00Z',
-              EndingDateTime: '2019-01-02T00:00:00Z',
-            },
-          },
-          GranuleUR: 'g1',
-        },
-      }], './test/granule_');
-      // eslint-disable-next-line prefer-destructuring
-      assets = (catalog.children[0] as StacItem).assets;
-      // eslint-disable-next-line prefer-destructuring
-      properties = (catalog.children[0] as StacItem).properties;
-    });
+    describe('when including OPeNDAP links', function () {
+      const catalog = new CmrCatalog({ description: 'test' });
+      catalog.addCmrUmmGranules(cmrUmmGranules, './test/granule_', logger, true);
+      const { assets, properties } = catalog.children[0] as StacItem;
 
-    it('extracts temporal info', function () {
-      expect(properties.start_datetime).to.equal('2019-01-01T00:00:00Z');
-      expect(properties.end_datetime).to.equal('2019-01-02T00:00:00Z');
-      expect(properties.datetime).to.equal('2019-01-01T00:00:00Z');
-    });
+      it('extracts temporal info', function () {
+        expect(properties.start_datetime).to.equal('2019-01-01T00:00:00Z');
+        expect(properties.end_datetime).to.equal('2019-01-02T00:00:00Z');
+        expect(properties.datetime).to.equal('2019-01-01T00:00:00Z');
+      });
 
-    it('extracts non-inherited data links', function () {
-      expect(_.map(_.values(assets), 'href')).to.include('./g0_0.nc4');
-      expect(_.map(_.values(assets), 'href')).to.include('./g0_1.nc4');
-    });
+      it('extracts non-inherited data links', function () {
+        expect(_.map(_.values(assets), 'href')).to.include('./g0_0.nc4');
+        expect(_.map(_.values(assets), 'href')).to.include('./g0_1.nc4');
+      });
 
-    it('names the first data link "data"', function () {
-      expect(assets.data).to.eql({
-        href: './g0_0.nc4',
-        title: 'g0_0.nc4',
-        description: 'Data 0',
-        type: 'application/x-netcdf4',
-        roles: ['data'],
+      it('names the first data link "data"', function () {
+        expect(assets.data).to.eql({
+          href: './g0_0.nc4',
+          title: 'g0_0.nc4',
+          description: 'Data 0',
+          type: 'application/x-netcdf4',
+          roles: ['data'],
+        });
+      });
+
+      it('numbers subsequent data links', function () {
+        expect(assets.data1).to.eql({
+          href: './g0_1.nc4',
+          title: 'g0_1.nc4',
+          description: 'Data 1',
+          type: 'application/x-netcdf4',
+          roles: ['data'],
+        });
+      });
+
+      it('names OPeNDAP links "opendap" and gives them an "opendap" role', function () {
+        expect(assets.opendap).to.eql({
+          href: './g0_4.nc4',
+          title: 'g0_4.nc4',
+          description: 'OPeNDAP Data 4',
+          type: 'application/x-netcdf4',
+          roles: ['data', 'opendap'],
+        });
+        expect(assets.opendap1).to.eql({
+          href: './g0_5.nc4',
+          title: 'g0_5.nc4',
+          description: 'OPeNDAP Data 5',
+          type: 'application/x-netcdf4',
+          roles: ['data', 'opendap'],
+        });
+        expect(assets.opendap2).to.eql({
+          href: 'https://gesdisc.nasa.gov/opendap/Aqua_AIRS_Level3/AIR222P5.006/2002/AIRS.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf',
+          title: 'AIRS.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf',
+          description: 'OPeNDAP request URL (GET DATA : OPENDAP DATA)',
+          type: 'application/x-hdf',
+          roles: ['data', 'opendap'],
+        });
+        expect(assets.opendap3).to.eql({
+          href: 'https://gesdisc.nasa.gov/opendap/Aqua_AIRS_Level3/AIR222P5.006/2002/123.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf',
+          title: '123.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf',
+          description: 'OPeNDAP request URL (GET DATA : OPENDAP DATA)',
+          type: 'application/x-hdf',
+          roles: ['data', 'opendap'],
+        });
+        expect(assets.browse).to.eql({
+          href: 'https://archive.gesdisc.nasa.gov/Aqua_AIRS_Level3/AIR222P5.006/browse_source.zip',
+          title: 'browse_source.zip',
+          description: 'Download browse_source.zip',
+          type: undefined,
+          roles: ['visual'],
+        });
+        expect(assets.data2).to.be.undefined;
+      });
+
+      it('includes OPeNDAP links with rel ending in both service# and data#', function () {
+        expect(_.map(_.values(assets), 'href'))
+          .to.include('https://gesdisc.nasa.gov/opendap/Aqua_AIRS_Level3/AIR222P5.006/2002/123.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf');
+        expect(_.map(_.values(assets), 'href'))
+          .to.include('https://gesdisc.nasa.gov/opendap/Aqua_AIRS_Level3/AIR222P5.006/2002/AIRS.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf');
+      });
+
+      it('ignores non-OPeNDAP non-data links', function () {
+        expect(_.map(_.values(assets), 'href')).to.not.include('./g0_3.json');
+        expect(_.map(_.values(assets), 'href')).to.not.include('./abcd.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf');
+      });
+
+      it('does not catalog granules with no valid data links', function () {
+        expect(catalog.children.length).to.equal(1);
+        expect(catalog.links.length).to.equal(1);
       });
     });
 
-    it('numbers subsequent data links', function () {
-      expect(assets.data1).to.eql({
-        href: './g0_1.nc4',
-        title: 'g0_1.nc4',
-        description: 'Data 1',
-        type: 'application/x-netcdf4',
-        roles: ['data'],
-      });
-    });
+    describe('when not including OPeNDAP links', function () {
+      const catalog = new CmrCatalog({ description: 'test' });
+      catalog.addCmrUmmGranules(cmrUmmGranules, './test/granule_', logger, false);
+      const { assets, properties } = catalog.children[0] as StacItem;
 
-    it('names OPeNDAP links "opendap" and gives them an "opendap" role', function () {
-      expect(assets.opendap).to.eql({
-        href: './g0_4.nc4',
-        title: 'g0_4.nc4',
-        description: 'OPeNDAP Data 4',
-        type: 'application/x-netcdf4',
-        roles: ['data', 'opendap'],
+      it('does not include OPeNDAP links', function () {
+        expect(assets.opendap).to.be.undefined;
+        expect(assets.opendap1).to.be.undefined;
+        expect(assets.opendap2).to.be.undefined;
+        expect(assets.opendap3).to.be.undefined;
       });
-      expect(assets.opendap1).to.eql({
-        href: './g0_5.nc4',
-        title: 'g0_5.nc4',
-        description: 'OPeNDAP Data 5',
-        type: 'application/x-netcdf4',
-        roles: ['data', 'opendap'],
-      });
-      expect(assets.opendap2).to.eql({
-        href: 'https://gesdisc.nasa.gov/opendap/Aqua_AIRS_Level3/AIR222P5.006/2002/AIRS.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf',
-        title: 'AIRS.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf',
-        description: 'OPeNDAP request URL (GET DATA : OPENDAP DATA)',
-        type: 'application/x-hdf',
-        roles: ['data', 'opendap'],
-      });
-      expect(assets.opendap3).to.eql({
-        href: 'https://gesdisc.nasa.gov/opendap/Aqua_AIRS_Level3/AIR222P5.006/2002/123.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf',
-        title: '123.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf',
-        description: 'OPeNDAP request URL (GET DATA : OPENDAP DATA)',
-        type: 'application/x-hdf',
-        roles: ['data', 'opendap'],
-      });
-      expect(assets.browse).to.eql({
-        href: 'https://archive.gesdisc.nasa.gov/Aqua_AIRS_Level3/AIR222P5.006/browse_source.zip',
-        title: 'browse_source.zip',
-        description: 'Download browse_source.zip',
-        type: undefined,
-        roles: ['visual'],
-      });
-      expect(assets.data2).to.be.undefined;
-    });
 
-    it('includes OPeNDAP links with rel ending in both service# and data#', function () {
-      expect(_.map(_.values(assets), 'href'))
-        .to.include('https://gesdisc.nasa.gov/opendap/Aqua_AIRS_Level3/AIR222P5.006/2002/123.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf');
-      expect(_.map(_.values(assets), 'href'))
-        .to.include('https://gesdisc.nasa.gov/opendap/Aqua_AIRS_Level3/AIR222P5.006/2002/AIRS.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf');
-    });
+      it('includes browse links', function () {
+        expect(assets.browse).to.eql({
+          href: 'https://archive.gesdisc.nasa.gov/Aqua_AIRS_Level3/AIR222P5.006/browse_source.zip',
+          title: 'browse_source.zip',
+          description: 'Download browse_source.zip',
+          type: undefined,
+          roles: ['visual'],
+        });
+        expect(assets.data2).to.be.undefined;
+      });
 
-    it('ignores non-OPeNDAP non-data links', function () {
-      expect(_.map(_.values(assets), 'href')).to.not.include('./g0_3.json');
-      expect(_.map(_.values(assets), 'href')).to.not.include('./abcd.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf');
-    });
+      it('extracts temporal info', function () {
+        expect(properties.start_datetime).to.equal('2019-01-01T00:00:00Z');
+        expect(properties.end_datetime).to.equal('2019-01-02T00:00:00Z');
+        expect(properties.datetime).to.equal('2019-01-01T00:00:00Z');
+      });
 
-    it('does not catalog granules with no valid data links', function () {
-      expect(catalog.children.length).to.equal(1);
-      expect(catalog.links.length).to.equal(1);
+      it('extracts non-inherited data links', function () {
+        expect(_.map(_.values(assets), 'href')).to.include('./g0_0.nc4');
+        expect(_.map(_.values(assets), 'href')).to.include('./g0_1.nc4');
+      });
+
+      it('names the first data link "data"', function () {
+        expect(assets.data).to.eql({
+          href: './g0_0.nc4',
+          title: 'g0_0.nc4',
+          description: 'Data 0',
+          type: 'application/x-netcdf4',
+          roles: ['data'],
+        });
+      });
+
+      it('numbers subsequent data links', function () {
+        expect(assets.data1).to.eql({
+          href: './g0_1.nc4',
+          title: 'g0_1.nc4',
+          description: 'Data 1',
+          type: 'application/x-netcdf4',
+          roles: ['data'],
+        });
+      });
+
+      it('ignores non-OPeNDAP non-data links', function () {
+        expect(_.map(_.values(assets), 'href')).to.not.include('./g0_3.json');
+        expect(_.map(_.values(assets), 'href')).to.not.include('./abcd.2222.09.01.L3.RetQuant_IR005.v6.0.9.0.G111160515.hdf');
+      });
+
+      it('does not catalog granules with no valid data links', function () {
+        expect(catalog.children.length).to.equal(1);
+        expect(catalog.links.length).to.equal(1);
+      });
     });
   });
 });

--- a/services/query-cmr/test/query-granules.ts
+++ b/services/query-cmr/test/query-granules.ts
@@ -1,17 +1,19 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
+import chai, { expect } from 'chai';
+import { Stream } from 'form-data';
 /* eslint-disable node/no-unpublished-require */
 import fs from 'fs';
-import path from 'path';
-import chai, { expect } from 'chai';
 import { describe, it } from 'mocha';
-import * as sinon from 'sinon';
 import * as fetch from 'node-fetch';
-import { Stream } from 'form-data';
-import { queryGranules } from '../app/query';
-import * as cmr from '../../harmony/app/util/cmr';
+import path from 'path';
+import * as sinon from 'sinon';
+
 import DataOperation from '../../harmony/app/models/data-operation';
-import { FileStore } from '../../harmony/app/util/object-store/file-store';
+import * as cmr from '../../harmony/app/util/cmr';
 import { CmrError } from '../../harmony/app/util/errors';
+import logger from '../../harmony/app/util/log';
+import { FileStore } from '../../harmony/app/util/object-store/file-store';
+import { queryGranules } from '../app/query';
 
 chai.use(require('chai-as-promised'));
 
@@ -80,7 +82,7 @@ function hookQueryGranules(maxCmrGranules = 100): void {
     this.downloadStub = sinon.stub(FileStore.prototype, 'getObject').returns(Promise.resolve('{"collection_concept_id": "C001-TEST"}'));
 
     // Actually call it
-    this.result = await queryGranules(operation, 'scrollId', maxCmrGranules);
+    this.result = await queryGranules(operation, 'scrollId', maxCmrGranules, logger);
 
     // Map the call arguments into something we can actually assert against
     this.queryFields = await Promise.all(fetchPost.args.map(fetchPostArgsToFields));
@@ -201,7 +203,7 @@ describe('query#queryGranules', function () {
     hookQueryGranulesWithError();
 
     it('throws an error containing the CMR error message', async function () {
-      await expect(queryGranules(operation, null, 1)).to.be.rejectedWith(CmrError, 'Failed to query CMR');
+      await expect(queryGranules(operation, null, 1, logger)).to.be.rejectedWith(CmrError, 'Failed to query CMR');
     });
 
   });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2054

## Description
When the harmony/download service is used we want the only outputs to be the granule download links. Previously it was including both the download links and OPeNDAP links as query-cmr was including both in its outputs since some service chains make use of both.

This change will allow query-cmr to provide both types of links when used as part of a service chain, but when the download service is used it will only provide the granule download links.

## Local Test Steps
1. `npm run build` in the query-cmr directory
2. Make this request that will go to the trajectory-subsetter (don't worry if you don't have it deployed - we're only looking at the links provided by the query-cmr step). http://localhost:3000/C1242267295-EEDTEST/ogc-api-coverages/1.0.0/collections/%2FBEAM0000%2Fagbd/coverage/rangeset?forceAsync=true&subset=lon(0%3A10)&subset=lat(0%3A10)&maxResults=1
3. Save the file locally and print out the contents to verify it includes both the download link and the OPeNDAP link as assets.
```
awslocal s3 cp s3://local-artifact-bucket/${job_id}/${query_cmr_work_item_id}/outputs/granule_G1242274850-EEDTEST_0000000.json .
```

4. Submit this request for the harmony/download service: http://localhost:3000/C1242267295-EEDTEST/ogc-api-coverages/1.0.0/collections/%2FBEAM0000%2Fagbd/coverage/rangeset?forceAsync=true&subset=lon(0%3A10)&subset=lat(0%3A10)&maxResults=1&serviceId=harmony%2Fdownload
5. Verify the job completes successfully and that the job status page only shows one output link (the granule download link).

You can make the same request above from the main branch or in UAT to see that previously it returned both types of links.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)