### PR TITLE
HARMONY-2304: Show on dashboard page load that services are sorted descending by number of queued requests.

### DIFF
--- a/services/harmony/app/views/dashboard.mustache.html
+++ b/services/harmony/app/views/dashboard.mustache.html
@@ -62,9 +62,9 @@
                     Service Name <i class="bi bi-arrow-down-up sort-icon"></i>
                   </button>
                 </th>
-                <th scope="col" class="sortable" aria-sort="descending">
-                  <button type="button" class="btn-sort" onclick="sortTable(1, this)">
-                    Queued Requests <i class="bi bi-arrow-down-up sort-icon"></i>
+                <th scope="col" class="sortable sorted-desc" aria-sort="descending">
+                  <button type="button" class="btn-sort" onclick="sortTable(1)">
+                    Queued Requests <i class="bi bi-sort-down sort-icon"></i>
                   </button>
                 </th>
               </tr>

--- a/services/harmony/app/views/dashboard.mustache.html
+++ b/services/harmony/app/views/dashboard.mustache.html
@@ -58,7 +58,7 @@
             <thead>
               <tr>
                 <th scope="col" class="sortable" aria-sort="none">
-                  <button type="button" class="btn-sort" onclick="sortTable(0, this)">
+                  <button type="button" class="btn-sort" onclick="sortTable(0)">
                     Service Name <i class="bi bi-arrow-down-up sort-icon"></i>
                   </button>
                 </th>
@@ -114,7 +114,6 @@
         return x.toLowerCase().localeCompare(y.toLowerCase()) * direction;
       });
 
-      // Clear existing rows and append sorted ones
       while (tbody.firstChild) {
         tbody.removeChild(tbody.firstChild);
       }
@@ -122,8 +121,16 @@
 
       table.querySelectorAll("th").forEach(th => {
         th.classList.remove("sorted-asc", "sorted-desc");
+        th.removeAttribute("aria-sort");
+        th.querySelector(".sort-icon").className = "bi bi-arrow-down-up sort-icon";
       });
-      header.classList.add(isAscending ? "sorted-desc" : "sorted-asc");
+
+      const nowAscending = !isAscending;
+      header.classList.add(nowAscending ? "sorted-asc" : "sorted-desc");
+      header.setAttribute("aria-sort", nowAscending ? "ascending" : "descending");
+      header.querySelector(".sort-icon").className = nowAscending
+        ? "bi bi-sort-up sort-icon"
+        : "bi bi-sort-down sort-icon";
     }
   </script>
   </body>


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2304

## Description
Minor fix to show on dashboard page load that services are sorted descending by number of queued requests.

## Local Test Steps
Load http://localhost:3000/admin/dashboard and compare to https://harmony.uat.earthdata.nasa.gov/admin/dashboard.

On localhost verify you can visually tell from the table header "Queued Requests" that the data is sorted descending based on the number of queued requests when first loading the page.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Queued Requests" column now shows the correct descending sort indicator by default and reliably toggles sort state when clicked.
* **Accessibility**
  * Column headers now update ARIA sort attributes and visual indicators consistently to improve screen reader and keyboard usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->