### PR TITLE
drop support for image/tiff output from nisar-py service in services-uat.yml

### DIFF
--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -739,15 +739,12 @@ https://cmr.uat.earthdata.nasa.gov:
         temporal: false
       output_formats:
         - image/png
-        - image/tiff
       reprojection: true
     steps:
       - image: !Env ${QUERY_CMR_IMAGE}
         is_sequential: true
       - image: !Env ${NISAR_PY_IMAGE}
       - image: !Env ${HYBIG_IMAGE}
-        conditional:
-          format: ['image/png']
 
   - name: net2cog
     description: |


### PR DESCRIPTION
ASF has chosen to de-scope this service to only producing .png format output to be sent to GIBS. We'd hoped to provide end users the ability to request geotiff output as well, but it conflicts with the variable subsetting work we're implementing via the net2cog service.

ASF will also open a PR eliminating the related test case from https://github.com/nasa/harmony-regression-tests/blob/main/test/nisar-py/nisar-py_Regression.ipynb

I've dropped the geotiff option from the service record in MMT UAT.