### PR TITLE
DAS-2410: Adds HOSS-regridder-reformatter and smap-l2-subsetter-net2cog configuration to Production

### DIFF
--- a/config/services-prod.yml
+++ b/config/services-prod.yml
@@ -288,6 +288,52 @@ https://cmr.earthdata.nasa.gov:
         conditional:
           exists: ['shapefileSubset', 'spatialSubset']
 
+  - name: sds/HOSS-regridder-reformatter
+    description: |
+      A service chain for applying the Harmony Metadata Annotator to HOSS/Maskfill
+      output, producing CF compliant annotated NetCDF4 outputs. This service chain
+      is also intended to be used for producing regridded outputs using the harmony-regridder
+      and to produce GeoTIFF outputs using net2cog.
+    data_operation_version: '0.22.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/sds/HOSS-regridder-reformatter
+    umm_s: S3671941188-XYZ_PROV
+    capabilities:
+      subsetting:
+        temporal: true
+        bbox: true
+        dimension: true
+        shape: true
+        variable: true
+      reprojection: true
+      output_formats:
+        - application/netcdf # Incorrect mime-type, remove when no longer needed
+        - application/x-netcdf4
+        - image/tiff
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${HOSS_IMAGE}
+        operations: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset', 'temporalSubset']
+        conditional:
+          exists: ['variableSubset', 'spatialSubset', 'dimensionSubset', 'shapefileSubset', 'temporalSubset']
+      - image: !Env ${SDS_MASKFILL_IMAGE}
+        operations: ['shapefileSubset', 'spatialSubset']
+        conditional:
+          exists: ['shapefileSubset', 'spatialSubset']
+      - image: !Env ${HARMONY_METADATA_ANNOTATOR_IMAGE}
+      - image: !Env ${HARMONY_REGRIDDER_IMAGE}
+        conditional:
+          exists: ['reproject']
+      - image: !Env ${NET2COG_IMAGE}
+        conditional:
+          format: ['image/tiff']
+
   - name: sds/swath-projector
     description: |
       Takes NetCDF-4 input files and projects input swath variables to an output grid.
@@ -612,6 +658,45 @@ https://cmr.earthdata.nasa.gov:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
       - image: !Env ${HARMONY_GDAL_ADAPTER_IMAGE}
+
+  - name: sds/smap-l2-subsetter-net2cog
+    description: |
+      A service chain for subsetting SMAP L2 collections with the Trajectory
+      Subsetter and reformatting that output to Cloud-Optimized GeoTIFF (COG).
+
+      In GeoTIFF reformatting the SMAP L2 Gridder is called first to convert
+      the output to NetCDF, which is then plugged into the Net2COG reformatter.
+    data_operation_version: '0.22.0'
+    type:
+      <<: *default-turbo-config
+      params:
+        <<: *default-turbo-params
+        env:
+          <<: *default-turbo-env
+          STAGING_PATH: public/sds/smap-l2-subsetter-net2cog
+    umm_s: S3671933145-XYZ_PROV
+    capabilities:
+      subsetting:
+        temporal: false
+        bbox: true
+        shape: true
+        variable: true
+      output_formats:
+        - application/x-hdf
+        - application/x-netcdf4
+        - image/tiff
+      reprojection: true
+    steps:
+      - image: !Env ${QUERY_CMR_IMAGE}
+        is_sequential: true
+      - image: !Env ${TRAJECTORY_SUBSETTER_IMAGE}
+        operations: ['variableSubset', 'spatialSubset', 'shapefileSubset']
+      - image: !Env ${HARMONY_SMAP_L2_GRIDDER_IMAGE}
+        conditional:
+          format: ['image/tiff', 'application/x-netcdf4']
+      - image: !Env ${NET2COG_IMAGE}
+        conditional:
+          format: ['image/tiff']
 
   - name: harmony/service-example
     description: |


### PR DESCRIPTION
## Jira Issue ID

[DAS-2410](https://bugs.earthdata.nasa.gov/browse/DAS-2410)

## Description

Adds configuration for the `sds/smap-l2-subsetter-net2cog` and
`sds/HOSS-regridder-reformatter` services to the production environment.

For these to work the production env will need to have both the Harmony SMAP L2
Gridder, the Harmony Regridder promoted to production.

## Local Test Steps

🤞 and hope it works?


## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added two public data-processing services:
    - HOSS regridder/reformatter: supports variable/shape/bbox/dimension/temporal subsetting, optional reprojection, and outputs NetCDF4 and Cloud-Optimized GeoTIFF.
    - SMAP L2 subsetter to COG: supports variable/shape/bbox subsetting, optional reprojection, and outputs HDF, NetCDF4, and Cloud-Optimized GeoTIFF.
  - Enables streamlined subsetting and format conversion for NASA CMR-hosted datasets without changes to existing services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->