### PR TITLE
HARMONY-2338: Fix performance issue with work scheduler queueing work items

### DIFF
--- a/bin/deploy-services
+++ b/bin/deploy-services
@@ -26,14 +26,12 @@ fi
 if [ ! "$LOCAL_DEV" = true ]; then
 
   # create the work scheduler
-  if [ "$USE_SERVICE_QUEUES" = true ]; then
-    file="services/work-scheduler/config/service-template.yaml"
-    if [ ! -f "$file" ]; then
-      echo "work scheduler template was not found."
-      exit 1
-    fi
-    envsubst < $file | kubectl apply -f - -n harmony
+  file="services/work-scheduler/config/service-template.yaml"
+  if [ ! -f "$file" ]; then
+    echo "work scheduler template was not found."
+    exit 1
   fi
+  envsubst < $file | kubectl apply -f - -n harmony
 
   # create the work updaters
   file="services/work-updater/config/service-template-large.yaml"
@@ -80,15 +78,13 @@ envsubst < $file | kubectl apply -f - -n harmony
 
 harmony_pod=$(kubectl get pods -n harmony -l app=harmony | grep -v NAME | awk '{print $1;}')
 # create the service queue
-if [ "$USE_SERVICE_QUEUES" == "true" ]; then
-  if [ "$harmony_pod" == "" ]; then
-    # Not running harmony in a box
-    awslocal sqs create-queue --queue-name "query-cmr.fifo" --attributes FifoQueue=true,ContentBasedDeduplication=true --region us-west-2
-  else
-    # Running harmony in a box
-    echo "Creating query-cmr queue using harmony container"
-    kubectl -n harmony exec -it $harmony_pod -- awslocal sqs create-queue --queue-name "query-cmr.fifo" --attributes FifoQueue=true,ContentBasedDeduplication=true --region us-west-2
-  fi
+if [ "$harmony_pod" == "" ]; then
+  # Not running harmony in a box
+  awslocal sqs create-queue --queue-name "query-cmr.fifo" --attributes FifoQueue=true,ContentBasedDeduplication=true --region us-west-2
+else
+  # Running harmony in a box
+  echo "Creating query-cmr queue using harmony container"
+  kubectl -n harmony exec -it $harmony_pod -- awslocal sqs create-queue --queue-name "query-cmr.fifo" --attributes FifoQueue=true,ContentBasedDeduplication=true --region us-west-2
 fi
 
 # create the other services
@@ -158,14 +154,12 @@ do
   envsubst < $file | kubectl apply -f - -n harmony
 
   # create the service queue
-  if [ "$USE_SERVICE_QUEUES" == "true" ]; then
-    if [ "$harmony_pod" == "" ]; then
-      # Not running harmony in a box
-      awslocal sqs create-queue --queue-name "${SERVICE_NAME}.fifo" --attributes FifoQueue=true,ContentBasedDeduplication=true --region us-west-2
-    else
-      # Running harmony in a box
-      echo "Creating ${SERVICE_NAME} queue using harmony container"
-      kubectl -n harmony exec -it $harmony_pod -- awslocal sqs create-queue --queue-name "${SERVICE_NAME}.fifo" --attributes FifoQueue=true,ContentBasedDeduplication=true --region us-west-2
-    fi
+  if [ "$harmony_pod" == "" ]; then
+    # Not running harmony in a box
+    awslocal sqs create-queue --queue-name "${SERVICE_NAME}.fifo" --attributes FifoQueue=true,ContentBasedDeduplication=true --region us-west-2
+  else
+    # Running harmony in a box
+    echo "Creating ${SERVICE_NAME} queue using harmony container"
+    kubectl -n harmony exec -it $harmony_pod -- awslocal sqs create-queue --queue-name "${SERVICE_NAME}.fifo" --attributes FifoQueue=true,ContentBasedDeduplication=true --region us-west-2
   fi
 done

--- a/db/migrations/20260521152407_add_index_to_support_fair_queueing_work_items.js
+++ b/db/migrations/20260521152407_add_index_to_support_fair_queueing_work_items.js
@@ -1,0 +1,15 @@
+exports.up = function (knex) {
+  return knex.schema
+    .raw(`
+      CREATE INDEX work_items_ready_lookup_index
+      ON work_items ("jobID", status, "serviceID", id)
+      WHERE status = 'ready'
+    `);
+};
+
+exports.down = function (knex) {
+  return knex.schema
+    .raw(`
+      DROP INDEX IF EXISTS work_items_ready_lookup_index;
+    `);
+};

