### PR TITLE
HARMONY-2023: Fix the /service-results route so that it can continue to serve test data from buckets in the harmony UAT account.

### DIFF
--- a/services/harmony/app/models/job.ts
+++ b/services/harmony/app/models/job.ts
@@ -1225,8 +1225,6 @@ export class Job extends DBRecord implements JobRecord {
 
     return result;
   }
-
-
 }
 
 interface JobWithLabels extends Job {

--- a/services/harmony/app/routers/router.ts
+++ b/services/harmony/app/routers/router.ts
@@ -209,6 +209,7 @@ export default function router({ USE_EDL_CLIENT_APP = 'false' }: RouterConfig): 
 
   // Routes and middleware not dealing with service requests
   result.get('/service-results/:bucket/public/:jobId/:workItemId/:remainingPath(*)', asyncHandler(getServiceResult));
+  result.get('/service-results/:bucket/:remainingPath(*)', asyncHandler(getServiceResult));
 
   // Routes and middleware for handling service requests
   result.use(logged(cmrCollectionReader));


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2023

## Description
Fix the /service-results route so that it can continue to serve test data from buckets in the harmony UAT account.

## Local Test Steps
You can continue to sanity check that the /service-results endpoint for accessing work outputs includes all 3 fields - A-userid, A-api-request-uuid, and A-provider:
```
{"A-userid":"cdurbin","A-api-request-uuid":"f45c4a3b-0978-4e37-b33f-5fa787b76f48","A-provider":"EEDTEST"}
```

We cannot test that the harmony test buckets continue to serve results until we've deployed this change to UAT. We do verify the behavior in the tests (prior to this change the test would fail with a 404 when trying that bucket route).

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)