### PR TITLE
DAS-2346-DAS-2352-fix: Rename sds/HOSS-HRS-GeoTIFF and make HOSS conditional

### DIFF
--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -533,12 +533,12 @@ https://cmr.uat.earthdata.nasa.gov:
         conditional:
           exists: ['shapefileSubset', 'spatialSubset']
 
-  - name: sds/HOSS-HRS-GeoTIFF
+  - name: sds/HOSS-regridder-reformatter
     description: |
       A service chain for applying the Harmony Metadata Annotator to HOSS/Maskfill
       output, producing CF compliant annotated NetCDF4 outputs. This service chain
       is also intended to be used for producing regridded outputs using the harmony-regridder
-      and  to produce GeoTIFF outputs using net2cog.
+      and to produce GeoTIFF outputs using net2cog.
     data_operation_version: '0.21.0'
     type:
       <<: *default-turbo-config
@@ -546,7 +546,7 @@ https://cmr.uat.earthdata.nasa.gov:
         <<: *default-turbo-params
         env:
           <<: *default-turbo-env
-          STAGING_PATH: public/sds/HOSS-HRS-GeoTIFF
+          STAGING_PATH: public/sds/HOSS-regridder-reformatter
     umm_s: S1273752002-EEDTEST
     capabilities:
       subsetting:
@@ -565,6 +565,8 @@ https://cmr.uat.earthdata.nasa.gov:
         is_sequential: true
       - image: !Env ${HOSS_IMAGE}
         operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset', 'temporalSubset']
+        conditional:
+          exists: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset', 'temporalSubset']
       - image: !Env ${SDS_MASKFILL_IMAGE}
         operations: ['shapefileSubset', 'spatialSubset']
         conditional:

--- a/services/harmony/test/versions.ts
+++ b/services/harmony/test/versions.ts
@@ -40,7 +40,7 @@ describe('Versions endpoint', function () {
           'sds/harmony-smap-l2-gridder',
           'sds/HOSS-geographic',
           'sds/HOSS-projection-gridded',
-          'sds/HOSS-HRS-GeoTIFF',
+          'sds/HOSS-regridder-reformatter',
           'l2-subsetter-batchee-stitchee-concise',
           'asf/opera-rtc-s1-browse',
           'net2cog',


### PR DESCRIPTION
## Jira Issue ID
[DAS-2346](https://bugs.earthdata.nasa.gov/browse/DAS-2346)
[DAS-2352](https://bugs.earthdata.nasa.gov/browse/DAS-2352)

## Description
This PR makes two updates:
1.  Renames `sds/HOSS-HRS-GeoTIFF` to `sds/HOSS-regridder-reformatter`
2. Makes HOSS conditional so that HOSS is not called when there is regridding/reformatting requested without subsetting

The MMT record has been updated to reflect the new service name:
https://mmt.uat.earthdata.nasa.gov/services/S1273752002-EEDTEST

## Local Test Steps
1. Pull down this branch and restart harmony-in-a-box.
2. Run the following requests and verify the correct services in the `sds/HOSS-regridder-reformatter` chain were called.

**Note: net2cog is expected to fail on these requests but the service failure is outside the scope of this PR**

- Test 1: subset: none, reformatting: yes
Expected chain: metadata-annotator, net2cog
http://localhost:3000/C1268452378-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&label=harmony-py&granuleId=G1268452388-EEDTEST&format=image%2Ftiff&variable=all

- Test 2: subset: spatial, reformatting: yes
Expected chain: hoss, maskfill, metadata-annotator, net2cog
http://localhost:3000/C1268452378-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&subset=lat(60%3A85)&subset=lon(-70%3A-10)&label=harmony-py&granuleId=G1268452388-EEDTEST&format=image%2Ftiff&variable=all

- Test 3: subset: variable, reformatting: yes
Expected chain: hoss, metadata-annotator, net2cog
http://localhost:3000/C1268452378-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&label=harmony-py&granuleId=G1268452388-EEDTEST&format=image%2Ftiff&variable=Soil_Moisture_Retrieval_Data_AM%2Fsurface_flag&variable=Soil_Moisture_Retrieval_Data_PM%2Fsurface_flag_pm

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [x] Harmony in a Box tested (if changes made to microservices or new dependencies added)