### PR TITLE
HARMONY-2154: Add cron job to publish CloudWatch metrics for service failures

### DIFF
--- a/ENV_CHANGELOG.md
+++ b/ENV_CHANGELOG.md
@@ -2,6 +2,11 @@
 Any changes to the environment variables will be documented in this file in chronological
 order with the most recent changes first.
 
+# 2025-07-30
+### Added
+- PUBLISH_SERVICE_FAILURE_METRICS_CRON - cron schedule for the job that writes cloudwatch metrics for service failures
+- FAILURE_METRICS_LOOK_BACK_MINUTES - how far back to go when computing cloudwatch metrics for service failures
+
 # 2025-07-24
 ### Added
 - MAX_PERCENT_ERRORS_FOR_JOB - the maximum percentage of failures for a service before failing a job

--- a/config/local-postgres-localstack-deployment.yml
+++ b/config/local-postgres-localstack-deployment.yml
@@ -16,7 +16,7 @@ spec:
           name: localstack-start
       env:
         - name: LOCALSTACK_SERVICES
-          value: "lambda,s3,sqs,sts"
+          value: "lambda,s3,sqs,sts,cloudwatch"
         - name: LOCALSTACK_DEBUG
           value: "1"
   volumes:

--- a/services/cron-service/README.md
+++ b/services/cron-service/README.md
@@ -35,6 +35,13 @@ There are two steps for adding new jobs:
    array containing the environment variable from step 2 and the class that you
    implemented in step 1. See the entry for the `WorkReaper` class for an example.
 
+### Disabling Specific Cron Jobs
+
+If you don't want to run a particular cron job, e.g., the one that computes CloudWatch service
+failure metrics, you can disable it by setting the environment variable for its cron schedule
+to something that will never be scheduled, like the 30th of February:
+`0 0 30 2 *`
+
 ## Pushing the Docker Image to ECR
 
 If you want to do sandbox deployments with your custom cron service image then you need to

