### PR TITLE
HARMONY-2172: Fixes bug with batched aggregation services not creating work items if any of the work items from the prior step have a no data warning.

### DIFF
--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -525,7 +525,7 @@ export async function createNextWorkItems(
         sortIndex = workItem.sortIndex;
       }
       let outputItemUrls = [];
-      if (workItem.status !== WorkItemStatus.FAILED) {
+      if (workItem.status !== WorkItemStatus.FAILED && workItem.message_category !== 'nodata') {
         outputItemUrls = await outputStacItemUrls(results);
       }
       didCreateWorkItem = await handleBatching(

--- a/services/harmony/test/aggregation-batching.ts
+++ b/services/harmony/test/aggregation-batching.ts
@@ -1397,12 +1397,14 @@ describe('when testing a batched aggregation service', function () {
     let batchSizeStub;
     let pageStub;
 
-    before(function () {
+    before(async function () {
       pageStub = stub(env, 'cmrMaxPageSize').get(() => 2);
       batchSizeStub = stub(env, 'maxBatchInputs').get(() => 2);
       sizeOfObjectStub = stub(aggregationBatch, 'sizeOfObject')
         .callsFake(async (_) => 1);
+      await truncateAll();
     });
+
     after(function () {
       if (pageStub.restore) {
         pageStub.restore();
@@ -1484,13 +1486,14 @@ describe('when testing a batched aggregation service', function () {
     let pageStub;
     let retryLimit;
 
-    before(function () {
+    before(async function () {
       pageStub = stub(env, 'cmrMaxPageSize').get(() => 2);
       batchSizeStub = stub(env, 'maxBatchInputs').get(() => 2);
       sizeOfObjectStub = stub(aggregationBatch, 'sizeOfObject')
         .callsFake(async (_) => 1);
       retryLimit = env.workItemRetryLimit;
       env.workItemRetryLimit = 0;
+      await truncateAll();
     });
 
     after(function () {
@@ -1512,10 +1515,6 @@ describe('when testing a batched aggregation service', function () {
       concatenate: true,
       maxResults: 2,
     };
-
-    before(async function () {
-      await truncateAll();
-    });
 
     hookRangesetRequest('1.0.0', l2ssCollection, 'all', { query: l2ssConciseQuery, username: 'joe' });
     hookRedirect('joe');
@@ -1575,13 +1574,14 @@ describe('when testing a batched aggregation service', function () {
     let pageStub;
     let retryLimit;
 
-    before(function () {
+    before(async function () {
       pageStub = stub(env, 'cmrMaxPageSize').get(() => 2);
       batchSizeStub = stub(env, 'maxBatchInputs').get(() => 2);
       sizeOfObjectStub = stub(aggregationBatch, 'sizeOfObject')
         .callsFake(async (_) => 1);
       retryLimit = env.workItemRetryLimit;
       env.workItemRetryLimit = 0;
+      await truncateAll();
     });
 
     after(function () {
@@ -1603,10 +1603,6 @@ describe('when testing a batched aggregation service', function () {
       concatenate: true,
       maxResults: 2,
     };
-
-    before(async function () {
-      await truncateAll();
-    });
 
     hookRangesetRequest('1.0.0', l2ssCollection, 'all', { query: l2ssConciseQuery, username: 'joe' });
     hookRedirect('joe');


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2172

## Description
Fixes bug with batched aggregation services not creating work items if any of the work items from the prior step have a no data warning.

## Local Test Steps
Deploy concise and l2ss-py locally and use the test version of l2ss-py that is returning nodata warnings instead of errors
```
LOCALLY_DEPLOYED_SERVICES=harmony-service-example,podaac-l2-subsetter,podaac-concise
PODAAC_L2_SUBSETTER_IMAGE=ghcr.io/podaac/l2ss-py:3.1.0rc4
PODAAC_L2_SUBSETTER_SERVICE_QUEUE_URLS='["ghcr.io/podaac/l2ss-py:3.1.0rc4,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/podaac-l2-subsetter.fifo"]'
```
From the main branch verify that you see the bug from the ticket where no concise step is executed for this request:
http://localhost:3000/C1272633014-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&subset=lat(70.84931%3A77.83342)&subset=lon(-27.57812%3A124.73438)&subset=time(%222025-06-06T18%3A00%3A00%2B00%3A00%22%3A%222025-06-08T07%3A00%3A00%2B00%3A00%22)&skipPreview=true&concatenate=true&maxResults=2

Checkout this branch and then repeat the same query. Verify that the concise step is now executed and there is a netcdf file included in the job status output.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Bug Fixes
  - Exclude “no data” items from contributing outputs during batched aggregation, preventing unintended items from affecting batch contents and downstream processing.

* Tests
  - Added scenarios covering success, failed, and “no data” combinations to verify correct batching behavior and whether concise downstream jobs are emitted or suppressed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->