### PR TITLE
HARMONY-2254 prevent jobs from becoming stuck in running with errors state

### DIFF
--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -667,7 +667,8 @@ export async function checkRemainingStepsForCompletion(
 
   const candidateSteps = (await tx(WorkflowStep.table)
     .where({ jobID })
-    .andWhere('stepIndex', '>=', step.stepIndex))
+    .andWhere('stepIndex', '>=', step.stepIndex)
+    .orderBy('stepIndex', 'asc'))
     .map((row) => ({ serviceID: row.serviceID, stepIndex: row.stepIndex }));
 
   // This is never a sequential call (querycmr) so we don't need a value

--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -655,12 +655,13 @@ export async function preprocessWorkItem(
  * traverses the user_work table and deletes any row for the jobID where there
  * is no work running or queued.
  *
- * @param tx - database transaction with lock on the related job in the jobs table
+ * @param tx - database transaction
  * @param jobID - Job of the work to clean
  * @param stepIndex - starting index to look for stranded user work items.
  *
- * @returns True if User Work is comlete for this job e.g. any steps in this
- *          job still had running or ready work .
+ * @returns true if no service at or beyond stepIndex still has running or
+ *          ready work (i.e., the job's user_work for the remaining chain is
+ *          fully complete); false otherwise.
  */
 export async function deleteStrandedUserWork(
   tx: Transaction, jobID: string, stepIndex: number,
@@ -677,6 +678,7 @@ export async function deleteStrandedUserWork(
       return false;
     }
   }
+  // All user work completed
   return true;
 }
 

