### PR TITLE
HARMONY-2111: Set the service_provider to always be harmony and the service_id to the UMM-S id in the request metric.

### DIFF
--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -537,7 +537,7 @@ https://cmr.uat.earthdata.nasa.gov:
     description: |
       A service chain for applying the Harmony Metadata Annotator to HOSS/Maskfill
       output, producing CF compliant annotated NetCDF4 outputs. This service chain
-      is intended to be used for testing the Metadata Annotator. This chain will 
+      is intended to be used for testing the Metadata Annotator. This chain will
       only be used temporarily until the Metadata Annotator is ready to be added
       to the sds/HOSS-projection-gridded service chain.
     data_operation_version: '0.21.0'

--- a/services/harmony/app/models/services/base-service.ts
+++ b/services/harmony/app/models/services/base-service.ts
@@ -305,7 +305,7 @@ export default abstract class BaseService<ServiceParamType> {
     await this._createAndSaveWorkflow(job);
 
     const { isAsync, jobID } = job;
-    const requestMetric = getRequestMetric(req, this.operation, this.config.name);
+    const requestMetric = getRequestMetric(req, this.operation, this.config.name, this.config.umm_s);
     logger.info(`Request metric for request ${jobID}`, { requestMetric: true, ...requestMetric });
     this.operation.callback = `${env.callbackUrlRoot}/service/${jobID}`;
     return new Promise((resolve, reject) => {

--- a/services/harmony/app/util/metrics.ts
+++ b/services/harmony/app/util/metrics.ts
@@ -17,8 +17,8 @@ export interface BboxMetric {
 
 export interface ParameterMetric {
   service_name: string; // We'll use the name from services.yml
-  service_provider?: string; // We do not track this information
-  service_id?: string; // We do not explicitly link to a single UMM-S, so do not populate
+  service_provider: string; // Hardcode to harmony
+  service_id: string | undefined; // Use the UMM-S concept ID if configured
 }
 
 export interface RequestMetric {
@@ -90,13 +90,15 @@ function constructBboxFromOperation(operation: DataOperation): BboxMetric {
 /**
  * Returns the request metric for a request
  *
+ * @param req - The harmony request
  * @param operation - The data operation
  * @param serviceName - The name of the service chain used for the request
+ * @param serviceId - The UMM-S id for the service
  *
  * @returns the request metric
  */
 export function getRequestMetric(
-  req: HarmonyRequest, operation: DataOperation, serviceName: string,
+  req: HarmonyRequest, operation: DataOperation, serviceName: string, serviceId: string,
 ): RequestMetric {
   const rangeBeginDateTime = operation.temporal?.start;
   const rangeEndDateTime = operation.temporal?.end;
@@ -108,7 +110,7 @@ export function getRequestMetric(
     request_id: operation.requestId,
     user_ip: user_ip || '',
     user_id: operation.user,
-    parameters: { service_name: serviceName },
+    parameters: { service_name: serviceName, service_provider: 'harmony', service_id: serviceId },
   };
 
   const bbox = constructBboxFromOperation(operation);


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2111

## Description
Set the service_provider to always be harmony and the service_id to the UMM-S id in the request metric.

## Local Test Steps
Make sure you have JSON logging turned on (in your .env set `TEXT_LOGGER=false`).

Make a request - e.g.
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&outputCrs=EPSG%3A31975&format=image%2Fpng&maxResults=1&subset=time(%222002-09-15T00%3A00%3A00.000Z%22%3A%222022-09-25T00%3A00%3A00Z%22)

Look for the log message which includes the field
```
"requestMetric": true
```
Verify the parameters field looks like the following:
```
    "parameters": {
      "service_id":"S1257851197-EEDTEST"
      "service_name": "harmony/service-example",
      "service_provider": "harmony"
    },
```

Submit another request for a service that doesn't have a UMM-S concept ID (the harmony download service).
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=1

Verify the parameters field looks like the following:
```
    "parameters": {
      "service_name": "harmony/download",
      "service_provider": "harmony"
    },
```

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)