### PR TITLE
HARMONY-2337: Downgrade fast-xml-parser due to errors with AWS S3 libraries on certain operations.

### DIFF
--- a/services/cron-service/.nsprc
+++ b/services/cron-service/.nsprc
@@ -12,5 +12,10 @@
   "GHSA-w5hq-g745-h8pq": {
     "active": true,
     "notes": "uuid through dev dependency nyc in packages/util"
+  },
+  "GHSA-gh4j-gqv2-49f6": {
+    "active": true,
+    "notes": "Will fix in HARMONY-2334",
+    "expiry": "2026-08-01"
   }
 }

--- a/services/cron-service/package-lock.json
+++ b/services/cron-service/package-lock.json
@@ -26,7 +26,7 @@
         "@xmldom/xmldom": ">=0.8.10 <0.9.0",
         "ajv": "^8.8.0",
         "ajv-formats": "^3.0.1",
-        "axios": "^1.7.4",
+        "axios": "^1.15.2",
         "class-validator": "^0.14.0",
         "croner": "^9.0.0",
         "date-fns": "^4.1.0",
@@ -6656,9 +6656,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/services/cron-service/package-lock.json
+++ b/services/cron-service/package-lock.json
@@ -4868,6 +4868,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.12.tgz",
+      "integrity": "sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
@@ -5397,18 +5417,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
@@ -7535,27 +7543,6 @@
       "license": "MIT",
       "dependencies": {
         "path-expression-matcher": "^1.1.3"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fecha": {

--- a/services/cron-service/package.json
+++ b/services/cron-service/package.json
@@ -100,7 +100,7 @@
   "overrides": {
     "braces": "^3.0.3",
     "cross-spawn": "7.0.5",
-    "fast-xml-parser": "^5.3.6",
+    "fast-xml-parser": "5.5.12",
     "semver": "^7.6.2",
     "tar": "^7.5.8"
   }

--- a/services/cron-service/package.json
+++ b/services/cron-service/package.json
@@ -55,7 +55,7 @@
     "@xmldom/xmldom": ">=0.8.10 <0.9.0",
     "ajv": "^8.8.0",
     "ajv-formats": "^3.0.1",
-    "axios": "^1.7.4",
+    "axios": "^1.15.2",
     "class-validator": "^0.14.0",
     "croner": "^9.0.0",
     "date-fns": "^4.1.0",

--- a/services/harmony/.nsprc
+++ b/services/harmony/.nsprc
@@ -12,5 +12,10 @@
   "GHSA-w5hq-g745-h8pq": {
     "active": true,
     "notes": "uuid through dev dependency nyc in packages/util"
+  },
+  "GHSA-gh4j-gqv2-49f6": {
+    "active": true,
+    "notes": "Will fix in HARMONY-2334",
+    "expiry": "2026-08-01"
   }
 }

--- a/services/harmony/package-lock.json
+++ b/services/harmony/package-lock.json
@@ -42,7 +42,7 @@
         "ajv": "^8.12.0",
         "ajv-formats": "^3.0.1",
         "ajv-formats-draft2019": "^1.6.1",
-        "axios": "^1.7.4",
+        "axios": "^1.15.2",
         "body-parser": "^1.19.0",
         "class-validator": "^0.14.0",
         "cookie-parser": "^1.4.5",
@@ -7693,9 +7693,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/services/harmony/package-lock.json
+++ b/services/harmony/package-lock.json
@@ -5007,6 +5007,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.12.tgz",
+      "integrity": "sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
@@ -5766,18 +5786,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@npmcli/fs": {
       "version": "1.1.1",
@@ -9381,27 +9389,6 @@
       "license": "MIT",
       "dependencies": {
         "path-expression-matcher": "^1.1.3"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fastq": {

--- a/services/harmony/package.json
+++ b/services/harmony/package.json
@@ -224,7 +224,7 @@
     "cross-spawn": "7.0.5",
     "diff": "^5.2.2",
     "fast-json-patch": "3.1.1",
-    "fast-xml-parser": "^5.3.6",
+    "fast-xml-parser": "5.5.12",
     "jsonpath-plus": "^10.0.7",
     "semver": "^7.6.2",
     "tar": "^7.5.8",

--- a/services/harmony/package.json
+++ b/services/harmony/package.json
@@ -104,7 +104,7 @@
     "ajv": "^8.12.0",
     "ajv-formats": "^3.0.1",
     "ajv-formats-draft2019": "^1.6.1",
-    "axios": "^1.7.4",
+    "axios": "^1.15.2",
     "body-parser": "^1.19.0",
     "class-validator": "^0.14.0",
     "cookie-parser": "^1.4.5",

--- a/services/query-cmr/.nsprc
+++ b/services/query-cmr/.nsprc
@@ -12,5 +12,10 @@
   "GHSA-w5hq-g745-h8pq": {
     "active": true,
     "notes": "uuid through dev dependency nyc in packages/util"
+  },
+  "GHSA-gh4j-gqv2-49f6": {
+    "active": true,
+    "notes": "Will fix in HARMONY-2334",
+    "expiry": "2026-08-01"
   }
 }

