### PR TITLE
HARMONY-2130: Changes to user_work design and user work updater to handle edge cases where work items are not being scheduled

### DIFF
--- a/services/cron-service/env-defaults
+++ b/services/cron-service/env-defaults
@@ -14,7 +14,8 @@ WORK_REAPER_BATCH_SIZE=2000
 RESTART_PROMETHEUS_CRON="*/10 * * * *" # every 10 minutes
 
 # The cron schedule for the user work updater
-USER_WORK_UPDATER_CRON="*/30 * * * *" # every thirty minutes
+USER_WORK_UPDATER_CRON="*/3 * * * *" # every 3 minutes
 
-# Rows in user_work older than this will cause the ready and running counts for a job to be recalculated
-USER_WORK_EXPIRATION_MINUTES=60
+# Rows in user_work with no work completed within this time interval this will cause the
+# ready and running counts for a job to be recalculated
+USER_WORK_EXPIRATION_MINUTES=3

--- a/services/cron-service/test/update-user-work.ts
+++ b/services/cron-service/test/update-user-work.ts
@@ -17,11 +17,11 @@ describe('UserWorkUpdater', () => {
   let loggerErrorStub: sinon.SinonStub;
   let loggerWarnStub: sinon.SinonStub;
   let recalculateCountsStub: sinon.SinonStub;
-  let setReadyAndRunningCountToZeroStub: sinon.SinonStub;
+  let deleteUserWorkForJobStub: sinon.SinonStub;
 
   beforeEach(async () => {
     await truncateAll();
-    // Set up logger stubs
+
     loggerInfoStub = sinon.stub();
     loggerErrorStub = sinon.stub();
     loggerWarnStub = sinon.stub();
@@ -36,18 +36,14 @@ describe('UserWorkUpdater', () => {
       db: db,
     } as unknown as Context;
 
-    // Set up recalculateCounts stub
     recalculateCountsStub = sinon.stub(userWork, 'recalculateCounts').resolves();
+    deleteUserWorkForJobStub = sinon.stub(userWork, 'deleteUserWorkForJob').resolves();
 
-    // Set up setReadyAndRunningCountToZero stub
-    setReadyAndRunningCountToZeroStub = sinon.stub(userWork, 'setReadyAndRunningCountToZero').resolves();
-
-    // Set environment variables
     env.userWorkExpirationMinutes = 60;
   });
 
   afterEach(() => {
-    setReadyAndRunningCountToZeroStub.reset();
+    deleteUserWorkForJobStub.reset();
     recalculateCountsStub.reset();
     sinon.restore();
   });
@@ -138,7 +134,7 @@ describe('UserWorkUpdater', () => {
     });
 
     it('should handle jobs with zero counts but still check last_worked date', async () => {
-      // Insert test data - job with zero counts but old last_worked date
+      // Insert test data - job with zero counts and old last_worked date
       const pastDate = new Date();
       pastDate.setHours(pastDate.getHours() - 2);
       const job1 = buildJob({});
@@ -146,11 +142,21 @@ describe('UserWorkUpdater', () => {
       const userWork5 = createUserWorkRecord({ job_id: job1.jobID, ready_count: 0, running_count: 0, last_worked: pastDate });
       await userWork5.save(db);
 
+      const job2 = buildJob({});
+      await job2.save(db);
+      const userWork5_2 = createUserWorkRecord({ job_id: job2.jobID, ready_count: 0, running_count: 0, last_worked: new Date() });
+      await userWork5_2.save(db);
+
       await updateUserWorkMod.updateUserWork(ctx);
 
-      // Should not have called recalculateCounts for jobs with zero counts
-      expect(recalculateCountsStub.neverCalledWith(sinon.match.any, job1.jobID)).to.be.true;
-      expect(loggerWarnStub.neverCalledWith(`Recalculating user_work counts for job ${job1.jobID} with status ${job1.status}`)).to.be.true;
+      // Should call recalculateCounts for older job1
+      expect(recalculateCountsStub.callCount).to.equal(1);
+      expect(recalculateCountsStub.calledWith(sinon.match.any, job1.jobID)).to.be.true;
+      expect(loggerWarnStub.calledOnceWith(`Recalculating user_work counts for job ${job1.jobID} with status ${job1.status}`)).to.be.true;
+
+      // Should not call recalculateCounts for recently worked on job2
+      expect(recalculateCountsStub.neverCalledWith(sinon.match.any, job2.jobID)).to.be.true;
+      expect(loggerWarnStub.neverCalledWith(`Recalculating user_work counts for job ${job2.jobID} with status ${job2.status}`)).to.be.true;
     });
 
     it('should handle multiple rows per job_id but only process each job_id once', async () => {
@@ -175,7 +181,7 @@ describe('UserWorkUpdater', () => {
       expect(loggerWarnStub.calledOnceWith(`Recalculating user_work counts for job ${job1.jobID} with status ${job1.status}`)).to.be.true;
     });
 
-    it('should set set the ready count and the running count for paused jobs to zero', async () => {
+    it('should delete user work rows for paused jobs', async () => {
       const pastDate = new Date();
       pastDate.setHours(pastDate.getHours() - 2);
 
@@ -189,11 +195,11 @@ describe('UserWorkUpdater', () => {
       await updateUserWorkMod.updateUserWork(ctx);
 
       // Should have called setReadyAndRunningCountToZero once for job6 and recalculateCounts not at all
-      expect(setReadyAndRunningCountToZeroStub.callCount).to.equal(1);
-      expect(setReadyAndRunningCountToZeroStub.calledWith(sinon.match.any, job1.jobID)).to.be.true;
+      expect(deleteUserWorkForJobStub.callCount).to.equal(1);
+      expect(deleteUserWorkForJobStub.calledWith(sinon.match.any, job1.jobID)).to.be.true;
       expect(recalculateCountsStub.callCount).to.equal(0);
 
-      expect(loggerWarnStub.calledOnceWith(`Resetting user_work counts to 0 for job ${job1.jobID} with status ${job1.status}`)).to.be.true;
+      expect(loggerWarnStub.calledOnceWith(`Removing user_work rows for job ${job1.jobID} with status ${job1.status}`)).to.be.true;
     });
   });
 });

--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -12,8 +12,8 @@ import JobMessage, {
   getErrorMessagesForJob, getMessageCountForJob, getWarningMessagesForJob, JobMessageLevel,
 } from '../../models/job-message';
 import {
-  decrementRunningCount, deleteUserWorkForJob, incrementReadyAndDecrementRunningCounts,
-  incrementReadyCount, setReadyCountToZero,
+  decrementRunningCount, deleteUserWorkForJob, deleteUserWorkForJobAndService,
+  incrementReadyAndDecrementRunningCounts, incrementReadyCount, setReadyCountToZero,
 } from '../../models/user-work';
 import WorkItem, {
   getWorkItemById, getWorkItemsByJobIdAndStepIndex, maxSortIndexForJobService, updateWorkItemStatus,
@@ -799,6 +799,9 @@ export async function processWorkItem(
 
     if (checkCompletion) {
       allWorkItemsForStepComplete = await updateIsComplete(tx, jobID, job.numInputGranules, thisStep);
+      if (allWorkItemsForStepComplete) {
+        await deleteUserWorkForJobAndService(tx, jobID, serviceId);
+      }
     }
 
     const continueProcessing = await (await logAsyncExecutionTime(

--- a/services/harmony/app/models/user-work.ts
+++ b/services/harmony/app/models/user-work.ts
@@ -231,6 +231,7 @@ export async function populateUserWorkForJobId(tx: Transaction, jobID: string): 
   + 'LEFT JOIN work_items i on "ws"."jobID" = "i"."jobID" AND "i"."jobID" = "j"."jobID" '
   + 'WHERE j.status not in (\'successful\', \'complete_with_errors\', \'failed\', \'canceled\') '
   + `AND "j"."jobID" = '${jobID}' `
+  + 'AND ws.is_complete IS NOT TRUE '
   + 'GROUP BY "j"."updatedAt", "ws"."serviceID", "ws"."jobID", j.username, "j"."isAsync" '
   + 'ORDER BY "j"."updatedAt" asc';
   await tx.raw(sql);

--- a/services/harmony/app/util/job.ts
+++ b/services/harmony/app/util/job.ts
@@ -6,9 +6,7 @@ import DataOperation, { CURRENT_SCHEMA_VERSION } from '../models/data-operation'
 import { getRelatedLinks, Job, JobForDisplay, JobStatus, terminalStates } from '../models/job';
 import JobLink from '../models/job-link';
 import JobMessage, { JobMessageLevel } from '../models/job-message';
-import {
-  deleteUserWorkForJob, recalculateReadyCount, setReadyCountToZero,
-} from '../models/user-work';
+import { deleteUserWorkForJob, recalculateCounts } from '../models/user-work';
 import { getTotalWorkItemSizesForJobID, updateWorkItemStatusesByJobId } from '../models/work-item';
 import { WorkItemStatus } from '../models/work-item-interface';
 import { getWorkflowStepByJobIdStepIndex, getWorkflowStepsByJobId } from '../models/workflow-steps';
@@ -287,7 +285,7 @@ export async function pauseAndSaveJob(
     const job = await lookupJob(tx, jobID, username);
     job.pause();
     await job.save(tx);
-    await setReadyCountToZero(tx, jobID);
+    await deleteUserWorkForJob(tx, jobID);
   });
 }
 
@@ -325,7 +323,7 @@ async function updateTokenAndChangeState(
     }
     jobStatusFn(job);
     await job.save(tx);
-    await recalculateReadyCount(tx, jobID);
+    await recalculateCounts(tx, jobID);
   });
 }
 

--- a/workload/README.md
+++ b/workload/README.md
@@ -36,7 +36,7 @@ $ HTTPS_PROXY=socks5h://localhost:8080 locust
 Note that you will also need to provide the EDC certificate in order to successfully connect to the load balancer
 in the sandbox environment. Save the EDC SSL certificate to a file locally and then run:
 ```
-REQUESTS_CA_BUNDLE=<local PEM file> BEARER_TOKEN=$UAT_BEARER HTTPS_PROXY=socks5h://localhost:8080 locust --exclude-tags uat
+REQUESTS_CA_BUNDLE=<local PEM file> WORKLOAD_BEARER_TOKEN=$UAT_BEARER HTTPS_PROXY=socks5h://localhost:8080 locust --exclude-tags uat
 ```
 
 #### Testing synchronous requests in sandbox

--- a/workload/locustfile.py
+++ b/workload/locustfile.py
@@ -211,12 +211,12 @@ class HarmonyUatUser(BaseHarmonyUser):
         self._concise_50_granules()
 
     @tag('async', 'hoss', 'demo')
-    @task(50)
+    @task(2)
     def hoss_spatial_and_variable_subset(self):
         self._hoss_spatial_and_variable_subset()
 
     @tag('ml', 'random')
-    @task(50)
+    @task(2)
     def random_num_granules_service_example(self):
         self._random_num_granules_service_example()
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2130

## Description
This is to fix an issue where 3 out of 10,000 requests tested with bignbit had work items that were never executed. Manually pausing and resuming those 3 requests caused the work to be scheduled (as a result of the call to resume forcing the counts on the user_work table to be recalculated for those jobs.

The change is look at any rows in the user_work table - even if both the ready_count and running_count are both 0 and recalculate their counts if it has been more than 3 minutes since any work as been done for that job.

## Local Test Steps
I didn't have a way to reproduce the problem locally. I tested in a sandbox environment (building and deploying my images) and running a test for a few hours with 120 concurrent requests from the workload drivers. In addition I submitted a large request (110K granules) while that test was ongoing. Every request completed (over 3900 jobs and 153K work items) - a couple failed for an unrelated reason (issues with the large-work-item-update queue).

In my testing I found many cases where counts were recalculated - in each case the user work updater ran quickly (in the 29 to 136 milliseconds range) - example:
```
{"cron_job":"UserWorkUpdater","env_name":"harmony-cdd-sandbox","level":"info","message":"Started user work updater cron job","timestamp":"2025-07-16T13:48:00.016Z"}
{"cron_job":"UserWorkUpdater","env_name":"harmony-cdd-sandbox","level":"warn","message":"Recalculating user_work counts for job f825f8c2-30f3-44ae-a77c-cff0c80151b6 with status running","timestamp":"2025-07-16T13:48:00.107Z"}
{"cron_job":"UserWorkUpdater","durationMs":121,"env_name":"harmony-cdd-sandbox","level":"info","message":"Finished updating user work counts for 1 jobs","timestamp":"2025-07-16T13:48:00.137Z"}
{"cron_job":"UserWorkUpdater","env_name":"harmony-cdd-sandbox","level":"info","message":"Started user work updater cron job","timestamp":"2025-07-16T13:51:00.010Z"}
{"cron_job":"UserWorkUpdater","env_name":"harmony-cdd-sandbox","level":"warn","message":"Recalculating user_work counts for job c38dee59-6ce1-405d-9f8f-6d7671afd369 with status running","timestamp":"2025-07-16T13:51:00.056Z"}
{"cron_job":"UserWorkUpdater","env_name":"harmony-cdd-sandbox","level":"warn","message":"Recalculating user_work counts for job f825f8c2-30f3-44ae-a77c-cff0c80151b6 with status running","timestamp":"2025-07-16T13:51:00.098Z"}
{"cron_job":"UserWorkUpdater","durationMs":97,"env_name":"harmony-cdd-sandbox","level":"info","message":"Finished updating user work counts for 2 jobs","timestamp":"2025-07-16T13:51:00.107Z"}
```

Also sanity check pausing and resuming works as before since those were both impacted by these changes.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)