--- a/packages/util/env-defaults
+++ b/packages/util/env-defaults
@@ -90,9 +90,6 @@ DATABASE_READONLY_PASSWORD=changeme
 # Whether to use encryption when communicating with the database.
 DB_USE_SSL=false
 
-# Whether or not to use queues for retrieving work-items when handling polling for work
-USE_SERVICE_QUEUES=true
-
 # SQS queue used to request scheduling of work items for a service
 WORK_ITEM_SCHEDULER_QUEUE_URL=http://sqs.us-west-2.localhost.localstack.cloud:4566/000000000000/work-item-scheduler-queue
 

--- a/packages/util/env.ts
+++ b/packages/util/env.ts
@@ -222,8 +222,6 @@ export class HarmonyEnv {
 
   useLocalstack: boolean;
 
-  useServiceQueues: boolean;
-
   @IsUrl(hostRegexWhitelist)
   workItemSchedulerQueueUrl: string;
 

--- a/packages/util/test/env.ts
+++ b/packages/util/test/env.ts
@@ -36,10 +36,6 @@ describe('HarmonyEnv', function () {
       expect(getValidationErrors(this.validEnv).length).to.eql(0);
     });
 
-    it('sets special values (values that are set manually) using env-defaults', function () {
-      expect(this.validEnv.useServiceQueues).to.eql(true);
-    });
-
     it('sets non-special values using env-defaults', function () {
       expect(this.validEnv.localstackHost).to.eql('localstack');
     });

--- a/services/harmony/app/backends/workflow-orchestration/work-item-polling.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-polling.ts
@@ -127,6 +127,7 @@ export async function getWorkItemsFromDatabase(
       });
     }
   } catch (err) {
+    reqLogger.error(err);
     reqLogger.error(`Error getting works from database: ${err.message}`);
   }
   return workItems;

--- a/services/harmony/app/backends/workflow-orchestration/work-item-polling.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-polling.ts
@@ -2,18 +2,16 @@ import { Logger } from 'winston';
 
 import { calculateQueryCmrLimit, processSchedulerQueue, QUERY_CMR_SERVICE_REGEX } from './util';
 import {
-  getNextJobIdForUsernameAndService, getNextJobIds, getNextUsernameForWork,
-  incrementRunningAndDecrementReadyCounts, recalculateCounts,
+  getNextJobIds, incrementRunningAndDecrementReadyCounts, recalculateCounts,
 } from '../../models/user-work';
 import WorkItem, {
-  getNextWorkItem, getNextWorkItems, getWorkItemStatus, updateWorkItemStatuses,
+  getNextWorkItems, getWorkItemStatus, updateWorkItemStatuses,
 } from '../../models/work-item';
 import { WorkItemStatus } from '../../models/work-item-interface';
 import WorkflowStep from '../../models/workflow-steps';
 import { Cache } from '../../util/cache/cache';
 import { MemoryCache } from '../../util/cache/memory-cache';
 import db, { Transaction } from '../../util/db';
