### PR TITLE
HARMONY-2093: Add exponential backoff on servie-runner retries

### DIFF
--- a/services/service-runner/app/service/service-runner.ts
+++ b/services/service-runner/app/service/service-runner.ts
@@ -320,7 +320,7 @@ export async function runServiceFromPull(
 
     let retryCount = 0;
     const maxRetries = 5;
-    let retryDelay = 3_000; // time in ms to wait before retrying
+    let retryDelay = 5_000; // time in ms to wait before retrying
     const retryDelayMultiplier = 2.0; // used to increase delay each retry
 
     while (retryCount < maxRetries) {

--- a/services/service-runner/app/service/service-runner.ts
+++ b/services/service-runner/app/service/service-runner.ts
@@ -11,9 +11,9 @@ import {
 } from '../../../harmony/app/models/work-item-interface';
 import logger from '../../../harmony/app/util/log';
 import { objectStoreForProtocol } from '../../../harmony/app/util/object-store';
+import sleep from '../../../harmony/app/util/sleep';
 import { resolve as resolveUrl } from '../../../harmony/app/util/url';
 import env from '../util/env';
-import { waitForContainerToStart } from '../util/k8s';
 
 const kc = new k8s.KubeConfig();
 kc.loadFromDefault();
@@ -320,6 +320,8 @@ export async function runServiceFromPull(
 
     let retryCount = 0;
     const maxRetries = 5;
+    let retryDelay = 3_000; // time in ms to wait before retrying
+    const retryDelayMultiplier = 2.0; // used to increase delay each retry
 
     while (retryCount < maxRetries) {
       const result: ServiceResponse = await new Promise<ServiceResponse>((resolve) => {
@@ -406,7 +408,8 @@ export async function runServiceFromPull(
       if ('retryable' in result) {
         retryCount += 1;
         workItemLogger.debug(`Retryable error encountered (attempt ${retryCount} of ${maxRetries})`);
-        await waitForContainerToStart('worker');
+        await sleep(retryDelay);
+        retryDelay = retryDelayMultiplier * retryDelay;
       } else {
         return result;
       }


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2093

## Description
Add exponential backoff to service-runner retries to help with errors connecting to the worker. Previously we were checking the container status to see if it was ready before retrying, but possibly due to this bug (https://github.com/kubernetes/kubernetes/issues/106896) the container status was reporting `ready` very quickly and subsequent retries would fail quickly. This change simply waits an increasing amount before retrying. 

## Local Test Steps
There is no easy way to force an error like the ones we were seeing in production. We were unable to reproduce it in the sandbox. To test, build the service-runner image then restart your local deployment. Then run some queries of various sizes and make sure they complete.

## PR Acceptance Checklist
* [?] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)