### PR TITLE
HARMONY-2066: Configure Giovanni averaging services to use PURE endpoint for validation

### DIFF
--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -704,6 +704,7 @@ https://cmr.uat.earthdata.nasa.gov:
           STAGING_PATH: public/gesdisc/giovanni
     umm_s: S1272947465-GES_DISC
     validate_variables: false
+    external_validation_url: https://api.giovanni.uat.earthdata.nasa.gov/authorizer
     capabilities:
       subsetting:
         bbox: true

--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -686,7 +686,7 @@ https://cmr.uat.earthdata.nasa.gov:
         is_sequential: true
       - image: !Env ${HARMONY_GDAL_ADAPTER_IMAGE}
 
-  - name: giovanni-averaging-services-adapter
+  - name: giovanni-averaging-services
     description: |
       A service to compute averaging over specified dimensions on Zarr data on a Dask cluster running in Cloud Giovanni. A time-averaged map
       will produce a GEOTIFF and an area-averaged timeseries will produce a CSV.

--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -686,7 +686,7 @@ https://cmr.uat.earthdata.nasa.gov:
         is_sequential: true
       - image: !Env ${HARMONY_GDAL_ADAPTER_IMAGE}
 
-  - name: giovanni-averaging-services
+  - name: giovanni-averaging-service
     description: |
       A service to compute averaging over specified dimensions on Zarr data on a Dask cluster running in Cloud Giovanni. A time-averaged map
       will produce a GEOTIFF and an area-averaged timeseries will produce a CSV.

--- a/services/harmony/app/backends/service-invoker.ts
+++ b/services/harmony/app/backends/service-invoker.ts
@@ -1,11 +1,10 @@
 import { RequestHandler, Response } from 'express';
-import * as services from '../models/services/index';
-import { objectStoreForProtocol } from '../util/object-store';
-import { ServiceError } from '../util/errors';
-import InvocationResult from '../models/services/invocation-result';
-import HarmonyRequest from '../models/harmony-request';
 
