### PR TITLE
updated giovanni time series adapter configuration to remove umm var validation 

### DIFF
--- a/config/services-prod.yml
+++ b/config/services-prod.yml
@@ -65,10 +65,7 @@ https://cmr.earthdata.nasa.gov:
           <<: *default-turbo-env
           STAGING_PATH: public/gesdisc/giovanni
     umm_s: S2739607260-GES_DISC
-    collections:
-      - id: C1276812830-GES_DISC
-        variables:
-        - V3171509330-GES_DISC
+    validate_variables: false
     capabilities:
       subsetting:
         temporal: true

--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -123,10 +123,7 @@ https://cmr.uat.earthdata.nasa.gov:
           <<: *default-turbo-env
           STAGING_PATH: public/gesdisc/giovanni
     umm_s: S1258984104-GES_DISC
-    collections:
-      - id: C1215802935-GES_DISC
-        variables:
-        - V1268438218-GES_DISC
+    validate_variables: false
     capabilities:
       subsetting:
         temporal: true


### PR DESCRIPTION
This PR remove the explicit list of variables and concept ids from the Giovanni time series adapter in both services yml files and replaces them with the field to make variable validation false. There will be a new corresponding image to this update for the time series adapter pushed after this is approved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded dataset compatibility for the time-series adapter in Production and UAT by removing per-service collection pinning.
  - Disabled variable validation for the adapter to allow broader variable usage across datasets.
- Chores
  - Updated service configurations in Production and UAT to align adapter behavior across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->