--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -14,7 +14,7 @@ import JobMessage, {
 import {
   decrementRunningCount, deleteUserWorkForJob, deleteUserWorkForCompletedJobAndServices, deleteUserWorkForJobAndService,
   incrementReadyAndDecrementRunningCounts, incrementReadyCount, setReadyCountToZero,
-  anyRemainingUserWorkForJobAndService,
+  isUserWorkForJobAndServiceComplete,
 } from '../../models/user-work';
 import WorkItem, {
   countOfWorkItemsByStepAndJobID, getWorkItemById, getWorkItemsByJobIdAndStepIndex,
@@ -672,7 +672,7 @@ export async function deleteStrandedUserWork(
   await deleteUserWorkForCompletedJobAndServices(tx, jobID, serviceIds);
 
   for (const serviceId of serviceIds) {
-    if (await anyRemainingUserWorkForJobAndService(tx, jobID, serviceId)) {
+    if (!(await isUserWorkForJobAndServiceComplete(tx, jobID, serviceId))) {
       return false;
     }
   }

--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -12,9 +12,8 @@ import JobMessage, {
   getErrorMessagesForJob, getMessageCountForJob, getWarningMessagesForJob, JobMessageLevel,
 } from '../../models/job-message';
 import {
-  decrementRunningCount, deleteUserWorkForJob, deleteUserWorkForCompletedJobAndServices, deleteUserWorkForJobAndService,
+  decrementRunningCount, deleteUserWorkForJob, deleteUserWorkForJobAndService,
   incrementReadyAndDecrementRunningCounts, incrementReadyCount, setReadyCountToZero,
-  isUserWorkForJobAndServiceComplete,
 } from '../../models/user-work';
 import WorkItem, {
   countOfWorkItemsByStepAndJobID, getWorkItemById, getWorkItemsByJobIdAndStepIndex,

--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -12,7 +12,7 @@ import JobMessage, {
   getErrorMessagesForJob, getMessageCountForJob, getWarningMessagesForJob, JobMessageLevel,
 } from '../../models/job-message';
 import {
-  decrementRunningCount, deleteUserWorkForJob, deleteUserWorkForJobAndService,
+  decrementRunningCount, deleteUserWorkForJob, deleteUserWorkForCompletedJobAndService, deleteUserWorkForJobAndService,
   incrementReadyAndDecrementRunningCounts, incrementReadyCount, setReadyCountToZero,
 } from '../../models/user-work';
 import WorkItem, {
@@ -650,6 +650,28 @@ export async function preprocessWorkItem(
 }
 
 /**
+ * Delete user work that is unreachable from the current step forward.
+ * traverses the user_work table and deletes any row for the jobID where there
+ * is no work running or queued.
+ *
+ * @param tx - database transaction with lock on the related job in the jobs table
+ * @param jobID - Job of the work to clean
+ * @param stepIndex - starting index to look for stranded user work items.
+ */
+export async function deleteStrandedUserWork(
+  tx: Transaction, jobID: string, stepIndex: number,
+): Promise<void> {
+  const serviceIds = (await tx(WorkflowStep.table)
+    .where({ jobID })
+    .andWhere('stepIndex', '>=', stepIndex))
+    .map((row) => row.serviceID);
+
+  for (const serviceId of serviceIds) {
+    await deleteUserWorkForCompletedJobAndService(tx, jobID, serviceId);
+  }
+}
+
+/**
  * Process the work item update using the preprocessed result info and the work item info.
  * Various other parameters are passed in to optimize the processing of a batch of work items.
  * A database lock on the work item related job needs to be acquired before calling this function.
@@ -888,7 +910,19 @@ export async function processWorkItem(
       }
 
       if (allWorkItemsForStepComplete) {
-        if (!didCreateWorkItem && (!nextWorkflowStep || nextWorkflowStep.workItemCount < 1)) {
+        const endedUngracefully = (!didCreateWorkItem && nextWorkflowStep);
+        if (endedUngracefully) {
+          // We're here because We didn't create a new workitem. but there are
+          // next steps to take. We completed, but might (always?) have status
+          // = "failed"
+          // check if the next workflows are complete.
+          await deleteStrandedUserWork(tx, nextWorkflowStep.jobID, nextWorkflowStep.stepIndex);
+        }
+
+        if (
+          !didCreateWorkItem && (!nextWorkflowStep || nextWorkflowStep.workItemCount < 1)
+            || endedUngracefully
+        ) {
           // If all granules are finished mark the job as finished
           const { finalStatus, finalMessage } = await getFinalStatusAndMessageForJob(tx, job);
           await (await logAsyncExecutionTime(

--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -651,34 +651,37 @@ export async function preprocessWorkItem(
 }
 
 /**
- * Delete user work that is unreachable from the current step forward.
- * traverses the user_work table and deletes any row for the jobID where there
- * is no work running or queued.
+ * Checks to see if subsequent worksteps had finished before a previous
+ * workstep. The updateIsComplete function can prevent downstream steps from
+ * being completed when they all finish before an upstream job can. e.g. when
+ * HOSS is retrying but a successful granule has completed it's entire workflow.
  *
  * @param tx - database transaction
  * @param jobID - Job of the work to clean
- * @param stepIndex - starting index to look for stranded user work items.
+ * @param step - Workflow Step to begin looking for completed work.
  *
- * @returns true if no service at or beyond stepIndex still has running or
- *          ready work (i.e., the job's user_work for the remaining chain is
- *          fully complete); false otherwise.
+ * @returns true if all subsequent steps have completed false otherwise
  */
-export async function deleteStrandedUserWork(
-  tx: Transaction, jobID: string, stepIndex: number,
+export async function checkRemainingStepsForCompletion(
+  tx: Transaction, jobID: string, step: WorkflowStep
 ): Promise<boolean> {
-  const serviceIds = (await tx(WorkflowStep.table)
+
+  const candidateSteps = (await tx(WorkflowStep.table)
     .where({ jobID })
-    .andWhere('stepIndex', '>=', stepIndex))
-    .map((row) => row.serviceID);
+    .andWhere('stepIndex', '>=', step.stepIndex))
+    .map((row) =>({serviceID: row.serviceID, stepIndex: row.stepIndex}) );
 
-  await deleteUserWorkForCompletedJobAndServices(tx, jobID, serviceIds);
-
-  for (const serviceId of serviceIds) {
-    if (!(await isUserWorkForJobAndServiceComplete(tx, jobID, serviceId))) {
+  // This is never a sequential call (querycmr) so we don't need a value
+  const numInputGranules = 0
+  for (const candidate of candidateSteps) {
+    step = await getWorkflowStepByJobIdStepIndex(tx, jobID, candidate.stepIndex)
+    const stepComplete = await updateIsComplete(tx, jobID, numInputGranules, step);
+    if (!stepComplete) {
       return false;
     }
+    await deleteUserWorkForJobAndService(tx, jobID, candidate.serviceID);
   }
-  // All user work completed
+  // All user work completed for job
   return true;
 }
 
@@ -924,16 +927,17 @@ export async function processWorkItem(
         const endedUngracefully = (!didCreateWorkItem && nextWorkflowStep);
         let userWorkCompleteForJob = false;
         if (endedUngracefully) {
-          // We're here because We didn't create a new workitem. but there are
+          // We're here because we didn't create a new WorkItem, but there are
           // next steps to take. A failed granule may have been retried while
-          // another completed, preventing the work from ever getting marked as
-          // done.
-          userWorkCompleteForJob = await deleteStrandedUserWork(
-            tx, nextWorkflowStep.jobID, nextWorkflowStep.stepIndex,
+          // another chain completed, preventing the work downstream in that
+          // chain from ever getting marked as done.
+          userWorkCompleteForJob = await checkRemainingStepsForCompletion(
+            tx, jobID, nextWorkflowStep,
           );
+          logger.info(`>>> checkRemainingStepsForCompletion -> ${userWorkCompleteForJob}: ${jobID}`)
         }
         if (
-          !didCreateWorkItem && (!nextWorkflowStep || nextWorkflowStep.workItemCount < 1)
+          (!didCreateWorkItem && (!nextWorkflowStep || nextWorkflowStep.workItemCount < 1))
             || userWorkCompleteForJob
         ) {
           // If all granules are finished mark the job as finished

--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -663,18 +663,18 @@ export async function preprocessWorkItem(
  * @returns true if all subsequent steps have completed false otherwise
  */
 export async function checkRemainingStepsForCompletion(
-  tx: Transaction, jobID: string, step: WorkflowStep
+  tx: Transaction, jobID: string, step: WorkflowStep,
 ): Promise<boolean> {
 
   const candidateSteps = (await tx(WorkflowStep.table)
     .where({ jobID })
     .andWhere('stepIndex', '>=', step.stepIndex))
-    .map((row) =>({serviceID: row.serviceID, stepIndex: row.stepIndex}) );
+    .map((row) => ({ serviceID: row.serviceID, stepIndex: row.stepIndex }));
 
   // This is never a sequential call (querycmr) so we don't need a value
-  const numInputGranules = 0
+  const numInputGranules = 0;
   for (const candidate of candidateSteps) {
-    step = await getWorkflowStepByJobIdStepIndex(tx, jobID, candidate.stepIndex)
+    step = await getWorkflowStepByJobIdStepIndex(tx, jobID, candidate.stepIndex);
     const stepComplete = await updateIsComplete(tx, jobID, numInputGranules, step);
     if (!stepComplete) {
       return false;
@@ -934,7 +934,6 @@ export async function processWorkItem(
           userWorkCompleteForJob = await checkRemainingStepsForCompletion(
             tx, jobID, nextWorkflowStep,
           );
-          logger.info(`>>> checkRemainingStepsForCompletion -> ${userWorkCompleteForJob}: ${jobID}`)
         }
         if (
           (!didCreateWorkItem && (!nextWorkflowStep || nextWorkflowStep.workItemCount < 1))

--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -659,7 +659,8 @@ export async function preprocessWorkItem(
  * @param jobID - Job of the work to clean
  * @param stepIndex - starting index to look for stranded user work items.
  *
- * @returns whether any steps in this job still had running or ready work.
+ * @returns True if User Work is comlete for this job e.g. any steps in this
+ *          job still had running or ready work .
  */
 export async function deleteStrandedUserWork(
   tx: Transaction, jobID: string, stepIndex: number,
@@ -925,9 +926,9 @@ export async function processWorkItem(
           // next steps to take. A failed granule may have been retried while
           // another completed, preventing the work from ever getting marked as
           // done.
-          userWorkCompleteForJob = await deleteStrandedUserWork(tx, nextWorkflowStep.jobID, nextWorkflowStep.stepIndex);
-          // I need more than this. for completing the job, because I end up in
-          // here more than just "ungraceful endings""
+          userWorkCompleteForJob = await deleteStrandedUserWork(
+            tx, nextWorkflowStep.jobID, nextWorkflowStep.stepIndex
+          );
         }
         if (
           !didCreateWorkItem && (!nextWorkflowStep || nextWorkflowStep.workItemCount < 1)

--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -764,8 +764,6 @@ export async function processWorkItem(
           { workFailureMessage: message, serviceId: workItem.serviceID, status },
         );
       } else if (workItem.retryCount < env.workItemRetryLimit) {
-        logger.info('Sleeping for 7 seconds for bug testing.');
-        await new Promise((res) => setTimeout(res, 7000));
         logger.info(`Retrying failed work-item ${workItemID}`);
         workItem.retryCount += 1;
         workItem.status = WorkItemStatus.READY;

--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -12,8 +12,9 @@ import JobMessage, {
   getErrorMessagesForJob, getMessageCountForJob, getWarningMessagesForJob, JobMessageLevel,
 } from '../../models/job-message';
 import {
-  decrementRunningCount, deleteUserWorkForJob, deleteUserWorkForCompletedJobAndService, deleteUserWorkForJobAndService,
+  decrementRunningCount, deleteUserWorkForJob, deleteUserWorkForCompletedJobAndServices, deleteUserWorkForJobAndService,
   incrementReadyAndDecrementRunningCounts, incrementReadyCount, setReadyCountToZero,
+  anyRemainingUserWorkForJobAndService,
 } from '../../models/user-work';
 import WorkItem, {
   countOfWorkItemsByStepAndJobID, getWorkItemById, getWorkItemsByJobIdAndStepIndex,
@@ -657,18 +658,25 @@ export async function preprocessWorkItem(
  * @param tx - database transaction with lock on the related job in the jobs table
  * @param jobID - Job of the work to clean
  * @param stepIndex - starting index to look for stranded user work items.
+ *
+ * @returns whether any steps in this job still had running or ready work.
  */
 export async function deleteStrandedUserWork(
   tx: Transaction, jobID: string, stepIndex: number,
-): Promise<void> {
+): Promise<boolean> {
   const serviceIds = (await tx(WorkflowStep.table)
     .where({ jobID })
     .andWhere('stepIndex', '>=', stepIndex))
     .map((row) => row.serviceID);
 
+  await deleteUserWorkForCompletedJobAndServices(tx, jobID, serviceIds);
+
   for (const serviceId of serviceIds) {
-    await deleteUserWorkForCompletedJobAndService(tx, jobID, serviceId);
+    if (await anyRemainingUserWorkForJobAndService(tx, jobID, serviceId)) {
+      return false;
+    }
   }
+  return true;
 }
 
 /**
@@ -756,6 +764,8 @@ export async function processWorkItem(
           { workFailureMessage: message, serviceId: workItem.serviceID, status },
         );
       } else if (workItem.retryCount < env.workItemRetryLimit) {
+        logger.info('Sleeping for 7 seconds for bug testing.');
+        await new Promise((res) => setTimeout(res, 7000));
         logger.info(`Retrying failed work-item ${workItemID}`);
         workItem.retryCount += 1;
         workItem.status = WorkItemStatus.READY;
@@ -911,17 +921,19 @@ export async function processWorkItem(
 
       if (allWorkItemsForStepComplete) {
         const endedUngracefully = (!didCreateWorkItem && nextWorkflowStep);
+        let userWorkCompleteForJob = false;
         if (endedUngracefully) {
           // We're here because We didn't create a new workitem. but there are
-          // next steps to take. We completed, but might (always?) have status
-          // = "failed"
-          // check if the next workflows are complete.
-          await deleteStrandedUserWork(tx, nextWorkflowStep.jobID, nextWorkflowStep.stepIndex);
+          // next steps to take. A failed granule may have been retried while
+          // another completed, preventing the work from ever getting marked as
+          // done.
+          userWorkCompleteForJob = await deleteStrandedUserWork(tx, nextWorkflowStep.jobID, nextWorkflowStep.stepIndex);
+          // I need more than this. for completing the job, because I end up in
+          // here more than just "ungraceful endings""
         }
-
         if (
           !didCreateWorkItem && (!nextWorkflowStep || nextWorkflowStep.workItemCount < 1)
-            || endedUngracefully
+            || userWorkCompleteForJob
         ) {
           // If all granules are finished mark the job as finished
           const { finalStatus, finalMessage } = await getFinalStatusAndMessageForJob(tx, job);

--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -927,7 +927,7 @@ export async function processWorkItem(
           // another completed, preventing the work from ever getting marked as
           // done.
           userWorkCompleteForJob = await deleteStrandedUserWork(
-            tx, nextWorkflowStep.jobID, nextWorkflowStep.stepIndex
+            tx, nextWorkflowStep.jobID, nextWorkflowStep.stepIndex,
           );
         }
         if (

--- a/services/harmony/app/models/user-work.ts
+++ b/services/harmony/app/models/user-work.ts
@@ -176,7 +176,7 @@ export async function deleteUserWorkForCompletedJobAndServices(
 }
 
 /**
- * Detects if this Jobs service has any running or ready items
+ * Detects if this JobId and service has any running or ready items
  *
  * @param tx - The database transaction
  * @param jobID - The job ID

--- a/services/harmony/app/models/user-work.ts
+++ b/services/harmony/app/models/user-work.ts
@@ -168,9 +168,9 @@ export async function deleteUserWorkForCompletedJobAndServices(
   tx: Transaction, jobID: string, serviceIds: string[],
 ): Promise<number> {
   const numDeleted = await tx(UserWork.table)
-    .where({ job_id: jobID})
+    .where({ job_id: jobID })
     .whereIn('service_id', serviceIds)
-    .where({running_count: 0, ready_count: 0})
+    .where({ running_count: 0, ready_count: 0 })
     .del();
   return numDeleted;
 }
@@ -189,9 +189,9 @@ export async function isUserWorkForJobAndServiceComplete(
 ): Promise<boolean> {
   const any = await tx(UserWork.table)
     .where({ job_id: jobID, service_id: serviceID })
-      .where(function () {
-        this.where('running_count', '!=', 0).orWhere('ready_count', '!=', 0);
-      })
+    .where(function () {
+      this.where('running_count', '!=', 0).orWhere('ready_count', '!=', 0);
+    })
     .first();
   return any == undefined;
 }

--- a/services/harmony/app/models/user-work.ts
+++ b/services/harmony/app/models/user-work.ts
@@ -156,13 +156,13 @@ export async function deleteUserWorkForJobAndService(
 }
 
 /**
- * Deletes a row for the given job and service ID from the user_work
- * table when running_count and ready_count are 0.
+ * Deletes rows for the given job and any of the supplied service IDs from
+ * the user_work table where both running_count and ready_count are 0.
  *
  * @param tx - The database transaction
  * @param jobID - The job ID
- * @param serviceID - The ID of the service
- * @returns the number of rows deleted (1)
+ * @param serviceIs - list of serviceIds to consider for deletion.
+ * @returns the number of rows deleted
  */
 export async function deleteUserWorkForCompletedJobAndServices(
   tx: Transaction, jobID: string, serviceIds: string[],

--- a/services/harmony/app/models/user-work.ts
+++ b/services/harmony/app/models/user-work.ts
@@ -182,9 +182,9 @@ export async function deleteUserWorkForCompletedJobAndServices(
  * @param jobID - The job ID
  * @param serviceID - The ID of the service
  *
- * @returns true if there are any rows with running or ready counts
+ * @returns true if there are no rows with running or ready counts
  */
-export async function anyRemainingUserWorkForJobAndService(
+export async function isUserWorkForJobAndServiceComplete(
   tx: Transaction, jobID: string, serviceID: string,
 ): Promise<boolean> {
   const any = await tx(UserWork.table)
@@ -193,7 +193,7 @@ export async function anyRemainingUserWorkForJobAndService(
         this.where('running_count', '!=', 0).orWhere('ready_count', '!=', 0);
       })
     .first();
-  return any != undefined;
+  return any == undefined;
 }
 
 /**

--- a/services/harmony/app/models/user-work.ts
+++ b/services/harmony/app/models/user-work.ts
@@ -164,15 +164,36 @@ export async function deleteUserWorkForJobAndService(
  * @param serviceID - The ID of the service
  * @returns the number of rows deleted (1)
  */
-export async function deleteUserWorkForCompletedJobAndService(
-  tx: Transaction, jobID: string, serviceID: string,
+export async function deleteUserWorkForCompletedJobAndServices(
+  tx: Transaction, jobID: string, serviceIds: string[],
 ): Promise<number> {
   const numDeleted = await tx(UserWork.table)
-    .where({ job_id: jobID, service_id: serviceID })
-    .andWhere('running_count', '=', 0)
-    .andWhere('ready_count', '=', 0)
+    .where({ job_id: jobID})
+    .whereIn('service_id', serviceIds)
+    .where({running_count: 0, ready_count: 0})
     .del();
   return numDeleted;
+}
+
+/**
+ * Detects if this Jobs service has any running or ready items
+ *
+ * @param tx - The database transaction
+ * @param jobID - The job ID
+ * @param serviceID - The ID of the service
+ *
+ * @returns true if there are any rows with running or ready counts
+ */
+export async function anyRemainingUserWorkForJobAndService(
+  tx: Transaction, jobID: string, serviceID: string,
+): Promise<boolean> {
+  const any = await tx(UserWork.table)
+    .where({ job_id: jobID, service_id: serviceID })
+      .where(function () {
+        this.where('running_count', '!=', 0).orWhere('ready_count', '!=', 0);
+      })
+    .first();
+  return any != undefined;
 }
 
 /**

--- a/services/harmony/app/models/user-work.ts
+++ b/services/harmony/app/models/user-work.ts
@@ -156,47 +156,6 @@ export async function deleteUserWorkForJobAndService(
 }
 
 /**
- * Deletes rows for the given job and any of the supplied service IDs from
- * the user_work table where both running_count and ready_count are 0.
- *
- * @param tx - The database transaction
- * @param jobID - The job ID
- * @param serviceIs - list of serviceIds to consider for deletion.
- * @returns the number of rows deleted
- */
-export async function deleteUserWorkForCompletedJobAndServices(
-  tx: Transaction, jobID: string, serviceIds: string[],
-): Promise<number> {
-  const numDeleted = await tx(UserWork.table)
-    .where({ job_id: jobID })
-    .whereIn('service_id', serviceIds)
-    .where({ running_count: 0, ready_count: 0 })
-    .del();
-  return numDeleted;
-}
-
-/**
- * Detects if this JobId and service has any running or ready items
- *
- * @param tx - The database transaction
- * @param jobID - The job ID
- * @param serviceID - The ID of the service
- *
- * @returns true if there are no rows with running or ready counts
- */
-export async function isUserWorkForJobAndServiceComplete(
-  tx: Transaction, jobID: string, serviceID: string,
-): Promise<boolean> {
-  const any = await tx(UserWork.table)
-    .where({ job_id: jobID, service_id: serviceID })
-    .where(function () {
-      this.where('running_count', '!=', 0).orWhere('ready_count', '!=', 0);
-    })
-    .first();
-  return any == undefined;
-}
-
-/**
  * Adds one to the ready_count for the given jobID and serviceID.
  * @param tx - The database transaction
  * @param jobID - The job ID

--- a/services/harmony/app/models/user-work.ts
+++ b/services/harmony/app/models/user-work.ts
@@ -156,6 +156,26 @@ export async function deleteUserWorkForJobAndService(
 }
 
 /**
+ * Deletes a row for the given job and service ID from the user_work
+ * table when running_count and ready_count are 0.
+ *
+ * @param tx - The database transaction
+ * @param jobID - The job ID
+ * @param serviceID - The ID of the service
+ * @returns the number of rows deleted (1)
+ */
+export async function deleteUserWorkForCompletedJobAndService(
+  tx: Transaction, jobID: string, serviceID: string,
+): Promise<number> {
+  const numDeleted = await tx(UserWork.table)
+    .where({ job_id: jobID, service_id: serviceID })
+    .andWhere('running_count', '=', 0)
+    .andWhere('ready_count', '=', 0)
+    .del();
+  return numDeleted;
+}
+
+/**
  * Adds one to the ready_count for the given jobID and serviceID.
  * @param tx - The database transaction
  * @param jobID - The job ID

--- a/services/harmony/test/helpers/user-work.ts
+++ b/services/harmony/test/helpers/user-work.ts
@@ -50,11 +50,3 @@ export function createUserWorkRecord(fields: Partial<UserWork> = {}): UserWork {
     job_id, service_id, username, ready_count, running_count, is_async, last_worked,
   });
 }
-
-/**
- * Returns true if a user_work row exists for the given job_id and service_id
- */
-export async function rowExists(job_id: string, service_id: string): Promise<boolean> {
-  const row = await db(UserWork.table).where({ job_id, service_id }).first();
-  return row !== undefined;
-}

--- a/services/harmony/test/helpers/user-work.ts
+++ b/services/harmony/test/helpers/user-work.ts
@@ -50,3 +50,11 @@ export function createUserWorkRecord(fields: Partial<UserWork> = {}): UserWork {
     job_id, service_id, username, ready_count, running_count, is_async, last_worked,
   });
 }
+
+/**
+ * Returns true if a user_work row exists for the given job_id and service_id
+ */
+export async function rowExists(job_id: string, service_id: string): Promise<boolean> {
+  const row = await db(UserWork.table).where({ job_id, service_id }).first();
+  return row !== undefined;
+}

--- a/services/harmony/test/helpers/user-work.ts
+++ b/services/harmony/test/helpers/user-work.ts
@@ -50,3 +50,11 @@ export function createUserWorkRecord(fields: Partial<UserWork> = {}): UserWork {
     job_id, service_id, username, ready_count, running_count, is_async, last_worked,
   });
 }
+
+/**
+ * Returns true if the user_work record table exists in the table .
+*/
+export async function rowExists(job_id: string, service_id: string): Promise<boolean> {
+  const row = await db(UserWork.table).where({ job_id, service_id }).first();
+  return row !== undefined;
+}

--- a/services/harmony/test/helpers/user-work.ts
+++ b/services/harmony/test/helpers/user-work.ts
@@ -52,8 +52,8 @@ export function createUserWorkRecord(fields: Partial<UserWork> = {}): UserWork {
 }
 
 /**
- * Returns true if the user_work record table exists in the table .
-*/
+ * Returns true if a user_work row exists for the given job_id and service_id
+ */
 export async function rowExists(job_id: string, service_id: string): Promise<boolean> {
   const row = await db(UserWork.table).where({ job_id, service_id }).first();
   return row !== undefined;

--- a/services/harmony/test/helpers/work-items.ts
+++ b/services/harmony/test/helpers/work-items.ts
@@ -57,6 +57,8 @@ export function buildWorkItem(fields: Partial<WorkItemRecord> = {}): WorkItem {
  */
 export async function rawSaveWorkItem(tx: Transaction, fields: Partial<WorkItemRecord> = {}): Promise<WorkItem> {
   const workItem = buildWorkItem(fields);
+  workItem.createdAt = workItem.createdAt || new Date();
+  workItem.updatedAt = workItem.updatedAt || workItem.createdAt;
   let stmt = tx((workItem.constructor as RecordConstructor).table)
     .insert(workItem);
   if (db.client.config.client === 'pg') {

--- a/services/harmony/test/models/user-work.ts
+++ b/services/harmony/test/models/user-work.ts
@@ -1,5 +1,8 @@
 import { expect } from 'chai';
-import { decrementRunningCount, getCount, incrementReadyAndDecrementRunningCounts, incrementRunningAndDecrementReadyCounts } from '../../app/models/user-work';
+import UserWork, {
+  decrementRunningCount, getCount, incrementReadyAndDecrementRunningCounts,
+  incrementRunningAndDecrementReadyCounts, deleteUserWorkForCompletedJobAndService,
+} from '../../app/models/user-work';
 import db from '../../app/util/db';
 import { truncateAll } from '../helpers/db';
 import { createUserWorkRecord } from '../helpers/user-work';
@@ -165,5 +168,74 @@ describe('user_work table', async function () {
         expect(runningCount).to.equal(3);
       });
     });
+  });
+
+  describe('calling the deleteUserWorkForCompletedJobAndService', function () {
+    const jobId = 'JobID-uuid';
+    const serviceId = 'harmony/service-image:1.0.0';
+
+    /**
+     * Helper to inspect the user_work table.
+     */
+    async function rowExists(job_id: string, service_id: string): Promise<boolean> {
+      const row = await db(UserWork.table).where({ job_id, service_id }).first();
+      return row !== undefined;
+    }
+
+    afterEach(async function () { await truncateAll(); });
+
+    it('deletes the row and returns 1 when ready_count and running_count are both 0', async function () {
+      await createUserWorkRecord({
+        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
+      }).save(db);
+
+      const numDeleted = await deleteUserWorkForCompletedJobAndService(db, jobId, serviceId);
+
+      expect(numDeleted).to.equal(1);
+      expect(await rowExists(jobId, serviceId)).to.equal(false);
+    });
+
+    it('leaves the row and returns 0 when ready_count > 0', async function () {
+      await createUserWorkRecord({
+        job_id: jobId, service_id: serviceId, ready_count: 3, running_count: 0,
+      }).save(db);
+
+      const numDeleted = await deleteUserWorkForCompletedJobAndService(db, jobId, serviceId);
+
+      expect(numDeleted).to.equal(0);
+      expect(await rowExists(jobId, serviceId)).to.equal(true);
+    });
+
+    it('leaves the row and returns 0 when running_count > 0', async function () {
+      await createUserWorkRecord({
+        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 2,
+      }).save(db);
+
+      const numDeleted = await deleteUserWorkForCompletedJobAndService(db, jobId, serviceId);
+
+      expect(numDeleted).to.equal(0);
+      expect(await rowExists(jobId, serviceId)).to.equal(true);
+    });
+
+    it('returns 0 when no matching row exists', async function () {
+      const numDeleted = await deleteUserWorkForCompletedJobAndService(db, 'missing-job', 'missing-svc');
+      expect(numDeleted).to.equal(0);
+    });
+
+    it('does not delete rows for other jobs that share the same serviceID', async function () {
+      await createUserWorkRecord({
+        job_id: 'other-jobs-uuid', service_id: serviceId, ready_count: 0, running_count: 0,
+      }).save(db);
+      await createUserWorkRecord({
+        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
+      }).save(db);
+
+      const numDeleted = await deleteUserWorkForCompletedJobAndService(db, jobId, serviceId);
+
+      expect(numDeleted).to.equal(1);
+      expect(await rowExists(jobId, serviceId)).to.equal(false);
+      expect(await rowExists('other-jobs-uuid', serviceId)).to.equal(true);
+    });
+
   });
 });

--- a/services/harmony/test/models/user-work.ts
+++ b/services/harmony/test/models/user-work.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
-import UserWork, {
+import {
   decrementRunningCount, getCount, incrementReadyAndDecrementRunningCounts,
   incrementRunningAndDecrementReadyCounts, deleteUserWorkForCompletedJobAndServices,
 } from '../../app/models/user-work';
 import db from '../../app/util/db';
 import { truncateAll } from '../helpers/db';
-import { createUserWorkRecord } from '../helpers/user-work';
+import { rowExists, createUserWorkRecord } from '../helpers/user-work';
 
 describe('user_work table', async function () {
   describe('when creating a row and setting the ready and running counts to positive values', async function () {
@@ -174,11 +174,6 @@ describe('user_work table', async function () {
     const jobId = 'JobID-uuid';
     const serviceId = 'harmony/service-image:1.0.0';
     const serviceId2 = 'harmony/service-image:2.0.0';
-
-    async function rowExists(job_id: string, service_id: string): Promise<boolean> {
-      const row = await db(UserWork.table).where({ job_id, service_id }).first();
-      return row !== undefined;
-    }
 
     afterEach(async function () { await truncateAll(); });
 

--- a/services/harmony/test/models/user-work.ts
+++ b/services/harmony/test/models/user-work.ts
@@ -1,12 +1,11 @@
 import { expect } from 'chai';
 import {
   decrementRunningCount, getCount, incrementReadyAndDecrementRunningCounts,
-  incrementRunningAndDecrementReadyCounts, deleteUserWorkForCompletedJobAndServices,
-  isUserWorkForJobAndServiceComplete,
+  incrementRunningAndDecrementReadyCounts,
 } from '../../app/models/user-work';
 import db from '../../app/util/db';
 import { truncateAll } from '../helpers/db';
-import { rowExists, createUserWorkRecord } from '../helpers/user-work';
+import { createUserWorkRecord } from '../helpers/user-work';
 
 describe('user_work table', async function () {
   describe('when creating a row and setting the ready and running counts to positive values', async function () {
@@ -168,161 +167,6 @@ describe('user_work table', async function () {
         const runningCount = await getCount(db, userWork.job_id, userWork.service_id, 'running');
         expect(runningCount).to.equal(3);
       });
-    });
-  });
-
-  describe('when calling deleteUserWorkForCompletedJobAndServices', function () {
-    const jobId = 'JobID-uuid';
-    const serviceId = 'harmony/service-image:1.0.0';
-    const serviceId2 = 'harmony/service-image:2.0.0';
-    const serviceIds = [serviceId, serviceId2];
-
-    afterEach(async function () { await truncateAll(); });
-
-    it('deletes matching rows and returns 1 when ready_count and running_count are both 0', async function () {
-      await createUserWorkRecord({
-        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
-      }).save(db);
-
-      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, serviceIds);
-
-      expect(numDeleted).to.equal(1);
-      expect(await rowExists(jobId, serviceId)).to.equal(false);
-    });
-
-    it('leaves the row and returns 0 when ready_count > 0', async function () {
-      await createUserWorkRecord({
-        job_id: jobId, service_id: serviceId, ready_count: 3, running_count: 0,
-      }).save(db);
-
-      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, serviceIds);
-
-      expect(numDeleted).to.equal(0);
-      expect(await rowExists(jobId, serviceId)).to.equal(true);
-    });
-
-    it('leaves the row and returns 0 when running_count > 0', async function () {
-      await createUserWorkRecord({
-        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 2,
-      }).save(db);
-
-      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, serviceIds);
-
-      expect(numDeleted).to.equal(0);
-      expect(await rowExists(jobId, serviceId)).to.equal(true);
-    });
-
-    it('returns 0 when no matching row exists', async function () {
-      const numDeleted = await deleteUserWorkForCompletedJobAndServices(
-        db, 'missing-job-uuid', ['missing-svc-id'],
-      );
-      expect(numDeleted).to.equal(0);
-    });
-
-    it('does not delete rows for other jobs that share the same serviceID', async function () {
-      await createUserWorkRecord({
-        job_id: 'other-jobs-uuid', service_id: serviceId, ready_count: 0, running_count: 0,
-      }).save(db);
-      await createUserWorkRecord({
-        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
-      }).save(db);
-
-      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, [serviceId]);
-
-      expect(numDeleted).to.equal(1);
-      expect(await rowExists(jobId, serviceId)).to.equal(false);
-      expect(await rowExists('other-jobs-uuid', serviceId)).to.equal(true);
-    });
-
-    it('deletes multiple service rows for the same job when all have zero counts', async function () {
-      await createUserWorkRecord({
-        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
-      }).save(db);
-      await createUserWorkRecord({
-        job_id: jobId, service_id: serviceId2, ready_count: 0, running_count: 0,
-      }).save(db);
-
-      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, [serviceId, serviceId2]);
-
-      expect(numDeleted).to.equal(2);
-      expect(await rowExists(jobId, serviceId)).to.equal(false);
-      expect(await rowExists(jobId, serviceId2)).to.equal(false);
-    });
-
-    it('only deletes completed rows when serviceIds list contains mixed-state services', async function () {
-      await createUserWorkRecord({
-        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
-      }).save(db);
-      await createUserWorkRecord({
-        job_id: jobId, service_id: serviceId2, ready_count: 1, running_count: 0,
-      }).save(db);
-
-      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, [serviceId, serviceId2]);
-
-      expect(numDeleted).to.equal(1);
-      expect(await rowExists(jobId, serviceId)).to.equal(false);
-      expect(await rowExists(jobId, serviceId2)).to.equal(true);
-    });
-
-  });
-
-  describe('when calling isUserWorkForJobAndServiceComplete', function () {
-    const jobId = 'complete-job-uuid';
-    const serviceId = 'harmony/service-image:1.0.0';
-
-    afterEach(async function () { await truncateAll(); });
-
-    it('returns true when both ready_count and running_count are 0', async function () {
-      await createUserWorkRecord({
-        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
-      }).save(db);
-
-      const result = await isUserWorkForJobAndServiceComplete(db, jobId, serviceId);
-      expect(result).to.equal(true);
-    });
-
-    it('returns false when ready_count > 0', async function () {
-      await createUserWorkRecord({
-        job_id: jobId, service_id: serviceId, ready_count: 3, running_count: 0,
-      }).save(db);
-
-      const result = await isUserWorkForJobAndServiceComplete(db, jobId, serviceId);
-      expect(result).to.equal(false);
-    });
-
-    it('returns false when running_count > 0', async function () {
-      await createUserWorkRecord({
-        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 2,
-      }).save(db);
-
-      const result = await isUserWorkForJobAndServiceComplete(db, jobId, serviceId);
-      expect(result).to.equal(false);
-    });
-
-    it('returns false when both ready_count and running_count > 0', async function () {
-      await createUserWorkRecord({
-        job_id: jobId, service_id: serviceId, ready_count: 1, running_count: 1,
-      }).save(db);
-
-      const result = await isUserWorkForJobAndServiceComplete(db, jobId, serviceId);
-      expect(result).to.equal(false);
-    });
-
-    it('returns true when no row exists for the job and service', async function () {
-      const result = await isUserWorkForJobAndServiceComplete(db, 'missing-job-uuid', 'missing-svc');
-      expect(result).to.equal(true);
-    });
-
-    it('does not consider rows for other services on the same job', async function () {
-      await createUserWorkRecord({
-        job_id: jobId, service_id: 'harmony/other-service:1.0.0', ready_count: 5, running_count: 0,
-      }).save(db);
-      await createUserWorkRecord({
-        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
-      }).save(db);
-
-      const result = await isUserWorkForJobAndServiceComplete(db, jobId, serviceId);
-      expect(result).to.equal(true);
     });
   });
 });

--- a/services/harmony/test/models/user-work.ts
+++ b/services/harmony/test/models/user-work.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import UserWork, {
   decrementRunningCount, getCount, incrementReadyAndDecrementRunningCounts,
-  incrementRunningAndDecrementReadyCounts, deleteUserWorkForCompletedJobAndService,
+  incrementRunningAndDecrementReadyCounts, deleteUserWorkForCompletedJobAndServices,
 } from '../../app/models/user-work';
 import db from '../../app/util/db';
 import { truncateAll } from '../helpers/db';
@@ -170,13 +170,11 @@ describe('user_work table', async function () {
     });
   });
 
-  describe('calling the deleteUserWorkForCompletedJobAndService', function () {
+  describe('calling deleteUserWorkForCompletedJobAndServices', function () {
     const jobId = 'JobID-uuid';
     const serviceId = 'harmony/service-image:1.0.0';
+    const serviceId2 = 'harmony/service-image:2.0.0';
 
-    /**
-     * Helper to inspect the user_work table.
-     */
     async function rowExists(job_id: string, service_id: string): Promise<boolean> {
       const row = await db(UserWork.table).where({ job_id, service_id }).first();
       return row !== undefined;
@@ -184,12 +182,12 @@ describe('user_work table', async function () {
 
     afterEach(async function () { await truncateAll(); });
 
-    it('deletes the row and returns 1 when ready_count and running_count are both 0', async function () {
+    it('deletes matching rows and returns 1 when ready_count and running_count are both 0', async function () {
       await createUserWorkRecord({
         job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
       }).save(db);
 
-      const numDeleted = await deleteUserWorkForCompletedJobAndService(db, jobId, serviceId);
+      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, [serviceId]);
 
       expect(numDeleted).to.equal(1);
       expect(await rowExists(jobId, serviceId)).to.equal(false);
@@ -200,7 +198,7 @@ describe('user_work table', async function () {
         job_id: jobId, service_id: serviceId, ready_count: 3, running_count: 0,
       }).save(db);
 
-      const numDeleted = await deleteUserWorkForCompletedJobAndService(db, jobId, serviceId);
+      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, [serviceId]);
 
       expect(numDeleted).to.equal(0);
       expect(await rowExists(jobId, serviceId)).to.equal(true);
@@ -211,14 +209,14 @@ describe('user_work table', async function () {
         job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 2,
       }).save(db);
 
-      const numDeleted = await deleteUserWorkForCompletedJobAndService(db, jobId, serviceId);
+      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, [serviceId]);
 
       expect(numDeleted).to.equal(0);
       expect(await rowExists(jobId, serviceId)).to.equal(true);
     });
 
     it('returns 0 when no matching row exists', async function () {
-      const numDeleted = await deleteUserWorkForCompletedJobAndService(db, 'missing-job', 'missing-svc');
+      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, 'missing-job', ['missing-svc']);
       expect(numDeleted).to.equal(0);
     });
 
@@ -230,11 +228,41 @@ describe('user_work table', async function () {
         job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
       }).save(db);
 
-      const numDeleted = await deleteUserWorkForCompletedJobAndService(db, jobId, serviceId);
+      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, [serviceId]);
 
       expect(numDeleted).to.equal(1);
       expect(await rowExists(jobId, serviceId)).to.equal(false);
       expect(await rowExists('other-jobs-uuid', serviceId)).to.equal(true);
+    });
+
+    it('deletes multiple service rows for the same job when all have zero counts', async function () {
+      await createUserWorkRecord({
+        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
+      }).save(db);
+      await createUserWorkRecord({
+        job_id: jobId, service_id: serviceId2, ready_count: 0, running_count: 0,
+      }).save(db);
+
+      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, [serviceId, serviceId2]);
+
+      expect(numDeleted).to.equal(2);
+      expect(await rowExists(jobId, serviceId)).to.equal(false);
+      expect(await rowExists(jobId, serviceId2)).to.equal(false);
+    });
+
+    it('only deletes completed rows when serviceIds list contains mixed-state services', async function () {
+      await createUserWorkRecord({
+        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
+      }).save(db);
+      await createUserWorkRecord({
+        job_id: jobId, service_id: serviceId2, ready_count: 1, running_count: 0,
+      }).save(db);
+
+      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, [serviceId, serviceId2]);
+
+      expect(numDeleted).to.equal(1);
+      expect(await rowExists(jobId, serviceId)).to.equal(false);
+      expect(await rowExists(jobId, serviceId2)).to.equal(true);
     });
 
   });

--- a/services/harmony/test/models/user-work.ts
+++ b/services/harmony/test/models/user-work.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import {
   decrementRunningCount, getCount, incrementReadyAndDecrementRunningCounts,
   incrementRunningAndDecrementReadyCounts, deleteUserWorkForCompletedJobAndServices,
+  isUserWorkForJobAndServiceComplete,
 } from '../../app/models/user-work';
 import db from '../../app/util/db';
 import { truncateAll } from '../helpers/db';
@@ -170,10 +171,11 @@ describe('user_work table', async function () {
     });
   });
 
-  describe('calling deleteUserWorkForCompletedJobAndServices', function () {
+  describe('when calling deleteUserWorkForCompletedJobAndServices', function () {
     const jobId = 'JobID-uuid';
     const serviceId = 'harmony/service-image:1.0.0';
     const serviceId2 = 'harmony/service-image:2.0.0';
+    const serviceIds = [serviceId, serviceId2];
 
     afterEach(async function () { await truncateAll(); });
 
@@ -182,7 +184,7 @@ describe('user_work table', async function () {
         job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
       }).save(db);
 
-      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, [serviceId]);
+      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, serviceIds);
 
       expect(numDeleted).to.equal(1);
       expect(await rowExists(jobId, serviceId)).to.equal(false);
@@ -193,7 +195,7 @@ describe('user_work table', async function () {
         job_id: jobId, service_id: serviceId, ready_count: 3, running_count: 0,
       }).save(db);
 
-      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, [serviceId]);
+      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, serviceIds);
 
       expect(numDeleted).to.equal(0);
       expect(await rowExists(jobId, serviceId)).to.equal(true);
@@ -204,14 +206,16 @@ describe('user_work table', async function () {
         job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 2,
       }).save(db);
 
-      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, [serviceId]);
+      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, jobId, serviceIds);
 
       expect(numDeleted).to.equal(0);
       expect(await rowExists(jobId, serviceId)).to.equal(true);
     });
 
     it('returns 0 when no matching row exists', async function () {
-      const numDeleted = await deleteUserWorkForCompletedJobAndServices(db, 'missing-job', ['missing-svc']);
+      const numDeleted = await deleteUserWorkForCompletedJobAndServices(
+        db, 'missing-job-uuid', ['missing-svc-id'],
+      );
       expect(numDeleted).to.equal(0);
     });
 
@@ -260,5 +264,65 @@ describe('user_work table', async function () {
       expect(await rowExists(jobId, serviceId2)).to.equal(true);
     });
 
+  });
+
+  describe('when calling isUserWorkForJobAndServiceComplete', function () {
+    const jobId = 'complete-job-uuid';
+    const serviceId = 'harmony/service-image:1.0.0';
+
+    afterEach(async function () { await truncateAll(); });
+
+    it('returns true when both ready_count and running_count are 0', async function () {
+      await createUserWorkRecord({
+        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
+      }).save(db);
+
+      const result = await isUserWorkForJobAndServiceComplete(db, jobId, serviceId);
+      expect(result).to.equal(true);
+    });
+
+    it('returns false when ready_count > 0', async function () {
+      await createUserWorkRecord({
+        job_id: jobId, service_id: serviceId, ready_count: 3, running_count: 0,
+      }).save(db);
+
+      const result = await isUserWorkForJobAndServiceComplete(db, jobId, serviceId);
+      expect(result).to.equal(false);
+    });
+
+    it('returns false when running_count > 0', async function () {
+      await createUserWorkRecord({
+        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 2,
+      }).save(db);
+
+      const result = await isUserWorkForJobAndServiceComplete(db, jobId, serviceId);
+      expect(result).to.equal(false);
+    });
+
+    it('returns false when both ready_count and running_count > 0', async function () {
+      await createUserWorkRecord({
+        job_id: jobId, service_id: serviceId, ready_count: 1, running_count: 1,
+      }).save(db);
+
+      const result = await isUserWorkForJobAndServiceComplete(db, jobId, serviceId);
+      expect(result).to.equal(false);
+    });
+
+    it('returns true when no row exists for the job and service', async function () {
+      const result = await isUserWorkForJobAndServiceComplete(db, 'missing-job-uuid', 'missing-svc');
+      expect(result).to.equal(true);
+    });
+
+    it('does not consider rows for other services on the same job', async function () {
+      await createUserWorkRecord({
+        job_id: jobId, service_id: 'harmony/other-service:1.0.0', ready_count: 5, running_count: 0,
+      }).save(db);
+      await createUserWorkRecord({
+        job_id: jobId, service_id: serviceId, ready_count: 0, running_count: 0,
+      }).save(db);
+
+      const result = await isUserWorkForJobAndServiceComplete(db, jobId, serviceId);
+      expect(result).to.equal(true);
+    });
   });
 });

--- a/services/harmony/test/workflow-orchestration.ts
+++ b/services/harmony/test/workflow-orchestration.ts
@@ -1291,11 +1291,12 @@ describe('when a job is paused and a work item completes', function () {
 });
 
 describe('when a downstream step completes before an upstream retrying item permanently fails', function () {
-  // Test for jobs stuck in running_with_errors forever.
+  // Test for jobs that became stuck in running_with_errors forever.
   // Race condition: HOSS granule B retries while MaskFill granule A completes.
   // When MaskFill's updateIsComplete runs, the prevStepComplete guard blocks it because
-  // HOSS still has a non-terminal item. When HOSS granule B later permanently fails,
-  // nothing re-evaluates MaskFill — is_complete stays false and the job never completes.
+  // HOSS still has a non-terminal item.
+  // Before when HOSS granule B later permanently fails nothing re-evaluated
+  // MaskFill — is_complete stays false and the job never completed.
   hookServersStartStop();
 
   let retryLimit;
@@ -1380,7 +1381,7 @@ describe('when a downstream step completes before an upstream retrying item perm
 
         it('leaves the MaskFill step incomplete (the bug condition)', async function () {
           const steps = await getWorkflowStepsByJobId(db, jobID);
-          expect(steps[1].is_complete).to.equal(0);  // HOSS — B still retrying
+          expect(steps[1].is_complete).to.equal(0);  // HOSS — B still non terminal
           expect(steps[2].is_complete).to.equal(0);  // MaskFill — prevStepComplete blocked it
         });
 
@@ -1392,8 +1393,6 @@ describe('when a downstream step completes before an upstream retrying item perm
 
         describe('and HOSS B then exhausts its retries', function () {
           before(async function () {
-            // HOSS (step 2) is now complete. The fix should detect that all
-            // user_work for the remainder of the chain is idle and finalize the job.
             let shouldLoop = true;
             while (shouldLoop) {
               const res = await getWorkForService(this.backend, 'ghcr.io/nasa/harmony-opendap-subsetter:latest');
@@ -1404,6 +1403,7 @@ describe('when a downstream step completes before an upstream retrying item perm
               const saved = await getWorkItemById(db, item.id);
               shouldLoop = saved.status !== WorkItemStatus.FAILED;
             }
+            // HOSS (step 2) is now complete.
           });
 
           it('transitions the job to complete_with_errors instead of staying in running_with_errors', async function () {

--- a/services/harmony/test/workflow-orchestration.ts
+++ b/services/harmony/test/workflow-orchestration.ts
@@ -1290,20 +1290,25 @@ describe('when a job is paused and a work item completes', function () {
   });
 });
 
-describe.skip('when a downstream step completes before an upstream retrying item permanently fails', function () {
-  // Regression test for jobs stuck in running_with_errors forever.
+describe('when a downstream step completes before an upstream retrying item permanently fails', function () {
+  // Test for jobs stuck in running_with_errors forever.
   // Race condition: HOSS granule B retries while MaskFill granule A completes.
   // When MaskFill's updateIsComplete runs, the prevStepComplete guard blocks it because
   // HOSS still has a non-terminal item. When HOSS granule B later permanently fails,
   // nothing re-evaluates MaskFill — is_complete stays false and the job never completes.
   hookServersStartStop();
 
+  let retryLimit;
+
   before(async function () {
     await truncateAll();
     resetQueues();
+    retryLimit = env.workItemRetryLimit;
+    env.workItemRetryLimit = 1;
   });
 
   after(async function () {
+    env.workItemRetryLimit = retryLimit;
     resetQueues();
     await truncateAll();
   });
@@ -1315,91 +1320,120 @@ describe.skip('when a downstream step completes before an upstream retrying item
     forceAsync: true,
     ignoreErrors: true,
   };
-  const atl16Collection = 'C1260128044-EEDTEST';
 
-  hookRangesetRequest('1.0.0', atl16Collection, 'all', { query: hossAndMaskfillQuery });
+  const collection = 'C1260128044-EEDTEST';  // ATL16: uses HOSS and MaskFill
+
+  hookRangesetRequest('1.0.0', collection, 'all', { query: hossAndMaskfillQuery });
   hookRedirect('joe');
 
   let jobID;
 
-  before(async function () {
-    const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:stable');
-    const { workItem, maxCmrGranules } = JSON.parse(res.text);
-    expect(maxCmrGranules).to.equal(2);
-    ({ jobID } = workItem);
-    workItem.status = WorkItemStatus.SUCCESSFUL;
-    workItem.results = [
-      getStacLocation(workItem, 'catalog0.json'),
-      getStacLocation(workItem, 'catalog1.json'),
-    ];
-    workItem.outputItemSizes = [1, 1];
-    await fakeServiceStacOutput(workItem.jobID, workItem.id, 2);
-    await updateWorkItem(this.backend, workItem);
-  });
-
-  before(async function () {
-    // Complete HOSS granule A successfully — creates a MaskFill item
-    const res = await getWorkForService(this.backend, 'ghcr.io/nasa/harmony-opendap-subsetter:latest');
-    const { workItem } = JSON.parse(res.text);
-    workItem.status = WorkItemStatus.SUCCESSFUL;
-    workItem.results = [getStacLocation(workItem, 'catalog.json')];
-    workItem.outputItemSizes = [1];
-    await fakeServiceStacOutput(workItem.jobID, workItem.id);
-    await updateWorkItem(this.backend, workItem);
-
-    // Fail HOSS granule B once — it retries, does NOT permanently fail yet
-    const res2 = await getWorkForService(this.backend, 'ghcr.io/nasa/harmony-opendap-subsetter:latest');
-    const badItem = JSON.parse(res2.text).workItem;
-    badItem.status = WorkItemStatus.FAILED;
-    badItem.results = [];
-    await updateWorkItem(this.backend, badItem);
-    const saved = await getWorkItemById(db, badItem.id);
-    expect(saved.status).to.not.equal(WorkItemStatus.FAILED, 'item should be retrying, not permanently failed yet');
-  });
-
-  before(async function () {
-    // Complete MaskFill granule A while HOSS granule B is still retrying.
-    // updateIsComplete for MaskFill (step 3) is blocked by prevStepComplete guard
-    // because HOSS (step 2) still has a non-terminal item — is_complete stays false.
-    const res = await getWorkForService(this.backend, 'ghcr.io/nasa/harmony-maskfill:latest');
-    const { workItem } = JSON.parse(res.text);
-    workItem.status = WorkItemStatus.SUCCESSFUL;
-    workItem.results = [getStacLocation(workItem, 'catalog.json')];
-    workItem.outputItemSizes = [1];
-    await fakeServiceStacOutput(workItem.jobID, workItem.id);
-    await updateWorkItem(this.backend, workItem);
-  });
-
-  before(async function () {
-    // Exhaust retries on HOSS granule B — permanent failure.
-    // HOSS (step 2) is now complete. The cascade should mark MaskFill (step 3)
-    // complete and transition the job to complete_with_errors.
-    let shouldLoop = true;
-    while (shouldLoop) {
-      const res = await getWorkForService(this.backend, 'ghcr.io/nasa/harmony-opendap-subsetter:latest');
-      const { workItem } = JSON.parse(res.text);
-      workItem.status = WorkItemStatus.FAILED;
-      workItem.results = [];
+  describe('after the query-cmr step completes', function () {
+    before(async function () {
+      const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:stable');
+      const { workItem, maxCmrGranules } = JSON.parse(res.text);
+      expect(maxCmrGranules).to.equal(2);
+      ({ jobID } = workItem);
+      workItem.status = WorkItemStatus.SUCCESSFUL;
+      workItem.results = [
+        getStacLocation(workItem, 'catalog0.json'),
+        getStacLocation(workItem, 'catalog1.json'),
+      ];
+      workItem.outputItemSizes = [1, 1];
+      await fakeServiceStacOutput(workItem.jobID, workItem.id, 2);
       await updateWorkItem(this.backend, workItem);
-      const saved = await getWorkItemById(db, workItem.id);
-      shouldLoop = saved.status !== WorkItemStatus.FAILED;
-    }
-  });
+    });
 
-  it('marks the MaskFill step as complete', async function () {
-    const steps = await getWorkflowStepsByJobId(db, jobID);
-    expect(steps[2].is_complete).to.equal(true);
-  });
+    describe('and HOSS A completes while HOSS B is retrying', function () {
+      before(async function () {
+        // Complete HOSS A successfully — creates MaskFill A
+        const aRes = await getWorkForService(this.backend, 'ghcr.io/nasa/harmony-opendap-subsetter:latest');
+        const a = JSON.parse(aRes.text).workItem;
+        a.status = WorkItemStatus.SUCCESSFUL;
+        a.results = [getStacLocation(a, 'catalog.json')];
+        a.outputItemSizes = [1];
+        await fakeServiceStacOutput(a.jobID, a.id);
+        await updateWorkItem(this.backend, a);
 
-  it('transitions the job to complete_with_errors instead of staying in running_with_errors', async function () {
-    const { job } = await Job.byJobID(db, jobID);
-    expect(job.status).to.equal(JobStatus.COMPLETE_WITH_ERRORS);
-    expect(job.progress).to.equal(100);
-  });
+        // Fail HOSS B once — it retries, does NOT permanently fail yet
+        const bRes = await getWorkForService(this.backend, 'ghcr.io/nasa/harmony-opendap-subsetter:latest');
+        const b = JSON.parse(bRes.text).workItem;
+        b.status = WorkItemStatus.FAILED;
+        b.results = [];
+        await updateWorkItem(this.backend, b);
+        const saved = await getWorkItemById(db, b.id);
+        expect(saved.status).to.equal(WorkItemStatus.READY);
+      });
 
-  it('has output links for the successful granule', async function () {
-    const { job } = await Job.byJobID(db, jobID);
-    const dataLinks = job.links.filter((l) => l.rel === 'data');
-    expect(dataLinks.length).to.equal(1);
+      describe('and MaskFill A completes before HOSS B has finished retrying', function () {
+        before(async function () {
+          // updateIsComplete for MaskFill (step 3) is blocked by the prevStepComplete guard
+          // because HOSS (step 2) still has a non-terminal item — is_complete stays false.
+          const res = await getWorkForService(this.backend, 'ghcr.io/nasa/harmony-maskfill:latest');
+          const item = JSON.parse(res.text).workItem;
+          item.status = WorkItemStatus.SUCCESSFUL;
+          item.results = [getStacLocation(item, 'catalog.json')];
+          item.outputItemSizes = [1];
+          await fakeServiceStacOutput(item.jobID, item.id, 1, 1);
+          await updateWorkItem(this.backend, item);
+        });
+
+        it('leaves the MaskFill step incomplete (the bug condition)', async function () {
+          const steps = await getWorkflowStepsByJobId(db, jobID);
+          expect(steps[1].is_complete).to.equal(0);  // HOSS — B still retrying
+          expect(steps[2].is_complete).to.equal(0);  // MaskFill — prevStepComplete blocked it
+        });
+
+        it('has not yet finalized the job', async function () {
+          const { job } = await Job.byJobID(db, jobID);
+          expect(job.status).to.equal(JobStatus.RUNNING);
+        });
+
+
+        describe('and HOSS B then exhausts its retries', function () {
+          before(async function () {
+            // HOSS (step 2) is now complete. The fix should detect that all
+            // user_work for the remainder of the chain is idle and finalize the job.
+            let shouldLoop = true;
+            while (shouldLoop) {
+              const res = await getWorkForService(this.backend, 'ghcr.io/nasa/harmony-opendap-subsetter:latest');
+              const item = JSON.parse(res.text).workItem;
+              item.status = WorkItemStatus.FAILED;
+              item.results = [];
+              await updateWorkItem(this.backend, item);
+              const saved = await getWorkItemById(db, item.id);
+              shouldLoop = saved.status !== WorkItemStatus.FAILED;
+            }
+          });
+
+          it('transitions the job to complete_with_errors instead of staying in running_with_errors', async function () {
+            const { job } = await Job.byJobID(db, jobID);
+            expect(job.status).to.equal(JobStatus.COMPLETE_WITH_ERRORS);
+            expect(job.progress).to.equal(100);
+          });
+
+          it('cleans up user_work for the job', async function () {
+            const rows = await db('user_work').where({ job_id: jobID });
+            expect(rows.length).to.equal(0);
+          });
+
+          it('produced output only for the successful granule', async function () {
+            const { workItems } = await getWorkItemsByJobId(db, jobID);
+
+            const hoss = workItems.filter(w => w.serviceID === 'ghcr.io/nasa/harmony-opendap-subsetter:latest');
+            const maskfill = workItems.filter(w => w.serviceID === 'ghcr.io/nasa/harmony-maskfill:latest');
+
+            expect(hoss.filter(w => w.status === WorkItemStatus.SUCCESSFUL).length).to.equal(1);
+            expect(hoss.filter(w => w.status === WorkItemStatus.FAILED).length).to.equal(1);
+            expect(maskfill.length).to.equal(1);
+            expect(maskfill[0].status).to.equal(WorkItemStatus.SUCCESSFUL);
+
+            const job = await getFirstJob(db);
+            const dataLinks = job.links.filter(l => l.rel === 'data');
+            expect(dataLinks.length).to.equal(1);
+          });
+        });
+      });
+    });
   });
 });

--- a/services/harmony/test/workflow-orchestration.ts
+++ b/services/harmony/test/workflow-orchestration.ts
@@ -1289,3 +1289,117 @@ describe('when a job is paused and a work item completes', function () {
     });
   });
 });
+
+describe.skip('when a downstream step completes before an upstream retrying item permanently fails', function () {
+  // Regression test for jobs stuck in running_with_errors forever.
+  // Race condition: HOSS granule B retries while MaskFill granule A completes.
+  // When MaskFill's updateIsComplete runs, the prevStepComplete guard blocks it because
+  // HOSS still has a non-terminal item. When HOSS granule B later permanently fails,
+  // nothing re-evaluates MaskFill — is_complete stays false and the job never completes.
+  hookServersStartStop();
+
+  before(async function () {
+    await truncateAll();
+    resetQueues();
+  });
+
+  after(async function () {
+    resetQueues();
+    await truncateAll();
+  });
+
+  const hossAndMaskfillQuery = {
+    maxResults: 2,
+    subset: 'lat(60:65)',
+    format: 'application/x-netcdf4',
+    forceAsync: true,
+    ignoreErrors: true,
+  };
+  const atl16Collection = 'C1260128044-EEDTEST';
+
+  hookRangesetRequest('1.0.0', atl16Collection, 'all', { query: hossAndMaskfillQuery });
+  hookRedirect('joe');
+
+  let jobID;
+
+  before(async function () {
+    const res = await getWorkForService(this.backend, 'harmonyservices/query-cmr:stable');
+    const { workItem, maxCmrGranules } = JSON.parse(res.text);
+    expect(maxCmrGranules).to.equal(2);
+    ({ jobID } = workItem);
+    workItem.status = WorkItemStatus.SUCCESSFUL;
+    workItem.results = [
+      getStacLocation(workItem, 'catalog0.json'),
+      getStacLocation(workItem, 'catalog1.json'),
+    ];
+    workItem.outputItemSizes = [1, 1];
+    await fakeServiceStacOutput(workItem.jobID, workItem.id, 2);
+    await updateWorkItem(this.backend, workItem);
+  });
+
+  before(async function () {
+    // Complete HOSS granule A successfully — creates a MaskFill item
+    const res = await getWorkForService(this.backend, 'ghcr.io/nasa/harmony-opendap-subsetter:latest');
+    const { workItem } = JSON.parse(res.text);
+    workItem.status = WorkItemStatus.SUCCESSFUL;
+    workItem.results = [getStacLocation(workItem, 'catalog.json')];
+    workItem.outputItemSizes = [1];
+    await fakeServiceStacOutput(workItem.jobID, workItem.id);
+    await updateWorkItem(this.backend, workItem);
+
+    // Fail HOSS granule B once — it retries, does NOT permanently fail yet
+    const res2 = await getWorkForService(this.backend, 'ghcr.io/nasa/harmony-opendap-subsetter:latest');
+    const badItem = JSON.parse(res2.text).workItem;
+    badItem.status = WorkItemStatus.FAILED;
+    badItem.results = [];
+    await updateWorkItem(this.backend, badItem);
+    const saved = await getWorkItemById(db, badItem.id);
+    expect(saved.status).to.not.equal(WorkItemStatus.FAILED, 'item should be retrying, not permanently failed yet');
+  });
+
+  before(async function () {
+    // Complete MaskFill granule A while HOSS granule B is still retrying.
+    // updateIsComplete for MaskFill (step 3) is blocked by prevStepComplete guard
+    // because HOSS (step 2) still has a non-terminal item — is_complete stays false.
+    const res = await getWorkForService(this.backend, 'ghcr.io/nasa/harmony-maskfill:latest');
+    const { workItem } = JSON.parse(res.text);
+    workItem.status = WorkItemStatus.SUCCESSFUL;
+    workItem.results = [getStacLocation(workItem, 'catalog.json')];
+    workItem.outputItemSizes = [1];
+    await fakeServiceStacOutput(workItem.jobID, workItem.id);
+    await updateWorkItem(this.backend, workItem);
+  });
+
+  before(async function () {
+    // Exhaust retries on HOSS granule B — permanent failure.
+    // HOSS (step 2) is now complete. The cascade should mark MaskFill (step 3)
+    // complete and transition the job to complete_with_errors.
+    let shouldLoop = true;
+    while (shouldLoop) {
+      const res = await getWorkForService(this.backend, 'ghcr.io/nasa/harmony-opendap-subsetter:latest');
+      const { workItem } = JSON.parse(res.text);
+      workItem.status = WorkItemStatus.FAILED;
+      workItem.results = [];
+      await updateWorkItem(this.backend, workItem);
+      const saved = await getWorkItemById(db, workItem.id);
+      shouldLoop = saved.status !== WorkItemStatus.FAILED;
+    }
+  });
+
+  it('marks the MaskFill step as complete', async function () {
+    const steps = await getWorkflowStepsByJobId(db, jobID);
+    expect(steps[2].is_complete).to.equal(true);
+  });
+
+  it('transitions the job to complete_with_errors instead of staying in running_with_errors', async function () {
+    const { job } = await Job.byJobID(db, jobID);
+    expect(job.status).to.equal(JobStatus.COMPLETE_WITH_ERRORS);
+    expect(job.progress).to.equal(100);
+  });
+
+  it('has output links for the successful granule', async function () {
+    const { job } = await Job.byJobID(db, jobID);
+    const dataLinks = job.links.filter((l) => l.rel === 'data');
+    expect(dataLinks.length).to.equal(1);
+  });
+});

--- a/services/harmony/test/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/test/workflow-orchestration/work-item-updates.ts
@@ -21,7 +21,7 @@ describe('Finalize via the checkRemainingStepsForCompletion function', function 
     let secondHoss: WorkItem;
 
     before(async function () {
-      // Upstream step is already complete; hoss and the downstream maskfill
+      // Upstream step is already complete; HOSS and the downstream maskfill
       // step are not yet marked complete.
       await rawSaveWorkflowStep(db, {
         jobID, serviceID: queryCmrService, stepIndex: 1, is_complete: true,
@@ -33,9 +33,9 @@ describe('Finalize via the checkRemainingStepsForCompletion function', function 
         jobID, serviceID: maskFillService, stepIndex: 3, is_complete: false,
       });
 
-      // The first hoss work item already finished and its downstream maskfill
-      // work item ran to completion. A second hoss work item is still running,
-      // which is why the hoss step has not been marked complete.
+      // The first HOSS work item already finished and its downstream maskfill
+      // work item ran to completion. A second HOSS work item is still running,
+      // which is why the HOSS step has not been marked complete.
       const now = new Date();
       await rawSaveWorkItem(db, {
         jobID, serviceID: hossService, workflowStepIndex: 2, status: WorkItemStatus.SUCCESSFUL,
@@ -111,7 +111,7 @@ describe('Finalize via the checkRemainingStepsForCompletion function', function 
     let result: boolean;
 
     before(async function () {
-      // query-cmr is done; hoss has one in-flight work item; maskfill exists
+      // query-cmr is done; HOSS has one in-flight work item; maskfill exists
       // downstream with a SUCCESSFUL item from a sibling chain.
       await rawSaveWorkflowStep(db, {
         jobID, serviceID: queryCmrService, stepIndex: 1, is_complete: true,
@@ -134,8 +134,8 @@ describe('Finalize via the checkRemainingStepsForCompletion function', function 
       });
 
       // user_work rows for both services so we can detect whether the loop
-      // advanced past hoss (deleteUserWorkForJobAndService is the per-iteration
-      // side effect that fires *after* the completeness check passes).
+      // advanced past HOSS (deleteUserWorkForJobAndService is the per-iteration
+      // side effect that fires after the completeness check passes).
       await createUserWorkRecord({ job_id: jobID, service_id: hossService }).save(db);
       await createUserWorkRecord({ job_id: jobID, service_id: maskFillService }).save(db);
 
@@ -172,8 +172,8 @@ describe('Finalize via the checkRemainingStepsForCompletion function', function 
     const net2cogService = 'harmony/net2cog-step:4.0.0';
 
     before(async function () {
-      // query-cmr is done; hoss has one in-flight work item; maskfill exists
-      // downstream with a SUCCESSFUL item from a sibling chain.
+      // query-cmr, HOSS, and maskfill are done; net2cog is the last step and still
+      // has an in-flight work item.
       await rawSaveWorkflowStep(db, {
         jobID, serviceID: queryCmrService, stepIndex: 1, is_complete: true,
       });
@@ -202,10 +202,8 @@ describe('Finalize via the checkRemainingStepsForCompletion function', function 
         createdAt: now, updatedAt: now,
       });
 
-
-      // user_work rows for both services so we can detect whether the loop
-      // advanced past hoss (deleteUserWorkForJobAndService is the per-iteration
-      // side effect that fires *after* the completeness check passes).
+      // user_work rows for all three services so we can detect how far the loop
+      // advanced before short-circuiting at net2cog.
       await createUserWorkRecord({ job_id: jobID, service_id: hossService }).save(db);
       await createUserWorkRecord({ job_id: jobID, service_id: maskFillService }).save(db);
       await createUserWorkRecord({ job_id: jobID, service_id: net2cogService }).save(db);
@@ -222,17 +220,17 @@ describe('Finalize via the checkRemainingStepsForCompletion function', function 
       expect(result).to.equal(false);
     });
 
-    it('does marks the HOSS step complete', async function () {
+    it('marks the HOSS step complete', async function () {
       const step = await getWorkflowStepByJobIdStepIndex(db, jobID, 2);
       expect(step.is_complete).to.equal(1);
     });
 
-    it('does marks the downstream maskfill step complete', async function () {
+    it('marks the downstream maskfill step complete', async function () {
       const step = await getWorkflowStepByJobIdStepIndex(db, jobID, 3);
       expect(step.is_complete).to.equal(1);
     });
 
-    it('does not marks the downstream net2cog step complete', async function () {
+    it('does not mark the downstream net2cog step complete', async function () {
       const step = await getWorkflowStepByJobIdStepIndex(db, jobID, 4);
       expect(step.is_complete).to.equal(0);
     });

--- a/services/harmony/test/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/test/workflow-orchestration/work-item-updates.ts
@@ -36,18 +36,14 @@ describe('Finalize via the checkRemainingStepsForCompletion function', function 
       // The first HOSS work item already finished and its downstream maskfill
       // work item ran to completion. A second HOSS work item is still running,
       // which is why the HOSS step has not been marked complete.
-      const now = new Date();
       await rawSaveWorkItem(db, {
         jobID, serviceID: hossService, workflowStepIndex: 2, status: WorkItemStatus.SUCCESSFUL,
-        createdAt: now, updatedAt: now,
       });
       await rawSaveWorkItem(db, {
         jobID, serviceID: maskFillService, workflowStepIndex: 3, status: WorkItemStatus.SUCCESSFUL,
-        createdAt: now, updatedAt: now,
       });
       secondHoss = await rawSaveWorkItem(db, {
         jobID, serviceID: hossService, workflowStepIndex: 2, status: WorkItemStatus.RUNNING,
-        createdAt: now, updatedAt: now,
       });
 
       // user_work rows for both services so we can verify the function deletes
@@ -123,14 +119,11 @@ describe('Finalize via the checkRemainingStepsForCompletion function', function 
         jobID, serviceID: maskFillService, stepIndex: 3, is_complete: false,
       });
 
-      const now = new Date();
       await rawSaveWorkItem(db, {
         jobID, serviceID: hossService, workflowStepIndex: 2, status: WorkItemStatus.RUNNING,
-        createdAt: now, updatedAt: now,
       });
       await rawSaveWorkItem(db, {
         jobID, serviceID: maskFillService, workflowStepIndex: 3, status: WorkItemStatus.SUCCESSFUL,
-        createdAt: now, updatedAt: now,
       });
 
       // user_work rows for both services so we can detect whether the loop
@@ -188,18 +181,14 @@ describe('Finalize via the checkRemainingStepsForCompletion function', function 
       });
 
 
-      const now = new Date();
       await rawSaveWorkItem(db, {
         jobID, serviceID: hossService, workflowStepIndex: 2, status: WorkItemStatus.SUCCESSFUL,
-        createdAt: now, updatedAt: now,
       });
       await rawSaveWorkItem(db, {
         jobID, serviceID: maskFillService, workflowStepIndex: 3, status: WorkItemStatus.SUCCESSFUL,
-        createdAt: now, updatedAt: now,
       });
       await rawSaveWorkItem(db, {
         jobID, serviceID: net2cogService, workflowStepIndex: 4, status: WorkItemStatus.RUNNING,
-        createdAt: now, updatedAt: now,
       });
 
       // user_work rows for all three services so we can detect how far the loop

--- a/services/harmony/test/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/test/workflow-orchestration/work-item-updates.ts
@@ -1,0 +1,61 @@
+import { expect } from 'chai';
+import { deleteStrandedUserWork } from '../../app/backends/workflow-orchestration/work-item-updates';
+import db from '../../app/util/db';
+import { truncateAll } from '../helpers/db';
+import { createUserWorkRecord, rowExists } from '../helpers/user-work';
+import { rawSaveWorkflowStep } from '../helpers/workflow-steps';
+
+describe('Cleanup via the deleteStrandedUserWork function', function () {
+  const jobID = 'job-stranded-uuid';
+  const otherJobID = 'job-other-uuid';
+  const step1Service = 'harmony/query-cmr-step-1';
+  const step2Service = 'harmony/hoss-step-2';
+  const step3Service = 'harmony/maskfill-step-3';
+
+
+  describe('with a three-step job and an initial stepIndex of 2', function () {
+    before(async function () {
+      await rawSaveWorkflowStep(db, { jobID, serviceID: step1Service, stepIndex: 1 });
+      await rawSaveWorkflowStep(db, { jobID, serviceID: step2Service, stepIndex: 2 });
+      await rawSaveWorkflowStep(db, { jobID, serviceID: step3Service, stepIndex: 3 });
+      // Unrelated job sharing the same stepIndex and serviceID — should be left alone.
+      await rawSaveWorkflowStep(db, { jobID: otherJobID, serviceID: step2Service, stepIndex: 2 });
+
+      await createUserWorkRecord({
+        job_id: jobID, service_id: step1Service, ready_count: 0, running_count: 0,
+      }).save(db);
+      await createUserWorkRecord({
+        job_id: jobID, service_id: step2Service, ready_count: 0, running_count: 0,
+      }).save(db);
+      await createUserWorkRecord({
+        job_id: jobID, service_id: step3Service, ready_count: 2, running_count: 0,
+      }).save(db);
+      await createUserWorkRecord({
+        job_id: otherJobID, service_id: step2Service, ready_count: 0, running_count: 0,
+      }).save(db);
+
+      await deleteStrandedUserWork(db, jobID, 2);
+    });
+
+    after(async function () {
+      await truncateAll();
+    });
+
+    it('leaves user_work for steps earlier than stepIndex untouched', async function () {
+      expect(await rowExists(jobID, step1Service)).to.equal(true);
+    });
+
+    it('deletes user_work at or beyond stepIndex when ready and running counts are both 0', async function () {
+      expect(await rowExists(jobID, step2Service)).to.equal(false);
+    });
+
+    it('leaves user_work at or beyond stepIndex when ready_count is non-zero', async function () {
+      expect(await rowExists(jobID, step3Service)).to.equal(true);
+    });
+
+    it('does not touch user_work rows for other jobs', async function () {
+      expect(await rowExists(otherJobID, step2Service)).to.equal(true);
+    });
+  });
+
+});

--- a/services/harmony/test/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/test/workflow-orchestration/work-item-updates.ts
@@ -64,11 +64,11 @@ describe('Finalize via the checkRemainingStepsForCompletion function', function 
       expect(maskFillStep.is_complete).to.equal(0);
     });
 
-    describe('when the second HOSS step finishes.', function () {
+    describe('when the second HOSS step fails.', function () {
       let result: boolean;
 
       before(async function () {
-        secondHoss.status = WorkItemStatus.SUCCESSFUL;
+        secondHoss.status = WorkItemStatus.FAILED;
         await secondHoss.save(db);
 
         const hossStep = await getWorkflowStepByJobIdStepIndex(db, jobID, 2);

--- a/services/harmony/test/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/test/workflow-orchestration/work-item-updates.ts
@@ -8,12 +8,14 @@ import { rawSaveWorkflowStep } from '../helpers/workflow-steps';
 describe('Cleanup via the deleteStrandedUserWork function', function () {
   const jobID = 'job-stranded-uuid';
   const otherJobID = 'job-other-uuid';
-  const step1Service = 'harmony/query-cmr-step-1';
-  const step2Service = 'harmony/hoss-step-2';
-  const step3Service = 'harmony/maskfill-step-3';
+  const step1Service = 'harmony/query-cmr-step-1:1.0.0';
+  const step2Service = 'harmony/hoss-step-2:2.0.0';
+  const step3Service = 'harmony/maskfill-step-3:3.0.0';
 
 
-  describe('with a three-step job and an initial stepIndex of 2', function () {
+  describe('with an incomplete three-step job and an initial stepIndex of 2', function () {
+    let result: boolean;
+
     before(async function () {
       await rawSaveWorkflowStep(db, { jobID, serviceID: step1Service, stepIndex: 1 });
       await rawSaveWorkflowStep(db, { jobID, serviceID: step2Service, stepIndex: 2 });
@@ -34,7 +36,7 @@ describe('Cleanup via the deleteStrandedUserWork function', function () {
         job_id: otherJobID, service_id: step2Service, ready_count: 0, running_count: 0,
       }).save(db);
 
-      await deleteStrandedUserWork(db, jobID, 2);
+      result = await deleteStrandedUserWork(db, jobID, 2);
     });
 
     after(async function () {
@@ -55,6 +57,95 @@ describe('Cleanup via the deleteStrandedUserWork function', function () {
 
     it('does not touch user_work rows for other jobs', async function () {
       expect(await rowExists(otherJobID, step2Service)).to.equal(true);
+    });
+
+    it('returns false because step3 still has remaining work', async function () {
+      expect(result).to.equal(false);
+    });
+  });
+
+  describe('with a complete three-step job.', function () {
+    let result: boolean;
+
+    before(async function () {
+      await rawSaveWorkflowStep(db, { jobID, serviceID: step1Service, stepIndex: 1 });
+      await rawSaveWorkflowStep(db, { jobID, serviceID: step2Service, stepIndex: 2 });
+      await rawSaveWorkflowStep(db, { jobID, serviceID: step3Service, stepIndex: 3 });
+
+      await createUserWorkRecord({
+        job_id: jobID, service_id: step1Service, ready_count: 5, running_count: 0,
+      }).save(db);
+      await createUserWorkRecord({
+        job_id: jobID, service_id: step2Service, ready_count: 0, running_count: 0,
+      }).save(db);
+      await createUserWorkRecord({
+        job_id: jobID, service_id: step3Service, ready_count: 0, running_count: 0,
+      }).save(db);
+
+      result = await deleteStrandedUserWork(db, jobID, 2);
+    });
+
+    after(async function () {
+      await truncateAll();
+    });
+
+    it('deletes all rows for stepIndex and beyond', async function () {
+      expect(await rowExists(jobID, step2Service)).to.equal(false);
+      expect(await rowExists(jobID, step3Service)).to.equal(false);
+    });
+
+    it('returns true when no remaining work exists at or beyond stepIndex', async function () {
+      expect(result).to.equal(true);
+    });
+  });
+
+  describe('when a step at or beyond stepIndex has a non-zero running_count', function () {
+    before(async function () {
+      await rawSaveWorkflowStep(db, { jobID, serviceID: step2Service, stepIndex: 2 });
+
+      await createUserWorkRecord({
+        job_id: jobID, service_id: step2Service, ready_count: 0, running_count: 3,
+      }).save(db);
+    });
+
+    after(async function () {
+      await truncateAll();
+    });
+
+    it('leaves the row intact', async function () {
+      await deleteStrandedUserWork(db, jobID, 2);
+      expect(await rowExists(jobID, step2Service)).to.equal(true);
+    });
+
+    it('returns false', async function () {
+      const result = await deleteStrandedUserWork(db, jobID, 2);
+      expect(result).to.equal(false);
+    });
+  });
+
+  describe('when stepIndex is beyond all workflow steps', function () {
+    let result: boolean;
+
+    before(async function () {
+      await rawSaveWorkflowStep(db, { jobID, serviceID: step1Service, stepIndex: 1 });
+
+      await createUserWorkRecord({
+        job_id: jobID, service_id: step1Service, ready_count: 5, running_count: 0,
+      }).save(db);
+
+      result = await deleteStrandedUserWork(db, jobID, 99);
+    });
+
+    after(async function () {
+      await truncateAll();
+    });
+
+    it('leaves all user_work rows untouched', async function () {
+      expect(await rowExists(jobID, step1Service)).to.equal(true);
+    });
+
+    it('returns true when there are no steps to inspect', async function () {
+      expect(result).to.equal(true);
     });
   });
 

--- a/services/harmony/test/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/test/workflow-orchestration/work-item-updates.ts
@@ -5,6 +5,7 @@ import WorkItem from '../../app/models/work-item';
 import { getWorkflowStepByJobIdStepIndex } from '../../app/models/workflow-steps';
 import db from '../../app/util/db';
 import { truncateAll } from '../helpers/db';
+import { createUserWorkRecord, rowExists } from '../helpers/user-work';
 import { rawSaveWorkItem } from '../helpers/work-items';
 import { rawSaveWorkflowStep } from '../helpers/workflow-steps';
 
@@ -48,6 +49,11 @@ describe('Finalize via the checkRemainingStepsForCompletion function', function 
         jobID, serviceID: hossService, workflowStepIndex: 2, status: WorkItemStatus.RUNNING,
         createdAt: now, updatedAt: now,
       });
+
+      // user_work rows for both services so we can verify the function deletes
+      // them as it walks the chain marking steps complete.
+      await createUserWorkRecord({ job_id: jobID, service_id: hossService }).save(db);
+      await createUserWorkRecord({ job_id: jobID, service_id: maskFillService }).save(db);
     });
 
     after(async function () {
@@ -62,6 +68,11 @@ describe('Finalize via the checkRemainingStepsForCompletion function', function 
     it('has completed the metadata steps, but not marked them as complete', async function () {
       const maskFillStep = await getWorkflowStepByJobIdStepIndex(db, jobID, 3);
       expect(maskFillStep.is_complete).to.equal(0);
+    });
+
+    it('has not yet deleted user_work for either service', async function () {
+      expect(await rowExists(jobID, hossService)).to.equal(true);
+      expect(await rowExists(jobID, maskFillService)).to.equal(true);
     });
 
     describe('when the second HOSS step fails.', function () {
@@ -88,6 +99,148 @@ describe('Finalize via the checkRemainingStepsForCompletion function', function 
       it('returns true', function () {
         expect(result).to.equal(true);
       });
+
+      it('deletes user_work for both completed services', async function () {
+        expect(await rowExists(jobID, hossService)).to.equal(false);
+        expect(await rowExists(jobID, maskFillService)).to.equal(false);
+      });
+    });
+  });
+
+  describe('when the HOSS step still has a running work item', function () {
+    let result: boolean;
+
+    before(async function () {
+      // query-cmr is done; hoss has one in-flight work item; maskfill exists
+      // downstream with a SUCCESSFUL item from a sibling chain.
+      await rawSaveWorkflowStep(db, {
+        jobID, serviceID: queryCmrService, stepIndex: 1, is_complete: true,
+      });
+      await rawSaveWorkflowStep(db, {
+        jobID, serviceID: hossService, stepIndex: 2, is_complete: false,
+      });
+      await rawSaveWorkflowStep(db, {
+        jobID, serviceID: maskFillService, stepIndex: 3, is_complete: false,
+      });
+
+      const now = new Date();
+      await rawSaveWorkItem(db, {
+        jobID, serviceID: hossService, workflowStepIndex: 2, status: WorkItemStatus.RUNNING,
+        createdAt: now, updatedAt: now,
+      });
+      await rawSaveWorkItem(db, {
+        jobID, serviceID: maskFillService, workflowStepIndex: 3, status: WorkItemStatus.SUCCESSFUL,
+        createdAt: now, updatedAt: now,
+      });
+
+      // user_work rows for both services so we can detect whether the loop
+      // advanced past hoss (deleteUserWorkForJobAndService is the per-iteration
+      // side effect that fires *after* the completeness check passes).
+      await createUserWorkRecord({ job_id: jobID, service_id: hossService }).save(db);
+      await createUserWorkRecord({ job_id: jobID, service_id: maskFillService }).save(db);
+
+      const hossStep = await getWorkflowStepByJobIdStepIndex(db, jobID, 2);
+      result = await checkRemainingStepsForCompletion(db, jobID, hossStep);
+    });
+
+    after(async function () {
+      await truncateAll();
+    });
+
+    it('returns false', function () {
+      expect(result).to.equal(false);
+    });
+
+    it('does not mark the HOSS step complete', async function () {
+      const step = await getWorkflowStepByJobIdStepIndex(db, jobID, 2);
+      expect(step.is_complete).to.equal(0);
+    });
+
+    it('does not mark the downstream maskfill step complete', async function () {
+      const step = await getWorkflowStepByJobIdStepIndex(db, jobID, 3);
+      expect(step.is_complete).to.equal(0);
+    });
+
+    it('short-circuits before deleting any user_work rows', async function () {
+      expect(await rowExists(jobID, hossService)).to.equal(true);
+      expect(await rowExists(jobID, maskFillService)).to.equal(true);
+    });
+  });
+
+  describe('when a 4 step chain has its last step still running', function () {
+    let result: boolean;
+    const net2cogService = 'harmony/net2cog-step:4.0.0';
+
+    before(async function () {
+      // query-cmr is done; hoss has one in-flight work item; maskfill exists
+      // downstream with a SUCCESSFUL item from a sibling chain.
+      await rawSaveWorkflowStep(db, {
+        jobID, serviceID: queryCmrService, stepIndex: 1, is_complete: true,
+      });
+      await rawSaveWorkflowStep(db, {
+        jobID, serviceID: hossService, stepIndex: 2, is_complete: false,
+      });
+      await rawSaveWorkflowStep(db, {
+        jobID, serviceID: maskFillService, stepIndex: 3, is_complete: false,
+      });
+      await rawSaveWorkflowStep(db, {
+        jobID, serviceID: net2cogService, stepIndex: 4, is_complete: false,
+      });
+
+
+      const now = new Date();
+      await rawSaveWorkItem(db, {
+        jobID, serviceID: hossService, workflowStepIndex: 2, status: WorkItemStatus.SUCCESSFUL,
+        createdAt: now, updatedAt: now,
+      });
+      await rawSaveWorkItem(db, {
+        jobID, serviceID: maskFillService, workflowStepIndex: 3, status: WorkItemStatus.SUCCESSFUL,
+        createdAt: now, updatedAt: now,
+      });
+      await rawSaveWorkItem(db, {
+        jobID, serviceID: net2cogService, workflowStepIndex: 4, status: WorkItemStatus.RUNNING,
+        createdAt: now, updatedAt: now,
+      });
+
+
+      // user_work rows for both services so we can detect whether the loop
+      // advanced past hoss (deleteUserWorkForJobAndService is the per-iteration
+      // side effect that fires *after* the completeness check passes).
+      await createUserWorkRecord({ job_id: jobID, service_id: hossService }).save(db);
+      await createUserWorkRecord({ job_id: jobID, service_id: maskFillService }).save(db);
+      await createUserWorkRecord({ job_id: jobID, service_id: net2cogService }).save(db);
+
+      const hossStep = await getWorkflowStepByJobIdStepIndex(db, jobID, 2);
+      result = await checkRemainingStepsForCompletion(db, jobID, hossStep);
+    });
+
+    after(async function () {
+      await truncateAll();
+    });
+
+    it('returns false', function () {
+      expect(result).to.equal(false);
+    });
+
+    it('does marks the HOSS step complete', async function () {
+      const step = await getWorkflowStepByJobIdStepIndex(db, jobID, 2);
+      expect(step.is_complete).to.equal(1);
+    });
+
+    it('does marks the downstream maskfill step complete', async function () {
+      const step = await getWorkflowStepByJobIdStepIndex(db, jobID, 3);
+      expect(step.is_complete).to.equal(1);
+    });
+
+    it('does not marks the downstream net2cog step complete', async function () {
+      const step = await getWorkflowStepByJobIdStepIndex(db, jobID, 4);
+      expect(step.is_complete).to.equal(0);
+    });
+
+    it('short-circuits before deleting the net2cog user_work rows', async function () {
+      expect(await rowExists(jobID, hossService)).to.equal(false);
+      expect(await rowExists(jobID, maskFillService)).to.equal(false);
+      expect(await rowExists(jobID, net2cogService)).to.equal(true);
     });
   });
 });

--- a/services/harmony/test/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/test/workflow-orchestration/work-item-updates.ts
@@ -1,152 +1,93 @@
 import { expect } from 'chai';
-import { deleteStrandedUserWork } from '../../app/backends/workflow-orchestration/work-item-updates';
+import { checkRemainingStepsForCompletion } from '../../app/backends/workflow-orchestration/work-item-updates';
+import { WorkItemStatus } from '../../app/models/work-item-interface';
+import WorkItem from '../../app/models/work-item';
+import { getWorkflowStepByJobIdStepIndex } from '../../app/models/workflow-steps';
 import db from '../../app/util/db';
 import { truncateAll } from '../helpers/db';
-import { createUserWorkRecord, rowExists } from '../helpers/user-work';
+import { rawSaveWorkItem } from '../helpers/work-items';
 import { rawSaveWorkflowStep } from '../helpers/workflow-steps';
 
-describe('Cleanup via the deleteStrandedUserWork function', function () {
+describe('Finalize via the checkRemainingStepsForCompletion function', function () {
+
   const jobID = 'job-stranded-uuid';
-  const otherJobID = 'job-other-uuid';
-  const step1Service = 'harmony/query-cmr-step-1:1.0.0';
-  const step2Service = 'harmony/hoss-step-2:2.0.0';
-  const step3Service = 'harmony/maskfill-step-3:3.0.0';
+  const queryCmrService = 'harmony/query-cmr-step:1.0.0';
+  const hossService = 'harmony/hoss-step:2.0.0';
+  const maskFillService = 'harmony/maskfill-step:3.0.0';
 
+  describe('when HOSS has two work items and the second fails after the first chain completes', function () {
 
-  describe('with an incomplete three-step job and an initial stepIndex of 2', function () {
-    let result: boolean;
+    let secondHoss: WorkItem;
 
     before(async function () {
-      await rawSaveWorkflowStep(db, { jobID, serviceID: step1Service, stepIndex: 1 });
-      await rawSaveWorkflowStep(db, { jobID, serviceID: step2Service, stepIndex: 2 });
-      await rawSaveWorkflowStep(db, { jobID, serviceID: step3Service, stepIndex: 3 });
-      // Unrelated job sharing the same stepIndex and serviceID — should be left alone.
-      await rawSaveWorkflowStep(db, { jobID: otherJobID, serviceID: step2Service, stepIndex: 2 });
+      // Upstream step is already complete; hoss and the downstream maskfill
+      // step are not yet marked complete.
+      await rawSaveWorkflowStep(db, {
+        jobID, serviceID: queryCmrService, stepIndex: 1, is_complete: true,
+      });
+      await rawSaveWorkflowStep(db, {
+        jobID, serviceID: hossService, stepIndex: 2, is_complete: false,
+      });
+      await rawSaveWorkflowStep(db, {
+        jobID, serviceID: maskFillService, stepIndex: 3, is_complete: false,
+      });
 
-      await createUserWorkRecord({
-        job_id: jobID, service_id: step1Service, ready_count: 0, running_count: 0,
-      }).save(db);
-      await createUserWorkRecord({
-        job_id: jobID, service_id: step2Service, ready_count: 0, running_count: 0,
-      }).save(db);
-      await createUserWorkRecord({
-        job_id: jobID, service_id: step3Service, ready_count: 2, running_count: 0,
-      }).save(db);
-      await createUserWorkRecord({
-        job_id: otherJobID, service_id: step2Service, ready_count: 0, running_count: 0,
-      }).save(db);
-
-      result = await deleteStrandedUserWork(db, jobID, 2);
+      // The first hoss work item already finished and its downstream maskfill
+      // work item ran to completion. A second hoss work item is still running,
+      // which is why the hoss step has not been marked complete.
+      const now = new Date();
+      await rawSaveWorkItem(db, {
+        jobID, serviceID: hossService, workflowStepIndex: 2, status: WorkItemStatus.SUCCESSFUL,
+        createdAt: now, updatedAt: now,
+      });
+      await rawSaveWorkItem(db, {
+        jobID, serviceID: maskFillService, workflowStepIndex: 3, status: WorkItemStatus.SUCCESSFUL,
+        createdAt: now, updatedAt: now,
+      });
+      secondHoss = await rawSaveWorkItem(db, {
+        jobID, serviceID: hossService, workflowStepIndex: 2, status: WorkItemStatus.RUNNING,
+        createdAt: now, updatedAt: now,
+      });
     });
 
     after(async function () {
       await truncateAll();
     });
 
-    it('leaves user_work for steps earlier than stepIndex untouched', async function () {
-      expect(await rowExists(jobID, step1Service)).to.equal(true);
+    it('has not yet marked the hoss step complete', async function () {
+      const hossStep = await getWorkflowStepByJobIdStepIndex(db, jobID, 2);
+      expect(hossStep.is_complete).to.equal(0);
     });
 
-    it('deletes user_work at or beyond stepIndex when ready and running counts are both 0', async function () {
-      expect(await rowExists(jobID, step2Service)).to.equal(false);
+    it('has completed the metadata steps, but not marked them as complete', async function () {
+      const maskFillStep = await getWorkflowStepByJobIdStepIndex(db, jobID, 3);
+      expect(maskFillStep.is_complete).to.equal(0);
     });
 
-    it('leaves user_work at or beyond stepIndex when ready_count is non-zero', async function () {
-      expect(await rowExists(jobID, step3Service)).to.equal(true);
-    });
+    describe('when the second HOSS step finishes.', function () {
+      let result: boolean;
 
-    it('does not touch user_work rows for other jobs', async function () {
-      expect(await rowExists(otherJobID, step2Service)).to.equal(true);
-    });
+      before(async function () {
+        secondHoss.status = WorkItemStatus.SUCCESSFUL;
+        await secondHoss.save(db);
 
-    it('returns false because step3 still has remaining work', async function () {
-      expect(result).to.equal(false);
-    });
-  });
+        const hossStep = await getWorkflowStepByJobIdStepIndex(db, jobID, 2);
+        result = await checkRemainingStepsForCompletion(db, jobID, hossStep);
+      });
 
-  describe('with a complete three-step job.', function () {
-    let result: boolean;
+      it('marks the hoss step complete', async function () {
+        const step = await getWorkflowStepByJobIdStepIndex(db, jobID, 2);
+        expect(step.is_complete).to.equal(1);
+      });
 
-    before(async function () {
-      await rawSaveWorkflowStep(db, { jobID, serviceID: step1Service, stepIndex: 1 });
-      await rawSaveWorkflowStep(db, { jobID, serviceID: step2Service, stepIndex: 2 });
-      await rawSaveWorkflowStep(db, { jobID, serviceID: step3Service, stepIndex: 3 });
+      it('marks the downstream maskfill step complete', async function () {
+        const step = await getWorkflowStepByJobIdStepIndex(db, jobID, 3);
+        expect(step.is_complete).to.equal(1);
+      });
 
-      await createUserWorkRecord({
-        job_id: jobID, service_id: step1Service, ready_count: 5, running_count: 0,
-      }).save(db);
-      await createUserWorkRecord({
-        job_id: jobID, service_id: step2Service, ready_count: 0, running_count: 0,
-      }).save(db);
-      await createUserWorkRecord({
-        job_id: jobID, service_id: step3Service, ready_count: 0, running_count: 0,
-      }).save(db);
-
-      result = await deleteStrandedUserWork(db, jobID, 2);
-    });
-
-    after(async function () {
-      await truncateAll();
-    });
-
-    it('deletes all rows for stepIndex and beyond', async function () {
-      expect(await rowExists(jobID, step2Service)).to.equal(false);
-      expect(await rowExists(jobID, step3Service)).to.equal(false);
-    });
-
-    it('returns true when no remaining work exists at or beyond stepIndex', async function () {
-      expect(result).to.equal(true);
+      it('returns true', function () {
+        expect(result).to.equal(true);
+      });
     });
   });
-
-  describe('when a step at or beyond stepIndex has a non-zero running_count', function () {
-    before(async function () {
-      await rawSaveWorkflowStep(db, { jobID, serviceID: step2Service, stepIndex: 2 });
-
-      await createUserWorkRecord({
-        job_id: jobID, service_id: step2Service, ready_count: 0, running_count: 3,
-      }).save(db);
-    });
-
-    after(async function () {
-      await truncateAll();
-    });
-
-    it('leaves the row intact', async function () {
-      await deleteStrandedUserWork(db, jobID, 2);
-      expect(await rowExists(jobID, step2Service)).to.equal(true);
-    });
-
-    it('returns false', async function () {
-      const result = await deleteStrandedUserWork(db, jobID, 2);
-      expect(result).to.equal(false);
-    });
-  });
-
-  describe('when stepIndex is beyond all workflow steps', function () {
-    let result: boolean;
-
-    before(async function () {
-      await rawSaveWorkflowStep(db, { jobID, serviceID: step1Service, stepIndex: 1 });
-
-      await createUserWorkRecord({
-        job_id: jobID, service_id: step1Service, ready_count: 5, running_count: 0,
-      }).save(db);
-
-      result = await deleteStrandedUserWork(db, jobID, 99);
-    });
-
-    after(async function () {
-      await truncateAll();
-    });
-
-    it('leaves all user_work rows untouched', async function () {
-      expect(await rowExists(jobID, step1Service)).to.equal(true);
-    });
-
-    it('returns true when there are no steps to inspect', async function () {
-      expect(result).to.equal(true);
-    });
-  });
-
 });


### PR DESCRIPTION
## Jira Issue ID

[HARMONY-2254](https://bugs.earthdata.nasa.gov/browse/HARMONY-2254)

## Description

More edge case handling to prevent jobs from being stuck in a `running-with-errors` state.

Determined (that at least one reason) jobs get stuck in running-with-errors is that workflow-steps.ts updateIsComplete() has a prevStepComplete guard that prevents step N from being marked complete until step N-1 is complete.
In practice we see multi-granule operations where Granule A is retrying, when Granule B competes all of it's work before Granule A has failed. There is no way to ever complete the job and make each step as complete.

This PR adds code that catches the case where all workitems have completed, there's a next workflow step, but a next workitem wasn't created.  In that case we try to delete all of the stranded work from the user_work table. and if there is no ready or queued work downstream of the current (probably failed) step. We assume the work is complete for the job and complete it.


## Local Test Steps

Best way to test is to first generate a failing state with the main branch code.

Set your harmony `.env` with these values

```sh
# HARMONY-2254
WORK_ITEM_RETRY_LIMIT=3
HOSS_IMAGE=ghcr.io/nasa/harmony-opendap-subsetter:1.2.3
HOSS_SERVICE_QUEUE_URLS='["ghcr.io/nasa/harmony-opendap-subsetter:1.2.3,http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/hoss.fifo"]'
```

This HOSS version retries with a missing opendap link and the request is set to find 2 granules one that is missing it's opendap link.

You could bump the retry limit a bunch, but it's more predicitive to add a delay around L785 of app/backends/workflow-orchestration/work-item-updates.ts to sleep right before doing the last retry.

``` javascript
      } else {
        logger.info('Sleeping for 15 seconds for bug testing.');
        await new Promise((res) => setTimeout(res, 15000));
        logger.warn(`Retry limit of ${env.workItemRetryLimit} exceeded`);
        logger.warn(
          `Updating work item for ${workItemID} to ${status} with message ${message}`,
          { workFailureMessage: message, serviceId: workItem.serviceID, status },
        );
      }
```


Run this Request.

http://localhost:3000/C1268429762-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&subset=lat(43.42694%3A44.67045)&subset=lon(5.03079%3A7.116)&subset=time(%222015-03-31T17%3A06%3A00Z%22%3A%222015-03-31T17%3A10%3A00Z%22)&label=harmony-py&format=image%2Ftiff&variable=Soil_Moisture_Retrieval_Data_1km%2Fretrieval_qual_flag_1km&variable=Soil_Moisture_Retrieval_Data_1km%2Fretrieval_qual_flag_apm_1km&variable=Soil_Moisture_Retrieval_Data_1km%2Fsoil_moisture_1km&variable=Soil_Moisture_Retrieval_Data_1km%2Fsoil_moisture_apm_1km


You will see the job stuck in running-with-errors.


pull and checkout this branch, restart harmony and run the same request.

You should see granlue B complete before granule A fails the HOSS step, but the job should complete with errors.


## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [X] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow orchestration now detects out-of-order step completion so jobs can finish correctly, clean up leftover work entries, and report final status/progress and outputs reliably during retries.

* **Tests**
  * Added regression and unit tests covering race conditions, multi-step completion scenarios, and job finalization under retry/failure conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->