### PR TITLE
Add IMAGENATOR to production configuration

### DIFF
--- a/config/services-prod.yml
+++ b/config/services-prod.yml
@@ -375,6 +375,62 @@ https://cmr.earthdata.nasa.gov:
           exists: [ 'variableSubset', 'dimensionSubset' ]
       - image: !Env ${GEOLOCO_IMAGE}
 
+  - name: asdc/imagenator_l2
+    description: Chain to create TEMPO L2 imagery for GIBS
+    data_operation_version: '0.22.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/harmony/imagenator_l2
+    umm_s: SD3611093087-LARC_CLOUD
+    capabilities:
+      concatenation: false
+      subsetting:
+        bbox: false
+        variable: true
+        temporal: false
+      output_formats:
+        - image/png
+      reprojection: false
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${SWATH_PROJECTOR_IMAGE}
+      - image: !Env ${FILTERING_IMAGE}
+      - image: !Env ${NET2COG_IMAGE}
+      - image: !Env ${HYBIG_IMAGE}
+
+  - name: asdc/imagenator_l3
+    description: Chain to create TEMPO L3 imagery for GIBS
+    data_operation_version: '0.22.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/harmony/imagenator_l3
+    umm_s: SD3611100450-LARC_CLOUD
+    capabilities:
+      concatenation: false
+      subsetting:
+        bbox: false
+        variable: true
+        temporal: false
+      output_formats:
+        - image/png
+      reprojection: false
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${FILTERING_IMAGE}
+      - image: !Env ${NET2COG_IMAGE}
+      - image: !Env ${HYBIG_IMAGE}
+
+
   - name: sds/HyBIG
     description: |
       The Harmony Browse Image Generator (HyBIG) supports the conversion of

--- a/config/services-prod.yml
+++ b/config/services-prod.yml
@@ -385,7 +385,7 @@ https://cmr.earthdata.nasa.gov:
         env:
           <<: *default-turbo-env
           STAGING_PATH: public/harmony/imagenator_l2
-    umm_s: SD3611093087-LARC_CLOUD
+    umm_s: S3616918926-LARC_CLOUD
     capabilities:
       concatenation: false
       subsetting:
@@ -413,7 +413,7 @@ https://cmr.earthdata.nasa.gov:
         env:
           <<: *default-turbo-env
           STAGING_PATH: public/harmony/imagenator_l3
-    umm_s: SD3611100450-LARC_CLOUD
+    umm_s: S3616918458-LARC_CLOUD
     capabilities:
       concatenation: false
       subsetting:


### PR DESCRIPTION
## Jira Issue ID
TRT-620

## Description
This PR adds the asdc/imagenator_l2 & asdc/imagenator_l3 service chains to services-prod.yml. The new service chains configuration mimics the existing asdc/imagenator_l2 & asdc/imagenator_l3 service chain in services-uat.yml.

The umm-s records we point to in the prod service chains are:
asdc/imagenator_l2: [S3616918926-LARC_CLOUD](https://mmt.earthdata.nasa.gov/services/S3616918458-LARC_CLOUD)
asdc/imagenator_l3: [S3616918458-LARC_CLOUD](https://mmt.earthdata.nasa.gov/services/S3616918926-LARC_CLOUD)

The TEMPO collections are associated with them at this time. 

## Local Test Steps
 
**Test URL for IMAGENATOR L3:** 
https://harmony.earthdata.nasa.gov/C2930763263-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?maxresults=1&granuleid=G3620400572-LARC_CLOUD&format=image/png&forceasync=true&variable=product/vertical_column_stratosphere

**Test URL for IMAGENATOR L2:** 
https://harmony.earthdata.nasa.gov/C2930725014-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?maxresults=1&granuleid=G3620375032-LARC_CLOUD&format=image/png&forceasync=true&variable=product/vertical_column_stratosphere

## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)