### PR TITLE
TRT-635: Remove HGA from production.

### DIFF
--- a/config/services-prod.yml
+++ b/config/services-prod.yml
@@ -627,38 +627,6 @@ https://cmr.earthdata.nasa.gov:
       - image: !Env ${OPERA_RTC_S1_BROWSE_IMAGE}
       - image: !Env ${HYBIG_IMAGE}
 
-  - name: nasa/harmony-gdal-adapter
-    description: |
-      Service translating Harmony operations to GDAL commands.
-      Supports spatial bounding box, temporal, variable, and shapefile, reprojection,
-      and output to NetCDF4 or COG.
-      Operates on input file types supported by GDAL (most EOSDIS data).
-      Most operations assume L3 data, though it is likely that some work on L2.
-    data_operation_version: '0.22.0'
-    type:
-      <<: *default-turbo-config
-      params:
-        <<: *default-turbo-params
-        env:
-          <<: *default-turbo-env
-          STAGING_PATH: public/nasa/harmony-gdal-adapter
-    umm_s: S2606110201-XYZ_PROV
-    capabilities:
-      subsetting:
-        temporal: true
-        shape: true
-        bbox: true
-        variable: true
-        multiple_variable: true
-      output_formats:
-        - application/x-netcdf4
-        - image/tiff
-      reprojection: true
-    steps:
-      - image: !Env ${QUERY_CMR_IMAGE}
-        is_sequential: true
-      - image: !Env ${HARMONY_GDAL_ADAPTER_IMAGE}
-
   - name: sds/smap-l2-subsetter-net2cog
     description: |
       A service chain for subsetting SMAP L2 collections with the Trajectory


### PR DESCRIPTION
## Jira Issue ID

TRT-635 (ish)

TRT-635 is the feature to process GeoTIFFs in Harmony. I want to link that feature to this PR, in case we need to revert this PR and reinstate HGA in production.

## Description

This PR removes idle resources for HGA from production. There are currently no collections associated with the service. The associated UMM-S record remains present in `XYZ_PROV`.

The service remains active in UAT and SIT, allowing for data providers to test collections with the service in those environments. All general environment variables, such as Docker image location, remain in the repository and the `harmony-ci-cd` repository.

## Local Test Steps

Possibly: copy `services-prod.yml` to `services-uat.yml` and check Harmony can build locally from the updates configuration file.

## PR Acceptance Checklist
* ~~Acceptance criteria met~~
* ~~Tests added/updated (if needed) and passing~~ No HGA specific tests in the Harmony repository.
* ~~Documentation updated (if needed)~~
* [x] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the nasa/harmony-gdal-adapter service from production.
  * Users will no longer be able to access its capabilities, including subsetting (temporal, shape, bounding box, variable, multi-variable), reprojection, and outputs in NetCDF-4 and GeoTIFF via this service.
  * All other services remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->