### PR TITLE
HARMONY-2023: Include parameters for tracking S3 access - added both A-provider and A-api-request-uuid

### DIFF
--- a/services/harmony/app/frontends/service-results.ts
+++ b/services/harmony/app/frontends/service-results.ts
@@ -56,12 +56,12 @@ export function createPublicPermalink(
 }
 
 /**
- * Wrapper function of getUserIdRequest to be set to fetchMethod of LRUCache.
+ * Wrapper function of getProviderIdForJobId to be set to fetchMethod of LRUCache.
  *
- * @param token - EDL bearer token
+ * @param jobId - the job identifier
  * @param _sv - stale value parameter of LRUCache fetchMethod, unused here
  * @param options - options parameter of LRUCache fetchMethod, carries the request context
- * @returns Promise of user name associated with the EDL token
+ * @returns resolves to the provider id for the job
  */
 async function fetchProviderId(jobId: string, _sv: string, { context }): Promise<string> {
   context.logger.info(`Fetching provider id for job id ${jobId}`);

--- a/services/harmony/app/frontends/service-results.ts
+++ b/services/harmony/app/frontends/service-results.ts
@@ -1,7 +1,13 @@
+import { NextFunction, Response } from 'express';
+import { LRUCache } from 'lru-cache';
 import { URL } from 'url';
-import { NextFunction } from 'express';
+
+import HarmonyRequest from '../models/harmony-request';
+import { Job } from '../models/job';
+import db from '../util/db';
+import env from '../util/env';
+import { NotFoundError, RequestValidationError } from '../util/errors';
 import { objectStoreForProtocol } from '../util/object-store';
-import { NotFoundError } from '../util/errors';
 
 /**
  * Given a URL that is not necessarily public-facing, produces a URL to that data
@@ -50,6 +56,27 @@ export function createPublicPermalink(
 }
 
 /**
+ * Wrapper function of getUserIdRequest to be set to fetchMethod of LRUCache.
+ *
+ * @param token - EDL bearer token
+ * @param _sv - stale value parameter of LRUCache fetchMethod, unused here
+ * @param options - options parameter of LRUCache fetchMethod, carries the request context
+ * @returns Promise of user name associated with the EDL token
+ */
+async function fetchProviderId(jobId: string, _sv: string, { context }): Promise<string> {
+  context.logger.info(`Fetching provider id for job id ${jobId}`);
+  return Job.getProviderIdForJobId(db, jobId);
+}
+
+// In memory cache for Job ID to provider Id
+export const providerIdCache = new LRUCache({
+  ttl: env.providerCacheTtl,
+  maxSize: env.providerCacheSize,
+  sizeCalculation: (value: string): number => value.length,
+  fetchMethod: fetchProviderId,
+});
+
+/**
  * Express.js handler that returns redirects to pre-signed URLs
  *
  * @param req - The request sent by the client
@@ -58,15 +85,27 @@ export function createPublicPermalink(
  * @returns Resolves when the request is complete
  * @throws NotFoundError - if the given URL cannot be signed, typically due to permissions
  */
-export async function getServiceResult(req, res, next: NextFunction): Promise<void> {
-  const { bucket, key } = req.params;
+export async function getServiceResult(
+  req: HarmonyRequest, res: Response, next: NextFunction,
+): Promise<void> {
+  const { bucket, jobId, workItemId, remainingPath } = req.params;
+
+  if (!bucket || !jobId || !workItemId || !remainingPath) {
+    req.context.logger.error('Invalid path to service result');
+    next(new RequestValidationError('Invalid path to service result'));
+  }
+
+  const key = `public/${jobId}/${workItemId}/${remainingPath}`;
   const url = `s3://${bucket}/${key}`;
+
+  const provider = await providerIdCache.fetch(jobId, { context: req.context });
 
   const objectStore = objectStoreForProtocol('s3');
   if (objectStore) {
     try {
-      req.context.logger.info(`Signing ${url}`);
-      const result = await objectStore.signGetObject(url, { 'A-userid': req.user });
+      const customParams = { 'A-userid': req.user, 'A-provider': provider?.toUpperCase(), 'A-api-request-uuid': jobId };
+      req.context.logger.info(`Signing ${url} with params ${JSON.stringify(customParams)}`);
+      const result = await objectStore.signGetObject(url, customParams);
       // Direct clients to reuse the redirect for 10 minutes before asking for a new one
       res.append('Cache-Control', 'private, max-age=600');
       res.redirect(307, result);

--- a/services/harmony/app/middleware/error-handler.ts
+++ b/services/harmony/app/middleware/error-handler.ts
@@ -1,15 +1,16 @@
-import mustache from 'mustache';
+import { NextFunction, Response } from 'express';
 import fs from 'fs';
+import mustache from 'mustache';
 import path from 'path';
-import { Response, NextFunction } from 'express';
-import {
-  HttpError, RequestValidationError, buildJsonErrorResponse, getHttpStatusCode,
-  getEndUserErrorMessage, getCodeForError,
-} from '../util/errors';
+
 import HarmonyRequest from '../models/harmony-request';
+import {
+  buildJsonErrorResponse, getCodeForError, getEndUserErrorMessage, getHttpStatusCode, HttpError,
+  RequestValidationError,
+} from '../util/errors';
 
 const errorTemplate = fs.readFileSync(path.join(__dirname, '../views/server-error.mustache.html'), { encoding: 'utf8' });
-const jsonErrorRoutesRegex = /jobs|labels|capabilities|ogc-api-coverages|ogc-api-edr|service-deployment(?:s-state)?|service-image-tag|stac|metrics|health|configuration|workflow-ui\/.*\/(?:links|logs|retry)/;
+const jsonErrorRoutesRegex = /jobs|labels|capabilities|ogc-api-coverages|ogc-api-edr|service-results|service-deployment(?:s-state)?|service-image-tag|stac|metrics|health|configuration|workflow-ui\/.*\/(?:links|logs|retry)/;
 
 /**
  * Returns true if the provided error should be returned as JSON.

--- a/services/harmony/app/models/job.ts
+++ b/services/harmony/app/models/job.ts
@@ -687,6 +687,21 @@ export class Job extends DBRecord implements JobRecord {
   }
 
   /**
+  * Returns the provider id for the given jobID
+  *
+  * @param tx - the database transaction to use for querying
+  * @param jobID - the jobID for the job that should be retrieved
+  * @returns the provider id for the job
+  */
+  static async getProviderIdForJobId(tx: Transaction, jobID: string): Promise<string> {
+    const results = await tx(Job.table)
+      .select('provider_id')
+      .where({ jobID });
+
+    return results[0]?.provider_id;
+  }
+
+  /**
    * Returns the job matching the given username and job ID, or null if
    * no such job exists.
    *

--- a/services/harmony/app/routers/router.ts
+++ b/services/harmony/app/routers/router.ts
@@ -208,7 +208,7 @@ export default function router({ USE_EDL_CLIENT_APP = 'false' }: RouterConfig): 
   }
 
   // Routes and middleware not dealing with service requests
-  result.get('/service-results/:bucket/:key(*)', asyncHandler(getServiceResult));
+  result.get('/service-results/:bucket/public/:jobId/:workItemId/:remainingPath(*)', asyncHandler(getServiceResult));
 
   // Routes and middleware for handling service requests
   result.use(logged(cmrCollectionReader));

--- a/services/harmony/app/util/env.ts
+++ b/services/harmony/app/util/env.ts
@@ -115,6 +115,14 @@ class HarmonyServerEnv extends HarmonyEnv {
 
   @IsInt()
   @Min(1)
+  providerCacheSize: number;
+
+  @IsInt()
+  @Min(1)
+  providerCacheTtl: number;
+
+  @IsInt()
+  @Min(1)
   edlCacheSize: number;
 
   @IsInt()

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -151,6 +151,12 @@ LABELS_FORBID_LIST=this_is_a_forbidden_label
 # The max number of labels to retrieve to populate label filter auto-complete
 LABEL_FILTER_COMPLETION_COUNT=10
 
+# Maximum size (in bytes) of the provider cache, 5MB
+PROVIDER_CACHE_SIZE=5000000
+
+# Provider Cache TTL in milliseconds, 1 hour
+PROVIDER_CACHE_TTL=3600000
+
 #############################################################################
 #                        OAuth 2 (Earthdata Login)                          #
 #                                                                           #

--- a/services/harmony/test/helpers/job-status.ts
+++ b/services/harmony/test/helpers/job-status.ts
@@ -1,8 +1,9 @@
-import { it } from 'mocha';
 import { expect } from 'chai';
+import { it } from 'mocha';
+
 import { Job } from '../../app/models/job';
-import { hookUrl } from './hooks';
 import env from '../../app/util/env';
+import { hookUrl } from './hooks';
 
 /**
  * Provides a parameterized `describe` blocks that tests expected format of data links.
@@ -62,7 +63,7 @@ export function itProvidesAWorkingHttpUrl(user: string): void {
     const job = new Job(JSON.parse(this.res.text));
     const jobOutputLinks = job.getRelatedLinks('data');
     expect(jobOutputLinks[0].href).to.match(/^http/);
-    expect(jobOutputLinks[0].href).to.have.string('/service-results/example-bucket/public/example/path.tif');
+    expect(jobOutputLinks[0].href).to.have.string('/service-results/example-bucket/public/example-job-id/work-item-id/path.tif');
   });
 
   describe('loading the provided Harmony HTTP URL', function () {
@@ -73,7 +74,7 @@ export function itProvidesAWorkingHttpUrl(user: string): void {
 
     it('temporarily redirects to a presigned URL for the data', function () {
       expect(this.res.statusCode).to.equal(307);
-      expect(this.res.headers.location).to.equal('https://example-bucket/public/example/path.tif?A-userid=jdoe1');
+      expect(this.res.headers.location).to.have.string('https://example-bucket/public/example-job-id/work-item-id/path.tif');
     });
   });
 }

--- a/services/harmony/test/jobs/job-sharing.ts
+++ b/services/harmony/test/jobs/job-sharing.ts
@@ -1,10 +1,11 @@
 import { expect } from 'chai';
-import { describe, it, before } from 'mocha';
+import { before, describe, it } from 'mocha';
+
 import { JobStatus } from '../../app/models/job';
+import { hookTransaction } from '../helpers/db';
+import { buildJob, hookJobStatus } from '../helpers/jobs';
 import hookServersStartStop from '../helpers/servers';
 import { hookStacCatalog, hookStacItem } from '../helpers/stac';
-import { hookTransaction } from '../helpers/db';
-import { hookJobStatus, buildJob } from '../helpers/jobs';
 
 const jobOwner = 'joe';
 const notJobOwner = 'jill'; // jill wants to access the results of joe's jobs
@@ -17,7 +18,7 @@ const collectionWithEULANonexistent = 'C1234088182-EEDTEST';
 const baseJobProperties = {
   numInputGranules: 5,
   links: [{
-    href: 's3://example-bucket/public/example/path1.tif',
+    href: 's3://example-bucket/public/example-job-id/work-item-id/path1.tif',
     type: 'image/tiff',
     rel: 'data',
     bbox: [-10, -10, 10, 10],
@@ -27,7 +28,7 @@ const baseJobProperties = {
     },
   },
   {
-    href: 's3://example-bucket/public/example/path2.tif',
+    href: 's3://example-bucket/public/example-job-id/work-item-id/path2.tif',
     type: 'image/tiff',
     rel: 'data',
     bbox: [-10, -10, 10, 10],

--- a/services/harmony/test/jobs/jobs-status.ts
+++ b/services/harmony/test/jobs/jobs-status.ts
@@ -702,7 +702,7 @@ describe('Individual job status route', function () {
     });
 
     describe('when a job has provided an S3 URL as a result', function () {
-      const s3Uri = 's3://example-bucket/public/example/path.tif';
+      const s3Uri = 's3://example-bucket/public/example-job-id/work-item-id/path.tif';
       StubService.hook({ params: { status: 'successful' } });
       hookRangesetRequest(version, collection, variableName, { query, username: 'jdoe1' });
       before(async function () {
@@ -726,7 +726,7 @@ describe('Individual job status route', function () {
             const job = new Job(JSON.parse(this.res.text));
             const jobOutputLinks = job.getRelatedLinks('data');
             expect(jobOutputLinks[0].href).to.match(/^s3/);
-            expect(jobOutputLinks[0].href).to.have.string('s3://example-bucket/public/example/path.tif');
+            expect(jobOutputLinks[0].href).to.have.string('s3://example-bucket/public/example-job-id/work-item-id/path.tif');
           });
         });
 
@@ -759,7 +759,7 @@ describe('Individual job status route', function () {
             const job = new Job(JSON.parse(this.res.text));
             const jobOutputLinks = job.getRelatedLinks('data');
             expect(jobOutputLinks[0].href).to.match(/^s3/);
-            expect(jobOutputLinks[0].href).to.have.string('s3://example-bucket/public/example/path.tif');
+            expect(jobOutputLinks[0].href).to.have.string('s3://example-bucket/public/example-job-id/work-item-id/path.tif');
           });
         });
       });
@@ -786,7 +786,7 @@ describe('Individual job status route', function () {
 
     // HARMONY-770 AC 9
     describe('when a job has provided an S3 URL result with application/x-zarr mime type', function () {
-      const s3Uri = 's3://example-bucket/public/example/path.tif';
+      const s3Uri = 's3://example-bucket/public/example-job-id/work-item-id/path.tif';
       StubService.hook({ params: { status: 'successful' } });
       hookRangesetRequest(version, collection, variableName, { username: 'jdoe1' });
       before(async function () {

--- a/services/harmony/test/service-results.ts
+++ b/services/harmony/test/service-results.ts
@@ -1,10 +1,11 @@
 import { expect } from 'chai';
-import { stub } from 'sinon';
 import { describe, it } from 'mocha';
-import { createPublicPermalink } from '../app/frontends/service-results';
-import hookServersStartStop from './helpers/servers';
-import { hookUrl } from './helpers/hooks';
+import sinon, { stub } from 'sinon';
+
+import { createPublicPermalink, providerIdCache } from '../app/frontends/service-results';
 import { FileStore } from '../app/util/object-store/file-store';
+import { hookUrl } from './helpers/hooks';
+import hookServersStartStop from './helpers/servers';
 
 describe('service-results', function () {
   hookServersStartStop({ USE_EDL_CLIENT_APP: true });
@@ -64,14 +65,32 @@ describe('service-results', function () {
 
   describe('getServiceResult', function () {
     describe('when given a valid bucket and key', function () {
-      hookUrl('/service-results/some-bucket/public/some/path.tif', 'jdoe');
-      it("passes the user's Earthdata Login username to the signing function for tracking", function () {
-        expect(this.res.headers.location).to.include('?A-userid=jdoe');
+      let providerIdCacheStub;
+
+      before(function () {
+        providerIdCacheStub = sinon.stub(providerIdCache, 'fetch').resolves('eedtest');
+      });
+
+      after(function () {
+        providerIdCacheStub.restore();
+      });
+
+      hookUrl('/service-results/some-bucket/public/some-job-id/some-work-item-id/some-path.tif', 'jdoe');
+      it('passes the user\'s Earthdata Login username to the signing function for tracking', function () {
+        expect(this.res.headers.location).to.include('A-userid=jdoe');
       });
 
       it('redirects temporarily to a presigned URL', function () {
         expect(this.res.statusCode).to.equal(307);
-        expect(this.res.headers.location).to.include('https://some-bucket/public/some/path.tif');
+        expect(this.res.headers.location).to.include('some-bucket/public/some-job-id/some-work-item-id/some-path.tif');
+      });
+
+      it('includes an api_request_id field', function () {
+        expect(this.res.headers.location).to.include('A-api-request-uuid=some-job-id');
+      });
+
+      it('includes a provider field', function () {
+        expect(this.res.headers.location).to.include('A-provider=EEDTEST');
       });
 
       it('sets a cache-control header to indicate the redirect should be reused', function () {
@@ -84,13 +103,27 @@ describe('service-results', function () {
       before(function () {
         stubObject = stub(FileStore.prototype, 'signGetObject').throws();
       });
-      hookUrl('/service-results/some-bucket/public/some/path.tif', 'jdoe');
+      hookUrl('/service-results/some-bucket/public/some-job-id/some-work-item-id/some-path.tif', 'jdoe');
       after(function () {
         stubObject.restore();
       });
 
       it('returns a 404 response', function () {
         expect(this.res.statusCode).to.equal(404);
+      });
+    });
+  });
+
+  describe('when given a bad service-results URL', function () {
+    hookUrl('/service-results/some-bucket/public/some-invalid-path.tif', 'jdoe');
+    it('returns a 404 error', function () {
+      expect(this.res.statusCode).to.equal(404);
+    });
+
+    it('includes the correct error message', function () {
+      expect(JSON.parse(this.res.text)).to.eql({
+        code: 'harmony.NotFoundError',
+        description: 'Error: The requested page was not found.',
       });
     });
   });

--- a/services/harmony/test/stac/stac-item.ts
+++ b/services/harmony/test/stac/stac-item.ts
@@ -1,12 +1,13 @@
 import { expect } from 'chai';
-import { describe, it, before } from 'mocha';
+import { before, describe, it } from 'mocha';
 import { v4 as uuid } from 'uuid';
-import itReturnsTheExpectedStacResponse from '../helpers/stac-item';
+
+import { JobStatus } from '../../app/models/job';
+import { hookTransaction } from '../helpers/db';
 import { buildJob } from '../helpers/jobs';
 import hookServersStartStop from '../helpers/servers';
-import { hookTransaction } from '../helpers/db';
 import { hookStacItem } from '../helpers/stac';
-import { JobStatus } from '../../app/models/job';
+import itReturnsTheExpectedStacResponse from '../helpers/stac-item';
 
 const runningJob = buildJob({
   username: 'joe',
@@ -34,7 +35,7 @@ const completedJob = buildJob({
   progress: 100,
   numInputGranules: 5,
   links: [{
-    href: 's3://example-bucket/public/example/path1.tif',
+    href: 's3://example-bucket/public/example-job-id/work-item-id/path1.tif',
     type: 'image/tiff',
     rel: 'data',
     bbox: [-10, -10, 10, 10],
@@ -44,7 +45,7 @@ const completedJob = buildJob({
     },
   },
   {
-    href: 's3://example-bucket/public/example/path2.tif',
+    href: 's3://example-bucket/public/example-job-id/work-item-id/path2.tif',
     type: 'image/tiff',
     rel: 'data',
     bbox: [-10, -10, 10, 10],
@@ -64,7 +65,7 @@ const completedJobWithDestinationUrl = buildJob({
   progress: 100,
   numInputGranules: 1,
   links: [{
-    href: 's3://example-bucket/public/example/path1.tif',
+    href: 's3://example-bucket/public/example-job-id/work-item-id/path1.tif',
     type: 'image/tiff',
     rel: 'data',
     bbox: [-10, -10, 10, 10],
@@ -74,7 +75,7 @@ const completedJobWithDestinationUrl = buildJob({
     },
   },
   {
-    href: 's3://example-bucket/public/example/path2.tif',
+    href: 's3://example-bucket/public/example-job-id/work-item-id/path2.tif',
     type: 'image/tiff',
     rel: 'data',
     bbox: [-10, -10, 10, 10],


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2023

## Description
Added two more parameters for tracking S3 access from pre-signed S3 URLs: A-provider and A-api-request-uuid.

Figuring out the provider for an output required parsing the URL for the job ID and then querying for the provider for that job. A common use case will be to download all of the outputs for a job, so I added a cache to only look up the provider id once for the output for a single job.

## Local Test Steps
1. Submit a request locally which completes successfully - e.g. http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&outputCrs=EPSG%3A31975&format=image%2Fpng&maxResults=1&subset=time(%222002-09-15T00%3A00%3A00.000Z%22%3A%222022-09-25T00%3A00%3A00Z%22)

2. Once it completes get the download link from the job status page.
3. Tail the harmony logs
4. `curl -O -H "Authorization: Bearer $UAT_BEARER" "<output_url>"`
5. Verify from the harmony logs that the A-provider and A-api-request-uuid were set correctly
6. Verify that you see a log message: `Fetching provider id for job id <job id>`
7. Issue the curl again and verify that it does not log `Fetching provider id for job id <job id>` again, and that the A-provider and A-api-request-uuid are still set correctly.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)