### PR TITLE
HARMONY-2041: Use Mac docker images for harmony and core services when running on arm64 Macs

### DIFF
--- a/.github/workflows/publish-mac.yml
+++ b/.github/workflows/publish-mac.yml
@@ -1,0 +1,38 @@
+name: Publish Mac service images to DockerHub
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - main
+
+env:
+  DOCKER_USER: bilts
+
+jobs:
+  push:
+    runs-on: macos-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.14.x
+      - name: Log into registry
+        run: echo "${{ secrets.DOCKERHUB }}" | docker login -u "${DOCKER_USER}" --password-stdin
+      - name: Setup Node
+        run: |
+          npm install
+      - name: Build and publish images
+        run: |
+          # For tagged versions, translate e.g. "refs/tags/v1.2.3" -> "1.2.3"
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # build and publish images for all services
+          VERSION="${VERSION}-arm64" lerna run build
+          VERSION="${VERSION}-arm64" lerna run publish
+

--- a/bin/bootstrap-harmony
+++ b/bin/bootstrap-harmony
@@ -35,6 +35,32 @@ fi
 export LOCAL_DEV
 export KUBE_CONTEXT
 
+# Use the arm64 version of the stable images if on an arm64 machine unless an explicit image has been set
+if [[ $(uname -m) == 'arm64' ]]; then
+  echo "We appear to be running on an arm64 platform"
+  if [[ -z "$HARMONY_IMAGE" ]]; then
+    export HARMONY_IMAGE=harmonyservices/harmony:stable-arm64
+  fi
+  if [[ -z "$SERVICE_RUNNER_IMAGE" ]]; then
+    export SERVICE_RUNNER_IMAGE=harmonyservices/service-runner:stable-arm64
+  fi
+  if [[ -z "$QUERY_CMR_IMAGE" ]]; then
+    export QUERY_CMR_IMAGE=harmonyservices/query-cmr:stable-arm64
+  fi
+  if [[ -z "$WORK_ITEM_SCHEDULER_IMAGE" ]]; then
+    export WORK_ITEM_SCHEDULER_IMAGE=harmonyservices/work-scheduler:stable-arm64
+  fi
+  if [[ -z "$WORK_ITEM_UPDATER_IMAGE" ]]; then
+    export WORK_ITEM_UPDATER_IMAGE=harmonyservices/work-updater:stable-arm64
+  fi
+  if [[ -z "$WORK_FAILER_IMAGE" ]]; then
+    export WORK_FAILER_IMAGE=harmonyservices/work-failer:stable-arm64
+  fi
+  if [[ -z "$CRON_SERVICE_IMAGE" ]]; then
+    export CRON_SERVICE_IMAGE=harmonyservices/cron-service:stable-arm64
+  fi
+fi
+
 # run localstack, postgresql, and harmony in kubernetes
 ./bin/start-all
 

--- a/bin/update-harmony
+++ b/bin/update-harmony
@@ -87,8 +87,34 @@ while read -r line; do
   all_images+=( "$line" )
 done < <(sort <(echo "${referenced_images[*]}") <(echo "${pulled_images[*]}") | uniq -d)
 
-# always reload the harmony image, query-cmr, work-updater, work-scheudler, and service-runner images
-all_images+=( "$HARMONY_IMAGE" "$QUERY_CMR_IMAGE" "$SERVICE_RUNNER_IMAGE" "$WORK_ITEM_UPDATER_IMAGE" "$WORK_ITEM_SCHEDULER_IMAGE" )
+# Use the arm64 version of the stable images if on an arm64 machine unless an explicit image has been set
+if [[ $(uname -m) == 'arm64' ]]; then
+  echo "We appear to be running on an arm64 platform"
+  if [[ -z "$HARMONY_IMAGE" ]]; then
+    export HARMONY_IMAGE=harmonyservices/harmony:stable-arm64
+  fi
+  if [[ -z "$SERVICE_RUNNER_IMAGE" ]]; then
+    export SERVICE_RUNNER_IMAGE=harmonyservices/service-runner:stable-arm64
+  fi
+  if [[ -z "$QUERY_CMR_IMAGE" ]]; then
+    export QUERY_CMR_IMAGE=harmonyservices/query-cmr:stable-arm64
+  fi
+  if [[ -z "$WORK_ITEM_SCHEDULER_IMAGE" ]]; then
+    export WORK_ITEM_SCHEDULER_IMAGE=harmonyservices/work-scheduler:stable-arm64
+  fi
+  if [[ -z "$WORK_ITEM_UPDATER_IMAGE" ]]; then
+    export WORK_ITEM_UPDATER_IMAGE=harmonyservices/work-updater:stable-arm64
+  fi
+  if [[ -z "$WORK_FAILER_IMAGE" ]]; then
+    export WORK_FAILER_IMAGE=harmonyservices/work-failer:stable-arm64
+  fi
+  if [[ -z "$CRON_SERVICE_IMAGE" ]]; then
+    export CRON_SERVICE_IMAGE=harmonyservices/cron-service:stable-arm64
+  fi
+fi
+
+# always reload the harmony image, query-cmr, service-runner, and all core service images
+all_images+=( "$HARMONY_IMAGE" "$QUERY_CMR_IMAGE" "$SERVICE_RUNNER_IMAGE" "$WORK_ITEM_UPDATER_IMAGE" "$WORK_ITEM_SCHEDULER_IMAGE" "$WORK_FAILER_IMAGE" "$CRON_SERVICE_IMAGE" )
 
 for image in ${all_images[@]}; do
   echo "${image}"


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2041

## Description
Builds and tags Mac docker images when the main branch is tagged and pushes them to dockerhub. Uses the images when running Harmony in a Box on an arm64 Mac unless service images have been overwritten through environment variables.

## Local Test Steps
There is a bit of a chicken/egg thing here. These changes need to be merged so that we can build the images, but we can't fully test the changes to `bootstrap-harmony` and `updated-harmony` until we have arm64 images tagged with `stable-arm64` in dockerhub.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)