### PR TITLE
HARMONY-2305: Add JSON dashboard endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3538,15 +3538,15 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -9873,11 +9873,14 @@
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/services/cron-service/package-lock.json
+++ b/services/cron-service/package-lock.json
@@ -6648,14 +6648,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -9412,8 +9412,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/qs": {
       "version": "6.14.2",

--- a/services/harmony/app/frontends/dashboard.ts
+++ b/services/harmony/app/frontends/dashboard.ts
@@ -88,14 +88,14 @@ export async function getDashboard(
 
     const result = {
       services: sortedServicesMap,
-      version: '1-alpha',
+      version: version?.toLowerCase() || currentApiVersion,
     };
 
     // Detect if client wants HTML explicitly - by default we will return JSON
     const acceptsHtml = req.accepts(['json', 'html']) === 'html';
 
     if (acceptsHtml) {
-      // TODO HTML endpoint
+      // TODO HARMONY-2304 HTML endpoint
       // res.render('dashboard', {
       //   ...
       // });
@@ -105,7 +105,6 @@ export async function getDashboard(
     }
 
   } catch (e) {
-    // req.context.logger.error(e);
     next(e);
   }
 }

--- a/services/harmony/app/frontends/dashboard.ts
+++ b/services/harmony/app/frontends/dashboard.ts
@@ -1,0 +1,111 @@
+import { NextFunction, Response } from 'express';
+
+import { listToText } from '@harmony/util/string';
+
+import HarmonyRequest from '../models/harmony-request';
+import { getCountsByService } from '../models/user-work';
+import db from '../util/db';
+import { RequestValidationError } from '../util/errors';
+import { keysToLowerCase } from '../util/object';
+import { getImageToServiceMap, getServiceName } from '../util/service-images';
+
+export const currentApiVersion = '1-alpha';
+const supportedApiVersions = ['1-alpha'];
+
+/**
+ * Throws an error if the version is not supported
+ * @param version - the version of the dashboard response
+ * @throws RequestValidationError if the version is not supported
+ */
+function validateVersion(version): void {
+  const normalizedVersion = version.toLowerCase();
+
+  const isSupported = supportedApiVersions.some(
+    v => v.toLowerCase() === normalizedVersion,
+  );
+
+  if (!isSupported) {
+    const message = `Invalid API version. Supported versions are: ${listToText(supportedApiVersions)}`;
+    throw new RequestValidationError(message);
+  }
+}
+
+/**
+ * Express.js handler that returns the harmony dashboard responding with JSON by default
+ * or HTML if requested.
+ */
+export async function getDashboard(
+  req: HarmonyRequest, res: Response, next: NextFunction,
+): Promise<void> {
+  const query = keysToLowerCase(req.query);
+  const version = query?.version;
+  const versionText = version ? version : 'unspecified';
+
+  try {
+    if (version !== undefined) {
+      validateVersion(version);
+    }
+
+    req.context.logger.info(`Dashboard requested by user ${req.user}, version: ${versionText}`);
+    const serviceWorkCounts = await getCountsByService(db);
+    const imageToServiceMap = getImageToServiceMap();
+
+    // Convert the image name returned from the database with the service name
+    const normalizedDb: Record<string, { queued: number }> = {};
+
+    for (const [image, value] of Object.entries(serviceWorkCounts)) {
+      const service = getServiceName(imageToServiceMap, image);
+
+      if (!normalizedDb[service]) {
+        normalizedDb[service] = { queued: 0 };
+      }
+
+      normalizedDb[service].queued += value.queued;
+    }
+
+    // Build full service set from imageToServiceMap (VALUES are service names)
+    // Include all deployed services in the response - not just the ones with active requests
+    const allServices = new Set(Object.values(imageToServiceMap));
+    const merged: Record<string, { queued: number }> = {};
+
+    for (const service of allServices) {
+      merged[service] = {
+        queued: normalizedDb[service]?.queued ?? 0,
+      };
+    }
+
+    // Add any unknown services returned from DB (could be from old images)
+    for (const [service, value] of Object.entries(normalizedDb)) {
+      if (!(service in merged)) {
+        merged[service] = value;
+      }
+    }
+
+    const sortedServicesMap = Object.keys(merged).sort().reduce((acc, key) => ({
+      ...acc,
+      [key]: merged[key],
+    }), {});
+
+    const result = {
+      services: sortedServicesMap,
+      version: '1-alpha',
+    };
+
+    // Detect if client wants HTML explicitly - by default we will return JSON
+    const acceptsHtml = req.accepts(['json', 'html']) === 'html';
+
+    if (acceptsHtml) {
+      // TODO HTML endpoint
+      // res.render('dashboard', {
+      //   ...
+      // });
+      res.json(result);
+    } else {
+      res.json(result);
+    }
+
+  } catch (e) {
+    // req.context.logger.error(e);
+    next(e);
+  }
+}

--- a/services/harmony/app/frontends/retry-stats.ts
+++ b/services/harmony/app/frontends/retry-stats.ts
@@ -83,4 +83,3 @@ export async function getRetryStatistics(
     next(e);
   }
 }
