### PR TITLE
HARMONY-2115: Add FAST_SERVICE_QUEUE_BATCH_SIZE_COEFFICIENT configuration to make work scheduling better for query-cmr service.

### DIFF
--- a/services/service-runner/app/util/axios-clients.ts
+++ b/services/service-runner/app/util/axios-clients.ts
@@ -72,9 +72,9 @@ export function isRetryable(error: AxiosError): boolean {
  * @param retries - how many times to retry a request
  * @param maxDelayMs - max delay between retried requests
  * @param exponentialOffset - offsets the exponent in calculateExponentialDelay
+ * @param retryCondition - a function that specifies when to retry a request
  * @param timeoutMs - requests time out after this many milliseconds
  * @param httpAgent - the http agent used by the axios instance
- * @param retryCondition - a function that specifies when to retry a request
  * @returns AxiosInstance
  */
 export default function createAxiosClientWithRetry(

--- a/services/work-scheduler/app/util/env.ts
+++ b/services/work-scheduler/app/util/env.ts
@@ -15,6 +15,10 @@ class HarmonyWorkSchedulerEnv extends HarmonyEnv {
   @Min(0)
   serviceQueueBatchSizeCoefficient: number;
 
+  @IsNumber()
+  @Min(0)
+  fastServiceQueueBatchSizeCoefficient: number;
+
   @IsNotEmpty()
   workingDir: string;
 

--- a/services/work-scheduler/env-defaults
+++ b/services/work-scheduler/env-defaults
@@ -12,6 +12,8 @@ WORK_ITEM_SCHEDULER_QUEUE_MAX_GET_MESSAGE_REQUESTS=20
 # to avoid queue starvation. 1.1 for example means to queue 10% more work items than there
 # are running pods for the service.
 SERVICE_QUEUE_BATCH_SIZE_COEFFICIENT=0.25
+# Used to allow queueing more work items for fast services (e.g. query-cmr) to avoid queue starvation.
+FAST_SERVICE_QUEUE_BATCH_SIZE_COEFFICIENT=1.25
 # Maximum number of work items to retrieve from database at once
 WORK_ITEM_SCHEDULER_BATCH_SIZE=50
 # Maximum number of work items allowed on the work item update queue before halting scheduling


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2115

## Description
Add FAST_SERVICE_QUEUE_BATCH_SIZE_COEFFICIENT configuration to make work scheduling better for query-cmr service.

## Local Test Steps
Test in a sandbox environment:
1. Build and push work-scheduler image to ECR.

2. Configure harmony-ci-cd to use the built image and run `bin/deploy` to deploy Harmony in Sandbox.

3. On the EC2 instance in the environment install vegeta
```
curl -LO https://github.com/tsenart/vegeta/releases/download/v12.12.0/vegeta_12.12.0_linux_amd64.tar.gz
tar -xzf vegeta_12.12.0_linux_amd64.tar.gz
sudo mv vegeta /usr/local/bin/
```
Verify it is working
`vegeta -version`

4. Set your EDL Token for the UAT environment
export EDL_TOKEN=<>
Kick off 1000 requests - in this case, 50 per second for 520seconds (change the URL to your LB URL)
```
echo "GET https://internal-harmony-...<LB URL>/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng&forceAsync=true
Authorization: Bearer $EDL_TOKEN" | vegeta attack -rate=50 -duration=20s | vegeta report
```

5. Sanity check in the workflow-ui that all 1000 requests were created

6. Tail the work-scheduler log to verify that work-scheduler uses the new FAST_SERVICE_QUEUE_BATCH_SIZE_COEFFICIENT configured scaler factor to schedule work for query-cmr and uses the old SERVICE_QUEUE_BATCH_SIZE_COEFFICIENT configured scaler factor to schedule work for other services.

7. Tail one of the query-cmr logs and see that it no long has long delays between polling and working on the next work item (generally start performing work within a second after polling).

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)