### PR TITLE
HARMONY-2103: Add links to service logs for warning work items on workflow-ui.

### DIFF
--- a/services/harmony/app/frontends/workflow-ui.ts
+++ b/services/harmony/app/frontends/workflow-ui.ts
@@ -507,8 +507,8 @@ function workItemRenderingFunctions(job: Job, isAdmin: boolean, isLogViewer: boo
     workflowItemLogsButton(): string {
       if (!isAdmin && !isLogViewer) return '';
       let logsLinks = '';
-      const isComplete = [WorkItemStatus.FAILED, WorkItemStatus.SUCCESSFUL].indexOf(this.status) > -1;
-      const isLogAvailable = (isComplete || this.retryCount > 0) && !this.serviceID.includes('query-cmr');
+      const hasRun = [WorkItemStatus.FAILED, WorkItemStatus.SUCCESSFUL, WorkItemStatus.WARNING].indexOf(this.status) > -1;
+      const isLogAvailable = (hasRun || this.retryCount > 0) && !this.serviceID.includes('query-cmr');
       if (isLogAvailable) {
         const logsUrl = `/logs/${job.jobID}/${this.id}`;
         logsLinks += `<a type="button" target="__blank" class="btn btn-sm btn-outline-primary logs-s3" href="${logsUrl}"` +


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2103

## Description
Add links to service logs for warning work items on workflow-ui.

## Local Test Steps
Follow the following steps to submit a harmony request with work items with warning messages and verify there are links to the service logs of the warning work items now on workflow-ui.

Modify harmony-service-example to create nodata warnings for specific granules to facilitate with the testing. e.g. add `from harmony_service_lib.exceptions import NoDataException` at the top and the following to around line 98 of `transform.py` in harmony-service-example:
```
if asset.href == 'https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/nc/001_00_7f00ff_global.nc' or asset.href == 'https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/nc/001_07_7f00ff_north_america.nc':
   raise NoDataException("Ain't got no data")
```
to simulate two nodata warnings for the first two granules in this harmony request:

http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/red_var,blue_var,green_var/coverage/rangeset/?subset=lat(20%3A60)&subset=lon(-140%3A-50)&outputCrs=EPSG%3A31975&format=image%2Fpng&maxResults=3

Build harmony-service-example and restart the services, then submit the above harmony request.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)