### PR TITLE
Harmony 2325: Add 'noretry' status when a service fails with an Out of Memory error (ExitCode 137)

### DIFF
--- a/services/service-runner/app/service/service-runner.ts
+++ b/services/service-runner/app/service/service-runner.ts
@@ -135,13 +135,23 @@ async function _getStacCatalogs(dir: string): Promise<string[]> {
  * @param msg - A default error message
  * @returns An error message for the status
  */
-function _getErrorMessageOfStatus(status: k8s.V1Status, msg = 'Unknown error'): string {
+function _getErrorMessageAndCategoryOfStatus(
+  status: k8s.V1Status,
+  msg = 'Unknown error',
+): { error: string; category?: string } {
   const exitCode = status.details?.causes?.find(i => i.reason === 'ExitCode');
   let errorMsg = null;
+  let category = null;
+
   if (exitCode?.message === OOM_EXIT_CODE) {
     errorMsg = 'Service failed due to running out of memory';
+    category = 'noretry';
   }
-  return (errorMsg ? errorMsg : msg);
+
+  return {
+    error: errorMsg ? errorMsg : msg,
+    category: category,
+  };
 }
 
 /**
@@ -173,13 +183,16 @@ async function _getErrorInfo(
       }
       return { error, level };
     }
-    const error = _getErrorMessageOfStatus(status);
-    return { error, level: 'error' };
+    const { error, category } = _getErrorMessageAndCategoryOfStatus(status);
+    return { error, level: 'error', category };
   } catch (e) {
     workItemLogger.error(`Caught exception: ${e}`);
     workItemLogger.error(`Unable to parse out error from catalog location: ${catalogDir}`);
-    const error = _getErrorMessageOfStatus(status, 'Service terminated without error message');
-    return { error, level: 'error' };
+    const { error, category } = _getErrorMessageAndCategoryOfStatus(
+      status,
+      'Service terminated without error message',
+    );
+    return { error, level: 'error', category };
   }
 }
 
@@ -381,6 +394,10 @@ export async function runServiceFromPull(
                 const errorLevel = errorEntries.level;
                 const errorCategory = errorEntries.category;
 
+                workItemLogger.debug(`Vu runServiceFromPull:errorMessage2: ${errorMessage}`);
+                workItemLogger.debug(`Vu runServiceFromPull:errorLevel2: ${errorLevel}`);
+                workItemLogger.debug(`Vu runServiceFromPull:errorCategory2: ${errorCategory}`);
+                workItemLogger.debug(`Vu runServiceFromPull:status.code2: ${status.code}`);
                 if (errorCategory) {
                   resolve({ error: errorMessage, errorLevel, errorCategory });
                 } else if (status.code === 500) {

--- a/services/service-runner/app/service/service-runner.ts
+++ b/services/service-runner/app/service/service-runner.ts
@@ -133,7 +133,7 @@ async function _getStacCatalogs(dir: string): Promise<string[]> {
  *
  * @param status - A kubernetes V1Status
  * @param msg - A default error message
- * @returns An error message for the status
+ * @returns An error message for the status and possibly an error category
  */
 function _getErrorMessageAndCategoryOfStatus(
   status: k8s.V1Status,

--- a/services/service-runner/app/service/service-runner.ts
+++ b/services/service-runner/app/service/service-runner.ts
@@ -394,10 +394,6 @@ export async function runServiceFromPull(
                 const errorLevel = errorEntries.level;
                 const errorCategory = errorEntries.category;
 
-                workItemLogger.debug(`Vu runServiceFromPull:errorMessage2: ${errorMessage}`);
-                workItemLogger.debug(`Vu runServiceFromPull:errorLevel2: ${errorLevel}`);
-                workItemLogger.debug(`Vu runServiceFromPull:errorCategory2: ${errorCategory}`);
-                workItemLogger.debug(`Vu runServiceFromPull:status.code2: ${status.code}`);
                 if (errorCategory) {
                   resolve({ error: errorMessage, errorLevel, errorCategory });
                 } else if (status.code === 500) {

--- a/services/service-runner/test/service-runner.ts
+++ b/services/service-runner/test/service-runner.ts
@@ -79,8 +79,12 @@ describe('Service Runner', function () {
       });
       describe('when the error status code is 137', async function () {
         it('returns "OOM error"', async function () {
-          const errorMessage = (await _getErrorInfo(oomStatus, workItemWithoutErrorJson)).error;
+          const errorInfo = await _getErrorInfo(oomStatus, workItemWithoutErrorJson);
+          const errorMessage = errorInfo.error;
+          const { level, category } = errorInfo;
           expect(errorMessage).equal('Service failed due to running out of memory');
+          expect(level).equal('error');
+          expect(category).equal('noretry');
         });
       });
     });


### PR DESCRIPTION
## Jira Issue ID
[HARMONY-2325](https://github.com/nasa/harmony/compare/main...harmony-2325)

## Description
Add 'noretry' status when a service fails with an Out of Memory error (ExitCode 137), So that we prevent the system from wasting resources on futile retry attempts.

## Changes
- Add category = noretries if exitCode?.message == 137
- `_getErrorMessageAndCategoryOfStatus` returns error message and possibly category(`noretries`|`null`)
- Update test code to return error message, level, and category

## Local Test Steps
Run the request below.  Verify Harmony retries 5x after harmony-opendap-subsetter service stop due to out of memory
```
https://harmony.uat.earthdata.nasa.gov/C1260123843-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&subset=lat(-77.839%3A-62.261)&subset=lon(12.318%3A49.452)&label=harmony-py&granuleId=G1260123847-EEDTEST&maxResults=1&variable=h&variable=ice_area
```
<img width="1393" height="484" alt="Screenshot 2026-04-07 at 7 29 02 AM" src="https://github.com/user-attachments/assets/82359573-31ee-4daa-9a60-38bbd04d8e0d" />


Build harmony locally
```
cd harmony
git checkout harmony-2325
npm run build-all
npm run build
npm test
./bin/bootstrap-harmony
```

Run the local request below.  Verify Harmony retries 1x after harmony-opendap-subsetter service stop due to out of memory
```
http://localhost:3000/C1260123843-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&subset=lat(-77.839%3A-62.261)&subset=lon(12.318%3A49.452)&label=harmony-py&granuleId=G1260123847-EEDTEST&maxResults=1&variable=h&variable=ice_area
```
<img width="1323" height="482" alt="Screenshot 2026-04-03 at 11 29 47 AM" src="https://github.com/user-attachments/assets/ff42ad53-2922-4e8f-a94f-7310cf409e01" />


## PR Acceptance Checklist
* [ x] Acceptance criteria met
* [ x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ x] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added error categorization to properly identify and classify out-of-memory errors, enabling appropriate handling and preventing unnecessary retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->