### PR TITLE
DAS-2313: Add reprojection to L2 SMAP service chain.

### DIFF
--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -822,6 +822,7 @@ https://cmr.uat.earthdata.nasa.gov:
         - application/x-hdf
         - application/x-netcdf4
         - image/tiff
+      reprojection: true
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true


### PR DESCRIPTION
## Jira Issue ID

DAS-2313 - addendum

## Description

This PR adds a missing capability from the L2 SMAP service chain in UAT. The SMAP L2 Gridder should also have reprojection capabilities. The requests in the [regression test notebook for the service](https://github.com/nasa/harmony-regression-tests/blob/main/test/smap-l2-gridder/smap-l2-gridder_Regression.ipynb) currently do not get routed to the service chain as reprojection is not a supported capability.

## Local Test Steps

* Build or pull the following Harmony service images:
  * [SMAP L2 Gridder]()
  * [Trajectory Subsetter]()
  * [net2cog]()
* Pull this branch.
* Build Harmony in a box with at least the following services: `LOCALLY_DEPLOYED_SERVICES=net2cog,harmony-smap-l2-gridder,trajectory-subsetter`
* Run the regression test notebook for the SMAP L2 Gridder. Note - the requests will complete successfully, but the comparisons will fail due to out-of-date reference files (no bounding box cropping used to be applied).

## PR Acceptance Checklist
* [x] Acceptance criteria met
* ~~Tests added/updated (if needed) and passing~~
* ~~Documentation updated (if needed)~~
* [x] Harmony in a Box tested (if changes made to microservices or new dependencies added)