### PR TITLE
HARMONY-2330: Redact sensitive info when Axios errors are generated and signficantly reduce the logging.

### DIFF
--- a/services/cron-service/package-lock.json
+++ b/services/cron-service/package-lock.json
@@ -7638,9 +7638,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/services/harmony/app/util/log-redactor.ts
+++ b/services/harmony/app/util/log-redactor.ts
@@ -1,10 +1,12 @@
-import DataOperation from '../models/data-operation';
-import HarmonyRequest from '../models/harmony-request';
-import TurboService from '../models/services/turbo-service';
-import HttpService from '../models/services/http-service';
+import { AxiosError } from 'axios';
 import * as _ from 'lodash';
 import { TransformableInfo } from 'logform';
+import winston from 'winston';
 
+import DataOperation from '../models/data-operation';
+import HarmonyRequest from '../models/harmony-request';
+import HttpService from '../models/services/http-service';
+import TurboService from '../models/services/turbo-service';
 
 /**
  * Redact sensitive values from an object if they exist.
@@ -36,6 +38,34 @@ function redactObject(/* eslint-disable @typescript-eslint/no-explicit-any */
   }
   return infoClone;
 }
+
+/**
+ * Strips the massive Axios request, config, and response objects and
+ * removes sensitive info
+ */
+export const axiosRedactor = winston.format((info) => {
+  if (info.isAxiosError || info.name === 'AxiosError') {
+    const error = info as unknown as AxiosError;
+
+    if (error.config) {
+      info.axiosConfig = {
+        url: error.config.url,
+        method: error.config.method,
+        timeout: error.config.timeout,
+      };
+    }
+
+    if (error.response) {
+      info.responseData = error.response.data;
+    }
+
+    delete info.request;
+    delete info.config;
+    delete info.response;
+  }
+
+  return info;
+});
 
 /**
  * Redact sensitive key values from an object. The object passed

--- a/services/harmony/app/util/log.ts
+++ b/services/harmony/app/util/log.ts
@@ -5,7 +5,7 @@ import { Conjunction, listToText } from '@harmony/util/string';
 
 import env from './env';
 import { RequestValidationError } from './errors';
-import redact from './log-redactor';
+import redact, { axiosRedactor } from './log-redactor';
 
 const envNameFormat = winston.format((info) => ({ ...info, env_name: env.clientId }));
 
@@ -26,8 +26,10 @@ const redactor = winston.format((info) => {
 export function createJsonLogger(transports: winston.transport[]): winston.Logger {
   const jsonLogger = winston.createLogger({
     format: winston.format.combine(
+      winston.format.errors({ stack: true }),
       winston.format.timestamp(),
       envNameFormat(),
+      axiosRedactor(),
       redactor(),
       winston.format.json(),
     ),

--- a/services/harmony/package-lock.json
+++ b/services/harmony/package-lock.json
@@ -9493,9 +9493,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/services/harmony/test/util/log.ts
+++ b/services/harmony/test/util/log.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import { createLoggerForTest } from '../helpers/log';
+import { FilterRequest } from 'express-winston';
+import { describe, it } from 'mocha';
+
 import DataOperation from '../../app/models/data-operation';
 import HarmonyRequest from '../../app/models/harmony-request';
 import { requestFilter } from '../../app/server';
-import { FilterRequest } from 'express-winston';
-
+import { createLoggerForTest } from '../helpers/log';
 
 describe('request logging filter', function () {
   it('returns a <redacted> cookie header, leaving other headers intact', function () {
@@ -24,6 +24,92 @@ describe('request logging filter', function () {
     const filtReq: FilterRequest = { headers: { 'cookie-secret': 'secret-value', Host: 'host-value' } } as any as FilterRequest;
     const filtered = requestFilter(filtReq, 'headers');
     expect(filtered).to.deep.equal({ 'cookie-secret': '<redacted>', Host: 'host-value' });
+  });
+});
+
+describe('axiosRedactor', function () {
+  let testLogger, getTestLogs;
+
+  beforeEach(function () {
+    ({ getTestLogs, testLogger } = createLoggerForTest());
+  });
+
+  afterEach(function () {
+    testLogger.close();
+  });
+
+  it('strips massive Axios objects and extracts metadata into axiosConfig and responseData', function () {
+    const mockAxiosError = {
+      isAxiosError: true,
+      name: 'AxiosError',
+      message: 'Request failed with status code 403',
+      config: {
+        url: 'https://uat.urs.earthdata.nasa.gov/oauth/tokens/user',
+        method: 'post',
+        timeout: 0,
+        headers: { authorization: 'Bearer SECRET_TOKEN' },
+      },
+      response: {
+        status: 403,
+        data: { error: 'invalid_token', error_description: 'The token is malformed' },
+        config: { headers: { authorization: 'Bearer SECRET_TOKEN' } },
+        request: { some: 'circular_object' },
+      },
+      request: { some: 'circular_object' },
+    };
+
+    testLogger.error('Axios call failed', mockAxiosError);
+
+    const logEntries = getTestLogs().split('\n').filter(l => l.trim() !== '');
+    const lastEntry = JSON.parse(logEntries[logEntries.length - 1]);
+
+    expect(lastEntry.axiosConfig).to.deep.equal({
+      url: 'https://uat.urs.earthdata.nasa.gov/oauth/tokens/user',
+      method: 'post',
+      timeout: 0,
+    });
+
+    expect(lastEntry.responseData).to.deep.equal({
+      error: 'invalid_token',
+      error_description: 'The token is malformed',
+    });
+
+    expect(lastEntry).to.not.have.property('request');
+    expect(lastEntry).to.not.have.property('response');
+    expect(lastEntry).to.not.have.property('config');
+
+    const rawLogString = getTestLogs();
+    expect(rawLogString).to.not.include('SECRET_TOKEN');
+  });
+
+  it('does not modify the original Error object (Immutability Check)', function () {
+    const originalError = {
+      isAxiosError: true,
+      config: { url: 'http://test.com' },
+      response: { data: 'some-data' },
+    };
+
+    testLogger.error('Logging an error', originalError);
+
+    expect(originalError.config).to.exist;
+    expect(originalError.response).to.exist;
+    expect(originalError.config.url).to.equal('http://test.com');
+  });
+
+  it('gracefully handles Axios errors that are missing a response (e.g., Network Error)', function () {
+    const networkError = {
+      isAxiosError: true,
+      name: 'AxiosError',
+      message: 'Network Error',
+      config: { url: 'http://unreachable.com', method: 'get' },
+      // No response object here
+    };
+
+    testLogger.error('Connection failed', networkError);
+
+    const logs = getTestLogs();
+    expect(logs).to.include('"url":"http://unreachable.com"');
+    expect(logs).to.not.have.property('responseData');
   });
 });
 

--- a/services/harmony/test/util/log.ts
+++ b/services/harmony/test/util/log.ts
@@ -109,7 +109,7 @@ describe('axiosRedactor', function () {
 
     const logs = getTestLogs();
     expect(logs).to.include('"url":"http://unreachable.com"');
-    expect(logs).to.not.have.property('responseData');
+    expect(logs).to.not.include('"responseData"');
   });
 });
 

--- a/services/service-runner/package-lock.json
+++ b/services/service-runner/package-lock.json
@@ -7556,9 +7556,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/services/work-failer/package-lock.json
+++ b/services/work-failer/package-lock.json
@@ -4577,9 +4577,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/services/work-scheduler/package-lock.json
+++ b/services/work-scheduler/package-lock.json
@@ -4170,9 +4170,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/services/work-updater/package-lock.json
+++ b/services/work-updater/package-lock.json
@@ -7722,9 +7722,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2330

## Description
Redact sensitive info when Axios errors are generated and signficantly reduce the logging.

## Local Test Steps
First test against main to see what was logged before on any EDL error.

In your .env file set `TEXT_LOGGER=false` to make sure you are using JSON logging.

Start harmony and then call `curl -H "Authorization: Bearer foo" http://localhost:3000/jobs` and look at the information logged.

Check out this branch and repeat the curl request and verify that the excessive logging and sensitive headers are not logged, but there is enough info logged to see the error "The token is either malformed or does not exist" and stack trace.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced error logging now captures full stack traces in log output for improved diagnostics.

* **Bug Fixes**
  * Strengthened sensitive data redaction from API error logs to better protect credentials and response information.

* **Tests**
  * Added comprehensive test coverage for error redaction and sensitive data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->