-import env from '../util/env';
+import HarmonyRequest from '../models/harmony-request';
+import * as services from '../models/services/index';
+import InvocationResult from '../models/services/invocation-result';
+import { ServiceError } from '../util/errors';
+import { objectStoreForProtocol } from '../util/object-store';
 
 /**
  * Copies the header with the given name from the given request to the given response
@@ -69,10 +68,6 @@ export default async function serviceInvoker(
   req: HarmonyRequest, res: Response,
 ): Promise<RequestHandler> {
   const startTime = new Date().getTime();
-
-  req.operation.user = req.user || 'anonymous';
-  req.operation.client = env.clientId;
-  req.operation.accessToken = req.accessToken || '';
   const service = services.buildService(req.context.serviceConfig, req.operation);
 
   let serviceResult = null;

--- a/services/harmony/app/middleware/external-validation.ts
+++ b/services/harmony/app/middleware/external-validation.ts
@@ -25,6 +25,11 @@ export async function externalValidation(
   // Staging location is a required field so need to include it otherwise calling
   // serialize on the operation will throw an exception
   operationCopy.stagingLocation = '';
+  // Access token is passed in the header and no reason to pass the encrypted access token
+  // which the endpoint will not be able to decrypt
+  operationCopy.accessToken = '';
+  // Validation endpoint may need to know the service chain being used
+  operationCopy.extraArgs = { service: req.context.serviceConfig.name };
   req.context.logger.warn(`CDD Serialized operation is ${operationCopy.serialize(CURRENT_SCHEMA_VERSION)}`);
 
   const startTime = new Date().getTime();

--- a/services/harmony/app/middleware/external-validation.ts
+++ b/services/harmony/app/middleware/external-validation.ts
@@ -19,7 +19,6 @@ export async function externalValidation(
   if (!url) return next();
 
   req.context.logger.info('timing.external-validation.start');
-  req.context.logger.warn(`CDD Operation is ${JSON.stringify(operation)}`);
   const operationCopy = operation.clone();
 
   // Staging location is a required field so need to include it otherwise calling
@@ -30,7 +29,6 @@ export async function externalValidation(
   operationCopy.accessToken = '';
   // Validation endpoint may need to know the service chain being used
   operationCopy.extraArgs = { service: req.context.serviceConfig.name };
-  req.context.logger.warn(`CDD Serialized operation is ${operationCopy.serialize(CURRENT_SCHEMA_VERSION)}`);
 
   const startTime = new Date().getTime();
   try {

--- a/services/harmony/app/middleware/external-validation.ts
+++ b/services/harmony/app/middleware/external-validation.ts
@@ -39,7 +39,8 @@ export async function externalValidation(
       operationCopy.serialize(CURRENT_SCHEMA_VERSION),
       {
         headers: {
-          'Authorization': `Bearer: ${req.accessToken}`,
+          'Authorization': `Bearer ${req.accessToken}`,
+          'Content-type': 'application/json',
         },
       },
     );

--- a/services/harmony/app/models/harmony-request.ts
+++ b/services/harmony/app/models/harmony-request.ts
@@ -1,6 +1,8 @@
-import { Response, NextFunction, Request } from 'express';
-import RequestContext from './request-context';
+import { NextFunction, Request, Response } from 'express';
+
+import env from '../util/env';
 import DataOperation from './data-operation';
+import RequestContext from './request-context';
 
 /**
  * Contains additional information about a request
@@ -35,5 +37,8 @@ export function addRequestContextToOperation(
     operation.message = req.context.messages.join(' ');
   }
   operation.requestStartTime = context.startTime;
+  operation.user = req.user || 'anonymous';
+  operation.client = env.clientId;
+  operation.accessToken = req.accessToken || '';
   return next();
 }

--- a/services/harmony/app/routers/router.ts
+++ b/services/harmony/app/routers/router.ts
@@ -228,7 +228,6 @@ export default function router({ USE_EDL_CLIENT_APP = 'false' }: RouterConfig): 
   result.use(logged(preServiceConcatenationHandler));
   result.use(logged(chooseService));
   result.use(logged(postServiceConcatenationHandler));
-  result.use(logged(externalValidation));
   result.use(logged(validateAndSetVariables));
   result.use(logged(validateRestrictedVariables));
 
@@ -236,6 +235,7 @@ export default function router({ USE_EDL_CLIENT_APP = 'false' }: RouterConfig): 
   result.use(logged(cmrGranuleLocator));
   result.use(logged(addRequestContextToOperation));
   result.use(logged(extendDefault));
+  result.use(logged(externalValidation));
   result.use(logged(redirectWithoutTrailingSlash));
 
   result.get('/', asyncHandler(landingPage));

--- a/services/harmony/test/middleware/external-validation.ts
+++ b/services/harmony/test/middleware/external-validation.ts
@@ -122,7 +122,7 @@ describe('external validation', function () {
       it('sets the Authorization header on the request to the external validator', async function () {
         const nextStub = stub();
         await externalValidation(this.reqWithValidation, this.res, nextStub);
-        expect(options.headers).to.eql({ 'Authorization': `Bearer: ${this.reqWithValidation.accessToken}` });
+        expect(options.headers).to.eql({ 'Authorization': `Bearer ${this.reqWithValidation.accessToken}` });
       });
 
     });

--- a/services/harmony/test/middleware/external-validation.ts
+++ b/services/harmony/test/middleware/external-validation.ts
@@ -122,7 +122,10 @@ describe('external validation', function () {
       it('sets the Authorization header on the request to the external validator', async function () {
         const nextStub = stub();
         await externalValidation(this.reqWithValidation, this.res, nextStub);
-        expect(options.headers).to.eql({ 'Authorization': `Bearer ${this.reqWithValidation.accessToken}` });
+        expect(options.headers).to.eql({
+          'Authorization': `Bearer ${this.reqWithValidation.accessToken}`,
+          'Content-type': 'application/json',
+        });
       });
 
     });

--- a/services/harmony/test/middleware/external-validation.ts
+++ b/services/harmony/test/middleware/external-validation.ts
@@ -3,9 +3,10 @@ import { expect } from 'chai';
 import { Response } from 'express';
 import { before, describe, it } from 'mocha';
 import sinon, { SinonStub, spy, stub } from 'sinon';
+import { v4 as uuid } from 'uuid';
 
 import { externalValidation } from '../../app/middleware/external-validation';
-import DataOperation from '../../app/models/data-operation';
+import DataOperation, { CURRENT_SCHEMA_VERSION } from '../../app/models/data-operation';
 import HarmonyRequest from '../../app/models/harmony-request';
 import { getEndUserErrorMessage, getHttpStatusCode } from '../../app/util/errors';
 import logger from '../../app/util/log';
@@ -23,6 +24,7 @@ describe('external validation', function () {
     const shortName = 'harmony_example';
     const versionId = '1';
     const operation = new DataOperation();
+    Object.assign(operation, { user: 'foo', client: 'harmony-test', requestId: uuid() });
     operation.addSource(collectionId, shortName, versionId);
 
     this.reqWithValidation = {
@@ -57,6 +59,12 @@ describe('external validation', function () {
         logger,
       },
     } as HarmonyRequest;
+
+    const expectedOperation = operation.clone();
+    expectedOperation.stagingLocation = '';
+    expectedOperation.accessToken = '';
+    expectedOperation.extraArgs = { service: 'external-valiation-service' };
+    this.expectedOperationJson = expectedOperation.serialize(CURRENT_SCHEMA_VERSION);
 
     this.res = mockResponse();
     this.next = sinon.stub().returns;
@@ -108,7 +116,7 @@ describe('external validation', function () {
       it('sends the operation to the external validator', async function () {
         const nextStub = stub();
         await externalValidation(this.reqWithValidation, this.res, nextStub);
-        expect(body).to.eql(this.reqWithValidation.operation);
+        expect(body).to.eql(this.expectedOperationJson);
       });
 
       it('sets the Authorization header on the request to the external validator', async function () {

--- a/services/harmony/test/versions.ts
+++ b/services/harmony/test/versions.ts
@@ -44,7 +44,7 @@ describe('Versions endpoint', function () {
           'asf/opera-rtc-s1-browse',
           'net2cog',
           'nasa/harmony-gdal-adapter',
-          'giovanni-averaging-services-adapter',
+          'giovanni-averaging-services',
           'sds/trajectory-susbetter-smap-l2-regridder',
           'harmony/netcdf-to-zarr',
           'harmony/podaac-l2-subsetter-netcdf-to-zarr',

--- a/services/harmony/test/versions.ts
+++ b/services/harmony/test/versions.ts
@@ -44,7 +44,7 @@ describe('Versions endpoint', function () {
           'asf/opera-rtc-s1-browse',
           'net2cog',
           'nasa/harmony-gdal-adapter',
-          'giovanni-averaging-services',
+          'giovanni-averaging-service',
           'sds/trajectory-susbetter-smap-l2-regridder',
           'harmony/netcdf-to-zarr',
           'harmony/podaac-l2-subsetter-netcdf-to-zarr',


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2066

## Description
Configures the Giovanni averaging services to use PURE external endpoint for validation.

## Local Test Steps
Test with http://localhost:3000/C1215802935-GES_DISC/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?format=image%2Ftiff&subset=time(%222009-01-01T00%3A00%3A00%22%3A%222009-01-05T10%3A31%3A12%22)&variable=M2T1NXAER_5_12_4_BCCMASS&subset=lat(-50%3A-48)&subset=lon(-90%3A-87)&average=time

and verify from the logs that the external validation endpoint is called (search for `timing.external-validation.start` and `timing.external-validation.end`).

To simulate a failure change the code to make the bearer token authorization header invalid. Change the code in `external-validation.ts` line 40 to add a colon after Bearer which is not valid:
`'Authorization': `Bearer: ${req.accessToken}`,`

Verify that a 401 is returned to the user with the appropriate error code.

I also deployed and tested in a sandbox environment.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)