### PR TITLE
HARMONY-2157: Fix bugs where extraArgs were not being added correctly

### DIFF
--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -989,7 +989,7 @@ async function handleGranuleValidation(
           'HWIUWJI.getWorkflowStepByJobIdStepIndex',
           logger))(db, jobID, update.workflowStepIndex);
         const op = JSON.parse(thisWorkflowStep.operation);
-        delete op.extraArgs;
+        op.extraArgs.granValidation = undefined;
         thisWorkflowStep.operation = JSON.stringify(op);
         await thisWorkflowStep.save(tx);
 

--- a/services/harmony/app/middleware/cmr-granule-locator.ts
+++ b/services/harmony/app/middleware/cmr-granule-locator.ts
@@ -2,15 +2,19 @@ import { NextFunction } from 'express';
 import { ServerResponse } from 'http';
 import _ from 'lodash';
 import { v4 as uuid } from 'uuid';
-import { keysToLowerCase } from '../util/object';
-import { CmrError, RequestValidationError, ServerError } from '../util/errors';
+
 import { HarmonyGranule } from '../models/data-operation';
 import HarmonyRequest from '../models/harmony-request';
-import { computeMbr } from '../util/spatial/mbr';
 import { BoundingBox } from '../util/bounding-box';
+import {
+  CmrCollection, CmrGranule, CmrQuery, filterGranuleLinks, queryGranulesForCollection,
+  queryGranulesWithSearchAfter, s3UrlForStoredQueryParams,
+} from '../util/cmr';
 import env from '../util/env';
+import { CmrError, RequestValidationError, ServerError } from '../util/errors';
+import { keysToLowerCase } from '../util/object';
 import { defaultObjectStore } from '../util/object-store';
-import { CmrCollection, CmrGranule, CmrQuery, filterGranuleLinks, s3UrlForStoredQueryParams, queryGranulesForCollection, queryGranulesWithSearchAfter } from '../util/cmr';
+import { computeMbr } from '../util/spatial/mbr';
 
 /** Reasons why the number of processed granules might be limited to less than what the CMR
  * returns
@@ -442,7 +446,7 @@ async function asyncGranuleLocator(
       const hasGranuleLimit = req.context.serviceConfig.has_granule_limit;
       const serviceName = req.context.serviceConfig.name;
       const shapeType = req.context.shapefile?.typeName;
-      operation.extraArgs = { granValidation: { reason, hasGranuleLimit, serviceName, shapeType, maxResults: operation.maxResults } };
+      operation.addExtraArgs({ granValidation: { reason, hasGranuleLimit, serviceName, shapeType, maxResults: operation.maxResults } }) ;
     }
 
   } catch (e) {

--- a/services/harmony/app/middleware/external-validation.ts
+++ b/services/harmony/app/middleware/external-validation.ts
@@ -28,7 +28,7 @@ export async function externalValidation(
   // which the endpoint will not be able to decrypt
   operationCopy.accessToken = '';
   // Validation endpoint may need to know the service chain being used
-  operationCopy.extraArgs = { service: req.context.serviceConfig.name };
+  operationCopy.addExtraArgs({ service: req.context.serviceConfig.name });
 
   const startTime = new Date().getTime();
   try {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2157

## Description
Fixes a bug that was causing OPeNDAP links to be included in results from the harmony/download service which should only be returning data links. The bug happened when `forceAsync=true` was passed in which caused the extra query-cmr granuleValidation step processing to occur. 

## Local Test Steps
I tested by pointing to CMR and EDL production and issuing the same request Andrey made:
http://localhost:3000/C2930725014-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&granuleId=G3598508234-LARC_CLOUD&concatenate=false&skipPreview=true&label=eed-edsc-prod%2Cedsc-id%3D4434906266

I believe you can also test with UAT configuration with this request I found from my prior PR for HARMONY-2054 that initially added this functionality to not include OPeNDAP links:
http://localhost:3000/C1242267295-EEDTEST/ogc-api-coverages/1.0.0/collections/%2FBEAM0000%2Fagbd/coverage/rangeset?forceAsync=true&subset=lon(0%3A10)&subset=lat(0%3A10)&maxResults=1&serviceId=harmony%2Fdownload

You should verify that only a single output is provided which is the data file link and no OPeNDAP links are included.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)