### PR TITLE
HARMONY-2304 and HARMONY-2307: Add HTML representation to dashboard and capture system queue metrics

### DIFF
--- a/packages/util/string.ts
+++ b/packages/util/string.ts
@@ -130,3 +130,16 @@ export function sanitizeImage(image: string): string {
 export function inEcr(image: string): boolean {
   return /.*amazonaws.com\//.test(image);
 }
+
+/**
+ * Convert camelCase to Spaced Title Case
+ *
+ * @param value - the string to convert
+ * @returns the value in Spaced Title Case
+ */
+export function camelCaseToSpacedTitleCase(value: string): string {
+  return value
+    .replace(/([A-Z])/g, ' $1') // Insert space before capital letters
+    .replace(/^./, (str) => str.toUpperCase()) // Capitalize the first letter
+    .trim();
+}

--- a/packages/util/string.ts
+++ b/packages/util/string.ts
@@ -139,7 +139,8 @@ export function inEcr(image: string): boolean {
  */
 export function camelCaseToSpacedTitleCase(value: string): string {
   return value
-    .replace(/([A-Z])/g, ' $1') // Insert space before capital letters
-    .replace(/^./, (str) => str.toUpperCase()) // Capitalize the first letter
-    .trim();
+    .replace(/([A-Z])/g, ' $1')   // Insert space before all capital letters
+    .replace(/\s+/g, ' ')         // Collapse multiple spaces into one
+    .trim()                       // Remove leading space (from the first capital) and any trailing space
+    .replace(/^./, (str) => str.toUpperCase()); // Capitalize the first letter
 }

--- a/packages/util/test/string.ts
+++ b/packages/util/test/string.ts
@@ -1,6 +1,10 @@
-import { describe, it } from 'mocha';
 import { expect } from 'chai';
-import { listToText, truncateString, Conjunction, isBoolean, isInteger, inEcr, parseBoolean, sanitizeImage } from '../string';
+import { describe, it } from 'mocha';
+
+import {
+  camelCaseToSpacedTitleCase, Conjunction, inEcr, isBoolean, isInteger, listToText, parseBoolean,
+  sanitizeImage, truncateString,
+} from '../string';
 
 describe('util/string', function () {
   describe('#listToText', function () {
@@ -149,6 +153,24 @@ describe('util/string', function () {
     });
     it('strips private earthdata location from image url', function () {
       expect(sanitizeImage('private.earthdata.nasa.gov/the-image-name')).to.equal('the-image-name');
+    });
+  });
+
+  describe('#camelCaseToSpacedTitleCase', function () {
+    it('handles multiple camelCaseWords', function () {
+      expect(camelCaseToSpacedTitleCase('camelCaseMultipleWords')).to.equal('Camel Case Multiple Words');
+    });
+    it('does not change dash case except to capitalize the first letter', function () {
+      expect(camelCaseToSpacedTitleCase('dash_case_test')).to.equal('Dash_case_test');
+    });
+    it('capitalizes a single word', function () {
+      expect(camelCaseToSpacedTitleCase('word')).to.equal('Word');
+    });
+    it('handles words already in the expected format', function () {
+      expect(camelCaseToSpacedTitleCase('Spaced Title Case Already')).to.equal('Spaced Title Case Already');
+    });
+    it('strips leading and trailing spaces', function () {
+      expect(camelCaseToSpacedTitleCase('   camelCaseMultipleWords   ')).to.equal('Camel Case Multiple Words');
     });
   });
 });

--- a/services/harmony/app/frontends/dashboard.ts
+++ b/services/harmony/app/frontends/dashboard.ts
@@ -8,6 +8,7 @@ import db from '../util/db';
 import { RequestValidationError } from '../util/errors';
 import { keysToLowerCase } from '../util/object';
 import { getImageToServiceMap, getServiceName } from '../util/service-images';
+import harmonyVersion from '../util/version';
 
 export const currentApiVersion = '1-alpha';
 const supportedApiVersions = ['1-alpha'];
@@ -95,11 +96,21 @@ export async function getDashboard(
     const acceptsHtml = req.accepts(['json', 'html']) === 'html';
 
     if (acceptsHtml) {
-      // TODO HARMONY-2304 HTML endpoint
-      // res.render('dashboard', {
-      //   ...
-      // });
-      res.json(result);
+      // Transform the object { "service": { "queued": 0 } }
+      // into an array [{ "name": "service", "queued": 0 }]
+      const servicesArray = Object.entries(result.services).map(([name, details]) => ({
+        name,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        queued: (details as any).queued,
+      }));
+
+      // Sort by queued count descending for the default page load
+      servicesArray.sort((a, b) => b.queued - a.queued);
+
+      res.render('dashboard', {
+        version: harmonyVersion,
+        services: servicesArray,
+      });
     } else {
       res.json(result);
     }

--- a/services/harmony/app/frontends/dashboard.ts
+++ b/services/harmony/app/frontends/dashboard.ts
@@ -95,16 +95,16 @@ async function getSystemQueueMetrics(): Promise<DashboardQueues> {
   const largeUpdateQueue = getQueueForType(WorkItemQueueType.LARGE_ITEM_UPDATE);
   const schedulerQueue = getWorkSchedulerQueue();
 
-  const [small, large, scheduler] = await Promise.all([
+  const [small, large, scheduler] = await Promise.allSettled([
     smallUpdateQueue.getApproximateNumberOfMessages(),
     largeUpdateQueue.getApproximateNumberOfMessages(),
     schedulerQueue.getApproximateNumberOfMessages(),
   ]);
 
   return {
-    smallWorkItemUpdates: small,
-    largeWorkItemUpdates: large,
-    workItemScheduler: scheduler,
+    smallWorkItemUpdates: small.status === 'fulfilled' ? small.value : -1,
+    largeWorkItemUpdates: large.status === 'fulfilled' ? large.value : -1,
+    workItemScheduler: scheduler.status === 'fulfilled' ? scheduler.value : -1,
   };
 }
 
@@ -132,6 +132,7 @@ function renderDashboardHtml(
   const queuesArray = Object.entries(queues).map(([name, count]) => ({
     name: camelCaseToSpacedTitleCase(name),
     count,
+    isFailed: count === -1,
   }));
 
   // Sort by queued count descending for the primary dashboard view

--- a/services/harmony/app/frontends/dashboard.ts
+++ b/services/harmony/app/frontends/dashboard.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Response } from 'express';
+import { Knex } from 'knex';
 
 import { camelCaseToSpacedTitleCase, listToText } from '@harmony/util/string';
 
@@ -33,15 +34,124 @@ function validateVersion(version): void {
   }
 }
 
+interface ServiceMetric {
+  queued: number;
+}
+
+interface DashboardQueues {
+  smallWorkItemUpdates: number;
+  largeWorkItemUpdates: number;
+  workItemScheduler: number;
+}
+
+/**
+ * Fetches and merges service work counts from the database, mapping image names
+ * to service names and ensuring all known services are included.
+ * @param dbConn - The database connection object
+ * @returns A record of service names and their associated queued work counts
+ */
+async function getServiceMetrics(dbConn: Knex): Promise<Record<string, ServiceMetric>> {
+  const serviceWorkCounts = await getCountsByService(dbConn);
+  const imageToServiceMap = getImageToServiceMap();
+
+  const normalizedDb: Record<string, ServiceMetric> = {};
+
+  for (const [image, value] of Object.entries(serviceWorkCounts)) {
+    const service = getServiceName(imageToServiceMap, image);
+    if (!normalizedDb[service]) {
+      normalizedDb[service] = { queued: 0 };
+    }
+    normalizedDb[service].queued += (value as ServiceMetric).queued;
+  }
+
+  const allServices = new Set(Object.values(imageToServiceMap));
+  const merged: Record<string, ServiceMetric> = {};
+
+  for (const service of allServices) {
+    merged[service] = { queued: normalizedDb[service]?.queued ?? 0 };
+  }
+
+  for (const [service, value] of Object.entries(normalizedDb)) {
+    if (!(service in merged)) {
+      merged[service] = value;
+    }
+  }
+
+  return Object.keys(merged).sort().reduce((acc, key) => ({
+    ...acc,
+    [key]: merged[key],
+  }), {});
+}
+
+/**
+ * Fetches approximate message counts for internal system queues.
+ * * @returns A record containing counts for small updates, large updates, and the scheduler
+ */
+async function getSystemQueueMetrics(): Promise<DashboardQueues> {
+  const smallUpdateQueue = getQueueForType(WorkItemQueueType.SMALL_ITEM_UPDATE);
+  const largeUpdateQueue = getQueueForType(WorkItemQueueType.LARGE_ITEM_UPDATE);
+  const schedulerQueue = getWorkSchedulerQueue();
+
+  const [small, large, scheduler] = await Promise.all([
+    smallUpdateQueue.getApproximateNumberOfMessages(),
+    largeUpdateQueue.getApproximateNumberOfMessages(),
+    schedulerQueue.getApproximateNumberOfMessages(),
+  ]);
+
+  return {
+    smallWorkItemUpdates: small,
+    largeWorkItemUpdates: large,
+    workItemScheduler: scheduler,
+  };
+}
+
+/**
+ * Transforms raw metrics into the format expected by the Mustache template
+ * and renders the HTML response.
+ * * @param res - The Express response object
+ * @param services - The map of service names to their queued counts
+ * @param queues - The map of system queue names to their message counts
+ * @param version - The version string to display on the dashboard
+ */
+function renderDashboardHtml(
+  res: Response,
+  services: Record<string, ServiceMetric>,
+  queues: DashboardQueues,
+  version: string,
+): void {
+  const servicesArray = Object.entries(services).map(([name, details]) => ({
+    name,
+    queued: details.queued,
+  }));
+
+  const queuesArray = Object.entries(queues).map(([name, count]) => ({
+    name: camelCaseToSpacedTitleCase(name),
+    count,
+  }));
+
+  // Sort by queued count descending for the primary dashboard view
+  servicesArray.sort((a, b) => b.queued - a.queued);
+
+  res.render('dashboard', {
+    version,
+    services: servicesArray,
+    queues: queuesArray,
+  });
+}
+
 /**
  * Express.js handler that returns the harmony dashboard responding with JSON by default
  * or HTML if requested.
+ * * @param req - The Harmony request object
+ * @param res - The Express response object
+ * @param next - The Express next function
+ * @throws RequestValidationError if the version is not supported
  */
 export async function getDashboard(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
   const query = keysToLowerCase(req.query);
-  const version = query?.version;
+  const version = (query?.version as string);
   const versionText = version ? version : 'unspecified';
 
   try {
@@ -50,90 +160,23 @@ export async function getDashboard(
     }
 
     req.context.logger.info(`Dashboard requested by user ${req.user}, version: ${versionText}`);
-    const serviceWorkCounts = await getCountsByService(db);
-    const imageToServiceMap = getImageToServiceMap();
 
-    // Convert the image name returned from the database with the service name
-    const normalizedDb: Record<string, { queued: number }> = {};
-
-    for (const [image, value] of Object.entries(serviceWorkCounts)) {
-      const service = getServiceName(imageToServiceMap, image);
-
-      if (!normalizedDb[service]) {
-        normalizedDb[service] = { queued: 0 };
-      }
-
-      normalizedDb[service].queued += value.queued;
-    }
-
-    // Build full service set from imageToServiceMap (VALUES are service names)
-    // Include all deployed services in the response - not just the ones with active requests
-    const allServices = new Set(Object.values(imageToServiceMap));
-    const merged: Record<string, { queued: number }> = {};
-
-    for (const service of allServices) {
-      merged[service] = {
-        queued: normalizedDb[service]?.queued ?? 0,
-      };
-    }
-
-    // Add any unknown services returned from DB (could be from old images)
-    for (const [service, value] of Object.entries(normalizedDb)) {
-      if (!(service in merged)) {
-        merged[service] = value;
-      }
-    }
-
-    const sortedServicesMap = Object.keys(merged).sort().reduce((acc, key) => ({
-      ...acc,
-      [key]: merged[key],
-    }), {});
-
-    const smallUpdateQueue = getQueueForType(WorkItemQueueType.SMALL_ITEM_UPDATE);
-    const largeUpdateQueue = getQueueForType(WorkItemQueueType.LARGE_ITEM_UPDATE);
-    const schedulerQueue = getWorkSchedulerQueue();
-
-    const smallUpdateQueueCount = await smallUpdateQueue.getApproximateNumberOfMessages();
-    const largeUpdateQueueCount = await largeUpdateQueue.getApproximateNumberOfMessages();
-    const schedulerQueueCount = await schedulerQueue.getApproximateNumberOfMessages();
-
-    const queues = {
-      'smallWorkItemUpdates': smallUpdateQueueCount,
-      'largeWorkItemUpdates': largeUpdateQueueCount,
-      'workItemScheduler': schedulerQueueCount,
-    };
+    const [serviceMetrics, queueMetrics] = await Promise.all([
+      getServiceMetrics(db),
+      getSystemQueueMetrics(),
+    ]);
 
     const result = {
-      services: sortedServicesMap,
-      queues,
-      version: version?.toLowerCase() || currentApiVersion,
+      services: serviceMetrics,
+      queues: queueMetrics,
+      version: harmonyVersion,
     };
 
-    // Detect if client wants HTML explicitly - by default we will return JSON
+    // Default to JSON unless caller explicitly requests html
     const acceptsHtml = req.accepts(['json', 'html']) === 'html';
 
     if (acceptsHtml) {
-      // Transform the object { "service": { "queued": 0 } }
-      // into an array [{ "name": "service", "queued": 0 }]
-      const servicesArray = Object.entries(result.services).map(([name, details]) => ({
-        name,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        queued: (details as any).queued,
-      }));
-
-      const queuesArray = Object.entries(result.queues).map(([name, queuedCount]) => ({
-        name: camelCaseToSpacedTitleCase(name),
-        count: queuedCount,
-      }));
-
-      // Sort by queued count descending for the default page load
-      servicesArray.sort((a, b) => b.queued - a.queued);
-
-      res.render('dashboard', {
-        version: harmonyVersion,
-        services: servicesArray,
-        queues: queuesArray,
-      });
+      renderDashboardHtml(res, result.services, result.queues, result.version);
     } else {
       res.json(result);
     }

--- a/services/harmony/app/frontends/dashboard.ts
+++ b/services/harmony/app/frontends/dashboard.ts
@@ -18,6 +18,7 @@ const supportedApiVersions = ['1-alpha'];
 
 /**
  * Throws an error if the version is not supported
+ *
  * @param version - the version of the dashboard response
  * @throws RequestValidationError if the version is not supported
  */
@@ -47,6 +48,7 @@ interface DashboardQueues {
 /**
  * Fetches and merges service work counts from the database, mapping image names
  * to service names and ensuring all known services are included.
+ *
  * @param dbConn - The database connection object
  * @returns A record of service names and their associated queued work counts
  */
@@ -85,7 +87,8 @@ async function getServiceMetrics(dbConn: Knex): Promise<Record<string, ServiceMe
 
 /**
  * Fetches approximate message counts for internal system queues.
- * * @returns A record containing counts for small updates, large updates, and the scheduler
+ *
+ * @returns A record containing counts for small updates, large updates, and the scheduler
  */
 async function getSystemQueueMetrics(): Promise<DashboardQueues> {
   const smallUpdateQueue = getQueueForType(WorkItemQueueType.SMALL_ITEM_UPDATE);
@@ -108,10 +111,12 @@ async function getSystemQueueMetrics(): Promise<DashboardQueues> {
 /**
  * Transforms raw metrics into the format expected by the Mustache template
  * and renders the HTML response.
- * * @param res - The Express response object
+ *
+ * @param res - The Express response object
  * @param services - The map of service names to their queued counts
  * @param queues - The map of system queue names to their message counts
- * @param version - The version string to display on the dashboard
+ * @param version - The version string to display on the dashboard in the footer
+ *        (harmony version not the dashboard API version)
  */
 function renderDashboardHtml(
   res: Response,
@@ -142,7 +147,8 @@ function renderDashboardHtml(
 /**
  * Express.js handler that returns the harmony dashboard responding with JSON by default
  * or HTML if requested.
- * * @param req - The Harmony request object
+ *
+ * @param req - The Harmony request object
  * @param res - The Express response object
  * @param next - The Express next function
  * @throws RequestValidationError if the version is not supported
@@ -169,14 +175,14 @@ export async function getDashboard(
     const result = {
       services: serviceMetrics,
       queues: queueMetrics,
-      version: harmonyVersion,
+      version: version || currentApiVersion,
     };
 
     // Default to JSON unless caller explicitly requests html
     const acceptsHtml = req.accepts(['json', 'html']) === 'html';
 
     if (acceptsHtml) {
-      renderDashboardHtml(res, result.services, result.queues, result.version);
+      renderDashboardHtml(res, result.services, result.queues, harmonyVersion);
     } else {
       res.json(result);
     }

--- a/services/harmony/app/frontends/dashboard.ts
+++ b/services/harmony/app/frontends/dashboard.ts
@@ -1,12 +1,14 @@
 import { NextFunction, Response } from 'express';
 
-import { listToText } from '@harmony/util/string';
+import { camelCaseToSpacedTitleCase, listToText } from '@harmony/util/string';
 
 import HarmonyRequest from '../models/harmony-request';
 import { getCountsByService } from '../models/user-work';
 import db from '../util/db';
 import { RequestValidationError } from '../util/errors';
 import { keysToLowerCase } from '../util/object';
+import { WorkItemQueueType } from '../util/queue/queue';
+import { getQueueForType, getWorkSchedulerQueue } from '../util/queue/queue-factory';
 import { getImageToServiceMap, getServiceName } from '../util/service-images';
 import harmonyVersion from '../util/version';
 
@@ -87,8 +89,23 @@ export async function getDashboard(
       [key]: merged[key],
     }), {});
 
+    const smallUpdateQueue = getQueueForType(WorkItemQueueType.SMALL_ITEM_UPDATE);
+    const largeUpdateQueue = getQueueForType(WorkItemQueueType.LARGE_ITEM_UPDATE);
+    const schedulerQueue = getWorkSchedulerQueue();
+
+    const smallUpdateQueueCount = await smallUpdateQueue.getApproximateNumberOfMessages();
+    const largeUpdateQueueCount = await largeUpdateQueue.getApproximateNumberOfMessages();
+    const schedulerQueueCount = await schedulerQueue.getApproximateNumberOfMessages();
+
+    const queues = {
+      'smallWorkItemUpdates': smallUpdateQueueCount,
+      'largeWorkItemUpdates': largeUpdateQueueCount,
+      'workItemScheduler': schedulerQueueCount,
+    };
+
     const result = {
       services: sortedServicesMap,
+      queues,
       version: version?.toLowerCase() || currentApiVersion,
     };
 
@@ -104,12 +121,18 @@ export async function getDashboard(
         queued: (details as any).queued,
       }));
 
+      const queuesArray = Object.entries(result.queues).map(([name, queuedCount]) => ({
+        name: camelCaseToSpacedTitleCase(name),
+        count: queuedCount,
+      }));
+
       // Sort by queued count descending for the default page load
       servicesArray.sort((a, b) => b.queued - a.queued);
 
       res.render('dashboard', {
         version: harmonyVersion,
         services: servicesArray,
+        queues: queuesArray,
       });
     } else {
       res.json(result);

--- a/services/harmony/app/frontends/retry-stats.ts
+++ b/services/harmony/app/frontends/retry-stats.ts
@@ -5,6 +5,7 @@ import { getRetryCounts } from '../models/work-item';
 import db from '../util/db';
 import { RequestValidationError } from '../util/errors';
 import { keysToLowerCase } from '../util/object';
+import version from '../util/version';
 
 const DEFAULT_MINUTES = 60;
 
@@ -73,6 +74,7 @@ export async function getRetryStatistics(
         totalWorkItemExecutions,
         percentSuccessful: `${percentSuccessful.toFixed(2)}%`,
         percentRetried: `${percentRetried.toFixed(2)}%`,
+        version,
       });
     } else {
       res.json(result);

--- a/services/harmony/app/views/dashboard.mustache.html
+++ b/services/harmony/app/views/dashboard.mustache.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en" class="h-100">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="/css/eui.min.css" />
+  <link rel="stylesheet" href="/css/default.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" />
+  <link href="https://cdn.jsdelivr.net/npm/@yaireo/tagify@4.16.4/dist/tagify.css" rel="stylesheet" type="text/css" />
+  <link rel="stylesheet" href="/css/workflow-ui/default.css" />
+
+  <style>
+    th.sortable { cursor: pointer; position: relative; white-space: nowrap; }
+    th.sortable:hover { background-color: rgba(0,0,0,0.05); }
+    .sort-icon { font-size: 0.8rem; margin-left: 5px; color: #adb5bd; }
+    th.sorted-asc .sort-icon::before { content: "\F145"; color: #000; } /* bi-sort-up */
+    th.sorted-desc .sort-icon::before { content: "\F128"; color: #000; } /* bi-sort-down */
+  </style>
+
+  <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify@4.16.4"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify@4.16.4/dist/tagify.polyfills.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
+          integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"
+          defer></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
+          integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+          crossorigin="anonymous" defer></script>
+  <script language="javascript" id="_fed_an_ua_tag"
+          src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=GSFC&dclink=true"
+          defer></script>
+  <title>Service Dashboard</title>
+</head>
+<body class="d-flex flex-column h-100">
+  {{> banner}}
+
+  <div class="container-lg pt-5 flex-grow-1">
+    <h1 class="display-4 text-center">Service Dashboard</h1>
+
+    <div class="table-responsive mt-4">
+      <table class="table table-striped" id="servicesTable">
+        <thead>
+          <tr>
+            <th class="sortable" onclick="sortTable(0)">
+              Service Name <i class="bi bi-arrow-down-up sort-icon"></i>
+            </th>
+            <th class="sortable sorted-desc" onclick="sortTable(1)">
+              Queued Requests <i class="bi bi-arrow-down-up sort-icon"></i>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#services}}
+          <tr>
+            <td class="font-monospace">{{name}}</td>
+            <td><strong>{{queued}}</strong></td>
+          </tr>
+          {{/services}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <footer class="mt-auto">
+    {{> footer}}
+  </footer>
+
+  <script>
+    /**
+     * Client-side sorting for the dashboard table
+     * @param {number} n - Column index
+     */
+    function sortTable(n) {
+      const table = document.getElementById("servicesTable");
+      const headers = table.querySelectorAll("th");
+      let rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
+
+      switching = true;
+      dir = "asc";
+
+      // If the header already has 'asc', toggle to 'desc'
+      if (headers[n].classList.contains("sorted-asc")) {
+        dir = "desc";
+      }
+
+      while (switching) {
+        switching = false;
+        rows = table.rows;
+        for (i = 1; i < (rows.length - 1); i++) {
+          shouldSwitch = false;
+          x = rows[i].getElementsByTagName("TD")[n];
+          y = rows[i + 1].getElementsByTagName("TD")[n];
+
+          let xVal = x.innerText.toLowerCase();
+          let yVal = y.innerText.toLowerCase();
+
+          // Numerical comparison for the 'Queued' column
+          if (n === 1) {
+            xVal = parseInt(xVal) || 0;
+            yVal = parseInt(yVal) || 0;
+          }
+
+          if (dir === "asc") {
+            if (xVal > yVal) { shouldSwitch = true; break; }
+          } else if (dir === "desc") {
+            if (xVal < yVal) { shouldSwitch = true; break; }
+          }
+        }
+        if (shouldSwitch) {
+          rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
+          switching = true;
+          switchcount++;
+        }
+      }
+
+      // Update UI classes for icons
+      headers.forEach(h => h.classList.remove("sorted-asc", "sorted-desc"));
+      headers[n].classList.add(dir === "asc" ? "sorted-asc" : "sorted-desc");
+    }
+  </script>
+</body>
+</html>

--- a/services/harmony/app/views/dashboard.mustache.html
+++ b/services/harmony/app/views/dashboard.mustache.html
@@ -9,23 +9,6 @@
   <link href="https://cdn.jsdelivr.net/npm/@yaireo/tagify@4.16.4/dist/tagify.css" rel="stylesheet" type="text/css" />
   <link rel="stylesheet" href="/css/workflow-ui/default.css" />
 
-  <style>
-    th.sortable { cursor: pointer; position: relative; white-space: nowrap; }
-    th.sortable:hover { background-color: rgba(0,0,0,0.05); }
-    .sort-icon { font-size: 0.8rem; margin-left: 5px; color: #adb5bd; }
-    th.sorted-asc .sort-icon::before { content: "\F145"; color: #000; } /* bi-sort-up */
-    th.sorted-desc .sort-icon::before { content: "\F128"; color: #000; } /* bi-sort-down */
-    .metric-card {
-      background: #f8f9fa;
-      border-top: 3px solid #0071bc; /* NASA Blue */
-      text-align: center;
-      padding: 15px;
-      border-radius: 4px;
-    }
-    .metric-value { font-size: 1.5rem; font-weight: bold; display: block; }
-    .metric-label { font-size: 0.85rem; text-transform: uppercase; color: #666; }
-  </style>
-
   <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify@4.16.4"></script>
   <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify@4.16.4/dist/tagify.polyfills.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
@@ -37,7 +20,7 @@
   <script language="javascript" id="_fed_an_ua_tag"
           src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=NASA&subagency=GSFC&dclink=true"
           defer></script>
-  <title>Service Dashboard</title>
+  <title>Harmony Dashboard</title>
 </head>
 <body class="d-flex flex-column h-100">
   {{> banner}}
@@ -92,6 +75,44 @@
     {{> footer}}
   </footer>
 
+  <script>
+    /**
+     * Handles table sorting for the Services list
+     * @param {number} n - Column index (0 for name, 1 for count)
+     */
+    function sortTable(n) {
+      const table = document.getElementById("servicesTable");
+      const tbody = table.querySelector("tbody");
+      const rows = Array.from(tbody.rows);
+      const header = table.querySelectorAll("th")[n];
+      const isAscending = header.classList.contains("sorted-asc");
+
+      const direction = isAscending ? -1 : 1;
+
+      const sortedRows = rows.sort((a, b) => {
+        let x = a.cells[n].innerText.trim();
+        let y = b.cells[n].innerText.trim();
+
+        // If sorting the 'Queued' column, treat as numbers
+        if (n === 1) {
+          return (parseInt(x) - parseInt(y)) * direction;
+        }
+
+        // Otherwise, treat as strings
+        return x.toLowerCase().localeCompare(y.toLowerCase()) * direction;
+      });
+
+      // Clear existing rows and append sorted ones
+      while (tbody.firstChild) {
+        tbody.removeChild(tbody.firstChild);
+      }
+      tbody.append(...sortedRows);
+
+      table.querySelectorAll("th").forEach(th => {
+        th.classList.remove("sorted-asc", "sorted-desc");
+      });
+      header.classList.add(isAscending ? "sorted-desc" : "sorted-asc");
+    }
+  </script>
   </body>
-</html>
 </html>

--- a/services/harmony/app/views/dashboard.mustache.html
+++ b/services/harmony/app/views/dashboard.mustache.html
@@ -35,7 +35,15 @@
       {{#queues}}
       <div class="col-md-4 mb-3">
         <div class="metric-card shadow-sm">
-          <span class="metric-value font-monospace">{{count}}</span>
+          <span class="metric-value font-monospace">
+            {{#isFailed}}
+              <small class="fs-6 text-muted">failed to retrieve</small>
+            {{/isFailed}}
+
+            {{^isFailed}}
+              {{count}}
+            {{/isFailed}}
+          </span>
           <span class="metric-label">{{name}}</span>
         </div>
       </div>
@@ -49,11 +57,15 @@
           <table class="table table-striped" id="servicesTable">
             <thead>
               <tr>
-                <th class="sortable" onclick="sortTable(0)">
-                  Service Name <i class="bi bi-arrow-down-up sort-icon"></i>
+                <th scope="col" class="sortable" aria-sort="none">
+                  <button type="button" class="btn-sort" onclick="sortTable(0, this)">
+                    Service Name <i class="bi bi-arrow-down-up sort-icon"></i>
+                  </button>
                 </th>
-                <th class="sortable sorted-desc" onclick="sortTable(1)">
-                  Queued Requests <i class="bi bi-arrow-down-up sort-icon"></i>
+                <th scope="col" class="sortable" aria-sort="descending">
+                  <button type="button" class="btn-sort" onclick="sortTable(1, this)">
+                    Queued Requests <i class="bi bi-arrow-down-up sort-icon"></i>
+                  </button>
                 </th>
               </tr>
             </thead>

--- a/services/harmony/app/views/dashboard.mustache.html
+++ b/services/harmony/app/views/dashboard.mustache.html
@@ -15,6 +15,15 @@
     .sort-icon { font-size: 0.8rem; margin-left: 5px; color: #adb5bd; }
     th.sorted-asc .sort-icon::before { content: "\F145"; color: #000; } /* bi-sort-up */
     th.sorted-desc .sort-icon::before { content: "\F128"; color: #000; } /* bi-sort-down */
+    .metric-card {
+      background: #f8f9fa;
+      border-top: 3px solid #0071bc; /* NASA Blue */
+      text-align: center;
+      padding: 15px;
+      border-radius: 4px;
+    }
+    .metric-value { font-size: 1.5rem; font-weight: bold; display: block; }
+    .metric-label { font-size: 0.85rem; text-transform: uppercase; color: #666; }
   </style>
 
   <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify@4.16.4"></script>
@@ -34,29 +43,48 @@
   {{> banner}}
 
   <div class="container-lg pt-5 flex-grow-1">
-    <h1 class="display-4 text-center">Service Dashboard</h1>
+    <h1 class="display-4 text-center">Harmony Dashboard</h1>
 
-    <div class="table-responsive mt-4">
-      <table class="table table-striped" id="servicesTable">
-        <thead>
-          <tr>
-            <th class="sortable" onclick="sortTable(0)">
-              Service Name <i class="bi bi-arrow-down-up sort-icon"></i>
-            </th>
-            <th class="sortable sorted-desc" onclick="sortTable(1)">
-              Queued Requests <i class="bi bi-arrow-down-up sort-icon"></i>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {{#services}}
-          <tr>
-            <td class="font-monospace">{{name}}</td>
-            <td><strong>{{queued}}</strong></td>
-          </tr>
-          {{/services}}
-        </tbody>
-      </table>
+    <div class="row mt-5 mb-4">
+      <div class="col-12">
+        <h2 class="h4 mb-3"><i class="bi bi-cpu"></i> System Queues</h2>
+      </div>
+      {{#queues}}
+      <div class="col-md-4 mb-3">
+        <div class="metric-card shadow-sm">
+          <span class="metric-value font-monospace">{{count}}</span>
+          <span class="metric-label">{{name}}</span>
+        </div>
+      </div>
+      {{/queues}}
+    </div>
+
+    <div class="row">
+      <div class="col-12">
+        <h2 class="h4 mb-3"><i class="bi bi-gear-wide-connected"></i> Services</h2>
+        <div class="table-responsive">
+          <table class="table table-striped" id="servicesTable">
+            <thead>
+              <tr>
+                <th class="sortable" onclick="sortTable(0)">
+                  Service Name <i class="bi bi-arrow-down-up sort-icon"></i>
+                </th>
+                <th class="sortable sorted-desc" onclick="sortTable(1)">
+                  Queued Requests <i class="bi bi-arrow-down-up sort-icon"></i>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {{#services}}
+              <tr>
+                <td class="font-monospace">{{name}}</td>
+                <td><strong>{{queued}}</strong></td>
+              </tr>
+              {{/services}}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   </div>
 
@@ -64,58 +92,6 @@
     {{> footer}}
   </footer>
 
-  <script>
-    /**
-     * Client-side sorting for the dashboard table
-     * @param {number} n - Column index
-     */
-    function sortTable(n) {
-      const table = document.getElementById("servicesTable");
-      const headers = table.querySelectorAll("th");
-      let rows, switching, i, x, y, shouldSwitch, dir, switchcount = 0;
-
-      switching = true;
-      dir = "asc";
-
-      // If the header already has 'asc', toggle to 'desc'
-      if (headers[n].classList.contains("sorted-asc")) {
-        dir = "desc";
-      }
-
-      while (switching) {
-        switching = false;
-        rows = table.rows;
-        for (i = 1; i < (rows.length - 1); i++) {
-          shouldSwitch = false;
-          x = rows[i].getElementsByTagName("TD")[n];
-          y = rows[i + 1].getElementsByTagName("TD")[n];
-
-          let xVal = x.innerText.toLowerCase();
-          let yVal = y.innerText.toLowerCase();
-
-          // Numerical comparison for the 'Queued' column
-          if (n === 1) {
-            xVal = parseInt(xVal) || 0;
-            yVal = parseInt(yVal) || 0;
-          }
-
-          if (dir === "asc") {
-            if (xVal > yVal) { shouldSwitch = true; break; }
-          } else if (dir === "desc") {
-            if (xVal < yVal) { shouldSwitch = true; break; }
-          }
-        }
-        if (shouldSwitch) {
-          rows[i].parentNode.insertBefore(rows[i + 1], rows[i]);
-          switching = true;
-          switchcount++;
-        }
-      }
-
-      // Update UI classes for icons
-      headers.forEach(h => h.classList.remove("sorted-asc", "sorted-desc"));
-      headers[n].classList.add(dir === "asc" ? "sorted-asc" : "sorted-desc");
-    }
-  </script>
-</body>
+  </body>
+</html>
 </html>

--- a/services/harmony/public/css/default.css
+++ b/services/harmony/public/css/default.css
@@ -13,3 +13,21 @@ a .badge-dark {
     z-index: 999;
     position: fixed;
 }
+
+.btn-sort {
+  background: none;
+  border: none;
+  font: inherit;
+  color: inherit;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  width: 100%; /* Ensures the whole header area is clickable */
+  text-align: left;
+}
+
+.btn-sort:focus {
+  outline: 2px solid #0056b3; /* Provide a clear focus state for keyboard users */
+  outline-offset: 2px;
+}

--- a/services/harmony/public/css/workflow-ui/default.css
+++ b/services/harmony/public/css/workflow-ui/default.css
@@ -2,11 +2,13 @@
     --tag-inset-shadow-size: 2em;
 }
 
-.helpful-th, .helpful-span {
+.helpful-th,
+.helpful-span {
     cursor: help;
 }
 
-#workflow-items-table-container, #jobs-table-container {
+#workflow-items-table-container,
+#jobs-table-container {
     overflow-y: scroll;
     max-height: 80vh;
 }
@@ -21,24 +23,24 @@
 }
 
 .bi-copy {
-    color:rgb(232, 181, 0)!important;
+    color: rgb(232, 181, 0) !important;
     cursor: pointer;
 }
 
 .bi-copy:hover {
-    color: #212529!important;
+    color: #212529 !important;
 }
 
 .job-url-th {
     font-size: .95em;
     background: linear-gradient(to top, rgb(252, 251, 251), white);
-    border-top-color:white;
+    border-top-color: white;
     padding-bottom: .3rem !important;
 }
 
 .job-url-text {
     font-size: .9em;
-    font-family: SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     font-weight: normal;
     max-width: 100%;
     word-break: break-all;
@@ -56,7 +58,7 @@
     margin-bottom: 0;
 }
 
-#label-nav-item > * {
+#label-nav-item>* {
     z-index: 1021;
 }
 
@@ -84,6 +86,53 @@
     word-wrap: break-word;
 }
 
-.toast, .toast-container {
+.toast,
+.toast-container {
     z-index: 1021;
+}
+
+th.sortable {
+    cursor: pointer;
+    position: relative;
+    white-space: nowrap;
+}
+
+th.sortable:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+}
+
+.sort-icon {
+    font-size: 0.8rem;
+    margin-left: 5px;
+    color: #adb5bd;
+}
+
+th.sorted-asc .sort-icon::before {
+    content: "\F145";
+    color: #000;
+}
+
+th.sorted-desc .sort-icon::before {
+    content: "\F128";
+    color: #000;
+}
+
+.metric-card {
+    background: #f8f9fa;
+    border-top: 3px solid #0071bc;
+    text-align: center;
+    padding: 15px;
+    border-radius: 4px;
+}
+
+.metric-value {
+    font-size: 1.5rem;
+    font-weight: bold;
+    display: block;
+}
+
+.metric-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    color: #666;
 }

--- a/services/harmony/test/dashboard.ts
+++ b/services/harmony/test/dashboard.ts
@@ -4,6 +4,8 @@ import sinon from 'sinon';
 
 import { getDashboard } from '../app/frontends/dashboard';
 import * as userWork from '../app/models/user-work';
+import { WorkItemQueueType } from '../app/util/queue/queue';
+import * as qf from '../app/util/queue/queue-factory';
 import * as serviceImages from '../app/util/service-images';
 
 describe('getDashboard', () => {
@@ -36,6 +38,14 @@ describe('getDashboard', () => {
       'harmony/query-cmr': 'query-cmr',
       'harmony/harmony-service-example': 'harmony-service-example',
     });
+
+    const schedulerQueue = qf.getWorkSchedulerQueue();
+    const smallUpdateQueue = qf.getQueueForType(WorkItemQueueType.SMALL_ITEM_UPDATE);
+    const largeUpdateQueue = qf.getQueueForType(WorkItemQueueType.LARGE_ITEM_UPDATE);
+
+    sandbox.stub(schedulerQueue, 'getApproximateNumberOfMessages').resolves(10);
+    sandbox.stub(smallUpdateQueue, 'getApproximateNumberOfMessages').resolves(20);
+    sandbox.stub(largeUpdateQueue, 'getApproximateNumberOfMessages').resolves(30);
   });
 
   afterEach(() => {
@@ -172,13 +182,14 @@ describe('getDashboard', () => {
       expect(res.json.calledOnce).to.be.true;
     });
 
-    it('still responds with JSON when client requests HTML (until HTML is implemented)', async () => {
+    it('responds with HTML when client requests HTML', async () => {
       req.accepts.returns('html');
       getCountsByServiceStub.resolves({});
 
       await getDashboard(req, res, next);
 
-      expect(res.json.calledOnce).to.be.true;
+      expect(res.render.calledOnce).to.be.true;
+      expect(res.json.called).to.be.false;
     });
 
     it('logs the requesting user', async () => {
@@ -206,6 +217,63 @@ describe('getDashboard', () => {
       await getDashboard(req, res, next);
 
       expect(res.json.called).to.be.false;
+    });
+  });
+
+  describe('system queue metrics', () => {
+    it('includes the correct queue counts in the response', async () => {
+      getCountsByServiceStub.resolves({});
+      await getDashboard(req, res, next);
+
+      const result = res.json.firstCall.args[0];
+      expect(result.queues.workItemScheduler).to.equal(10);
+      expect(result.queues.smallWorkItemUpdates).to.equal(20);
+    });
+  });
+
+  describe('HTML response', () => {
+    beforeEach(() => {
+      req.accepts.returns('html');
+      getCountsByServiceStub.resolves({});
+    });
+
+    it('calls res.render with "dashboard" when HTML is requested', async () => {
+      await getDashboard(req, res, next);
+
+      expect(res.render.calledOnce).to.be.true;
+      expect(res.render.firstCall.args[0]).to.equal('dashboard');
+    });
+
+    it('transforms service metrics into an array sorted by queued count (descending)', async () => {
+      getCountsByServiceStub.resolves({
+        'low-service': { queued: 5 },
+        'high-service': { queued: 100 },
+      });
+      // Mock mapping so we don't rely on real image logic
+      imageMapStub.returns({ 'low-service': 'low-service', 'high-service': 'high-service' });
+
+      await getDashboard(req, res, next);
+
+      const data = res.render.firstCall.args[1];
+      expect(data.services).to.be.an('array');
+      expect(data.services[0].name).to.equal('high-service');
+      expect(data.services[0].queued).to.equal(100);
+    });
+
+    it('transforms camelCase queue names into Title Case for the UI', async () => {
+      await getDashboard(req, res, next);
+
+      const data = res.render.firstCall.args[1];
+      const smallUpdateQueue = data.queues.find(q => q.name === 'Small Work Item Updates');
+      expect(smallUpdateQueue).to.exist;
+      expect(smallUpdateQueue.count).to.be.a('number');
+    });
+
+    it('includes the harmony version in the rendered view', async () => {
+      await getDashboard(req, res, next);
+
+      const data = res.render.firstCall.args[1];
+      expect(data.version).to.exist;
     });
   });
 });

--- a/services/harmony/test/dashboard.ts
+++ b/services/harmony/test/dashboard.ts
@@ -275,5 +275,50 @@ describe('getDashboard', () => {
       const data = res.render.firstCall.args[1];
       expect(data.version).to.exist;
     });
+
+    it('sets isFailed to true when a queue count is -1 (error state)', async () => {
+      const schedulerQueue = qf.getWorkSchedulerQueue();
+      (schedulerQueue.getApproximateNumberOfMessages as sinon.SinonStub).resolves(-1);
+
+      await getDashboard(req, res, next);
+
+      const data = res.render.firstCall.args[1];
+      const schedulerData = data.queues.find((q: any) => q.name === 'Work Item Scheduler');
+
+      expect(schedulerData.isFailed).to.be.true;
+      expect(schedulerData.count).to.equal(-1);
+    });
+
+    it('sets isFailed to false when a queue count is valid', async () => {
+      await getDashboard(req, res, next);
+
+      const data = res.render.firstCall.args[1];
+      const smallUpdateData = data.queues.find((q: any) => q.name === 'Small Work Item Updates');
+
+      expect(smallUpdateData.isFailed).to.be.false;
+      expect(smallUpdateData.count).to.equal(20);
+    });
+
+    it('sorts the services array by queued count descending for the initial view', async () => {
+      getCountsByServiceStub.resolves({
+        'service-a': { queued: 19 },
+        'service-b': { queued: 1000 },
+        'service-c': { queued: 500 },
+      });
+      imageMapStub.returns({
+        'service-a': 'service-a',
+        'service-b': 'service-b',
+        'service-c': 'service-c',
+      });
+
+      await getDashboard(req, res, next);
+
+      const { services } = res.render.firstCall.args[1];
+
+      // Verify order: 1000 -> 500 -> 19
+      expect(services[0].name).to.equal('service-b');
+      expect(services[1].name).to.equal('service-c');
+      expect(services[2].name).to.equal('service-a');
+    });
   });
 });

--- a/services/harmony/test/retry-stats.ts
+++ b/services/harmony/test/retry-stats.ts
@@ -250,6 +250,7 @@ describe('getRetryStatistics', () => {
         totalWorkItemExecutions: 125,
         percentSuccessful: '80.00%',
         percentRetried: '20.00%',
+        version: '0.0.0',
       });
     });
 


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2304, HARMONY-2307

## Description
Add HTML representation to dashboard and capture system queue metrics

## Local Test Steps
In a browser navigate to http://localhost:3000/admin/dashboard - verify you see an HTML representation that includes the system queue metrics as well as the service metrics with how many work items are in the system for each service. Verify you can sort the service names alphabetically or by the work queued for each service numerically.

Verify the JSON representation now includes the system queue metrics as well:
```
curl -Ln -bj http://localhost:3000/admin/dashboard
```
e.g.
```
{
  "services": {
    "harmony-service-example": {
      "queued": 0
    },
    "podaac/l2ss-py": {
      "queued": 110000
    },
    "query-cmr": {
      "queued": 0
    }
  },
  "queues": {
    "smallWorkItemUpdates": 0,
    "largeWorkItemUpdates": 0,
    "workItemScheduler": 78
  },
  "version": "1-alpha"
}
```

It can be difficult to capture anything in any of the queues since they are all in memory and updates are handled quickly.  Maybe stopping one of the components temporarily could work. You can also deploy to sandbox and submit large requests to see an non-zero queue size.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Harmony Dashboard now renders as HTML (in addition to JSON) and includes system queue metrics alongside services.
  * Services table is sortable and displays queued request counts.

* **Chores**
  * Added a string utility to convert camelCase into spaced Title Case.

* **Tests**
  * Expanded tests for dashboard rendering/JSON payloads and added coverage for the new string utility and version propagation.

* **Style**
  * CSS added for sortable headers, sort buttons, and metric card styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->