### PR TITLE
Set up Harmony Filtering Service for UAT

### DIFF
--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -30,7 +30,7 @@ https://cmr.uat.earthdata.nasa.gov:
         env:
           <<: *default-turbo-env
           STAGING_PATH: public/harmony/filtering
-    umm_s: 'S1273163940-LARC_CLOUD'
+    umm_s: 'S1273529849-LARC_CLOUD'
     capabilities:
       concatenation: false
       subsetting:

--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -20,6 +20,31 @@ x-turbo-config: &default-turbo-config
 
 https://cmr.uat.earthdata.nasa.gov:
 
+  - name: asdc/filtering
+    description: Harmony service to filter netCDF based on user specified filtering criteria (spatial, min/max, glamping, and variable).
+    data_operation_version: '0.21.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/harmony/filtering
+    umm_s: 'S1273163940-LARC_CLOUD'
+    capabilities:
+      concatenation: true
+      subsetting:
+        bbox: false
+        variable: false
+        temporal: false
+      output_formats:
+        - application/netcdf4
+      reprojection: false
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${FILTERING_IMAGE}
+
   - name: harmony/download
     description: Service that performs no processing, it only returns download links for all of the matched granules from the CMR.
     data_operation_version: '0.21.0'

--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -32,7 +32,7 @@ https://cmr.uat.earthdata.nasa.gov:
           STAGING_PATH: public/harmony/filtering
     umm_s: 'S1273163940-LARC_CLOUD'
     capabilities:
-      concatenation: true
+      concatenation: false
       subsetting:
         bbox: false
         variable: false

--- a/packages/util/env-defaults
+++ b/packages/util/env-defaults
@@ -128,7 +128,8 @@ PODAAC_NETCDF_CONVERTER_SERVICE_QUEUE_URLS='["podaac/podaac-cloud/podaac-netcdf-
 QUERY_CMR_SERVICE_QUEUE_URLS='["harmonyservices/query-cmr:stable,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/query-cmr.fifo"]'
 BATCHEE_SERVICE_QUEUE_URLS='["ghcr.io/nasa/batchee:latest,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/batchee.fifo"]'
 STITCHEE_SERVICE_QUEUE_URLS='["ghcr.io/nasa/stitchee:latest,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/stitchee.fifo"]'
-FILTERING_SERVICE_QUEUE_URLS='["ghcr.io/srizvi-nasa/harmony-filtering:latest,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/filtering.fifo"]'
+FILTERING_SERVICE_QUEUE_URLS='["harmony/filtering:latest,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/filtering.fifo"]'
+
 
 # The number of seconds to allow a pod to continue processing an active request before terminating a pod
 DEFAULT_POD_GRACE_PERIOD_SECS=14400

--- a/packages/util/env-defaults
+++ b/packages/util/env-defaults
@@ -128,6 +128,7 @@ PODAAC_NETCDF_CONVERTER_SERVICE_QUEUE_URLS='["podaac/podaac-cloud/podaac-netcdf-
 QUERY_CMR_SERVICE_QUEUE_URLS='["harmonyservices/query-cmr:stable,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/query-cmr.fifo"]'
 BATCHEE_SERVICE_QUEUE_URLS='["ghcr.io/nasa/batchee:latest,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/batchee.fifo"]'
 STITCHEE_SERVICE_QUEUE_URLS='["ghcr.io/nasa/stitchee:latest,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/stitchee.fifo"]'
+FILTERING_SERVICE_QUEUE_URLS='["ghcr.io/srizvi-nasa/harmony-filtering:latest,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/filtering.fifo"]'
 
 # The number of seconds to allow a pod to continue processing an active request before terminating a pod
 DEFAULT_POD_GRACE_PERIOD_SECS=14400

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -538,3 +538,9 @@ HARMONY_SMAP_L2_GRIDDER_REQUESTS_MEMORY=128Mi
 HARMONY_SMAP_L2_GRIDDER_LIMITS_MEMORY=8Gi
 HARMONY_SMAP_L2_GRIDDER_INVOCATION_ARGS='python -m harmony_service'
 HARMONY_SMAP_L2_GRIDDER_SERVICE_QUEUE_URLS='["ghcr.io/nasa/harmony-smap-l2-gridder:latest,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/harmony-smap-l2-gridder.fifo"]'
+
+FILTERING_IMAGE=harmony/filtering:latest
+FILTERING_REQUESTS_MEMORY=4Gi
+FILTERING_LIMITS_MEMORY=6Gi
+FILTERING_INVOCATION_ARGS='./docker-entrypoint.sh'
+FILTERING_SERVICE_QUEUE_URLS='["harmony/filtering:latest,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/filtering.fifo"]'

--- a/services/harmony/test/versions.ts
+++ b/services/harmony/test/versions.ts
@@ -23,6 +23,7 @@ describe('Versions endpoint', function () {
       it('returns a listing of all of the turbo services from services.yml', function () {
         const services = JSON.parse(this.res.text);
         expect(services.map((s) => s.name)).to.eql([
+          'asdc/filtering',
           'harmony/download',
           'ldds/subset-band-name',
           'ldds/geoloco',


### PR DESCRIPTION
Updated services-uat/env-defaults,/versions.ts for the deployment of the Filtering Service on UAT

## Jira Issue ID
HARMONY-2067

## Description
This PR defines the filtering service chain for UAT.

## Local Test Steps
The Test URL for this service:
/C1262899964-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxresults=1&forceasync=true

## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)