### PR TITLE
DAS-2420 Increase memory limit for Net2Cog- in harmony in a box

### DIFF
--- a/ENV_CHANGELOG.md
+++ b/ENV_CHANGELOG.md
@@ -2,6 +2,10 @@
 Any changes to the environment variables will be documented in this file in chronological
 order with the most recent changes first.
 
+## 2025-09-18
+### Changed
+- NET2COG_LIMITS_MEMORY - Increased to 8Gi to accommodate large MODIS v.7 granules.
+
 # 2025-07-30
 ### Added
 - PUBLISH_SERVICE_FAILURE_METRICS_CRON - cron schedule for the job that writes cloudwatch metrics for service failures

--- a/services/cron-service/test/resources/test-env-defaults
+++ b/services/cron-service/test/resources/test-env-defaults
@@ -540,7 +540,7 @@ NET2COG_IMAGE=ghcr.io/podaac/net2cog:SIT
 NET2COG_REQUESTS_CPU=128m
 NET2COG_REQUESTS_MEMORY=128Mi
 NET2COG_LIMITS_CPU=128m
-NET2COG_LIMITS_MEMORY=512Mi
+NET2COG_LIMITS_MEMORY=8Gi
 NET2COG_INVOCATION_ARGS='./docker-entrypoint.sh'
 NET2COG_QUEUE_URLS='["ghcr.io/podaac/net2cog:SIT,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/net2cog.fifo"]'
 

--- a/services/harmony/env-defaults
+++ b/services/harmony/env-defaults
@@ -540,7 +540,7 @@ NET2COG_IMAGE=ghcr.io/podaac/net2cog:SIT
 NET2COG_REQUESTS_CPU=128m
 NET2COG_REQUESTS_MEMORY=128Mi
 NET2COG_LIMITS_CPU=128m
-NET2COG_LIMITS_MEMORY=512Mi
+NET2COG_LIMITS_MEMORY=8Gi
 NET2COG_INVOCATION_ARGS='./docker-entrypoint.sh'
 NET2COG_QUEUE_URLS='["ghcr.io/podaac/net2cog:SIT,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/net2cog.fifo"]'
 


### PR DESCRIPTION
## Jira Issue ID
DAS-2420

## Description
This is to increase the memory limit to 8Gi for net2cog service when running  in harmony in a box. 
It is needed for MOD10C1 and MYD10C1 v7 collections .

## Local Test Steps
- Run harmony in a box locally with hoss, mask fill, metadata-annotator and net2cog
- net2cog needs to be built with the changes in branch DAS-2406 (to test MODIS v.7 collections)
- This request should succeed. without memory failure.
https://localhost:3000/C1276476011-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?forceAsync=true&granuleId=G1276476012-EEDTEST&format=image%2Ftiff&skipPreview=true&

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [X ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added changelog entry noting increased NET2COG memory limit to 8Gi to better accommodate large MODIS v7 granules.

- Chores
  - Raised NET2COG memory limit from 512Mi to 8Gi across relevant environments and test defaults to improve reliability when processing large granules.
  - No functional changes to other settings; minor formatting/no-op adjustments retained existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->