### PR TITLE
HARMONY-2248 Remove extraneous eslint-disable directives

### DIFF
--- a/packages/util/env.ts
+++ b/packages/util/env.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/dot-notation */
 import _ from 'lodash';
 import * as dotenv from 'dotenv';
 import * as fs from 'fs';

--- a/services/cron-service/app/cronjobs/memory-usage-collector.ts
+++ b/services/cron-service/app/cronjobs/memory-usage-collector.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { CloudWatchClient, GetMetricStatisticsCommand } from '@aws-sdk/client-cloudwatch';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import * as k8s from '@kubernetes/client-node';

--- a/services/cron-service/test/helpers/env.ts
+++ b/services/cron-service/test/helpers/env.ts
@@ -25,7 +25,6 @@ process.env.MAX_BATCH_SIZE_IN_BYTES = '10000';
 
 process.env.PORT = '4000';
 
-// eslint-disable-next-line import/first
 import env from '../../app/util/env'; // Must set required env before loading the env file
 
 env.nodeEnv = 'test';

--- a/services/harmony/app/backends/service-response.ts
+++ b/services/harmony/app/backends/service-response.ts
@@ -31,7 +31,6 @@ export interface CallbackQuery {
  * @param bbox - A bounding box
  */
 export function validateBbox(bbox: number[]): void {
-  // eslint-disable-next-line no-restricted-globals
   if (bbox.length !== 4 || bbox.some(isNaN)) {
     throw new TypeError('Unrecognized bounding box format.  Must be 4 comma-separated floats as West,South,East,North');
   }
@@ -42,7 +41,6 @@ export function validateBbox(bbox: number[]): void {
  * @param temporal - An array containing two RFC-3339 strings (start and end datetime)
  */
 export function validateTemporal(temporal: number[]): void {
-  // eslint-disable-next-line no-restricted-globals
   if (temporal.length !== 2 || temporal.some(isNaN)) {
     throw new TypeError('Unrecognized temporal format.  Must be 2 RFC-3339 dates with optional fractional seconds as Start,End');
   }
@@ -63,7 +61,7 @@ export function updateJobFields(
   logger: Logger,
   job: Job,
   query: CallbackQuery,
-): void { /* eslint-disable no-param-reassign */
+): void {
   const { error, item, status, redirect, progress } = query;
   try {
     if (item) {

--- a/services/harmony/app/models/job.ts
+++ b/services/harmony/app/models/job.ts
@@ -845,7 +845,6 @@ export class Job extends DBRecord implements JobRecord {
    * @param link - Adds a link to the list of links for the object.
    */
   addLink(link: JobLink): void {
-    // eslint-disable-next-line no-param-reassign
     link.jobID = this.jobID;
     this.links.push(link);
   }

--- a/services/harmony/app/models/record.ts
+++ b/services/harmony/app/models/record.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 import _ from 'lodash';
 import logger from '../util/log';
 import db, { Transaction } from '../util/db';

--- a/services/harmony/app/models/services/index.ts
+++ b/services/harmony/app/models/services/index.ts
@@ -1013,7 +1013,7 @@ function filterServiceConfigs(
   }
   const outputFormat = selectFormat(operation, context, matches);
   if (outputFormat) {
-    operation.outputFormat = outputFormat; // eslint-disable-line no-param-reassign
+    operation.outputFormat = outputFormat;
     matches = selectServicesForFormat(outputFormat, matches);
   }
   const serviceConfig = matches[0];

--- a/services/harmony/app/models/work-item.ts
+++ b/services/harmony/app/models/work-item.ts
@@ -654,7 +654,6 @@ export async function workItemCountForStep(
 ): Promise<number> {
   // Record<string, unknown> clashes with imported database Record class
   // so we use '{}' causing a linter error
-  // eslint-disable-next-line @typescript-eslint/ban-types
   const whereClause: {} = {
     jobID, workflowStepIndex: stepIndex,
   };

--- a/services/harmony/app/models/work-item.ts
+++ b/services/harmony/app/models/work-item.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/dot-notation */
 import { subMinutes } from 'date-fns';
 import { ILengthAwarePagination } from 'knex-paginate';
 import _ from 'lodash';

--- a/services/harmony/app/util/cmr.ts
+++ b/services/harmony/app/util/cmr.ts
@@ -156,7 +156,6 @@ export interface CmrUmmGranuleHits {
 
 export interface CmrUmmVariable {
   meta: {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     'concept-id': string;
     associations?: {
       visualizations?: string[];
@@ -211,7 +210,6 @@ export interface UmmServiceOptions {
 
 export interface CmrUmmService {
   meta: {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     'concept-id': string;
   };
   umm: {
@@ -222,7 +220,6 @@ export interface CmrUmmService {
 
 export interface CmrUmmGrid {
   meta: {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     'concept-id': string;
   };
   umm: {
@@ -340,7 +337,6 @@ export interface CmrUmmVisResponse extends CmrResponse {
 
 export interface CmrUmmCollection {
   meta: {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     'concept-id': string;
   };
   umm: {

--- a/services/harmony/app/util/date.ts
+++ b/services/harmony/app/util/date.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/prefer-default-export */
 /**
  * Converts a Date object into an ISO String representation (truncates milliseconds)
  *

--- a/services/harmony/app/util/db.ts
+++ b/services/harmony/app/util/db.ts
@@ -1,5 +1,4 @@
 // Import has to happen after the knexfile, so disable that rule
-// eslint-disable-next-line import/order
 import knexfile from '../../../../db/knexfile';
 import { knex, Knex } from 'knex';
 import { attachPaginate } from 'knex-paginate';

--- a/services/harmony/app/util/errors.ts
+++ b/services/harmony/app/util/errors.ts
@@ -1,6 +1,5 @@
 import { Application } from 'express';
 
-/* eslint-disable max-classes-per-file */ // This file creates multiple tag classes
 export class HttpError extends Error {
   statusCode: number;
 

--- a/services/harmony/app/util/spatial/geo.ts
+++ b/services/harmony/app/util/spatial/geo.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-bitwise */
 import * as _ from 'lodash';
 import Arc from './arc';
 import { Coordinate, LatLng } from './coordinate';

--- a/services/harmony/app/util/spatial/geo.ts
+++ b/services/harmony/app/util/spatial/geo.ts
@@ -422,7 +422,6 @@ export function dividePolygon(latLngs: LatLng[][]): SplitPoly {
     latLngs.slice(1).forEach((hole) => {
       holes.push(makeCounterClockwise(convertLatLngs(hole)));
     });
-    // eslint-disable-next-line prefer-destructuring
     newLatLngs = latLngs[0];
   }
 

--- a/services/harmony/app/util/spatial/mbr.ts
+++ b/services/harmony/app/util/spatial/mbr.ts
@@ -131,7 +131,6 @@ function mergeMbrs(mbrs: BoundingBox[]): BoundingBox {
       maxLng = circularMax(maxLng, lng1);
     } else {
       // If the ranges are disjoint
-      // eslint-disable-next-line no-lonely-if
       if (lng0Distance < lng1Distance) {
         // Both points are on the same side
         if (lng0Distance < 0) {
@@ -141,7 +140,6 @@ function mergeMbrs(mbrs: BoundingBox[]): BoundingBox {
         }
       } else {
         // The maximum point and minimum point are on opposite sides of the interval
-        // eslint-disable-next-line no-lonely-if
         if (Math.abs(lng0Distance - 360) < Math.abs(lng1Distance + 360)) {
           // It's closer to extend to the minimum
           minLng = lng0;

--- a/services/harmony/public/js/workflow-ui/job/work-items-table.js
+++ b/services/harmony/public/js/workflow-ui/job/work-items-table.js
@@ -101,7 +101,6 @@ function initFilter(tableFilter) {
   ];
   const allowedValues = allowedList.map((t) => t.value);
   allowedList.push({ value: 'message category: nodata', dbValue: 'nodata', field: 'message_category' });
-  // eslint-disable-next-line no-new
   const tagInput = new Tagify(filterInput, {
     whitelist: allowedList,
     delimiters: null,

--- a/services/harmony/test/helpers/env.ts
+++ b/services/harmony/test/helpers/env.ts
@@ -25,7 +25,6 @@ process.env.MAX_BATCH_SIZE_IN_BYTES = '10000';
 
 process.env.PORT = '4000';
 
-// eslint-disable-next-line import/first
 import env from '../../app/util/env'; // Must set required env before loading the env file
 
 env.nodeEnv = 'test';

--- a/services/harmony/test/jobs/auto-pause-jobs.ts
+++ b/services/harmony/test/jobs/auto-pause-jobs.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-loop-func */
 import { expect } from 'chai';
 import _ from 'lodash';
 import { stub } from 'sinon';

--- a/services/harmony/test/jobs/batch-status-change.ts
+++ b/services/harmony/test/jobs/batch-status-change.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-loop-func */
 import { expect } from 'chai';
 import _ from 'lodash';
 import hookServersStartStop from '../helpers/servers';

--- a/services/harmony/test/jobs/cancel-jobs.ts
+++ b/services/harmony/test/jobs/cancel-jobs.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-loop-func */
 import { expect } from 'chai';
 import _ from 'lodash';
 import hookServersStartStop from '../helpers/servers';

--- a/services/harmony/test/jobs/pause-jobs.ts
+++ b/services/harmony/test/jobs/pause-jobs.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-loop-func */
 import { expect } from 'chai';
 import { v4 as uuid } from 'uuid';
 import _ from 'lodash';

--- a/services/harmony/test/ogc-api-coverages/get-coverage-rangeset-shapefile.ts
+++ b/services/harmony/test/ogc-api-coverages/get-coverage-rangeset-shapefile.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from 'chai';
-/* eslint-disable max-len */
 import { parse } from 'cookie';
 import { Application } from 'express';
 import * as fs from 'fs';

--- a/services/harmony/test/ogc-api-edr/get-data-for-area.ts
+++ b/services/harmony/test/ogc-api-edr/get-data-for-area.ts
@@ -818,9 +818,7 @@ describe('OGC API EDR - getEdrArea', function () {
       queryParams: object, message: string, code = 'openapi.ValidationError',
     ): void {
       it(`returns an HTTP 400 "Bad Request" error with explanatory message ${message}`, async function () {
-        // eslint-disable-next-line @typescript-eslint/dot-notation
         if (queryParams['parameter-name'] === undefined) {
-          // eslint-disable-next-line @typescript-eslint/dot-notation
           queryParams['parameter-name'] = 'all';
         }
         const res = await edrRequest(

--- a/services/harmony/test/ogc-api-edr/get-data-for-cube.ts
+++ b/services/harmony/test/ogc-api-edr/get-data-for-cube.ts
@@ -848,9 +848,7 @@ describe('OGC API EDR - getEdrCube', function () {
       queryParams: object, message: string, code = 'openapi.ValidationError',
     ): void {
       it(`returns an HTTP 400 "Bad Request" error with explanatory message ${message}`, async function () {
-        // eslint-disable-next-line @typescript-eslint/dot-notation
         if (queryParams['parameter-name'] === undefined) {
-          // eslint-disable-next-line @typescript-eslint/dot-notation
           queryParams['parameter-name'] = 'all';
         }
         const res = await edrRequest(

--- a/services/harmony/test/ogc-api-edr/get-data-for-point.ts
+++ b/services/harmony/test/ogc-api-edr/get-data-for-point.ts
@@ -875,9 +875,7 @@ describe('OGC API EDR - getEdrPosition', function () {
       queryParams: object, message: string, code = 'openapi.ValidationError',
     ): void {
       it(`returns an HTTP 400 "Bad Request" error with explanatory message ${message}`, async function () {
-        // eslint-disable-next-line @typescript-eslint/dot-notation
         if (queryParams['parameter-name'] === undefined) {
-          // eslint-disable-next-line @typescript-eslint/dot-notation
           queryParams['parameter-name'] = 'all';
         }
         const res = await edrRequest(

--- a/services/harmony/test/ogc-api-edr/get-data-for-trajectory.ts
+++ b/services/harmony/test/ogc-api-edr/get-data-for-trajectory.ts
@@ -404,9 +404,7 @@ describe('OGC API EDR - getEdrTrajectory', function () {
       queryParams: object, message: string, code = 'openapi.ValidationError',
     ): void {
       it(`returns an HTTP 400 "Bad Request" error with explanatory message ${message}`, async function () {
-        // eslint-disable-next-line @typescript-eslint/dot-notation
         if (queryParams['parameter-name'] === undefined) {
-          // eslint-disable-next-line @typescript-eslint/dot-notation
           queryParams['parameter-name'] = 'all';
         }
         const res = await edrRequest(

--- a/services/harmony/test/util/spatial/geo.ts
+++ b/services/harmony/test/util/spatial/geo.ts
@@ -14,7 +14,6 @@ function makeLatLng(latLng: [number, number]): LatLng {
 }
 
 describe('geo#calculateArea', () => {
-  // eslint-disable-next-line max-len
   const lls = (latlngs: [number, number][]): LatLng[] => Array.from(latlngs).map((ll: [number, number]) => makeLatLng(ll));
 
   it('returns 0 for strings of fewer than 3 lat lngs', () => {

--- a/services/harmony/test/workflow-ui/log-viewer.ts
+++ b/services/harmony/test/workflow-ui/log-viewer.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-named-as-default-member */
 import { expect } from 'chai';
 import { describe, it, before } from 'mocha';
 import { buildWorkItem } from '../helpers/work-items';

--- a/services/query-cmr/app/util/env.ts
+++ b/services/query-cmr/app/util/env.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-empty-interface */
 import { HarmonyEnv } from '@harmony/util/env';
 import _ from 'lodash';
 

--- a/services/query-cmr/test/query-granules.ts
+++ b/services/query-cmr/test/query-granules.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import chai, { expect } from 'chai';
 import { Stream } from 'form-data';
-/* eslint-disable node/no-unpublished-require */
 import fs from 'fs';
 import { describe, it } from 'mocha';
 import * as fetch from 'node-fetch';

--- a/services/service-runner/test/service-metrics.ts
+++ b/services/service-runner/test/service-metrics.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-/* eslint-disable  node/no-unpublished-require */
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import chai, { expect } from 'chai';

--- a/services/work-failer/test/helpers/env.ts
+++ b/services/work-failer/test/helpers/env.ts
@@ -25,7 +25,6 @@ process.env.MAX_BATCH_SIZE_IN_BYTES = '10000';
 
 process.env.PORT = '4000';
 
-// eslint-disable-next-line import/first
 import env from '../../app/util/env'; // Must set required env before loading the env file
 
 env.nodeEnv = 'test';


### PR DESCRIPTION
Pre-work for migration of eslint. This just removes unused (confusing) directives from the code.



These directives suppress rules that are either not configured at all
or explicitly set to "off" in the resolved ESLint configuration, meaning
they were never doing any work. Verified via `eslint --print-config`
and `eslint --report-unused-disable-directives`.

Rules removed:
- no-restricted-globals (not configured)
- no-param-reassign (not configured)
- no-loop-func (off)
- no-lonely-if (not configured)
- no-bitwise (not configured)
- import/first (not configured)
- import/prefer-default-export (not configured)
- import/no-named-as-default-member (off)
- import/order (not configured)
- max-classes-per-file (not configured)
- max-len (not configured)
- @typescript-eslint/no-empty-interface (not configured)
- @typescript-eslint/ban-types (off)
- node/no-unpublished-require (off in test overrides)
- no-new (not configured)



## Jira Issue ID

HARMONY-2248 (a)


## Description

Pre-work for migration of eslint.  This just removes unused (confusing) directives from the code.

  How we know these are safe to remove

  The project's default lint configuration does not flag unused eslint-disable directives. To find them, we ran ESLint with an additional flag:

  `npx eslint --report-unused-disable-directives .`

  This tells ESLint to actually run every enabled rule and then check whether each eslint-disable comment prevented a real violation. If ESLint reports zero problems for a directive, the directive is doing nothing — either:

  1. The rule isn't enabled in the resolved config, so there's nothing to suppress
  2. The code no longer triggers the rule, so the suppression is stale

  To distinguish between these two cases, we inspected the fully-resolved rule configuration (after all extends, plugins, and overrides are merged) using:

  `npx eslint --print-config <file>`

  This outputs every rule's final severity for a given file path. If the rule resolves to undefined or "off", the directive was always dead code (Commit 1). If the rule is active at "error" or "warn" but ESLint still reports no problem on that line, the code was refactored and the directive is stale (Commit 2).

  Commit 1: Rules not enabled in config (27 directives, 24 files)

  These directives suppress rules that resolve to undefined (not configured) or "off" in the merged ESLint config. They were never doing any work. This includes rules like no-param-reassign, no-restricted-globals, no-bitwise, max-len, etc. — commonly enabled in full airbnb but not included in airbnb-typescript/base which this project extends.

  Notably:
  - no-loop-func is explicitly "off" — the 4 test file disables were always redundant
  - node/no-unpublished-require is turned off in the test overrides, so test-file disables for it are redundant
  - @typescript-eslint/ban-types is explicitly "off" in root config

  Commit 2: Rules enabled but code no longer triggers them (16 directives, 9 files)

  These directives suppress rules that are active, but the code was refactored after the disable was added and no longer produces a
  violation:

  - @typescript-eslint/dot-notation (10 directives): Bracket notation was replaced with dot notation in prior changes
  - @typescript-eslint/naming-convention (5 directives): 4 were redundant with an existing file-level disable in cmr.ts; 1 file-level disable in memory-usage-collector.ts where no violations exist
  - prefer-destructuring (1 directive): Code in geo.ts already uses destructuring

  How to verify

  On main — shows 43 unused directives:
  `npx eslint --report-unused-disable-directives .`

  On this branch — shows 0:
  `npx eslint --report-unused-disable-directives .`

  Further Recommendation:

  Consider adding "reportUnusedDisableDirectives": true to the ESLint config (or --report-unused-disable-directives-severity error in the
  lint script) to catch stale directives automatically going forward.

## Local Test Steps

Make sure tests and lint still pass as before.

Also run `eslint --report-unused-disable-directives` and you should see no output 


## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed linting directives across multiple files to enforce consistent code standards throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->