--- a/services/service-runner/package-lock.json
+++ b/services/service-runner/package-lock.json
@@ -19,7 +19,7 @@
         "@smithy/util-uri-escape": "^4.2.0",
         "agentkeepalive": "^4.1.4",
         "aws-sdk": "^2.1482.0",
-        "axios": "^1.7.4",
+        "axios": "^1.15.2",
         "axios-retry": "^4.5.0",
         "class-validator": "^0.14.0",
         "date-fns": "^4.1.0",
@@ -6206,6 +6206,8 @@
     },
     "node_modules/axios": {
       "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/services/service-runner/package.json
+++ b/services/service-runner/package.json
@@ -44,7 +44,7 @@
     "@smithy/util-uri-escape": "^4.2.0",
     "agentkeepalive": "^4.1.4",
     "aws-sdk": "^2.1482.0",
-    "axios": "^1.7.4",
+    "axios": "^1.15.2",
     "axios-retry": "^4.5.0",
     "class-validator": "^0.14.0",
     "date-fns": "^4.1.0",

--- a/services/work-failer/.nsprc
+++ b/services/work-failer/.nsprc
@@ -2,5 +2,10 @@
   "GHSA-w5hq-g745-h8pq": {
     "active": true,
     "notes": "uuid through dev dependency nyc in packages/util"
+  },
+  "GHSA-gh4j-gqv2-49f6": {
+    "active": true,
+    "notes": "Will fix in HARMONY-2334",
+    "expiry": "2026-08-01"
   }
 }

--- a/services/work-failer/package-lock.json
+++ b/services/work-failer/package-lock.json
@@ -28,7 +28,7 @@
         "ajv": "^8.8.0",
         "ajv-formats": "^3.0.1",
         "ajv-formats-draft2019": "^1.6.1",
-        "axios": "^1.7.4",
+        "axios": "^1.15.2",
         "axios-retry": "^4.5.0",
         "class-validator": "^0.14.0",
         "date-fns": "^4.1.0",
@@ -3367,9 +3367,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/services/work-failer/package-lock.json
+++ b/services/work-failer/package-lock.json
@@ -1082,6 +1082,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.12.tgz",
+      "integrity": "sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
@@ -1652,18 +1672,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
@@ -4458,27 +4466,6 @@
       "license": "MIT",
       "dependencies": {
         "path-expression-matcher": "^1.1.3"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fecha": {

--- a/services/work-failer/package.json
+++ b/services/work-failer/package.json
@@ -54,7 +54,7 @@
     "ajv": "^8.8.0",
     "ajv-formats": "^3.0.1",
     "ajv-formats-draft2019": "^1.6.1",
-    "axios": "^1.7.4",
+    "axios": "^1.15.2",
     "axios-retry": "^4.5.0",
     "class-validator": "^0.14.0",
     "date-fns": "^4.1.0",

--- a/services/work-failer/package.json
+++ b/services/work-failer/package.json
@@ -107,7 +107,7 @@
   "overrides": {
     "semver": "^7.6.2",
     "braces": "^3.0.3",
-    "fast-xml-parser": "^5.3.6",
+    "fast-xml-parser": "5.5.12",
     "cross-spawn": "7.0.5"
   }
 }

--- a/services/work-scheduler/.nsprc
+++ b/services/work-scheduler/.nsprc
@@ -7,5 +7,10 @@
   "GHSA-w5hq-g745-h8pq": {
     "active": true,
     "notes": "uuid through dev dependency nyc in packages/util"
+  },
+  "GHSA-gh4j-gqv2-49f6": {
+    "active": true,
+    "notes": "Will fix in HARMONY-2334",
+    "expiry": "2026-08-01"
   }
 }

