### PR TITLE
TRT-635: Reorder HGA output formats: image/tiff first.

### DIFF
--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -725,8 +725,8 @@ https://cmr.uat.earthdata.nasa.gov:
         variable: true
         multiple_variable: true
       output_formats:
-        - application/x-netcdf4
         - image/tiff
+        - application/x-netcdf4
       reprojection: true
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}

--- a/services/harmony/test/collection-capabilities.ts
+++ b/services/harmony/test/collection-capabilities.ts
@@ -85,7 +85,7 @@ describe('Testing collection capabilities', function () {
         it('sets the outputFormats field correctly', function () {
           const capabilities = JSON.parse(this.res.text);
           const expectedFormats = [
-            'application/x-netcdf4', 'image/tiff', 'image/png', 'image/gif',
+            'image/tiff', 'application/x-netcdf4', 'image/png', 'image/gif',
           ];
           expect(capabilities.outputFormats).to.eql(expectedFormats);
         });
@@ -247,7 +247,7 @@ describe('Testing collection capabilities', function () {
         it('sets the outputFormats field correctly in the version 1 response', function () {
           const capabilities = JSON.parse(this.res.text);
           const expectedFormats = [
-            'application/x-netcdf4', 'image/tiff', 'image/png', 'image/gif',
+            'image/tiff', 'application/x-netcdf4', 'image/png', 'image/gif',
           ];
           expect(capabilities.outputFormats).to.eql(expectedFormats);
         });


### PR DESCRIPTION
## Jira Issue ID

TRT-635 (continuing efforts to spruce up HGA and make it solid for potential future use)

## Description

This PR is part of the larger effort to tidy up HGA. As part of that, HGA accepts only two types of input: GeoTIFF or zipfiles containing GeoTIFFs. The current behaviour of Harmony is that if a format is not specified in a request, the default is `application/x-netcdf4`. Reordering the output formats changes that to `image/tiff`. So if `format` is not specified, a GeoTIFF (or zip file of GeoTIFFs) will output a GeoTIFF. A user has to specifically ask for a reformat to netCDF4.

## Local Test Steps

Run the following request against SIT or UAT - the output will be a netCDF4 file.

```
https://harmony.uat.earthdata.nasa.gov/C1244141281-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&subset=lat(-0.05%3A0.25)&subset=lon(-51.0%3A-50.75)&label=harmony-py&granuleId=G1244144597-EEDTEST&variable=all
```
* Build the HGA image: `bin/build-image` from the [HGA repository]().
* Set `LOCALLY_DEPLOYED_SERVICES=harmony-gdal-adapter` in your Harmony `.env`.
* Start Harmony in a Box: `./bin/bootstrap-harmony`

Run the equivalent request to above, but locally. The output should be a GeoTIFF:

```
http://localhost:3000/C1244141281-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&subset=lat(-0.05%3A0.25)&subset=lon(-51.0%3A-50.75)&label=harmony-py&granuleId=G1244144597-EEDTEST&variable=all
```

## PR Acceptance Checklist
* ~~Acceptance criteria met~~
* [x] Tests added/updated (if needed) and passing
* ~~Documentation updated (if needed)~~
* [x] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Adjusted output format ordering for Harmony collections: GeoTIFF (image/tiff) now appears before NetCDF-4 in available formats. This updates displayed capabilities and any format pickers without changing the supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->