-import env from '../../util/env';
 import logger from '../../util/log';
 import {
   getQueueForUrl, getQueueUrlForService, getWorkSchedulerQueue,
@@ -51,48 +49,6 @@ async function operationFetcher(key: string): Promise<string> {
 }
 
 const operationCache: Cache = new MemoryCache(operationFetcher);
-
-
-/**
- * Get a work item from the database for the given service ID.
- *
- * @param serviceID - the id of the service to get work for
- * @param reqLogger - a logger instance
- * @returns A work item from the database for the given service ID
- */
-export async function getWorkFromDatabase(serviceID: string, reqLogger: Logger): Promise<WorkItemData | null> {
-  let result: WorkItemData | null = null;
-  try {
-    await db.transaction(async (tx) => {
-      const username = await getNextUsernameForWork(tx, serviceID as string);
-      if (username) {
-        const jobID = await getNextJobIdForUsernameAndService(tx, serviceID as string, username);
-        if (jobID) {
-          const workItem = await getNextWorkItem(tx, serviceID as string, jobID);
-          if (workItem) {
-            await incrementRunningAndDecrementReadyCounts(tx, jobID, serviceID as string);
-
-            if (workItem && QUERY_CMR_SERVICE_REGEX.test(workItem.serviceID)) {
-              const childLogger = reqLogger.child({ workItemId: workItem.id });
-              const maxCmrGranules = await calculateQueryCmrLimit(tx, workItem, childLogger);
-              reqLogger.debug(`Found work item ${workItem.id} for service ${serviceID} with max CMR granules ${maxCmrGranules}`);
-              result = { workItem, maxCmrGranules };
-            } else {
-              result = { workItem };
-            }
-          } else {
-            reqLogger.warn(`user_work is out of sync for user ${username} and job ${jobID}, could not find ready work item`);
-            reqLogger.warn(`recalculating ready and running counts for job ${jobID}`);
-            await recalculateCounts(tx, jobID);
-          }
-        }
-      }
-    });
-  } catch (err) {
-    reqLogger.error(`Error getting work from database: ${err.message}`);
-  }
-  return result;
-}
 
 /**
  * Return a randomly shuffled list of the given list.
@@ -138,7 +94,7 @@ export async function getWorkItemsFromDatabase(
     let workSize;
 
     // Define the inner function outside of the loop
-    const processJob = async (tx: Transaction, jobId: string) : Promise<void> => {
+    const processJob = async (tx: Transaction, jobId: string): Promise<void> => {
       // the work size is readjusted based on work items retrieved from the previous job
       workSize = (remainingNumOfJobs > 0) ? Math.ceil(remainingBatchSize / remainingNumOfJobs) : 1;
       const nextWorkItems = await getNextWorkItems(tx, serviceID as string, jobId, workSize);
@@ -182,11 +138,8 @@ export async function getWorkItemsFromDatabase(
  * @param serviceID - The service ID for which to request work
  */
 export async function makeWorkScheduleRequest(serviceID: string): Promise<void> {
-  // only do this if we are using service queues
-  if (env.useServiceQueues) {
-    const schedulerQueue = getWorkSchedulerQueue();
-    await schedulerQueue.sendMessage(serviceID);
-  }
+  const schedulerQueue = getWorkSchedulerQueue();
+  await schedulerQueue.sendMessage(serviceID);
 }
 
 /**

--- a/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
+++ b/services/harmony/app/backends/workflow-orchestration/work-item-updates.ts
@@ -937,7 +937,7 @@ export async function processWorkItem(
         }
         if (
           (!didCreateWorkItem && (!nextWorkflowStep || nextWorkflowStep.workItemCount < 1))
-            || userWorkCompleteForJob
+          || userWorkCompleteForJob
         ) {
           // If all granules are finished mark the job as finished
           const { finalStatus, finalMessage } = await getFinalStatusAndMessageForJob(tx, job);

--- a/services/harmony/app/backends/workflow-orchestration/workflow-orchestration.ts
+++ b/services/harmony/app/backends/workflow-orchestration/workflow-orchestration.ts
@@ -2,11 +2,10 @@ import { NextFunction, Response } from 'express';
 import _ from 'lodash';
 import { Logger } from 'winston';
 
-import { getWorkFromDatabase, getWorkFromQueue, WorkItemData } from './work-item-polling';
+import { getWorkFromQueue } from './work-item-polling';
 import DataOperation from '../../models/data-operation';
 import HarmonyRequest from '../../models/harmony-request';
 import WorkItemUpdate from '../../models/work-item-update';
-import env from '../../util/env';
 import { WorkItemQueueType } from '../../util/queue/queue';
 import { getQueueForType } from '../../util/queue/queue-factory';
 
@@ -30,13 +29,9 @@ export async function getWork(
 
 
   let responded = false;
-  let workItemData: WorkItemData | null;
 
-  if (env.useServiceQueues) {
-    workItemData = await getWorkFromQueue(serviceID as string, reqLogger);
-  } else {
-    workItemData = await getWorkFromDatabase(serviceID as string, reqLogger);
-  }
+  const workItemData = await getWorkFromQueue(serviceID as string, reqLogger);
+
 
   if (workItemData) {
     const { workItem, maxCmrGranules } = workItemData;

--- a/services/harmony/app/models/user-work.ts
+++ b/services/harmony/app/models/user-work.ts
@@ -121,7 +121,7 @@ export async function getNextJobIds(
   + 'SELECT R.job_id, R.last_worked, R.username, R.is_async, ROW_NUMBER() OVER (ORDER BY R.user_row_num, R.last_worked ASC) AS overall_row_num '
   + `FROM RankedJobs R) Interleaved WHERE overall_row_num <= ${batchSize} ORDER BY is_async, overall_row_num`;
   const results = await tx.raw(sql);
-  return results.rows.map((r) => r.job_id) || [];
+  return results.rows?.map((r) => r.job_id) || [];
 }
 
 /**

--- a/services/harmony/app/models/work-item.ts
+++ b/services/harmony/app/models/work-item.ts
@@ -192,10 +192,7 @@ export async function getNextWorkItem(
         // in case a service for the same job produces an output with the same file name
         workItemData.operation.stagingLocation += `${workItemData.id}/`;
         const startedAt = new Date();
-        let status = WorkItemStatus.RUNNING;
-        if (env.useServiceQueues) {
-          status = WorkItemStatus.QUEUED;
-        }
+        const status = WorkItemStatus.QUEUED;
         await tx(WorkItem.table)
           .update({
             status,
@@ -248,10 +245,7 @@ export async function getNextWorkItems(
 
     if (workItemData?.length > 0) {
       const startedAt = new Date();
-      let status = WorkItemStatus.RUNNING;
-      if (env.useServiceQueues) {
-        status = WorkItemStatus.QUEUED;
-      }
+      const status = WorkItemStatus.QUEUED;
       await tx(WorkItem.table)
         .update({
           status,
@@ -874,10 +868,8 @@ export async function getRetryCounts(
 // Listen for work items being created and put a message on the scheduler queue asking it to
 // schedule some WorkItems for the service
 eventEmitter.on(WorkItemEvent.CREATED, async (workItem: WorkItem) => {
-  if (env.useServiceQueues) {
-    const { serviceID } = workItem;
-    logger.debug(`Work item created for service ${serviceID}, putting message on scheduler queue`);
-    const queue = getWorkSchedulerQueue();
-    await queue.sendMessage(serviceID);
-  }
+  const { serviceID } = workItem;
+  logger.debug(`Work item created for service ${serviceID}, putting message on scheduler queue`);
+  const queue = getWorkSchedulerQueue();
+  await queue.sendMessage(serviceID);
 });

--- a/services/harmony/test/helpers/queue.ts
+++ b/services/harmony/test/helpers/queue.ts
@@ -3,7 +3,7 @@ import { Logger } from 'winston';
 
 import { MemoryQueue } from './memory-queue';
 import * as util from '../../app/backends/workflow-orchestration/util';
-import { getWorkFromDatabase } from '../../app/backends/workflow-orchestration/work-item-polling';
+import { getWorkItemsFromDatabase } from '../../app/backends/workflow-orchestration/work-item-polling';
 import logger from '../../app/util/log';
 import { WorkItemQueueType } from '../../app/util/queue/queue';
 import * as qf from '../../app/util/queue/queue-factory';
@@ -28,7 +28,7 @@ async function processSchedulerQueue(reqLogger: Logger): Promise<void> {
     const queueUrl = qf.getQueueUrlForService(serviceID);
     const queue = qf.getQueueForUrl(queueUrl);
     if (queue) {
-      const workItemData = await getWorkFromDatabase(serviceID, reqLogger);
+      const workItemData = await getWorkItemsFromDatabase(serviceID, reqLogger, 1);
       if (workItemData) {
         reqLogger.debug(`Sending work item data to queue ${queueUrl}`);
         // must include groupId for FIFO queues, but we don't care about it so just use 'w'

--- a/services/harmony/test/helpers/queue.ts
+++ b/services/harmony/test/helpers/queue.ts
@@ -3,13 +3,57 @@ import { Logger } from 'winston';
 
 import { MemoryQueue } from './memory-queue';
 import * as util from '../../app/backends/workflow-orchestration/util';
-import { getWorkItemsFromDatabase } from '../../app/backends/workflow-orchestration/work-item-polling';
+import { WorkItemData } from '../../app/backends/workflow-orchestration/work-item-polling';
+import { getNextJobIdForUsernameAndService, getNextUsernameForWork, incrementRunningAndDecrementReadyCounts, recalculateCounts } from '../../app/models/user-work';
+import { getNextWorkItem } from '../../app/models/work-item';
+import db from '../../app/util/db';
 import logger from '../../app/util/log';
 import { WorkItemQueueType } from '../../app/util/queue/queue';
 import * as qf from '../../app/util/queue/queue-factory';
 
 let serviceQueues;
 let typeQueues;
+
+/**
+ * Get a work item from the database for the given service ID.
+ *
+ * @param serviceID - the id of the service to get work for
+ * @param reqLogger - a logger instance
+ * @returns A work item from the database for the given service ID
+ */
+export async function getWorkFromDatabase(serviceID: string, reqLogger: Logger): Promise<WorkItemData | null> {
+  let result: WorkItemData | null = null;
+  try {
+    await db.transaction(async (tx) => {
+      const username = await getNextUsernameForWork(tx, serviceID as string);
+      if (username) {
+        const jobID = await getNextJobIdForUsernameAndService(tx, serviceID as string, username);
+        if (jobID) {
+          const workItem = await getNextWorkItem(tx, serviceID as string, jobID);
+          if (workItem) {
+            await incrementRunningAndDecrementReadyCounts(tx, jobID, serviceID as string);
+
+            if (workItem && util.QUERY_CMR_SERVICE_REGEX.test(workItem.serviceID)) {
+              const childLogger = reqLogger.child({ workItemId: workItem.id });
+              const maxCmrGranules = await util.calculateQueryCmrLimit(tx, workItem, childLogger);
+              reqLogger.debug(`Found work item ${workItem.id} for service ${serviceID} with max CMR granules ${maxCmrGranules}`);
+              result = { workItem, maxCmrGranules };
+            } else {
+              result = { workItem };
+            }
+          } else {
+            reqLogger.warn(`user_work is out of sync for user ${username} and job ${jobID}, could not find ready work item`);
+            reqLogger.warn(`recalculating ready and running counts for job ${jobID}`);
+            await recalculateCounts(tx, jobID);
+          }
+        }
+      }
+    });
+  } catch (err) {
+    reqLogger.error(`Error getting work from database: ${err.message}`);
+  }
+  return result;
+}
 
 /**
  * Process the scheduler queue. This function is only used for tests since they won't have a
@@ -28,7 +72,7 @@ async function processSchedulerQueue(reqLogger: Logger): Promise<void> {
     const queueUrl = qf.getQueueUrlForService(serviceID);
     const queue = qf.getQueueForUrl(queueUrl);
     if (queue) {
-      const workItemData = await getWorkItemsFromDatabase(serviceID, reqLogger, 1);
+      const workItemData = await getWorkFromDatabase(serviceID, reqLogger);
       if (workItemData) {
         reqLogger.debug(`Sending work item data to queue ${queueUrl}`);
         // must include groupId for FIFO queues, but we don't care about it so just use 'w'


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2338

## Description
I found the cause of the poor performance of the work scheduler in production was not a result of locked tables - it was just we needed an index to improve selecting the work item to queue as part of the fair queueing algorithm. After adding the index in production I saw the query went from taking over 7 seconds to just milliseconds.

In addition to adding the index I removed some code that wasn't being used and a feature flag USE_SERVICE_QUEUES that was obsolete.

## Local Test Steps
Test the migration up and down.
```
NODE_ENV=production DATABASE_URL=postgresql://postgres:<password>@localhost:5432/postgres knex --cwd db migrate:up
NODE_ENV=production DATABASE_URL=postgresql://postgres:<password>@localhost:5432/postgres knex --cwd db migrate:down
NODE_ENV=production DATABASE_URL=postgresql://postgres:<password>@localhost:5432/postgres knex --cwd db migrate:up
```

Verify the index `work_items_ready_lookup_index` is added to the work_items table.

If testing harmony in a box build all the images and then run `bin/bootstrap-harmony` and make sure the migrations run. Verify requests continue to work as expected.

I tested with harmony in a box and a deployment to sandbox as well.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [X] Harmony in a Box tested (if changes made to microservices or new dependencies added)