### PR TITLE
HARMONY-2127: Remove underscore from the allowed characters for service image tag.

### DIFF
--- a/docs/guides/managing-existing-services.md
+++ b/docs/guides/managing-existing-services.md
@@ -94,7 +94,7 @@ Only one service deployment can be run at any given time. If your request is rej
 Harmony validates that the image and tag are reachable - an error will be returned if not.
 
 **Important** from the [Docker documentation](https://docs.docker.com/engine/reference/commandline/image_tag/):
->A tag name may contain lowercase and uppercase characters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
+>A tag name may contain lowercase and uppercase characters, digits, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.
 
 ## Get backend service image tag update status
 

--- a/services/harmony/.nsprc
+++ b/services/harmony/.nsprc
@@ -1,5 +1,5 @@
 {
-  "1105443": {
+  "1105444": {
     "active": true,
     "notes": "Will fix in HARMONY-2117",
     "expiry": "2025-08-01"

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -278,7 +278,7 @@ async function validateCookieSecretOrUserIsInDeployerOrCoreGroup(
  */
 export function checkTag(tag: string): string {
   // See https://docs.docker.com/engine/reference/commandline/image_tag/
-  const tagRegex = /^[a-zA-Z\d_][a-zA-Z\d\-_.]{0,127}$/;
+  const tagRegex = /^[a-zA-Z\d][a-zA-Z\d\-.]{0,127}$/;
   if (!tagRegex.test(tag)) {
     const message = 'A tag name may contain lowercase and uppercase characters, digits, ' +
       'underscores, periods and dashes. A tag name may not start with a period or a dash and ' +

--- a/services/harmony/app/frontends/service-image-tags.ts
+++ b/services/harmony/app/frontends/service-image-tags.ts
@@ -281,7 +281,7 @@ export function checkTag(tag: string): string {
   const tagRegex = /^[a-zA-Z\d][a-zA-Z\d\-.]{0,127}$/;
   if (!tagRegex.test(tag)) {
     const message = 'A tag name may contain lowercase and uppercase characters, digits, ' +
-      'underscores, periods and dashes. A tag name may not start with a period or a dash and ' +
+      'periods and dashes. A tag name may not start with a period or a dash and ' +
       'may contain a maximum of 128 characters.';
     return message;
   }

--- a/services/harmony/package-lock.json
+++ b/services/harmony/package-lock.json
@@ -53,7 +53,7 @@
         "express-winston": "^4.1.0",
         "fastq": "^1.11.0",
         "form-data": "^4.0.0",
-        "gdal-async": "~3.9.0",
+        "gdal-async": "~3.11.0",
         "geo-split": "^0.1.2",
         "geojson-antimeridian-cut": "^0.1.0",
         "highlight.js": "^11.7.0",
@@ -10884,6 +10884,18 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "dev": true,
@@ -11054,7 +11066,6 @@
     },
     "node_modules/@mapbox/node-pre-gyp": {
       "version": "1.0.11",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "detect-libc": "^2.0.0",
@@ -11073,7 +11084,6 @@
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/chownr": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -11081,7 +11091,6 @@
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
@@ -11092,7 +11101,6 @@
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -11103,7 +11111,6 @@
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/minipass": {
       "version": "5.0.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=8"
@@ -11111,7 +11118,6 @@
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/tar": {
       "version": "6.2.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
@@ -11171,7 +11177,9 @@
       }
     },
     "node_modules/@npmcli/agent": {
-      "version": "2.2.2",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/agent/-/agent-3.0.0.tgz",
+      "integrity": "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==",
       "license": "ISC",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -11181,11 +11189,13 @@
         "socks-proxy-agent": "^8.0.3"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/agent/node_modules/agent-base": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -11193,6 +11203,8 @@
     },
     "node_modules/@npmcli/agent/node_modules/https-proxy-agent": {
       "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -11204,16 +11216,20 @@
     },
     "node_modules/@npmcli/agent/node_modules/lru-cache": {
       "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
     "node_modules/@npmcli/fs": {
-      "version": "3.1.1",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-4.0.0.tgz",
+      "integrity": "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==",
       "license": "ISC",
       "dependencies": {
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/@npmcli/move-file": {
@@ -11277,6 +11293,12 @@
       "dependencies": {
         "@noble/hashes": "^1.1.5"
       }
+    },
+    "node_modules/@petamoriken/float16": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
+      "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -13387,7 +13409,6 @@
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/accepts": {
@@ -13431,7 +13452,6 @@
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -13453,6 +13473,7 @@
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "clean-stack": "^2.0.0",
@@ -13570,7 +13591,6 @@
     },
     "node_modules/aproba": {
       "version": "2.0.0",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/archy": {
@@ -13580,7 +13600,6 @@
     },
     "node_modules/are-we-there-yet": {
       "version": "2.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "delegates": "^1.0.0",
@@ -14121,10 +14140,12 @@
       }
     },
     "node_modules/cacache": {
-      "version": "18.0.4",
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz",
+      "integrity": "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==",
       "license": "ISC",
       "dependencies": {
-        "@npmcli/fs": "^3.1.0",
+        "@npmcli/fs": "^4.0.0",
         "fs-minipass": "^3.0.0",
         "glob": "^10.2.2",
         "lru-cache": "^10.0.1",
@@ -14132,24 +14153,19 @@
         "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "p-map": "^4.0.0",
-        "ssri": "^10.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^3.0.0"
+        "p-map": "^7.0.2",
+        "ssri": "^12.0.0",
+        "tar": "^7.4.3",
+        "unique-filename": "^4.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/chownr": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/cacache/node_modules/glob": {
       "version": "10.4.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
+      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -14168,48 +14184,20 @@
     },
     "node_modules/cacache/node_modules/lru-cache": {
       "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
-    "node_modules/cacache/node_modules/tar": {
-      "version": "6.2.1",
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+    "node_modules/cacache/node_modules/p-map": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cacache/node_modules/tar/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/cacache/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cacache/node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/caching-transform": {
@@ -14410,6 +14398,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/class-validator": {
       "version": "0.14.1",
       "license": "MIT",
@@ -14421,6 +14418,7 @@
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -14487,7 +14485,6 @@
     },
     "node_modules/color-support": {
       "version": "1.1.3",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "color-support": "bin.js"
@@ -14573,7 +14570,6 @@
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/content-disposition": {
@@ -14962,7 +14958,6 @@
     },
     "node_modules/delegates": {
       "version": "1.0.0",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/depd": {
@@ -15842,7 +15837,9 @@
       }
     },
     "node_modules/exponential-backoff": {
-      "version": "3.1.1",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
+      "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
       "license": "Apache-2.0"
     },
     "node_modules/express": {
@@ -16401,6 +16398,8 @@
     },
     "node_modules/fs-minipass": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
+      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.3"
@@ -16474,7 +16473,6 @@
     },
     "node_modules/gauge": {
       "version": "3.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
@@ -16492,60 +16490,173 @@
       }
     },
     "node_modules/gdal-async": {
-      "version": "3.9.2",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/gdal-async/-/gdal-async-3.11.0.tgz",
+      "integrity": "sha512-ql5X4xj9jbMh0TxYlaohnUQC1rQjTy93zuViV/X415A/cqSntrBzumSMncmDezq+vnqJUxkS6rU5579u6Y8GAg==",
       "bundleDependencies": [
         "@mapbox/node-pre-gyp"
       ],
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@mapbox/node-pre-gyp": "^1.0.8",
+        "@mapbox/node-pre-gyp": "^2.0.0",
+        "@petamoriken/float16": "^3.9.2",
         "nan": "^2.17.0",
-        "node-gyp": "^10.0.0",
+        "node-gyp": "^11.0.0",
         "xmlbuilder2": "^3.0.2",
         "yatag": "^1.2.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/mmomtchev"
       }
     },
-    "node_modules/gdal-async/node_modules/@mapbox/node-pre-gyp": {
-      "version": "1.0.11",
+    "node_modules/gdal-async/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
       "inBundle": true,
-      "license": "BSD-3-Clause",
+      "license": "ISC",
       "dependencies": {
-        "detect-libc": "^2.0.0",
-        "https-proxy-agent": "^5.0.0",
-        "make-dir": "^3.1.0",
-        "node-fetch": "^2.6.7",
-        "nopt": "^5.0.0",
-        "npmlog": "^5.0.1",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "tar": "^6.1.11"
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
       },
-      "bin": {
-        "node-pre-gyp": "bin/node-pre-gyp"
+      "engines": {
+        "node": ">=12"
       }
     },
-    "node_modules/gdal-async/node_modules/abbrev": {
-      "version": "1.1.1",
+    "node_modules/gdal-async/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
       "inBundle": true,
-      "license": "ISC"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
     },
-    "node_modules/gdal-async/node_modules/agent-base": {
-      "version": "6.0.2",
+    "node_modules/gdal-async/node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/gdal-async/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/gdal-async/node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "4"
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gdal-async/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/gdal-async/node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/gdal-async/node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/gdal-async/node_modules/@mapbox/node-pre-gyp": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "consola": "^3.2.3",
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^7.0.5",
+        "node-fetch": "^2.6.7",
+        "nopt": "^8.0.0",
+        "semver": "^7.5.3",
+        "tar": "^7.4.0"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gdal-async/node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gdal-async/node_modules/abbrev": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/gdal-async/node_modules/agent-base": {
+      "version": "7.1.3",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/gdal-async/node_modules/ansi-regex": {
@@ -16556,21 +16667,18 @@
         "node": ">=8"
       }
     },
-    "node_modules/gdal-async/node_modules/aproba": {
-      "version": "2.0.0",
+    "node_modules/gdal-async/node_modules/ansi-styles": {
+      "version": "4.3.0",
       "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/gdal-async/node_modules/are-we-there-yet": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
+        "color-convert": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/gdal-async/node_modules/balanced-match": {
@@ -16579,37 +16687,56 @@
       "license": "MIT"
     },
     "node_modules/gdal-async/node_modules/chownr": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
-    "node_modules/gdal-async/node_modules/color-support": {
-      "version": "1.1.3",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
-    "node_modules/gdal-async/node_modules/concat-map": {
-      "version": "0.0.1",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/gdal-async/node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/gdal-async/node_modules/debug": {
-      "version": "4.3.6",
+    "node_modules/gdal-async/node_modules/color-convert": {
+      "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/gdal-async/node_modules/color-name": {
+      "version": "1.1.4",
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/gdal-async/node_modules/consola": {
+      "version": "3.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/gdal-async/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/gdal-async/node_modules/debug": {
+      "version": "4.4.0",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -16620,11 +16747,6 @@
         }
       }
     },
-    "node_modules/gdal-async/node_modules/delegates": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/gdal-async/node_modules/detect-libc": {
       "version": "2.0.3",
       "inBundle": true,
@@ -16633,109 +16755,42 @@
         "node": ">=8"
       }
     },
+    "node_modules/gdal-async/node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/gdal-async/node_modules/emoji-regex": {
       "version": "8.0.0",
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/gdal-async/node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/gdal-async/node_modules/gauge": {
-      "version": "3.0.2",
+    "node_modules/gdal-async/node_modules/foreground-child": {
+      "version": "3.3.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.2",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.1",
-        "object-assign": "^4.1.1",
-        "signal-exit": "^3.0.0",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.2"
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gdal-async/node_modules/gauge/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/gdal-async/node_modules/glob": {
-      "version": "7.2.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/gdal-async/node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/gdal-async/node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/gdal-async/node_modules/has-unicode": {
-      "version": "2.0.1",
-      "inBundle": true,
-      "license": "ISC"
-    },
     "node_modules/gdal-async/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
+      "version": "7.0.6",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
-    },
-    "node_modules/gdal-async/node_modules/inflight": {
-      "version": "1.0.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/gdal-async/node_modules/inherits": {
-      "version": "2.0.4",
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/gdal-async/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -16745,69 +16800,116 @@
         "node": ">=8"
       }
     },
-    "node_modules/gdal-async/node_modules/make-dir": {
-      "version": "3.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/gdal-async/node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/gdal-async/node_modules/minizlib": {
-      "version": "2.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^3.0.0",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/gdal-async/node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gdal-async/node_modules/minizlib/node_modules/yallist": {
-      "version": "4.0.0",
+    "node_modules/gdal-async/node_modules/isexe": {
+      "version": "2.0.0",
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/gdal-async/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/gdal-async/node_modules/minipass": {
+      "version": "7.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/gdal-async/node_modules/minizlib": {
+      "version": "3.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.4",
+        "rimraf": "^5.0.5"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/gdal-async/node_modules/minizlib/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/gdal-async/node_modules/minizlib/node_modules/glob": {
+      "version": "10.4.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gdal-async/node_modules/minizlib/node_modules/minimatch": {
+      "version": "9.0.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gdal-async/node_modules/minizlib/node_modules/rimraf": {
+      "version": "5.0.10",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gdal-async/node_modules/mkdirp": {
-      "version": "1.0.4",
+      "version": "3.0.1",
       "inBundle": true,
       "license": "MIT",
       "bin": {
-        "mkdirp": "bin/cmd.js"
+        "mkdirp": "dist/cjs/src/bin.js"
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gdal-async/node_modules/ms": {
-      "version": "2.1.2",
+      "version": "2.1.3",
       "inBundle": true,
       "license": "MIT"
     },
@@ -16831,99 +16933,51 @@
       }
     },
     "node_modules/gdal-async/node_modules/nopt": {
-      "version": "5.0.0",
+      "version": "8.1.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "1"
+        "abbrev": "^3.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": ">=6"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/gdal-async/node_modules/npmlog": {
-      "version": "5.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^2.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^3.0.0",
-        "set-blocking": "^2.0.0"
-      }
-    },
-    "node_modules/gdal-async/node_modules/object-assign": {
-      "version": "4.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gdal-async/node_modules/once": {
-      "version": "1.4.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/gdal-async/node_modules/path-is-absolute": {
+    "node_modules/gdal-async/node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
+      "license": "BlueOak-1.0.0"
     },
-    "node_modules/gdal-async/node_modules/readable-stream": {
-      "version": "3.6.2",
+    "node_modules/gdal-async/node_modules/path-key": {
+      "version": "3.1.1",
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
       "engines": {
-        "node": ">= 6"
+        "node": ">=8"
       }
     },
-    "node_modules/gdal-async/node_modules/rimraf": {
-      "version": "3.0.2",
+    "node_modules/gdal-async/node_modules/path-scurry": {
+      "version": "1.11.1",
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "glob": "^7.1.3"
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
-      "bin": {
-        "rimraf": "bin.js"
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/gdal-async/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
+    "node_modules/gdal-async/node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
       "inBundle": true,
-      "license": "MIT"
+      "license": "ISC"
     },
     "node_modules/gdal-async/node_modules/semver": {
       "version": "7.6.3",
@@ -16936,20 +16990,51 @@
         "node": ">=10"
       }
     },
-    "node_modules/gdal-async/node_modules/set-blocking": {
+    "node_modules/gdal-async/node_modules/shebang-command": {
       "version": "2.0.0",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/gdal-async/node_modules/string_decoder": {
-      "version": "1.3.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gdal-async/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gdal-async/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/gdal-async/node_modules/string-width": {
+      "version": "4.2.3",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gdal-async/node_modules/string-width-cjs": {
+      "name": "string-width",
       "version": "4.2.3",
       "inBundle": true,
       "license": "MIT",
@@ -16973,64 +17058,44 @@
         "node": ">=8"
       }
     },
+    "node_modules/gdal-async/node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/gdal-async/node_modules/tar": {
-      "version": "6.2.1",
+      "version": "7.4.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gdal-async/node_modules/tar/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/gdal-async/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gdal-async/node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
     "node_modules/gdal-async/node_modules/tar/node_modules/yallist": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "inBundle": true,
-      "license": "ISC"
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/gdal-async/node_modules/tr46": {
       "version": "0.0.3",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/gdal-async/node_modules/util-deprecate": {
-      "version": "1.0.2",
       "inBundle": true,
       "license": "MIT"
     },
@@ -17048,18 +17113,36 @@
         "webidl-conversions": "^3.0.0"
       }
     },
-    "node_modules/gdal-async/node_modules/wide-align": {
-      "version": "1.1.5",
+    "node_modules/gdal-async/node_modules/which": {
+      "version": "2.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
-    "node_modules/gdal-async/node_modules/wrappy": {
-      "version": "1.0.2",
+    "node_modules/gdal-async/node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
       "inBundle": true,
-      "license": "ISC"
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -17439,7 +17522,6 @@
     },
     "node_modules/has-unicode": {
       "version": "2.0.1",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/hasha": {
@@ -17615,7 +17697,6 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -17683,6 +17764,7 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18013,7 +18095,8 @@
     },
     "node_modules/is-lambda": {
       "version": "1.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/is-map": {
       "version": "2.0.3",
@@ -19033,7 +19116,6 @@
     },
     "node_modules/make-dir": {
       "version": "3.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^6.0.0"
@@ -19050,24 +19132,34 @@
       "license": "ISC"
     },
     "node_modules/make-fetch-happen": {
-      "version": "13.0.1",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
+      "integrity": "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==",
       "license": "ISC",
       "dependencies": {
-        "@npmcli/agent": "^2.0.0",
-        "cacache": "^18.0.0",
+        "@npmcli/agent": "^3.0.0",
+        "cacache": "^19.0.1",
         "http-cache-semantics": "^4.1.1",
-        "is-lambda": "^1.0.1",
         "minipass": "^7.0.2",
-        "minipass-fetch": "^3.0.0",
+        "minipass-fetch": "^4.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
-        "proc-log": "^4.2.0",
+        "negotiator": "^1.0.0",
+        "proc-log": "^5.0.0",
         "promise-retry": "^2.0.1",
-        "ssri": "^10.0.0"
+        "ssri": "^12.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/markdown-it": {
@@ -19281,6 +19373,8 @@
     },
     "node_modules/minipass-collect": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-2.0.1.tgz",
+      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.3"
@@ -19290,18 +19384,32 @@
       }
     },
     "node_modules/minipass-fetch": {
-      "version": "3.0.5",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-4.0.1.tgz",
+      "integrity": "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==",
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.0.3",
         "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
+        "minizlib": "^3.0.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       },
       "optionalDependencies": {
         "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/minipass-fetch/node_modules/minizlib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/minipass-flush": {
@@ -19891,123 +19999,66 @@
       }
     },
     "node_modules/node-gyp": {
-      "version": "10.3.1",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.2.0.tgz",
+      "integrity": "sha512-T0S1zqskVUSxcsSTkAsLc7xCycrRYmtDHadDinzocrThjyQCn5kMlEBSj6H4qDbgsIOSLmmlRIeb0lZXj+UArA==",
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
-        "glob": "^10.3.10",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^13.0.0",
-        "nopt": "^7.0.0",
-        "proc-log": "^4.1.0",
+        "make-fetch-happen": "^14.0.3",
+        "nopt": "^8.0.0",
+        "proc-log": "^5.0.0",
         "semver": "^7.3.5",
-        "tar": "^6.2.1",
-        "which": "^4.0.0"
+        "tar": "^7.4.3",
+        "tinyglobby": "^0.2.12",
+        "which": "^5.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/node-gyp/node_modules/abbrev": {
-      "version": "2.0.0",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
+      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/chownr": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-gyp/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/node-gyp/node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/node-gyp/node_modules/glob": {
-      "version": "10.4.5",
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/node-gyp/node_modules/isexe": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
+      "integrity": "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==",
       "license": "ISC",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/node-gyp/node_modules/nopt": {
-      "version": "7.2.1",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
+      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^2.0.0"
+        "abbrev": "^3.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/node-gyp/node_modules/tar": {
-      "version": "6.2.1",
-      "license": "ISC",
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-gyp/node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=8"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/node-gyp/node_modules/which": {
-      "version": "4.0.0",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
+      "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
       "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
@@ -20016,7 +20067,7 @@
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/node-int64": {
@@ -20071,7 +20122,6 @@
     },
     "node_modules/nopt": {
       "version": "5.0.0",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "abbrev": "1"
@@ -20093,7 +20143,6 @@
     },
     "node_modules/npmlog": {
       "version": "5.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "are-we-there-yet": "^2.0.0",
@@ -20654,6 +20703,7 @@
     "node_modules/p-map": {
       "version": "4.0.0",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -21114,10 +21164,12 @@
       }
     },
     "node_modules/proc-log": {
-      "version": "4.2.0",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
+      "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/process": {
@@ -21525,7 +21577,6 @@
     },
     "node_modules/rimraf": {
       "version": "3.0.2",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "glob": "^7.1.3"
@@ -21809,7 +21860,6 @@
     },
     "node_modules/set-blocking": {
       "version": "2.0.0",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/set-cookie-parser": {
@@ -21972,7 +22022,6 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/simple-concat": {
@@ -22129,6 +22178,8 @@
     },
     "node_modules/socks-proxy-agent": {
       "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -22141,6 +22192,8 @@
     },
     "node_modules/socks-proxy-agent/node_modules/agent-base": {
       "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -22518,13 +22571,15 @@
       }
     },
     "node_modules/ssri": {
-      "version": "10.0.6",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-12.0.0.tgz",
+      "integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.3"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/stack-trace": {
@@ -22966,6 +23021,23 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
@@ -22994,6 +23066,42 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minizlib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/tar/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tarn": {
@@ -23126,6 +23234,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
+      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tldts": {
@@ -23571,23 +23721,27 @@
       "license": "MIT"
     },
     "node_modules/unique-filename": {
-      "version": "3.0.0",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
+      "integrity": "sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==",
       "license": "ISC",
       "dependencies": {
-        "unique-slug": "^4.0.0"
+        "unique-slug": "^5.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/unique-slug": {
-      "version": "4.0.0",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-5.0.0.tgz",
+      "integrity": "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==",
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/universalify": {
@@ -24041,7 +24195,6 @@
     },
     "node_modules/wide-align": {
       "version": "1.1.5",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"

--- a/services/harmony/package.json
+++ b/services/harmony/package.json
@@ -116,7 +116,7 @@
     "express-winston": "^4.1.0",
     "fastq": "^1.11.0",
     "form-data": "^4.0.0",
-    "gdal-async": "~3.9.0",
+    "gdal-async": "~3.11.0",
     "geo-split": "^0.1.2",
     "geojson-antimeridian-cut": "^0.1.0",
     "highlight.js": "^11.7.0",

--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -166,7 +166,7 @@ describe('checkTag', function () {
       'latest',
       '1.0',
       'v1.0.1',
-      'version_1.2.3',
+      'version-1.2.3',
       'a'.repeat(128), // Maximum length
     ];
 
@@ -182,6 +182,7 @@ describe('checkTag', function () {
       '.startwithdot',
       '-startwithdash',
       '!invalidchar',
+      'version_1.2.3',
       'a'.repeat(129), // Exceeds maximum length
     ];
 

--- a/services/harmony/test/service-image-tags.ts
+++ b/services/harmony/test/service-image-tags.ts
@@ -44,7 +44,7 @@ const errorMsg404 = 'Service foo does not exist.\nThe existing services and thei
 
 const userErrorMsg = 'User joe does not have permission to access this resource';
 
-const tagContentErrorMsg = 'A tag name may contain lowercase and uppercase characters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.';
+const tagContentErrorMsg = 'A tag name may contain lowercase and uppercase characters, digits, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.';
 
 /**
  * Get deployment id from the given status link
@@ -186,11 +186,9 @@ describe('checkTag', function () {
       'a'.repeat(129), // Exceeds maximum length
     ];
 
-    const errorMessage = 'A tag name may contain lowercase and uppercase characters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.';
-
     invalidTags.forEach(tag => {
       const result = checkTag(tag);
-      expect(result).to.equal(errorMessage);
+      expect(result).to.equal(tagContentErrorMsg);
     });
   });
 });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2127

## Description
Remove underscore from the allowed characters for service image tag.
Updated brace-expansion vulnerability id.
Updated gdal-async version to 3.11.0.

## Local Test Steps
Verify deploy a service with underscore in tag returns a validation error:
curl -i -XPUT -H "Authorization: Bearer $HARMONY_UAT_TOKEN" -H 'Content-type: application/json' http://localhost:3000/service-image-tag/harmony-service-example -d '{"tag": "v_1"}'

Deployed in Sandbox and verified that there is no gdal-async error on EC2 instance.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)
* [x] Harmony in a Box tested (if changes made to microservices or new dependencies added)