### PR TITLE
HARMONY-2125: Add caching for concept permissions lookup

### DIFF
--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -766,15 +766,13 @@ https://cmr.uat.earthdata.nasa.gov:
     steps:
       - image: !Env ${GIOVANNI_AVERAGING_SERVICES_ADAPTER_IMAGE}
 
-  - name: sds/trajectory-susbetter-smap-l2-regridder
+  - name: sds/smap-l2-subsetter-net2cog
     description: |
-      A service chain for applying the SMAP L2 Regridder to Trajectory Subsetter
-      output, producing NetCDF4 output.
+      A service chain for subsetting SMAP L2 collections with the Trajectory
+      Subsetter and reformatting that output to Cloud-Optimized GeoTIFF (COG).
 
-      The purpose of this chain is to test the intermediate regridding step
-      for the future Trajectory Subsetter Net2COG (GeoTIFF reformatting)
-      service chain. This current chain will eventually be updated to become
-      the Trajectory Subsetter SMAP L2 GeoTIFF Reformatter.
+      In GeoTIFF reformatting the SMAP L2 Gridder is called first to convert
+      the output to NetCDF, which is then plugged into the Net2COG reformatter.
     data_operation_version: '0.22.0'
     type:
       <<: *default-turbo-config
@@ -782,7 +780,7 @@ https://cmr.uat.earthdata.nasa.gov:
         <<: *default-turbo-params
         env:
           <<: *default-turbo-env
-          STAGING_PATH: public/sds/trajectory-subsetter
+          STAGING_PATH: public/sds/smap-l2-subsetter-net2cog
     umm_s: S1273345267-EEDTEST
     capabilities:
       subsetting:
@@ -791,13 +789,20 @@ https://cmr.uat.earthdata.nasa.gov:
         shape: true
         variable: true
       output_formats:
+        - application/x-hdf
         - application/x-netcdf4
+        - image/tiff
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
       - image: !Env ${TRAJECTORY_SUBSETTER_IMAGE}
         operations: ['variableSubset', 'spatialSubset', 'shapefileSubset']
       - image: !Env ${HARMONY_SMAP_L2_GRIDDER_IMAGE}
+        conditional:
+          format: ['image/tiff', 'application/x-netcdf4']
+      - image: !Env ${NET2COG_IMAGE}
+        conditional:
+          format: ['image/tiff']
 
   - name: harmony/service-example
     description: |

--- a/services/harmony/test/versions.ts
+++ b/services/harmony/test/versions.ts
@@ -46,7 +46,7 @@ describe('Versions endpoint', function () {
           'net2cog',
           'nasa/harmony-gdal-adapter',
           'giovanni-averaging-service',
-          'sds/trajectory-susbetter-smap-l2-regridder',
+          'sds/smap-l2-subsetter-net2cog',
           'harmony/service-example',
         ]);
       });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2125

## Description
Add caching for concept permissions lookup

## Local Test Steps
tail the server log and grep for 'Calling CMR to fetch permissions'. 
Issue the following query
```
 curl -Ln -bj "http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng&forceAsync=true"
```
Load the job status page. You should see the 'Calling CMR to fetch permissions' entry in the log.
Load the job status page again. You should not see the message in the log.
Wait five minutes for the cache to expire. Reload the job status page. You should see the message again.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)