### PR TITLE
HARMONY-2098: Treat NA SizeUnits as MB 

### DIFF
--- a/services/query-cmr/app/query.ts
+++ b/services/query-cmr/app/query.ts
@@ -33,6 +33,9 @@ export function getGranuleSizeInBytes(
         granuleSizeInBytes += info.Size * 1024;
         break;
       case 'MB':
+      case 'NA':
+        // Historically ECHO and CMR metadata formats always reported sizes in MB so when
+        // the unit is not explicitly set we assume MB
         granuleSizeInBytes += info.Size * 1024 * 1024;
         break;
       case 'GB':

--- a/services/query-cmr/test/query.ts
+++ b/services/query-cmr/test/query.ts
@@ -41,8 +41,8 @@ describe('#getGranuleSizeInBytes', () => {
     expect(getGranuleSizeInBytes(logger, archiveInfo)).to.equal(expectedSize);
   });
 
-  it('should treat an entry with an unknown SizeUnit as 0', () => {
-    expect(getGranuleSizeInBytes(logger, [{ Size: 10, SizeUnit: 'NA' }])).to.equal(0);
+  it('should treat an entry with an unknown SizeUnit as MB', () => {
+    expect(getGranuleSizeInBytes(logger, [{ Size: 10, SizeUnit: 'NA' }])).to.equal(10 * 1024 * 1024);
   });
 
   it('should use SizeInBytes when all fields are present', () => {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2098

## Description
We were running into issues for many of the NSIDC datasets where the query-cmr task was not providing a size and so the work item updates would take several minutes when a job had more than a few hundred granules often resulting in timeouts and retries being triggered and blocking other updates from other jobs. The root cause is that the UMM granule metadata has "NA" for the SizeUnit. We found the CMR JSON endpoint treats the value as MB in this case which is the correct behavior for all of the NSIDC datasets and makes since because historically granule metadata was ingested in ECHO10 format which treated all sizes as MB.

The change in this PR causes the work item update to take seconds now instead of many minutes.

## Local Test Steps
Build the query-cmr docker image.

I'm not sure if there are examples in UAT, but if you point your local harmony environment to production you can test and verify with http://localhost:3000/C2670138092-NSIDC_CPRD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lon(-1.7058969999999802%3A2.7683910000000047)&subset=lat(42.00446399999998%3A43.25712700000002)&label=intermittent-failures&skipPreview=true

Make sure that you do not see warnings in the query-cmr logs about being unable to determine the file size and make sure that the query-cmr task finishes and populates all 892 granules in well under the 7+ minutes it was taking before. You can cancel the request after query-cmr runs.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)