### PR TITLE
HARMONY-2159: Add support in Harmony to handle non-retriable errors from services

### DIFF
--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -708,7 +708,13 @@ export async function processWorkItem(
 
     // retry failed work-items up to a limit
     if (status === WorkItemStatus.FAILED) {
-      if (workItem.retryCount < env.workItemRetryLimit) {
+      if (message_category === 'noretry') {
+        logger.warn('This error is not retriable.');
+        logger.warn(
+          `Updating work item for ${workItemID} to ${status} with message ${message}`,
+          { workFailureMessage: message, serviceId: workItem.serviceID, status },
+        );
+      } else if (workItem.retryCount < env.workItemRetryLimit) {
         logger.info(`Retrying failed work-item ${workItemID}`);
         workItem.retryCount += 1;
         workItem.status = WorkItemStatus.READY;


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2159

## Description
Add support in Harmony to handle non-retriable errors from services.

## Local Test Steps
This PR is to be tested together with [this harmony-service-lib-py PR](https://github.com/nasa/harmony-service-lib-py/pull/65) with the NoRetryException change.

Change harmony-service-example to create a non-retryable error for specific granules to facilitate with the testing. e.g. 
add `from harmony_service_lib.exceptions import NoRetryException` at the top of transform.py in harmony-service-example and the following to around line 96:
```
if asset.href == 'https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/nc/001_00_7f00ff_global.nc' or asset.href == 'https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/nc/001_07_7f00ff_north_america.nc':
                raise NoRetryException("I'm done with it")
```
Build harmony-service-example with the above harmony-service-lib-py PR branch.

Then run harmony locally with the built harmony-service-example service, submit the following request and see the work item is failed immediately without any retry. The workflow ui indicate the correct noretry error category with the proper error message and the service log show only one execution.

http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/red_var,blue_var,green_var/coverage/rangeset/?subset=lat(20%3A60)&subset=lon(-140%3A-50)&outputCrs=EPSG%3A31975&format=image%2Fpng&maxResults=1

You can see job with multiple granules with the following request:
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/red_var,blue_var,green_var/coverage/rangeset/?subset=lat(20%3A60)&subset=lon(-140%3A-50)&outputCrs=EPSG%3A31975&format=image%2Fpng&maxResults=3

Then either submit a request with service returns a retriable error on a different service, or modify the harmony-service-example code to throw a retryable error instead of the NoRetryException (e.g. raise ForbiddenException('not allowed')), verify the work item will be retried 5 times.

Speaking of the ForbiddenException, any reason we want to retry it 5 times? Feels like we should not retry this error.

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)