### PR TITLE
HARMONY-2104: Log the successful completion of work item updates including the service id

### DIFF
--- a/services/harmony/app/backends/workflow-orchestration/workflow-orchestration.ts
+++ b/services/harmony/app/backends/workflow-orchestration/workflow-orchestration.ts
@@ -26,7 +26,7 @@ export async function getWork(
 ): Promise<void> {
   const reqLogger = req.context.logger;
   const { serviceID, podName } = req.query;
-  // reqLogger.info(`Getting work for service ${serviceID} and pod ${podName}`);
+  reqLogger.silly(`Getting work for service ${serviceID} and pod ${podName}`);
 
   let responded = false;
   let workItemData: WorkItemData | null;

--- a/services/harmony/app/models/work-item-update.ts
+++ b/services/harmony/app/models/work-item-update.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+
 import { WorkItemStatus } from './work-item-interface';
 
 /**
@@ -37,7 +38,6 @@ export default interface WorkItemUpdate {
 
   // The category of the message from the service
   message_category?: string;
-
 
   // how long the work item took to process
   duration?: number;

--- a/services/work-updater/app/workers/updater.ts
+++ b/services/work-updater/app/workers/updater.ts
@@ -21,7 +21,8 @@ import env from '../util/env';
  */
 export async function handleBatchWorkItemUpdates(
   updates: WorkItemUpdateQueueItem[],
-  logger: Logger): Promise<void> {
+  logger: Logger,
+): Promise<void> {
   logger.debug(`Processing ${updates.length} work item updates`);
   // create a map of jobIDs to updates
   const jobUpdates: Record<string, WorkItemUpdateQueueItem[]> =


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2104

## Description
Adds a log message that can be used for metrics to track successful completion of work items by service id. Also adds jobId to the fields logged for all work item update log messages.

## Local Test Steps
Disable the TEXT_LOGGER in your .env (`TEXT_LOGGER=false`). Start all the harmony services and submit a request. Verify in the large work item updater log that the query-cmr work item has a successful work item message logged and in the small work item updater each work item has a successful message logged.

The message should look like this (make sure at a minimum the serviceId field is logged)
```
{"durationMs":258,"env_name":"harmony-local","jobId":"15df1ffb-4ffb-45f6-bb2e-427de06e7dd3","level":"info","message":"Finished handling work item update for work item id 24 for service harmonyservices/service-example:latest and status successful in 258 ms","serviceId":"harmonyservices/service-example:latest","status":"successful","timestamp":"2025-05-28T13:32:58.930Z","workItemId":24}
```

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)