### PR TITLE
HARMONY-2173: Remove inadvertent checkin to obsolete work-reaper project

### DIFF
--- a/services/work-reaper/.npmrc
+++ b/services/work-reaper/.npmrc
@@ -1,1 +1,0 @@
-node-options=--no-experimental-strip-types


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2173

## Description
Deployment is failing due to the work-reaper directory existing because of an inadvertent file checked in.

## Local Test Steps
Make sure the work-reaper directory does not exist on a fresh clone and then checking out this branch.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)