### PR TITLE
DAS-2346 DAS-2352 Add new service chain for services after HOSS

### DIFF
--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -570,6 +570,50 @@ https://cmr.uat.earthdata.nasa.gov:
           exists: ['shapefileSubset', 'spatialSubset']
       - image: !Env ${HARMONY_METADATA_ANNOTATOR_IMAGE}
 
+  - name: sds/HOSS-HRS-GeoTIFF
+    description: |
+      A service chain for applying the Harmony Metadata Annotator to HOSS/Maskfill
+      output, producing CF compliant annotated NetCDF4 outputs. This service chain
+      is also intended to be used for producing regridded outputs using the harmony-regridder 
+      and  to produce GeoTIFF outputs using net2cog.
+    data_operation_version: '0.21.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/sds/HOSS-HRS-GeoTIFF
+    umm_s: S1273752002-EEDTEST
+    capabilities:
+      subsetting:
+        temporal: true
+        bbox: true
+        dimension: true
+        shape: true
+        variable: true
+      reprojection: true
+      output_formats:
+        - application/netcdf # Incorrect mime-type, remove when no longer needed
+        - application/x-netcdf4
+        - image/tiff
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${HOSS_IMAGE}
+        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset', 'temporalSubset']
+      - image: !Env ${SDS_MASKFILL_IMAGE}
+        operations: ['shapefileSubset', 'spatialSubset']
+        conditional:
+          exists: ['shapefileSubset', 'spatialSubset']
+      - image: !Env ${HARMONY_METADATA_ANNOTATOR_IMAGE}
+      - image: !Env ${HARMONY_REGRIDDER_IMAGE}
+        conditional:
+          exists: ['reproject']
+      - image: !Env ${NET2COG_IMAGE}
+        conditional:
+          format: ['image/tiff']
+
   - name: l2-subsetter-batchee-stitchee-concise
     description: |
       ### Subsetter And Multi-dimensional Batched Aggregation in Harmony (SAMBAH)

--- a/services/harmony/test/versions.ts
+++ b/services/harmony/test/versions.ts
@@ -41,6 +41,7 @@ describe('Versions endpoint', function () {
           'sds/HOSS-geographic',
           'sds/HOSS-projection-gridded',
           'sds/HOSS-projection-gridded-annotated',
+          'sds/HOSS-HRS-GeoTIFF',
           'l2-subsetter-batchee-stitchee-concise',
           'asf/opera-rtc-s1-browse',
           'net2cog',


### PR DESCRIPTION

## Jira Issue ID
DAS-2346, DAS-2352

## Description
Add new service chain after HOSS to include harmony-metadata-annotator, net2cog and harmony-regridder after maskfill
The new service chain is called HOSS_HRS_GeoTIFF and the UMM Service record is S1273752002

## Local Test Steps
Update  local Harmony-In-A-Box configuration to include "hoss", "maskfill", "harmony-metadata-annotator" , "net2cog", "harmony-regridder"  in the LOCALLY_DEPLOYED_SERVICES

Start Harmony-In-A-Box
./bin/bootstrap-harmony

Run the following test requests. Confirm in the workflow-ui that the job completes successfully.
http://localhost:3000/C1268612127-EEDTEST/ogc-api-coverages/1.0.0/collections/Land-Model-Constants_Data%2Fcell_land_fraction/coverage/rangeset?forceAsync=true&outputCrs=EPSG:4326&maxResults=1&scaleSize=5.0,5.0&scaleExtent=-180,-90,180,90&height=36&width=72&format=image/tiff

On the workflow-ui Ensure that the sds/HOSS-HRS-GeoTIFF service chain is called. 
The steps should include harmony-metadata-annotator followed by harmony-regridding-service  and net2cog. 
The request should be successful.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [x ] Harmony in a Box tested (if changes made to microservices or new dependencies added)