-

--- a/services/harmony/app/models/user-work.ts
+++ b/services/harmony/app/models/user-work.ts
@@ -378,3 +378,34 @@ export async function populateUserWorkFromWorkItems(tx: Transaction): Promise<vo
     + 'ORDER BY "j"."updatedAt" asc';
   await tx.raw(sql);
 }
+
+/**
+ * Get the aggregated number of work items in the system grouped by service
+ * @param tx - The database transaction
+ * @returns the number of work items in the system grouped by service
+ */
+export async function getCountsByService(
+  tx: Transaction,
+): Promise<{ [service: string]: { queued: number } }> {
+  const results = await tx(UserWork.table)
+    .select(
+      'service_id',
+      tx.raw('SUM(ready_count) + SUM(running_count) AS queued'),
+    )
+    .groupBy('service_id')
+    .orderBy('queued', 'desc');
+
+  console.log(JSON.stringify(Object.fromEntries(
+    results.map(r => [
+      r.service_id,
+      { queued: Number(r.queued) },
+    ]),
+  )));
+
+  return Object.fromEntries(
+    results.map(r => [
+      r.service_id,
+      { queued: Number(r.queued) },
+    ]),
+  );
+}

--- a/services/harmony/app/models/user-work.ts
+++ b/services/harmony/app/models/user-work.ts
@@ -395,13 +395,6 @@ export async function getCountsByService(
     .groupBy('service_id')
     .orderBy('queued', 'desc');
 
-  console.log(JSON.stringify(Object.fromEntries(
-    results.map(r => [
-      r.service_id,
-      { queued: Number(r.queued) },
-    ]),
-  )));
-
   return Object.fromEntries(
     results.map(r => [
       r.service_id,

--- a/services/harmony/app/routers/router.ts
+++ b/services/harmony/app/routers/router.ts
@@ -9,6 +9,7 @@ import serviceInvoker from '../backends/service-invoker';
 import { getCollectionCapabilitiesJson } from '../frontends/capabilities';
 import { cloudAccessJson, cloudAccessSh } from '../frontends/cloud-access';
 import { setLogLevel } from '../frontends/configuration';
+import { getDashboard } from '../frontends/dashboard';
 import docsPage from '../frontends/docs/docs';
 import { getAdminHealth, getHealth } from '../frontends/health';
 import {
@@ -304,6 +305,7 @@ export default function router({ USE_EDL_CLIENT_APP = 'false' }: RouterConfig): 
 
   result.get('/admin/request-metrics', asyncHandler(getRequestMetrics));
   result.get('/admin/retry-stats', asyncHandler(getRetryStatistics));
+  result.get('/admin/dashboard', asyncHandler(getDashboard));
 
   result.get('/workflow-ui', asyncHandler(getJobs));
   result.get('/workflow-ui/:jobID', asyncHandler(getJob));

--- a/services/harmony/app/util/service-images.ts
+++ b/services/harmony/app/util/service-images.ts
@@ -1,0 +1,80 @@
+import { sanitizeImage } from '@harmony/util/string';
+
+import env from './env';
+
+/**
+ * Convert image string into a normalized "base name"
+ * - strips registry (ghcr.io, ECR, etc.)
+ * - strips tag
+ */
+function getBaseImageName(image: string): string {
+  const noTag = image.split(':')[0];
+  return sanitizeImage(noTag);
+}
+
+/**
+ * Convert ENV var name to service name
+ * e.g. PODAAC_L2_SUBSETTER_IMAGE to podaac-l2-subsetter
+ */
+function envVarToServiceName(envVar: string): string {
+  return envVar
+    .replace(/_IMAGE$/, '')
+    .toLowerCase()
+    .replaceAll('_', '-');
+}
+
+/**
+ * Create a map of the base Docker image name to the name of the service
+ * for all services deployed to the environment
+*/
+export function _getImageToServiceMap(
+  environment: NodeJS.ProcessEnv,
+  services: Set<string>,
+): Record<string, string> {
+  return Object.keys(environment)
+    .filter(k => k.endsWith('_IMAGE') && environment[k])
+    .reduce((acc, key) => {
+      const serviceName = envVarToServiceName(key);
+
+      // only include deployed services
+      if (!services.has(serviceName)) {
+        return acc;
+      }
+
+      const base = getBaseImageName(environment[key]!);
+      acc[base] = serviceName;
+
+      return acc;
+    }, {} as { [key: string]: string });
+}
+
+/**
+ * Given a full image string, return the service name.
+ * Falls back to repo path if no match is found.
+ */
+export function getServiceName(serviceMap, image: string): string {
+  const base = getBaseImageName(image);
+  return serviceMap[base] || base;
+}
+
+// Build up the list of all possible service names once at system start
+const deployedServices = new Set(
+  env.locallyDeployedServices.split(',').map(s => s.trim()),
+);
+
+deployedServices.add('query-cmr');
+
+let _imageToServiceMap: Record<string, string> | undefined;
+
+/**
+ * As a singleton return the map of the base Docker image name to the name of the service
+ * for all services deployed to the environment
+ */
+export function getImageToServiceMap(): Record<string, string> {
+  if (_imageToServiceMap) {
+    return _imageToServiceMap;
+  }
+
+  _imageToServiceMap = _getImageToServiceMap(process.env, deployedServices);
+  return _imageToServiceMap;
+}

--- a/services/harmony/app/util/service-images.ts
+++ b/services/harmony/app/util/service-images.ts
@@ -25,7 +25,10 @@ function envVarToServiceName(envVar: string): string {
 
 /**
  * Create a map of the base Docker image name to the name of the service
- * for all services deployed to the environment
+ * for all services deployed to the environment.
+ *
+ * Note this function is only exported for use in tests - external callers
+ * should be calling getImageToServiceMap
 */
 export function _getImageToServiceMap(
   environment: NodeJS.ProcessEnv,

--- a/services/harmony/package-lock.json
+++ b/services/harmony/package-lock.json
@@ -7671,14 +7671,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-mock-adapter": {
@@ -13368,8 +13368,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.4",

--- a/services/harmony/test/dashboard.ts
+++ b/services/harmony/test/dashboard.ts
@@ -42,134 +42,170 @@ describe('getDashboard', () => {
     sandbox.restore();
   });
 
-  it('returns all services sorted alphabetically with version', async () => {
-    getCountsByServiceStub.resolves({
-      'ghcr.io/podaac/l2ss-py:3.1.0rc4': { queued: 110000 },
+  describe('version validation', () => {
+    it('succeeds when a valid version (1-alpha) is provided', async () => {
+      req.query.version = '1-alpha';
+      getCountsByServiceStub.resolves({});
+
+      await getDashboard(req, res, next);
+
+      expect(next.called).to.be.false;
+      expect(res.json.calledOnce).to.be.true;
     });
 
-    await getDashboard(req, res, next);
+    it('is case-insensitive when validating the version parameter', async () => {
+      req.query.version = '1-ALPHA';
+      getCountsByServiceStub.resolves({});
 
-    expect(res.json.calledOnce).to.be.true;
-    const result = res.json.firstCall.args[0];
+      await getDashboard(req, res, next);
 
-    expect(result.version).to.equal('1-alpha');
-    expect(Object.keys(result.services)).to.deep.equal([
-      'harmony-service-example',
-      'podaac/l2ss-py',
-      'query-cmr',
-    ]);
-  });
-
-  it('maps image names to service names and sums queued counts', async () => {
-    getCountsByServiceStub.resolves({
-      'ghcr.io/podaac/l2ss-py:3.1.0rc4': { queued: 110000 },
+      expect(next.called).to.be.false;
+      expect(res.json.calledOnce).to.be.true;
     });
 
-    await getDashboard(req, res, next);
+    it('calls next with an error when an unsupported version is provided', async () => {
+      req.query.version = '2.0-beta';
+      getCountsByServiceStub.resolves({});
 
-    const { services } = res.json.firstCall.args[0];
-    expect(services['podaac/l2ss-py'].queued).to.equal(110000);
+      await getDashboard(req, res, next);
+
+      expect(next.calledOnce).to.be.true;
+      const error = next.firstCall.args[0];
+      expect(error.message).to.include('Invalid API version');
+      expect(res.json.called).to.be.false;
+    });
   });
 
-  it('fills in zero queued for services not present in DB results', async () => {
-    getCountsByServiceStub.resolves({});
+  describe('data mapping and response', () => {
+    it('returns all services sorted alphabetically with version', async () => {
+      getCountsByServiceStub.resolves({
+        'ghcr.io/podaac/l2ss-py:3.1.0rc4': { queued: 110000 },
+      });
 
-    await getDashboard(req, res, next);
+      await getDashboard(req, res, next);
 
-    const { services } = res.json.firstCall.args[0];
-    expect(services['harmony-service-example'].queued).to.equal(0);
-    expect(services['query-cmr'].queued).to.equal(0);
-    expect(services['podaac/l2ss-py'].queued).to.equal(0);
-  });
+      expect(res.json.calledOnce).to.be.true;
+      const result = res.json.firstCall.args[0];
 
-  it('includes all services from imageToServiceMap even when DB is empty', async () => {
-    getCountsByServiceStub.resolves({});
-
-    await getDashboard(req, res, next);
-
-    const { services } = res.json.firstCall.args[0];
-    expect(Object.keys(services)).to.have.members([
-      'harmony-service-example',
-      'podaac/l2ss-py',
-      'query-cmr',
-    ]);
-  });
-
-  it('aggregates queued counts when multiple images map to the same service', async () => {
-    imageMapStub.returns({
-      'ghcr.io/podaac/l2ss-py:3.1.0rc4': 'podaac/l2ss-py',
-      'ghcr.io/podaac/l2ss-py:3.0.0': 'podaac/l2ss-py',
-      'ghcr.io/harmony/query-cmr:latest': 'query-cmr',
+      expect(result.version).to.equal('1-alpha');
+      expect(Object.keys(result.services)).to.deep.equal([
+        'harmony-service-example',
+        'podaac/l2ss-py',
+        'query-cmr',
+      ]);
     });
 
-    getCountsByServiceStub.resolves({
-      'ghcr.io/podaac/l2ss-py:3.1.0rc4': { queued: 60000 },
-      'ghcr.io/podaac/l2ss-py:3.0.0': { queued: 50000 },
+    it('maps image names to service names and sums queued counts', async () => {
+      getCountsByServiceStub.resolves({
+        'ghcr.io/podaac/l2ss-py:3.1.0rc4': { queued: 110000 },
+      });
+
+      await getDashboard(req, res, next);
+
+      const { services } = res.json.firstCall.args[0];
+      expect(services['podaac/l2ss-py'].queued).to.equal(110000);
     });
 
-    await getDashboard(req, res, next);
+    it('fills in zero queued for services not present in DB results', async () => {
+      getCountsByServiceStub.resolves({});
 
-    const { services } = res.json.firstCall.args[0];
-    expect(services['podaac/l2ss-py'].queued).to.equal(110000);
-  });
+      await getDashboard(req, res, next);
 
-  it('includes unknown images from DB that are not in imageToServiceMap', async () => {
-    imageMapStub.returns({
-      'ghcr.io/harmony/query-cmr:latest': 'query-cmr',
+      const { services } = res.json.firstCall.args[0];
+      expect(services['harmony-service-example'].queued).to.equal(0);
+      expect(services['query-cmr'].queued).to.equal(0);
+      expect(services['podaac/l2ss-py'].queued).to.equal(0);
     });
 
-    getCountsByServiceStub.resolves({
-      'ghcr.io/some-old-image:deprecated': { queued: 5 },
+    it('includes all services from imageToServiceMap even when DB is empty', async () => {
+      getCountsByServiceStub.resolves({});
+
+      await getDashboard(req, res, next);
+
+      const { services } = res.json.firstCall.args[0];
+      expect(Object.keys(services)).to.have.members([
+        'harmony-service-example',
+        'podaac/l2ss-py',
+        'query-cmr',
+      ]);
     });
 
-    await getDashboard(req, res, next);
+    it('aggregates queued counts when multiple images map to the same service', async () => {
+      imageMapStub.returns({
+        'ghcr.io/podaac/l2ss-py:3.1.0rc4': 'podaac/l2ss-py',
+        'ghcr.io/podaac/l2ss-py:3.0.0': 'podaac/l2ss-py',
+        'ghcr.io/harmony/query-cmr:latest': 'query-cmr',
+      });
 
-    const { services } = res.json.firstCall.args[0];
-    expect(services['some-old-image']).to.deep.equal({ queued: 5 });
-  });
+      getCountsByServiceStub.resolves({
+        'ghcr.io/podaac/l2ss-py:3.1.0rc4': { queued: 60000 },
+        'ghcr.io/podaac/l2ss-py:3.0.0': { queued: 50000 },
+      });
 
-  it('responds with JSON when client accepts JSON', async () => {
-    req.accepts.returns('json');
-    getCountsByServiceStub.resolves({});
+      await getDashboard(req, res, next);
 
-    await getDashboard(req, res, next);
+      const { services } = res.json.firstCall.args[0];
+      expect(services['podaac/l2ss-py'].queued).to.equal(110000);
+    });
 
-    expect(res.json.calledOnce).to.be.true;
-  });
+    it('includes unknown images from DB that are not in imageToServiceMap', async () => {
+      imageMapStub.returns({
+        'ghcr.io/harmony/query-cmr:latest': 'query-cmr',
+      });
 
-  it('still responds with JSON when client requests HTML (until HTML is implemented)', async () => {
-    req.accepts.returns('html');
-    getCountsByServiceStub.resolves({});
+      getCountsByServiceStub.resolves({
+        'ghcr.io/some-old-image:deprecated': { queued: 5 },
+      });
 
-    await getDashboard(req, res, next);
+      await getDashboard(req, res, next);
 
-    expect(res.json.calledOnce).to.be.true;
-  });
+      const { services } = res.json.firstCall.args[0];
+      expect(services['some-old-image']).to.deep.equal({ queued: 5 });
+    });
 
-  it('logs the requesting user', async () => {
-    getCountsByServiceStub.resolves({});
+    it('responds with JSON when client accepts JSON', async () => {
+      req.accepts.returns('json');
+      getCountsByServiceStub.resolves({});
 
-    await getDashboard(req, res, next);
+      await getDashboard(req, res, next);
 
-    expect(req.context.logger.info.calledOnce).to.be.true;
-    expect(req.context.logger.info.firstCall.args[0]).to.include('test-user');
-  });
+      expect(res.json.calledOnce).to.be.true;
+    });
 
-  it('calls next(err) when getCountsByService rejects', async () => {
-    const error = new Error('DB connection failed');
-    getCountsByServiceStub.rejects(error);
+    it('still responds with JSON when client requests HTML (until HTML is implemented)', async () => {
+      req.accepts.returns('html');
+      getCountsByServiceStub.resolves({});
 
-    await getDashboard(req, res, next);
+      await getDashboard(req, res, next);
 
-    expect(next.calledOnce).to.be.true;
-    expect(next.firstCall.args[0]).to.equal(error);
-  });
+      expect(res.json.calledOnce).to.be.true;
+    });
 
-  it('does not call res.json when an error occurs', async () => {
-    getCountsByServiceStub.rejects(new Error('oops'));
+    it('logs the requesting user', async () => {
+      getCountsByServiceStub.resolves({});
 
-    await getDashboard(req, res, next);
+      await getDashboard(req, res, next);
 
-    expect(res.json.called).to.be.false;
+      expect(req.context.logger.info.calledOnce).to.be.true;
+      expect(req.context.logger.info.firstCall.args[0]).to.include('test-user');
+    });
+
+    it('calls next(err) when getCountsByService rejects', async () => {
+      const error = new Error('DB connection failed');
+      getCountsByServiceStub.rejects(error);
+
+      await getDashboard(req, res, next);
+
+      expect(next.calledOnce).to.be.true;
+      expect(next.firstCall.args[0]).to.equal(error);
+    });
+
+    it('does not call res.json when an error occurs', async () => {
+      getCountsByServiceStub.rejects(new Error('oops'));
+
+      await getDashboard(req, res, next);
+
+      expect(res.json.called).to.be.false;
+    });
   });
 });

--- a/services/harmony/test/dashboard.ts
+++ b/services/harmony/test/dashboard.ts
@@ -1,0 +1,175 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { getDashboard } from '../app/frontends/dashboard';
+import * as userWork from '../app/models/user-work';
+import * as serviceImages from '../app/util/service-images';
+
+describe('getDashboard', () => {
+  const sandbox = sinon.createSandbox();
+  let req: any;
+  let res: any;
+  let next: sinon.SinonSpy;
+  let getCountsByServiceStub: sinon.SinonStub;
+  let imageMapStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    req = {
+      user: 'test-user',
+      context: { logger: { info: sandbox.stub(), error: sandbox.stub() } },
+      accepts: sandbox.stub().returns('json'),
+      query: {},
+    };
+
+    res = {
+      json: sandbox.stub(),
+      render: sandbox.stub(),
+    };
+
+    next = sandbox.spy();
+
+    getCountsByServiceStub = sandbox.stub(userWork, 'getCountsByService');
+
+    imageMapStub = sandbox.stub(serviceImages, 'getImageToServiceMap').returns({
+      'ghcr.io/podaac/l2ss-py:3.1.0rc4': 'podaac/l2ss-py',
+      'ghcr.io/harmony/query-cmr:latest': 'query-cmr',
+      'ghcr.io/harmony/harmony-service-example:latest': 'harmony-service-example',
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('returns all services sorted alphabetically with version', async () => {
+    getCountsByServiceStub.resolves({
+      'ghcr.io/podaac/l2ss-py:3.1.0rc4': { queued: 110000 },
+    });
+
+    await getDashboard(req, res, next);
+
+    expect(res.json.calledOnce).to.be.true;
+    const result = res.json.firstCall.args[0];
+
+    expect(result.version).to.equal('1-alpha');
+    expect(Object.keys(result.services)).to.deep.equal([
+      'harmony-service-example',
+      'podaac/l2ss-py',
+      'query-cmr',
+    ]);
+  });
+
+  it('maps image names to service names and sums queued counts', async () => {
+    getCountsByServiceStub.resolves({
+      'ghcr.io/podaac/l2ss-py:3.1.0rc4': { queued: 110000 },
+    });
+
+    await getDashboard(req, res, next);
+
+    const { services } = res.json.firstCall.args[0];
+    expect(services['podaac/l2ss-py'].queued).to.equal(110000);
+  });
+
+  it('fills in zero queued for services not present in DB results', async () => {
+    getCountsByServiceStub.resolves({});
+
+    await getDashboard(req, res, next);
+
+    const { services } = res.json.firstCall.args[0];
+    expect(services['harmony-service-example'].queued).to.equal(0);
+    expect(services['query-cmr'].queued).to.equal(0);
+    expect(services['podaac/l2ss-py'].queued).to.equal(0);
+  });
+
+  it('includes all services from imageToServiceMap even when DB is empty', async () => {
+    getCountsByServiceStub.resolves({});
+
+    await getDashboard(req, res, next);
+
+    const { services } = res.json.firstCall.args[0];
+    expect(Object.keys(services)).to.have.members([
+      'harmony-service-example',
+      'podaac/l2ss-py',
+      'query-cmr',
+    ]);
+  });
+
+  it('aggregates queued counts when multiple images map to the same service', async () => {
+    imageMapStub.returns({
+      'ghcr.io/podaac/l2ss-py:3.1.0rc4': 'podaac/l2ss-py',
+      'ghcr.io/podaac/l2ss-py:3.0.0': 'podaac/l2ss-py',
+      'ghcr.io/harmony/query-cmr:latest': 'query-cmr',
+    });
+
+    getCountsByServiceStub.resolves({
+      'ghcr.io/podaac/l2ss-py:3.1.0rc4': { queued: 60000 },
+      'ghcr.io/podaac/l2ss-py:3.0.0': { queued: 50000 },
+    });
+
+    await getDashboard(req, res, next);
+
+    const { services } = res.json.firstCall.args[0];
+    expect(services['podaac/l2ss-py'].queued).to.equal(110000);
+  });
+
+  it('includes unknown images from DB that are not in imageToServiceMap', async () => {
+    imageMapStub.returns({
+      'ghcr.io/harmony/query-cmr:latest': 'query-cmr',
+    });
+
+    getCountsByServiceStub.resolves({
+      'ghcr.io/some-old-image:deprecated': { queued: 5 },
+    });
+
+    await getDashboard(req, res, next);
+
+    const { services } = res.json.firstCall.args[0];
+    expect(services['some-old-image']).to.deep.equal({ queued: 5 });
+  });
+
+  it('responds with JSON when client accepts JSON', async () => {
+    req.accepts.returns('json');
+    getCountsByServiceStub.resolves({});
+
+    await getDashboard(req, res, next);
+
+    expect(res.json.calledOnce).to.be.true;
+  });
+
+  it('still responds with JSON when client requests HTML (until HTML is implemented)', async () => {
+    req.accepts.returns('html');
+    getCountsByServiceStub.resolves({});
+
+    await getDashboard(req, res, next);
+
+    expect(res.json.calledOnce).to.be.true;
+  });
+
+  it('logs the requesting user', async () => {
+    getCountsByServiceStub.resolves({});
+
+    await getDashboard(req, res, next);
+
+    expect(req.context.logger.info.calledOnce).to.be.true;
+    expect(req.context.logger.info.firstCall.args[0]).to.include('test-user');
+  });
+
+  it('calls next(err) when getCountsByService rejects', async () => {
+    const error = new Error('DB connection failed');
+    getCountsByServiceStub.rejects(error);
+
+    await getDashboard(req, res, next);
+
+    expect(next.calledOnce).to.be.true;
+    expect(next.firstCall.args[0]).to.equal(error);
+  });
+
+  it('does not call res.json when an error occurs', async () => {
+    getCountsByServiceStub.rejects(new Error('oops'));
+
+    await getDashboard(req, res, next);
+
+    expect(res.json.called).to.be.false;
+  });
+});

--- a/services/harmony/test/dashboard.ts
+++ b/services/harmony/test/dashboard.ts
@@ -32,9 +32,9 @@ describe('getDashboard', () => {
     getCountsByServiceStub = sandbox.stub(userWork, 'getCountsByService');
 
     imageMapStub = sandbox.stub(serviceImages, 'getImageToServiceMap').returns({
-      'ghcr.io/podaac/l2ss-py:3.1.0rc4': 'podaac/l2ss-py',
-      'ghcr.io/harmony/query-cmr:latest': 'query-cmr',
-      'ghcr.io/harmony/harmony-service-example:latest': 'harmony-service-example',
+      'podaac/l2ss-py': 'podaac-l2-subsetter',
+      'harmony/query-cmr': 'query-cmr',
+      'harmony/harmony-service-example': 'harmony-service-example',
     });
   });
 
@@ -90,7 +90,7 @@ describe('getDashboard', () => {
       expect(result.version).to.equal('1-alpha');
       expect(Object.keys(result.services)).to.deep.equal([
         'harmony-service-example',
-        'podaac/l2ss-py',
+        'podaac-l2-subsetter',
         'query-cmr',
       ]);
     });
@@ -103,7 +103,7 @@ describe('getDashboard', () => {
       await getDashboard(req, res, next);
 
       const { services } = res.json.firstCall.args[0];
-      expect(services['podaac/l2ss-py'].queued).to.equal(110000);
+      expect(services['podaac-l2-subsetter'].queued).to.equal(110000);
     });
 
     it('fills in zero queued for services not present in DB results', async () => {
@@ -114,7 +114,7 @@ describe('getDashboard', () => {
       const { services } = res.json.firstCall.args[0];
       expect(services['harmony-service-example'].queued).to.equal(0);
       expect(services['query-cmr'].queued).to.equal(0);
-      expect(services['podaac/l2ss-py'].queued).to.equal(0);
+      expect(services['podaac-l2-subsetter'].queued).to.equal(0);
     });
 
     it('includes all services from imageToServiceMap even when DB is empty', async () => {
@@ -125,7 +125,7 @@ describe('getDashboard', () => {
       const { services } = res.json.firstCall.args[0];
       expect(Object.keys(services)).to.have.members([
         'harmony-service-example',
-        'podaac/l2ss-py',
+        'podaac-l2-subsetter',
         'query-cmr',
       ]);
     });

--- a/services/harmony/test/util/service-images.ts
+++ b/services/harmony/test/util/service-images.ts
@@ -1,0 +1,176 @@
+import { expect } from 'chai';
+
+import { _getImageToServiceMap, getServiceName } from '../../app/util/service-images';
+
+describe('envVarToServiceName (via _getImageToServiceMap)', () => {
+  it('converts PODAAC_L2_SUBSETTER_IMAGE → podaac-l2-subsetter', () => {
+    const env = { PODAAC_L2_SUBSETTER_IMAGE: 'ghcr.io/podaac/l2ss-py:sit' };
+    const services = new Set(['podaac-l2-subsetter']);
+    const map = _getImageToServiceMap(env, services);
+    expect(Object.values(map)).to.include('podaac-l2-subsetter');
+  });
+
+  it('converts QUERY_CMR_IMAGE to query-cmr', () => {
+    const env = { QUERY_CMR_IMAGE: 'harmonyservices/query-cmr:latest' };
+    const services = new Set(['query-cmr']);
+    const map = _getImageToServiceMap(env, services);
+    expect(Object.values(map)).to.include('query-cmr');
+  });
+
+  it('converts HARMONY_MASKFILL_IMAGE to harmony-maskfill', () => {
+    const env = { HARMONY_MASKFILL_IMAGE: '1234567.dkr.ecr.us-west-2.amazonaws.com/nasa/harmony-maskfill:latest' };
+    const services = new Set(['harmony-maskfill']);
+    const map = _getImageToServiceMap(env, services);
+    expect(Object.values(map)).to.include('harmony-maskfill');
+  });
+});
+
+describe('getImageToServiceMap', () => {
+  it('maps a single deployed ghcr image correctly', () => {
+    const env = { HARMONY_MASKFILL_IMAGE: 'ghcr.io/nasa/harmony-maskfill:latest' };
+    const services = new Set(['harmony-maskfill']);
+    const map = _getImageToServiceMap(env, services);
+
+    // sanitizeImage strips the registry; key is the repo path without the tag
+    expect(map).to.deep.equal({ 'nasa/harmony-maskfill': 'harmony-maskfill' });
+  });
+
+  it('maps multiple deployed services', () => {
+    const env = {
+      L2SS_PY_IMAGE: 'ghcr.io/podaac/l2ss-py:sit',
+      CONCISE_IMAGE: 'ghcr.io/podaac/concise:sit',
+    };
+    const services = new Set(['l2ss-py', 'concise']);
+    const map = _getImageToServiceMap(env, services);
+
+    expect(map).to.deep.equal({
+      'podaac/l2ss-py': 'l2ss-py',
+      'podaac/concise': 'concise',
+    });
+  });
+
+  it('excludes services absent from the deployed set', () => {
+    const env = {
+      HARMONY_MASKFILL_IMAGE: 'ghcr.io/nasa/harmony-maskfill:latest',
+      NET2COG_IMAGE: 'ghcr.io/podaac/net2cog:sit',
+    };
+    const services = new Set(['harmony-maskfill']); // net2cog deliberately omitted
+    const map = _getImageToServiceMap(env, services);
+
+    expect(Object.values(map)).to.include('harmony-maskfill');
+    expect(Object.values(map)).not.to.include('net2cog');
+  });
+
+  it('strips the image tag — only the base name becomes the map key', () => {
+    const env = { STITCHEE_IMAGE: 'ghcr.io/nasa/stitchee:1.9.0' };
+    const services = new Set(['stitchee']);
+    const map = _getImageToServiceMap(env, services);
+
+    expect(map).to.have.key('nasa/stitchee');
+    expect(map).not.to.have.key('nasa/stitchee:1.9.0');
+  });
+
+  it('strips an ECR registry via sanitizeImage', () => {
+    const ecrImage = '1234567.dkr.ecr.us-west-2.amazonaws.com/ldds/subset-band-name:2.0.0';
+    const env = { LDDS_SUBSET_BAND_NAME_IMAGE: ecrImage };
+    const services = new Set(['ldds-subset-band-name']);
+    const map = _getImageToServiceMap(env, services);
+
+    // sanitizeImage strips the ECR host; the key becomes the repo path
+    expect(map).to.have.key('ldds/subset-band-name');
+  });
+
+  it('ignores env keys that do not end with _IMAGE', () => {
+    const env = {
+      HARMONY_MASKFILL_TAG: 'ghcr.io/nasa/harmony-maskfill:latest',
+      SOME_RANDOM_VAR: 'some-value',
+    };
+    const services = new Set(['harmony-maskfill']);
+    const map = _getImageToServiceMap(env, services);
+
+    expect(map).to.deep.equal({});
+  });
+
+  it('ignores _IMAGE keys whose value is an empty string', () => {
+    const env = { HARMONY_MASKFILL_IMAGE: '' };
+    const services = new Set(['harmony-maskfill']);
+    const map = _getImageToServiceMap(env, services);
+
+    expect(map).to.deep.equal({});
+  });
+
+  it('ignores _IMAGE keys whose value is undefined', () => {
+    const env: NodeJS.ProcessEnv = { HARMONY_MASKFILL_IMAGE: undefined };
+    const services = new Set(['harmony-maskfill']);
+    const map = _getImageToServiceMap(env, services);
+
+    expect(map).to.deep.equal({});
+  });
+
+  it('returns an empty map when the environment has no _IMAGE keys', () => {
+    const map = _getImageToServiceMap({}, new Set(['harmony-maskfill']));
+    expect(map).to.deep.equal({});
+  });
+
+  it('returns an empty map when the deployed services set is empty', () => {
+    const env = { HARMONY_MASKFILL_IMAGE: 'ghcr.io/nasa/harmony-maskfill:latest' };
+    const map = _getImageToServiceMap(env, new Set());
+    expect(map).to.deep.equal({});
+  });
+
+  it('handles an image with no tag (no colon) without throwing', () => {
+    const env = { HARMONY_MASKFILL_IMAGE: 'ghcr.io/nasa/harmony-maskfill' };
+    const services = new Set(['harmony-maskfill']);
+    expect(() => _getImageToServiceMap(env, services)).not.to.throw();
+  });
+});
+
+describe('getServiceName', () => {
+  const imageToServiceMap = {
+    'nasa/harmony-maskfill': 'harmony-maskfill',
+    'nasa/stitchee': 'stitchee',
+    'podaac/l2ss-py': 'l2ss-py',
+    'harmonyservices/query-cmr': 'query-cmr',
+    'ldds/subset-band-name': 'ldds-subset-band-name',
+    'nasa/harmony-swath-projector': 'harmony-swath-projector',
+  };
+
+  it('returns the mapped service name for a known ghcr image', () => {
+    expect(getServiceName(imageToServiceMap, 'ghcr.io/nasa/harmony-maskfill:latest'))
+      .to.equal('harmony-maskfill');
+  });
+
+  it('resolves correctly regardless of image tag', () => {
+    expect(getServiceName(imageToServiceMap, 'ghcr.io/nasa/stitchee:1.9.0'))
+      .to.equal('stitchee');
+    expect(getServiceName(imageToServiceMap, 'ghcr.io/nasa/stitchee:2.0.0'))
+      .to.equal('stitchee');
+  });
+
+  it('returns query-cmr for the harmonyservices image', () => {
+    expect(getServiceName(imageToServiceMap, 'harmonyservices/query-cmr:latest'))
+      .to.equal('query-cmr');
+  });
+
+  it('returns the correct name for an ECR image', () => {
+    expect(getServiceName(
+      imageToServiceMap,
+      '1234567.dkr.ecr.us-west-2.amazonaws.com/ldds/subset-band-name:2.0.0',
+    )).to.equal('ldds-subset-band-name');
+  });
+
+  it('falls back to the sanitized base name when the image is not in the map', () => {
+    expect(getServiceName(imageToServiceMap, 'ghcr.io/asfhyp3/nisar-py:latest'))
+      .to.equal('asfhyp3/nisar-py');
+  });
+
+  it('falls back gracefully when the map is empty', () => {
+    expect(getServiceName({}, 'ghcr.io/podaac/concise:sit'))
+      .to.equal('podaac/concise');
+  });
+
+  it('handles an image with no tag without throwing', () => {
+    expect(() => getServiceName(imageToServiceMap, 'ghcr.io/nasa/harmony-maskfill'))
+      .not.to.throw();
+  });
+});

--- a/services/service-runner/package-lock.json
+++ b/services/service-runner/package-lock.json
@@ -6486,14 +6486,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-mock-adapter": {
@@ -9355,8 +9355,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/services/work-failer/package-lock.json
+++ b/services/work-failer/package-lock.json
@@ -3359,14 +3359,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-mock-adapter": {
@@ -6793,10 +6793,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/services/work-scheduler/package-lock.json
+++ b/services/work-scheduler/package-lock.json
@@ -2948,14 +2948,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-mock-adapter": {
@@ -6383,10 +6383,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/services/work-updater/package-lock.json
+++ b/services/work-updater/package-lock.json
@@ -6708,14 +6708,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axios-mock-adapter": {
@@ -9574,8 +9574,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2305

## Description
Add initial /admin/dashboard endpoint that shows the current amount of work in the system for all deployed services.

## Local Test Steps
Navigate to /admin/dashboard

Verify that all services in your LOCALLY_DEPLOYED_SERVICES are reported in the "services" section with a queued count of 0. Submit requests for some of the services you have deployed and verify the counts are correctly updated to reflect anything in the ready, queued, or running state.

If "queued" on the dashboard doesn't sound like a good term to reflect the amount of accepted work in the system that hasn't finished processing suggest another word I can use.

Here's an example response:
```
{
  "services": {
    "harmony-service-example": {
      "queued": 0
    },
    "podaac-l2-subsetter": {
      "queued": 110000
    },
    "query-cmr": {
      "queued": 0
    }
  },
  "version": "1-alpha"
}
```

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin dashboard endpoint showing per-service queued work counts, canonical service names, and any unknown/extra services; responses use API version "1-alpha".
* **Behavior**
  * API version handling is case-insensitive and validated; responses are JSON (HTML branch currently responds with JSON).
  * Service image names are normalized and mapped to service names; services with no counts show queued: 0.
* **Tests**
  * Added tests validating dashboard responses, version handling, service-name mapping, counts aggregation, accepts negotiation, logging, and error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->