--- a/services/cron-service/app/cronjobs/publish-failure-metrics.ts
+++ b/services/cron-service/app/cronjobs/publish-failure-metrics.ts
@@ -1,0 +1,203 @@
+import { CloudWatchClient, PutMetricDataCommand, StandardUnit } from '@aws-sdk/client-cloudwatch';
+
+import { WorkItemStatus } from '../../../harmony/app/models/work-item-interface';
+import { Context } from '../util/context';
+import env from '../util/env';
+import { CronJob } from './cronjob';
+
+interface MetricData {
+  metricName: string;
+  namespace: string;
+  value: number;
+  unit?: StandardUnit;
+  dimensions?: { [key: string]: string; };
+  timestamp?: Date;
+}
+
+interface FailedWorkItemPercentage {
+  service: string;
+  percent: number;
+}
+
+interface WorkItemsQueryResult {
+  serviceID: string;
+  status: string;
+  count: string; // Knex returns count as string, we'll convert to number
+}
+
+/**
+ * Get a CloudWatch client config for either localstack or a real environment.
+ * @returns a configuration appropriate for the working environment
+ */
+function getCloudWatchClientConfg(): object {
+  let config = {};
+
+  if (process.env.USE_LOCALSTACK === 'true') {
+    const { localstackHost } = env;
+
+    config = {
+      region: env.awsDefaultRegion,
+      endpoint: `http://${localstackHost}:4572`,
+      credentials: {
+        accessKeyId: 'localstack',
+        secretAccessKey: 'localstack',
+      },
+    };
+  } else {
+    config = {
+      region: env.awsDefaultRegion,
+      // Credentials will be automatically loaded from environment, IAM role, or AWS config
+    };
+  }
+
+  return config;
+}
+
+/**
+ * Get the percentage of failed work-items for all services over the given timeframe
+ *
+ * @param ctx - The Cron job context
+ * @param minutesBack - How many minutes back to look for metrics (default 60)
+ * @returns
+ */
+export async function getFailedWorkItemPercentageByServiceWithTimeWindow(
+  ctx: Context,
+  minutesBack: number = 60,
+): Promise<FailedWorkItemPercentage[]> {
+  const { logger, db } = ctx;
+  logger.info('Getting service status counts');
+  try {
+    const now = new Date();
+    const timeAgo = new Date(now.getTime() - minutesBack * 60 * 1000);
+
+    // const serviceCounts = new Map<string, number[]>();
+    const serviceCounts = {};
+
+    // get all the services - need to do this here as some of the services may not have recent
+    // work-items, but we still want to report metrics for them
+    const allServices = await db('work_items')
+      .distinct('serviceID');
+
+    // normalize service names by removing tags from service IDs
+    for (const { serviceID } of allServices) {
+      // remove the tag from the serviceID
+      const match = serviceID.match(/^(.+):/);
+      const service = match ? match[1] : serviceID;
+      serviceCounts[service] = [0, 0];
+    }
+
+    const queryResults = await db('work_items')
+      .select('serviceID', 'status')
+      .count('* as count')
+      .whereIn('status', [WorkItemStatus.FAILED, WorkItemStatus.SUCCESSFUL, WorkItemStatus.WARNING])
+      .where('updatedAt', '>=', timeAgo.toISOString())
+      .groupBy('serviceID', 'status')
+      .orderBy(['serviceID', 'status']) as WorkItemsQueryResult[];
+
+    // normalize service names by removing tags from service IDs and combine counts to normalized
+    // service name
+    for (const { serviceID, status, count } of queryResults) {
+      // remove the tag from the serviceID
+      const match = serviceID.match(/^(.+):/);
+      const service = match ? match[1] : serviceID;
+      const numCount = parseInt(count, 10);
+      if (status === WorkItemStatus.FAILED) {
+        serviceCounts[service][0] += numCount;
+      } else {
+        serviceCounts[service][1] += numCount;
+      }
+    }
+
+    const results = [];
+    for (const service of Object.keys(serviceCounts)) {
+      const values = serviceCounts[service];
+      const failureCount = values[0];
+      const totalCount = failureCount + values[1];
+      let percent = 0;
+      if (totalCount > 0) {
+        percent = 100.0 * failureCount / totalCount;
+      }
+      results.push({
+        service,
+        percent,
+      });
+    }
+
+    return results;
+
+  } catch (error) {
+    logger.error('Error querying failed for work items:', error);
+    throw error;
+  }
+}
+
+/**
+ * Publishes a single metric to CloudWatch
+ */
+export async function publishMetric(ctx: Context, client: CloudWatchClient, metricData: MetricData): Promise<void> {
+  const { logger } = ctx;
+  const { metricName, namespace, value, unit = 'Percent', dimensions, timestamp } = metricData;
+
+  // Convert dimensions object to CloudWatch format
+  const dimensionsArray = dimensions
+    ? Object.entries(dimensions).map(([name, val]) => ({
+      Name: name,
+      Value: val,
+    }))
+    : undefined;
+
+  const params = {
+    Namespace: namespace,
+    MetricData: [
+      {
+        MetricName: metricName,
+        Value: value,
+        Unit: unit,
+        Timestamp: timestamp || new Date(),
+        Dimensions: dimensionsArray,
+      },
+    ],
+  };
+
+  try {
+    const command = new PutMetricDataCommand(params);
+    await client.send(command);
+  } catch (error) {
+    logger.error('Error publishing failure metric:', error);
+    throw error;
+  }
+}
+
+/**
+ * Publish service failure metrics to CloudWatch
+ */
+export class PublisServiceFailureMetrics extends CronJob {
+  static async run(ctx: Context): Promise<void> {
+    const { logger } = ctx;
+    logger.info('Failure metrics publisher started.');
+
+    const serviceFailurePercentages = await getFailedWorkItemPercentageByServiceWithTimeWindow(ctx, env.failureMetricsLookBackMinutes);
+    const namespace = `harmony-services-${env.clientId}`;
+    logger.info(`Publishing ${serviceFailurePercentages.length} metrics to namespace ${namespace}`);
+
+    // Initialize the CloudWatch client
+    const config = getCloudWatchClientConfg();
+    const client = new CloudWatchClient(config);
+
+    for (const serviceFailure of serviceFailurePercentages) {
+      const data: MetricData = {
+        metricName: 'harmony-service-percent-failures',
+        namespace: namespace,
+        value: serviceFailure.percent,
+        dimensions: {
+          'service': serviceFailure.service,
+        },
+        timestamp: new Date(),
+      };
+
+      await publishMetric(ctx, client, data);
+    }
+
+    logger.info('Failure metrics publication completed.');
+  }
+}

