### PR TITLE
HARMONY-2345: Add longName and units to the variables in the collection capabilities version 3 response.

### DIFF
--- a/services/harmony/app/frontends/capabilities.ts
+++ b/services/harmony/app/frontends/capabilities.ts
@@ -57,7 +57,9 @@ interface ScienceKeyword {
 }
 interface VariableV3 {
   name: string;
+  longName: string;
   href: string;
+  units: string;
   scienceKeywords: ScienceKeyword[];
 }
 
@@ -324,7 +326,9 @@ function getVariableV2(variable: CmrUmmVariable): VariableV2 {
  */
 function getVariableV3(variable: CmrUmmVariable): VariableV3 {
   const name = variable.umm.Name;
+  const longName = variable.umm.LongName;
   const href = `${process.env.CMR_ENDPOINT}/search/concepts/${variable.meta['concept-id']}`;
+  const units = variable.umm.Units;
   const scienceKeywords = [];
   if (variable.umm.ScienceKeywords) {
     for (const scienceKeyword of variable.umm.ScienceKeywords) {
@@ -340,7 +344,7 @@ function getVariableV3(variable: CmrUmmVariable): VariableV3 {
     }
   }
 
-  return { name, href, scienceKeywords };
+  return { name, longName, href, units, scienceKeywords };
 }
 
 /**

--- a/services/harmony/app/util/cmr.ts
+++ b/services/harmony/app/util/cmr.ts
@@ -178,6 +178,7 @@ export interface CmrUmmVariable {
     RelatedURLs?: CmrRelatedUrl[];
     VariableType?: string;
     VariableSubType?: string;
+    Units?: string;
     ScienceKeywords?: ScienceKeyword[];
   };
 }

--- a/services/harmony/test/collection-capabilities.ts
+++ b/services/harmony/test/collection-capabilities.ts
@@ -519,21 +519,25 @@ describe('Testing collection capabilities', function () {
           const capabilities = JSON.parse(this.res.text);
           const expectedVariables = [{
             'name': 'alpha_var',
+            'longName': 'Alpha Channel',
             'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088190-EEDTEST',
             'scienceKeywords': [],
           },
           {
             'name': 'blue_var',
+            'longName': 'Blue Channel',
             'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088189-EEDTEST',
             'scienceKeywords': [],
           },
           {
             'name': 'green_var',
+            'longName': 'Green Channel',
             'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088188-EEDTEST',
             'scienceKeywords': [],
           },
           {
             'name': 'red_var',
+            'longName': 'Red Channel',
             'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088187-EEDTEST',
             'scienceKeywords': [],
           }];
@@ -545,7 +549,7 @@ describe('Testing collection capabilities', function () {
           expect(capabilities.capabilitiesVersion).to.equal('3-alpha');
         });
 
-        describe('for a collection with scienceKeywords in the variables', function () {
+        describe('for a collection with scienceKeywords and units in the variables', function () {
           hookGetCollectionCapabilities({ collectionId: 'C1238538022-EEDTEST', version: '3' });
           it('returns a 200 success status code', function () {
             expect(this.res.status).to.equal(200);
@@ -557,7 +561,9 @@ describe('Testing collection capabilities', function () {
             // set correctly
             const expectedVariables = [{
               'name': '/ancillary_data/atlas_sdp_gps_epoch',
+              'longName': 'ATLAS Epoch Offset',
               'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1238628268-EEDTEST',
+              'units': 'seconds since 1980-01-06T00:00:00.000000Z',
               'scienceKeywords': [
                 {
                   'category': 'EARTH SCIENCE',
@@ -603,7 +609,9 @@ describe('Testing collection capabilities', function () {
               ],
             }, {
               'name': '/ancillary_data/control',
+              'longName': 'Control File',
               'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1238628280-EEDTEST',
+              'units': '1',
               'scienceKeywords': [
                 {
                   'category': 'EARTH SCIENCE',


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2345

## Description
Add longName and units to the variables in the collection capabilities version 3 response.

## Local Test Steps
Verify the variables section now has longName and units (units are omitted if not included in the UMM-Var metadata).

With longName and units:
http://localhost:3000/capabilities?collectionId=C1238538022-EEDTEST&version=3

No units:
http://localhost:3000/capabilities?collectionId=C1234088182-EEDTEST&version=3

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)