--- a/services/work-scheduler/package-lock.json
+++ b/services/work-scheduler/package-lock.json
@@ -1067,6 +1067,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.12.tgz",
+      "integrity": "sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
@@ -1674,18 +1694,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
@@ -4051,27 +4059,6 @@
       "license": "MIT",
       "dependencies": {
         "path-expression-matcher": "^1.1.3"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fecha": {

--- a/services/work-scheduler/package-lock.json
+++ b/services/work-scheduler/package-lock.json
@@ -21,7 +21,7 @@
         "@smithy/util-uri-escape": "^4.2.0",
         "@types/node-fetch": "^2.5.12",
         "agentkeepalive": "^4.1.4",
-        "axios": "^1.7.4",
+        "axios": "^1.15.2",
         "axios-retry": "^4.5.0",
         "class-validator": "^0.14.0",
         "date-fns": "^4.1.0",
@@ -1054,37 +1054,17 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.18",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.18.tgz",
-      "integrity": "sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==",
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
+      "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.5.8",
+        "fast-xml-parser": "5.7.1",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
-      "version": "5.5.12",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.12.tgz",
-      "integrity": "sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
@@ -2956,9 +2936,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -4059,6 +4039,26 @@
       "license": "MIT",
       "dependencies": {
         "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.12.tgz",
+      "integrity": "sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fecha": {

--- a/services/work-scheduler/package.json
+++ b/services/work-scheduler/package.json
@@ -46,7 +46,7 @@
     "@smithy/util-uri-escape": "^4.2.0",
     "@types/node-fetch": "^2.5.12",
     "agentkeepalive": "^4.1.4",
-    "axios": "^1.7.4",
+    "axios": "^1.15.2",
     "axios-retry": "^4.5.0",
     "class-validator": "^0.14.0",
     "date-fns": "^4.1.0",

--- a/services/work-scheduler/package.json
+++ b/services/work-scheduler/package.json
@@ -91,7 +91,7 @@
   "overrides": {
     "braces": "^3.0.3",
     "cross-spawn": "^7.0.5",
-    "fast-xml-parser": "^5.3.6",
+    "fast-xml-parser": "5.5.12",
     "form-data": "4.0.4",
     "jsonpath-plus": "^10.0.7",
     "qs": "^6.14.1",

--- a/services/work-updater/.nsprc
+++ b/services/work-updater/.nsprc
@@ -12,5 +12,10 @@
   "GHSA-w5hq-g745-h8pq": {
     "active": true,
     "notes": "Dev dependency in packages/util"
+  },
+  "GHSA-gh4j-gqv2-49f6": {
+    "active": true,
+    "notes": "Will fix in HARMONY-2334",
+    "expiry": "2026-08-01"
   }
 }

--- a/services/work-updater/package-lock.json
+++ b/services/work-updater/package-lock.json
@@ -4826,6 +4826,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.12.tgz",
+      "integrity": "sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
@@ -5312,18 +5332,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
@@ -7621,27 +7629,6 @@
       "license": "MIT",
       "dependencies": {
         "path-expression-matcher": "^1.1.3"
-      }
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
-      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fecha": {

--- a/services/work-updater/package-lock.json
+++ b/services/work-updater/package-lock.json
@@ -29,7 +29,7 @@
         "ajv": "^8.8.0",
         "ajv-formats": "^3.0.1",
         "ajv-formats-draft2019": "^1.6.1",
-        "axios": "^1.7.4",
+        "axios": "^1.15.2",
         "axios-retry": "^4.5.0",
         "class-validator": "^0.14.0",
         "date-fns": "^4.1.0",
@@ -6716,9 +6716,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",

--- a/services/work-updater/package.json
+++ b/services/work-updater/package.json
@@ -108,7 +108,7 @@
   "overrides": {
     "semver": "^7.6.2",
     "braces": "^3.0.3",
-    "fast-xml-parser": "^5.3.6",
+    "fast-xml-parser": "5.5.12",
     "cross-spawn": "7.0.5"
   }
 }

--- a/services/work-updater/package.json
+++ b/services/work-updater/package.json
@@ -58,7 +58,7 @@
     "ajv": "^8.8.0",
     "ajv-formats": "^3.0.1",
     "ajv-formats-draft2019": "^1.6.1",
-    "axios": "^1.7.4",
+    "axios": "^1.15.2",
     "axios-retry": "^4.5.0",
     "class-validator": "^0.14.0",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2337

## Description
Harmony requests that deliver results to external S3 buckets (like with bignbit) were failing due to a security vulnerability update to the fast-xml-parser library. Needed to downgrade the library in order to fix the issues.


## Local Test Steps
Any request using an external S3 destination URL fails without this change. Sanity check on the main branch this fails: http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=image%2Fpng&destinationUrl=s3%3A%2F%2Flocal-upload-bucket&subset=time(%222002-09-15T00%3A00%3A00.000Z%22%3A%222022-09-25T00%3A00%3A00Z%22)

Then on this branch:
run npm install, restart harmony, and then repeat this request and make sure it succeeds.
Also verify `npm run better-audit` succeeds.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned a critical dependency to version 5.5.12 across multiple services to ensure consistent and stable dependency resolution during package installation, replacing the previous flexible version constraint for predictability
  * Updated security vulnerability tracking configurations to acknowledge identified vulnerabilities with associated tracking information and planned remediation target dates extending through August 2026

<!-- end of auto-generated comment: release notes by coderabbit.ai -->