--- a/services/cron-service/app/server.ts
+++ b/services/cron-service/app/server.ts
@@ -3,6 +3,7 @@ import express from 'express';
 
 import db from '../../harmony/app/util/db';
 import log from '../../harmony/app/util/log';
+import { PublisServiceFailureMetrics } from './cronjobs/publish-failure-metrics';
 import { RestartPrometheus } from './cronjobs/restart-prometheus';
 import { UserWorkUpdater } from './cronjobs/update-user-work';
 import { WorkReaper } from './cronjobs/work-reaper';
@@ -21,6 +22,7 @@ export default function start(): void {
     [env.workReaperCron, WorkReaper],
     [env.restartPrometheusCron, RestartPrometheus],
     [env.userWorkUpdaterCron, UserWorkUpdater],
+    [env.publishServiceFailureMetricsCron, PublisServiceFailureMetrics],
   ];
 
   for (const [cronSpec, jobClass] of cronEntries) {

--- a/services/cron-service/app/util/env.ts
+++ b/services/cron-service/app/util/env.ts
@@ -39,6 +39,15 @@ class CronServiceHarmonyEnv extends HarmonyEnv {
   @Min(1)
   userWorkExpirationMinutes: number;
   // End user work update variables
+
+  // Begin publish service failure metrics variables
+  @IsCrontab()
+  publishServiceFailureMetricsCron: string;
+
+  @IsInt()
+  @Min(1)
+  failureMetricsLookBackMinutes: number;
+  // End publish service failure metrics variables
 }
 
 const localPath = path.resolve(__dirname, '../../env-defaults');

--- a/services/cron-service/env-defaults
+++ b/services/cron-service/env-defaults
@@ -19,3 +19,11 @@ USER_WORK_UPDATER_CRON="*/3 * * * *" # every 3 minutes
 # Rows in user_work with no work completed within this time interval this will cause the
 # ready and running counts for a job to be recalculated
 USER_WORK_EXPIRATION_MINUTES=3
+
+# The cron schedule for publishing service failure metrics to CloudWatch
+PUBLISH_SERVICE_FAILURE_METRICS_CRON="0 * * * *" # every hour on the hour
+
+# How far to go back from the current time when computing service failure percentages.
+# This should correspond to how often the computation runs based on
+# PUBLISH_SERVICE_FAILURE_METRICS_CRON
+FAILURE_METRICS_LOOK_BACK_MINUTES=60

--- a/services/cron-service/package-lock.json
+++ b/services/cron-service/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@2toad/profanity": "^3.0.1",
+        "@aws-sdk/client-cloudwatch": "^3.437.0",
         "@aws-sdk/client-s3": "3.437.0",
         "@aws-sdk/client-sqs": "3.437.0",
         "@aws-sdk/credential-provider-imds": "^3.374.0",
@@ -273,6 +274,406 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/@aws-sdk/client-cloudwatch": {
+      "version": "3.437.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudwatch/-/client-cloudwatch-3.437.0.tgz",
+      "integrity": "sha512-pJQShshd2szsOOdQ+ve4L0Chjh3ItCBtRsX0U5RI1/J4UYlOHWhZ+PTCEqbE7jbCOvOXieqx1eYhX5Bb8nhRjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.437.0",
+        "@aws-sdk/core": "3.436.0",
+        "@aws-sdk/credential-provider-node": "3.437.0",
+        "@aws-sdk/middleware-host-header": "3.433.0",
+        "@aws-sdk/middleware-logger": "3.433.0",
+        "@aws-sdk/middleware-recursion-detection": "3.433.0",
+        "@aws-sdk/middleware-signing": "3.433.0",
+        "@aws-sdk/middleware-user-agent": "3.433.0",
+        "@aws-sdk/region-config-resolver": "3.433.0",
+        "@aws-sdk/types": "3.433.0",
+        "@aws-sdk/util-endpoints": "3.433.0",
+        "@aws-sdk/util-user-agent-browser": "3.433.0",
+        "@aws-sdk/util-user-agent-node": "3.437.0",
+        "@smithy/config-resolver": "^2.0.16",
+        "@smithy/fetch-http-handler": "^2.2.4",
+        "@smithy/hash-node": "^2.0.12",
+        "@smithy/invalid-dependency": "^2.0.12",
+        "@smithy/middleware-content-length": "^2.0.14",
+        "@smithy/middleware-endpoint": "^2.1.3",
+        "@smithy/middleware-retry": "^2.0.18",
+        "@smithy/middleware-serde": "^2.0.12",
+        "@smithy/middleware-stack": "^2.0.6",
+        "@smithy/node-config-provider": "^2.1.3",
+        "@smithy/node-http-handler": "^2.1.8",
+        "@smithy/protocol-http": "^3.0.8",
+        "@smithy/smithy-client": "^2.1.12",
+        "@smithy/types": "^2.4.0",
+        "@smithy/url-parser": "^2.0.12",
+        "@smithy/util-base64": "^2.0.0",
+        "@smithy/util-body-length-browser": "^2.0.0",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.16",
+        "@smithy/util-defaults-mode-node": "^2.0.21",
+        "@smithy/util-retry": "^2.0.5",
+        "@smithy/util-utf8": "^2.0.0",
+        "@smithy/util-waiter": "^2.0.12",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/core": {
+      "version": "3.436.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.436.0.tgz",
+      "integrity": "sha512-vX5/LjXvCejC2XUY6TSg1oozjqK6BvkE75t0ys9dgqyr5PlZyZksMoeAFHUlj0sCjhT3ziWCujP1oiSpPWY9hg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/smithy-client": "^2.1.12"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@aws-sdk/types": {
+      "version": "3.433.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.433.0.tgz",
+      "integrity": "sha512-0jEE2mSrNDd8VGFjTc1otYrwYPIkzZJEIK90ZxisKvQ/EURGBhNzWn7ejWB9XCMFT6XumYLBR0V9qq5UPisWtA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.4.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/abort-controller": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.2.0.tgz",
+      "integrity": "sha512-wRlta7GuLWpTqtFfGo+nZyOO1vEvewdNR1R4rTxpC8XU6vG/NDyrFBhwLZsqg1NUoR1noVaXJPC/7ZK47QCySw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/fetch-http-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.5.0.tgz",
+      "integrity": "sha512-BOWEBeppWhLn/no/JxUL/ghTfANTjT7kg3Ww2rPqTUY9R4yHPXxJ9JhMe3Z03LN3aPwiwlpDIUcVw1xDyHqEhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/middleware-endpoint": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+      "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/url-parser": "^2.2.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/middleware-serde": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.3.0.tgz",
+      "integrity": "sha512-sIADe7ojwqTyvEQBe1nc/GXB9wdHhi9UwyX0lTyttmUWDJLP655ZYE1WngnNyXREme8I27KCaUhyhZWRXL0q7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/middleware-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.2.0.tgz",
+      "integrity": "sha512-Qntc3jrtwwrsAC+X8wms8zhrTr0sFXnyEGhZd9sLtsJ/6gGQKFzNB+wWbOcpJd7BR8ThNCoKt76BuQahfMvpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/node-config-provider": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.3.0.tgz",
+      "integrity": "sha512-0elK5/03a1JPWMDPaS726Iw6LpQg80gFut1tNpPfxFuChEEklo2yL823V94SpTZTxmKlXFtFgsP55uh3dErnIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^2.2.0",
+        "@smithy/shared-ini-file-loader": "^2.4.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/node-http-handler": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.5.0.tgz",
+      "integrity": "sha512-mVGyPBzkkGQsPoxQUbxlEfRjrj6FPyA3u3u2VXGr9hT8wilsoQdZdvKpMBFMB8Crfhv5dNkKHIW0Yyuc7eABqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/querystring-builder": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/property-provider": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.2.0.tgz",
+      "integrity": "sha512-+xiil2lFhtTRzXkx8F053AV46QnIw6e7MV8od5Mi68E1ICOjCeCHw2XfLnDEUHnT9WGUIkwcqavXjfwuJbGlpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/protocol-http": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/querystring-builder": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.2.0.tgz",
+      "integrity": "sha512-L1kSeviUWL+emq3CUVSgdogoM/D9QMFaqxL/dd0X7PCNWmPXqt+ExtrBjqT0V7HLN03Vs9SuiLrG3zy3JGnE5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-uri-escape": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/querystring-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.2.0.tgz",
+      "integrity": "sha512-BvHCDrKfbG5Yhbpj4vsbuPV2GgcpHiAkLeIlcA1LtfpMz3jrqizP1+OguSNSj1MwBHEiN+jwNisXLGdajGDQJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/shared-ini-file-loader": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.4.0.tgz",
+      "integrity": "sha512-WyujUJL8e1B6Z4PBfAqC/aGY1+C7T0w20Gih3yrvJSk97gpiVfB+y7c46T4Nunk+ZngLq0rOIdeVeIklk0R3OA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/smithy-client": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+      "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-stack": "^2.2.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-stream": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/types": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.12.0.tgz",
+      "integrity": "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/url-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.2.0.tgz",
+      "integrity": "sha512-hoA4zm61q1mNTpksiSWp2nEl1dt3j726HdRhiNgVJQMj7mLp7dprtF57mOB6JvEk/x9d2bsuL5hlqZbBuHQylQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^2.2.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/util-base64": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.3.0.tgz",
+      "integrity": "sha512-s3+eVwNeJuXUwuMbusncZNViuhv2LjVJ1nMwTqSA0XAC7gjKhqqxRdJPhR8+YrkoZ9IiIbFk/yK6ACe/xlF+hw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/util-body-length-browser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.2.0.tgz",
+      "integrity": "sha512-dtpw9uQP7W+n3vOtx0CfBD5EWd7EPdIdsQnWTDoFf77e3VUf05uA7R7TGipIo8e4WL2kuPdnsr3hMQn9ziYj5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/util-hex-encoding": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.2.0.tgz",
+      "integrity": "sha512-7iKXR+/4TpLK194pVjKiasIyqMtTYJsgKgM242Y9uzt5dhHnUDvMNb+3xIhRJ9QhvqGii/5cRUt4fJn3dtXNHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/util-middleware": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.2.0.tgz",
+      "integrity": "sha512-L1qpleXf9QD6LwLCJ5jddGkgWyuSvWBkJwWAZ6kFkdifdso+sk3L3O1HdmPvCdnCK3IS4qWyPxev01QMnfHSBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/util-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.2.0.tgz",
+      "integrity": "sha512-17faEXbYWIRst1aU9SvPZyMdWmqIrduZjVOqCPMIsWFNxs5yQQgFrJL6b2SdiCzyW9mJoDjFtgi53xx7EH+BXA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^2.5.0",
+        "@smithy/node-http-handler": "^2.5.0",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-base64": "^2.3.0",
+        "@smithy/util-buffer-from": "^2.2.0",
+        "@smithy/util-hex-encoding": "^2.2.0",
+        "@smithy/util-utf8": "^2.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/util-uri-escape": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.2.0.tgz",
+      "integrity": "sha512-jtmJMyt1xMD/d8OtbVJ2gFZOSKc+ueYJZPW20ULW1GOp/q/YIM0wNh+u8ZFao9UaIGz4WoPW8hC64qlWLIfoDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cloudwatch/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.437.0",

--- a/services/cron-service/package.json
+++ b/services/cron-service/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@2toad/profanity": "^3.0.1",
+    "@aws-sdk/client-cloudwatch": "^3.437.0",
     "@aws-sdk/client-s3": "3.437.0",
     "@aws-sdk/client-sqs": "3.437.0",
     "@aws-sdk/credential-provider-imds": "^3.374.0",


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2154

## Description

Adds a new cron job that computes percentage of failure for each service over a given time range and writes these out as CloudWatch metrics. These will be used with CloudWatch anomaly detection.

## Local Test Steps

1. Start dev services
2. Run a job that has some failure

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [x] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)