### PR TITLE
HARMONY-2312: Implement steps endpoint.

### DIFF
--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -166,30 +166,57 @@ interface ResolvedCatalogs {
 }
 
 /**
- * Read query-cmr's `batch-catalogs.json` and return absolute
- * URLs to each. Caps the returned URLs at MAX_BATCH_CATALOGS to bound the
- * downstream S3 reads; reports any extras as omittedCount.
+ * Sorting function to return the catalogs in the order they are presumed to be
+ * generated.
  *
- * Only meaningful for query-cmr WIs; regular services write a top-level
- * `catalog.json` instead of `batch-catalogs.json`.
+ * @param filename - a `catalog.json` / `catalogN.json` basename
+ * @returns the numeric index, or -1 if the filename has none
+ */
+function catalogIndex(filename: string): number {
+  const m = filename.match(/catalog(\d+)\.json$/);
+  return m ? Number(m[1]) : -1;
+}
+
+/**
+ * Determine a completed work item's output catalog file URLs, mirroring
+ * service-runner's `_getStacCatalogs` discovery so that every catalog a service
+ * writes is found:
+ *   - if the work item wrote a `batch-catalogs.json` (query-cmr, and aggregating
+ *     services such as batchee/stitchee), use the catalogN.json files it lists;
+ *   - otherwise list the `catalog*.json` files in the outputs directory, which
+ *     covers both the common single `catalog.json` and services that might write
+ *     several `catalogN.json` files without an index.
+ * The result is capped at MAX_BATCH_CATALOGS to bound the downstream S3 reads;
+ * any extras are reported as omittedCount.
  *
  * @param outputDir - the WI's outputs directory URL
  * @returns the (capped) catalog URLs and the count of additional catalog
  *   files that were not included
  */
-async function readBatchCatalogs(outputDir: string): Promise<WiOutputCatalogs> {
-  try {
-    const filenames = await defaultObjectStore().getObjectJson(
-      `${outputDir}batch-catalogs.json`,
-    ) as string[];
-    const capped = filenames.slice(0, MAX_BATCH_CATALOGS);
-    return {
-      urls: capped.map((f) => `${outputDir}${f}`),
-      omittedCount: Math.max(0, filenames.length - MAX_BATCH_CATALOGS),
-    };
-  } catch {
-    return { urls: [], omittedCount: 0 };
+async function readOutputCatalogs(outputDir: string): Promise<WiOutputCatalogs> {
+  const store = defaultObjectStore();
+  const batchCatalogsUrl = `${outputDir}batch-catalogs.json`;
+
+  let filenames: string[];
+  if (await store.objectExists(batchCatalogsUrl)) {
+    try {
+      filenames = await store.getObjectJson(batchCatalogsUrl) as string[];
+    } catch {
+      return { urls: [], omittedCount: 0 };
+    }
+  } else {
+    const keys = await store.listObjectKeys(outputDir);
+    filenames = keys
+      .map((k) => k.split('/').pop())
+      .filter((f) => /^catalog\d*\.json$/.test(f))
+      .sort((a, b) => catalogIndex(a) - catalogIndex(b));
   }
+
+  const capped = filenames.slice(0, MAX_BATCH_CATALOGS);
+  return {
+    urls: capped.map((f) => `${outputDir}${f}`),
+    omittedCount: Math.max(0, filenames.length - MAX_BATCH_CATALOGS),
+  };
 }
 
 /**
@@ -209,21 +236,11 @@ async function resolveAllCatalogs(
 ): Promise<ResolvedCatalogs> {
   const completed_workitems = workItems.filter((wi) => COMPLETED_WORK_ITEM_STATUSES.includes(wi.status));
 
-  // Determine each completed WI's *output* catalog file URLs.
-  //   - query-cmr WIs (wi.scrollID is set) write multiple catalogN.json files
-  //     indexed by batch-catalogs.json
-  //   - All other services write a single top-level catalog.json (does it?)
+  // Determine each completed WI's *output* catalog file URLs
   const wiOutputCatalogs = new Map<number, WiOutputCatalogs>();
   await Promise.all(completed_workitems.map(async (wi) => {
-    if (wi.scrollID) {
-      const outputDir = getStacLocation({ id: wi.id, jobID: wi.jobID });
-      wiOutputCatalogs.set(wi.id, await readBatchCatalogs(outputDir));
-    } else {
-      wiOutputCatalogs.set(wi.id, {
-        urls: [getStacLocation({ id: wi.id, jobID: wi.jobID }, 'catalog.json')],
-        omittedCount: 0,
-      });
-    }
+    const outputDir = getStacLocation({ id: wi.id, jobID: wi.jobID });
+    wiOutputCatalogs.set(wi.id, await readOutputCatalogs(outputDir));
   }));
 
   // Collect every unique catalog file URL: each completed WI's

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -36,6 +36,7 @@ interface StepWorkItem {
   retryCount: number;
   inputFiles: string[] | null;
   outputFiles: string[] | null;
+  warning?: string;
 }
 
 interface JobStep {
@@ -259,16 +260,16 @@ function buildWorkItem(
   const { catalogHrefs, wiOutputCatalogs } = resolved;
   const outputCatalogs = wiOutputCatalogs.get(wi.id);
   let outputFiles: string[] | null;
+  let truncationWarning: string | undefined = undefined;
   if (outputCatalogs === undefined) {
     outputFiles = null;
   } else {
     outputFiles = outputCatalogs.urls.flatMap((url) => catalogHrefs.get(url) ?? []);
     if (outputCatalogs.omittedCount > 0) {
-      outputFiles.push(
-        `Not all files resolved, there are ${outputCatalogs.omittedCount} more files not shown.`,
-      );
+      truncationWarning = `Not all stac catalogs resolved, there are ${outputCatalogs.omittedCount} unshown catalogs.`;
     }
   }
+
   return {
     id: wi.id,
     status: wi.status,
@@ -277,6 +278,7 @@ function buildWorkItem(
       ? (catalogHrefs.get(wi.stacCatalogLocation) ?? null)
       : null,
     outputFiles,
+    ...(truncationWarning !== undefined && { warning: truncationWarning }),
   };
 }
 

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -1,0 +1,396 @@
+import { NextFunction, Response } from 'express';
+
+import { sanitizeImage } from '@harmony/util/string';
+
+import { createPublicPermalink } from './service-results';
+import HarmonyRequest from '../models/harmony-request';
+import WorkItem, {
+  queryAll as queryWorkItems, workItemStatusCountsForJob,
+} from '../models/work-item';
+import {
+  COMPLETED_WORK_ITEM_STATUSES, getStacLocation, WorkItemQuery, WorkItemStatus,
+} from '../models/work-item-interface';
+import WorkflowStep, { getWorkflowStepsByJobId } from '../models/workflow-steps';
+import db from '../util/db';
+import { isAdminUser } from '../util/edl-api';
+import { RequestValidationError } from '../util/errors';
+import { getJobIfAllowed } from '../util/job';
+import { defaultObjectStore } from '../util/object-store';
+import { readCatalogItems, StacItem } from '../util/stac';
+import { getRequestRoot } from '../util/url';
+
+export const DEFAULT_PER_PAGE = 50;
+const MAX_BATCH_CATALOGS = 100;
+const VALID_STATUSES = Object.values(WorkItemStatus);
+
+
+interface StepsQueryParams {
+  step?: number;
+  status?: WorkItemStatus;
+  workItem?: number;
+}
+
+interface StepWorkItem {
+  id: number;
+  status: WorkItemStatus;
+  retryCount: number;
+  inputFiles: string[] | null;
+  outputFiles: string[] | null;
+}
+
+interface JobStep {
+  serviceID: string;
+  stepIndex: number;
+  workItemCount: number;
+  statuses: Partial<Record<WorkItemStatus, number>>;
+  workItems: StepWorkItem[];
+  paging?: StepPaging;
+}
+
+interface StepPaging {
+  message: string;
+}
+
+/**
+ * Parse the query parameters used to filter and shape the steps response.
+ *
+ * @param query - the raw request query string parameters
+ * @returns the validated and normalized steps query
+ * @throws RequestValidationError - if any parameter is not a valid value
+ */
+function parseQuery(query: Record<string, unknown>): StepsQueryParams {
+  const out: StepsQueryParams = {};
+
+  if (query.step !== undefined) {
+    const n = Number(query.step);
+    if (!Number.isInteger(n) || n < 1) {
+      throw new RequestValidationError('step must be a positive integer');
+    }
+    out.step = n;
+  }
+
+  if (query.status !== undefined) {
+    const s = String(query.status) as WorkItemStatus;
+    if (!VALID_STATUSES.includes(s)) {
+      throw new RequestValidationError(`status must be one of: ${VALID_STATUSES.join(', ')}`);
+    }
+    out.status = s;
+  }
+
+  if (query.workItem !== undefined) {
+    const n = Number(query.workItem);
+    if (!Number.isInteger(n) || n < 1) {
+      throw new RequestValidationError('workItem must be a positive integer');
+    }
+    out.workItem = n;
+  }
+
+  return out;
+}
+
+/**
+ * Collect every asset href from a list of STAC items.
+ *
+ * @param items - the STAC items whose asset hrefs should be collected
+ * @returns every asset href found across the items
+ */
+function getAllAssetHrefs(items: StacItem[]): string[] {
+  const hrefs: string[] = [];
+  for (const item of items) {
+    for (const name in item.assets ?? {}) {
+      const { href } = item.assets[name];
+      if (href) hrefs.push(href);
+    }
+  }
+  return hrefs;
+}
+
+/**
+ * Read a STAC catalog and return every asset href it references.
+ *
+ * @param catalogUrl - the location of the STAC catalog to read
+ * @returns the asset hrefs from the catalog, or an empty array if the catalog
+ *   cannot be read (e.g. the service failed before producing it, or the
+ *   catalog has no assets)
+ */
+async function resolveDataHrefs(catalogUrl: string): Promise<string[]> {
+  try {
+    const items = await readCatalogItems(catalogUrl);
+    return getAllAssetHrefs(items);
+  } catch {
+    return [];
+  }
+}
+
+// Placeholder used in inputFiles / outputFiles when a STAC asset href cannot
+// be turned into a public/valid link.
+const PRIVATE_FILE_PLACEHOLDER = '<private file location>';
+
+/**
+ * Convert a raw STAC asset href into the public-facing form.
+ * S3 URLs under `.../public/` become `<frontendRoot>/service-results/...`
+ * HTTPS URLs pass through.
+ * User provided S3:// urls are returned for allowed locations.
+ *
+ * @param href - the raw STAC asset href to convert
+ * @param frontendRoot - The root URL to use when producing Harmony permalinks
+ * @param destinationBucket - the job's destinationUrl bucket name, or undefined
+ *     if the job has no destinationUrl
+ * @returns the Harmony permalink result for a signable href; the raw href if it is in
+ *   the job's destination bucket; otherwise the PRIVATE_FILE_PLACEHOLDER sentinel
+ */
+export function safePublicLink(href: string, frontendRoot: string, destinationBucket: string | undefined): string {
+  try {
+    return createPublicPermalink(href, frontendRoot);
+  } catch {
+    if (destinationBucket && href.startsWith(`s3://${destinationBucket}/`)) {
+      return href;
+    }
+    return PRIVATE_FILE_PLACEHOLDER;
+  }
+}
+
+// Per-WI output catalog list, plus how many additional catalog files (if any)
+// were dropped to keep the S3 fan-out bounded.
+interface WiOutputCatalogs {
+  urls: string[];
+  omittedCount: number;
+}
+
+interface ResolvedCatalogs {
+  // Map of local catalog.json location -> Array of public links to file.
+  catalogHrefs: Map<string, string[]>;
+  // Map of work item id to its output catalog.json list (plus the omitted count).
+  wiOutputCatalogs: Map<number, WiOutputCatalogs>;
+}
+
+/**
+ * Read query-cmr's `batch-catalogs.json` and return absolute
+ * URLs to each. Caps the returned URLs at MAX_BATCH_CATALOGS to bound the
+ * downstream S3 reads; reports any extras as omittedCount.
+ *
+ * Only meaningful for query-cmr WIs; regular services write a top-level
+ * `catalog.json` instead of `batch-catalogs.json`.
+ *
+ * @param outputDir - the WI's outputs directory URL
+ * @returns the (capped) catalog URLs and the count of additional catalog
+ *   files that were not included
+ */
+async function readBatchCatalogs(outputDir: string): Promise<WiOutputCatalogs> {
+  try {
+    const filenames = await defaultObjectStore().getObjectJson(
+      `${outputDir}batch-catalogs.json`,
+    ) as string[];
+    const capped = filenames.slice(0, MAX_BATCH_CATALOGS);
+    return {
+      urls: capped.map((f) => `${outputDir}${f}`),
+      omittedCount: Math.max(0, filenames.length - MAX_BATCH_CATALOGS),
+    };
+  } catch {
+    return { urls: [], omittedCount: 0 };
+  }
+}
+
+/**
+ * For every completed work item, determine its output catalog file URLs, then
+ * resolve each unique catalog URL (inputs + outputs) to public-facing data
+ * hrefs.
+ *
+ * @param workItems - the page of work items whose catalogs should be resolved
+ * @param frontendRoot - the root URL to use when producing Harmony permalinks
+ * @returns the per-catalog to  hrefs map and per-WI output to catalog list (see
+ *   ResolvedCatalogs)
+ */
+async function resolveAllCatalogs(
+  workItems: WorkItem[],
+  frontendRoot: string,
+  destinationBucket: string = undefined,
+): Promise<ResolvedCatalogs> {
+  const completed_workitems = workItems.filter((wi) => COMPLETED_WORK_ITEM_STATUSES.includes(wi.status));
+
+  // Determine each completed WI's *output* catalog file URLs.
+  //   - query-cmr WIs (wi.scrollID is set) write multiple catalogN.json files
+  //     indexed by batch-catalogs.json
+  //   - All other services write a single top-level catalog.json (does it?)
+  const wiOutputCatalogs = new Map<number, WiOutputCatalogs>();
+  await Promise.all(completed_workitems.map(async (wi) => {
+    if (wi.scrollID) {
+      const outputDir = getStacLocation({ id: wi.id, jobID: wi.jobID });
+      wiOutputCatalogs.set(wi.id, await readBatchCatalogs(outputDir));
+    } else {
+      wiOutputCatalogs.set(wi.id, {
+        urls: [getStacLocation({ id: wi.id, jobID: wi.jobID }, 'catalog.json')],
+        omittedCount: 0,
+      });
+    }
+  }));
+
+  // Collect every unique catalog file URL: each completed WI's
+  // input (stacCatalogLocation) plus every output catalog file.
+  const allCatalogUrls = new Set<string>();
+  for (const wi of completed_workitems) {
+    if (wi.stacCatalogLocation) allCatalogUrls.add(wi.stacCatalogLocation);
+    for (const url of wiOutputCatalogs.get(wi.id)?.urls ?? []) allCatalogUrls.add(url);
+  }
+
+  const catalogHrefs = new Map<string, string[]>();
+  await Promise.all(Array.from(allCatalogUrls).map(async (url) => {
+    const rawHrefs = await resolveDataHrefs(url);
+    catalogHrefs.set(url, rawHrefs.map((h) => safePublicLink(h, frontendRoot, destinationBucket)));
+  }));
+
+  return { catalogHrefs, wiOutputCatalogs };
+}
+
+/**
+ * Build the work item portion of the response. inputFiles / outputFiles are
+ * populated from the precomputed `resolved` maps; a WI absent from
+ * `wiOutputCatalogs` displays `outputFiles: null`. WIs that never have a STAC
+ * input (e.g.  query-cmr step 1) always report `inputFiles: null`.
+ *
+ * @param wi - the work item to serialize
+ * @param resolved - the catalog hrefs map + per-WI output catalog list
+ * @returns the work item shaped for the steps response
+ */
+function buildWorkItem(
+  wi: WorkItem,
+  resolved: ResolvedCatalogs,
+): StepWorkItem {
+  const { catalogHrefs, wiOutputCatalogs } = resolved;
+  const outputCatalogs = wiOutputCatalogs.get(wi.id);
+  let outputFiles: string[] | null;
+  if (outputCatalogs === undefined) {
+    outputFiles = null;
+  } else {
+    outputFiles = outputCatalogs.urls.flatMap((url) => catalogHrefs.get(url) ?? []);
+    if (outputCatalogs.omittedCount > 0) {
+      outputFiles.push(
+        `Not all files resolved, there are ${outputCatalogs.omittedCount} more files not shown (HARMONY-2352)`,
+      );
+    }
+  }
+  return {
+    id: wi.id,
+    status: wi.status,
+    retryCount: wi.retryCount,
+    inputFiles: wi.stacCatalogLocation
+      ? (catalogHrefs.get(wi.stacCatalogLocation) ?? null)
+      : null,
+    outputFiles,
+  };
+}
+
+
+// A workflow step paired with its bounded page of work items and the total
+// number of work items that matched (used to decide whether to page).
+interface StepWorkItems {
+  step: WorkflowStep;
+  workItems: WorkItem[];
+  total: number;
+}
+
+/**
+ * Build the full step list from each step's already-bounded page of work items.
+ * A step whose total matching work item count exceeds DEFAULT_PER_PAGE gets a
+ * placeholder `paging` block. When a status/workItem filter is active, steps
+ * with no matching work items are omitted.
+ *
+ * @param stepResults - each workflow step with its bounded work items and total
+ * @param resolved - resolved-catalog data from resolveAllCatalogs
+ * @param statusCounts - per-step, per-status work item counts for the whole job
+ * @param q - the parsed steps query, used to honor the status/workItem filters
+ * @returns the steps with their work items, status summary, and any paging note
+ */
+function buildSteps(
+  stepResults: StepWorkItems[],
+  resolved: ResolvedCatalogs,
+  statusCounts: Map<number, Partial<Record<WorkItemStatus, number>>>,
+  q: StepsQueryParams,
+): JobStep[] {
+  const result: JobStep[] = [];
+  const filtering = q.status !== undefined || q.workItem !== undefined;
+  for (const { step, workItems, total } of stepResults) {
+    // Don't show steps without workitems.
+    if (filtering && workItems.length === 0) continue;
+
+    const jobStep: JobStep = {
+      serviceID: sanitizeImage(step.serviceID),
+      stepIndex: step.stepIndex,
+      workItemCount: step.workItemCount,
+      statuses: statusCounts.get(step.stepIndex) ?? {},
+      workItems: workItems.map((wi) => buildWorkItem(wi, resolved)),
+    };
+    // workItems is capped at DEFAULT_PER_PAGE per step; flag steps with more.
+    if (total > DEFAULT_PER_PAGE) {
+      jobStep.paging = { message: 'Paging of results available with HARMONY-2354' };
+    }
+
+    result.push(jobStep);
+  }
+
+  return result;
+}
+
+/**
+ * Express.js handler for GET /jobs/:jobID/steps. Returns a JSON document
+ * describing the job, its workflow steps, and the inputs/outputs of those
+ * steps.
+ *
+ * @param req - The request sent by the client
+ * @param res - The response to send to the client
+ * @param next - The next function in the call chain
+ * @returns Resolves when the request is complete
+ */
+export async function getJobSteps(
+  req: HarmonyRequest, res: Response, next: NextFunction,
+): Promise<void> {
+  const { jobID } = req.params;
+  try {
+    const q = parseQuery(req.query as Record<string, unknown>);
+
+    const isAdmin = await isAdminUser(req);
+    const job = await getJobIfAllowed(jobID, req.user, isAdmin, req.accessToken, true);
+    const destinationBucket = job.destination_url?.substring(5).split('/')[0];
+
+    const steps = await getWorkflowStepsByJobId(db, jobID);
+    const statusCounts = await workItemStatusCountsForJob(db, jobID);
+
+    const selectedSteps = q.step !== undefined
+      ? steps.filter((s) => s.stepIndex === q.step)
+      : steps;
+
+    // Bound each step's work items independently at DEFAULT_PER_PAGE. Per-step
+    // paging links are coming in HARMONY-2354.
+    const stepResults: StepWorkItems[] = await Promise.all(selectedSteps.map(async (step) => {
+      const where: WorkItemQuery['where'] = { jobID, workflowStepIndex: step.stepIndex };
+      if (q.status !== undefined) where.status = q.status;
+      if (q.workItem !== undefined) where.id = q.workItem;
+      const { workItems, pagination } = await queryWorkItems(
+        db, { where, orderBy: { field: 'id', value: 'asc' } }, 1, DEFAULT_PER_PAGE,
+      );
+      return { step, workItems, total: pagination.total };
+    }));
+
+    const frontendRoot = getRequestRoot(req);
+    const allWorkItems = stepResults.flatMap((r) => r.workItems);
+    const resolvedCatalogs = await resolveAllCatalogs(allWorkItems, frontendRoot, destinationBucket);
+    const jobSteps = buildSteps(stepResults, resolvedCatalogs, statusCounts, q);
+
+    const responseBody = {
+      jobID: job.jobID,
+      serviceName: job.service_name,
+      status: job.status,
+      progress: job.progress,
+      message: job.message,
+      username: job.username,
+      numInputGranules: job.numInputGranules,
+      request: job.request,
+      steps: jobSteps,
+    };
+
+    res.json(responseBody);
+  } catch (e) {
+    req.context.logger.error(e);
+    next(e);
+  }
+}

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -283,7 +283,7 @@ function buildWorkItem(
   } else {
     outputFiles = outputCatalogs.urls.flatMap((url) => catalogHrefs.get(url) ?? []);
     if (outputCatalogs.omittedCount > 0) {
-      truncationWarning = `Not all output files are included. Only the outputs from the first ` +
+      truncationWarning = 'Not all output files are included. Only the outputs from the first ' +
         `${outputCatalogs.urls.length} STAC catalogs were resolved, there are ${outputCatalogs.omittedCount} catalogs that were not resolved.`;
     }
   }

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -20,7 +20,7 @@ import { readCatalogItems, StacItem } from '../util/stac';
 import { getRequestRoot } from '../util/url';
 
 export const DEFAULT_PER_PAGE = 50;
-const MAX_BATCH_CATALOGS = 100;
+const MAX_BATCH_CATALOGS = 5;
 const VALID_STATUSES = Object.values(WorkItemStatus);
 
 
@@ -265,7 +265,7 @@ function buildWorkItem(
     outputFiles = outputCatalogs.urls.flatMap((url) => catalogHrefs.get(url) ?? []);
     if (outputCatalogs.omittedCount > 0) {
       outputFiles.push(
-        `Not all files resolved, there are ${outputCatalogs.omittedCount} more files not shown (HARMONY-2352)`,
+        `Not all files resolved, there are ${outputCatalogs.omittedCount} more files not shown.`,
       );
     }
   }
@@ -322,7 +322,7 @@ function buildSteps(
     };
     // workItems is capped at DEFAULT_PER_PAGE per step; flag steps with more.
     if (total > DEFAULT_PER_PAGE) {
-      jobStep.paging = { message: 'Paging of results available with HARMONY-2354' };
+      jobStep.paging = { message: 'results paging not implemented' };
     }
 
     result.push(jobStep);
@@ -360,7 +360,7 @@ export async function getJobSteps(
       : steps;
 
     // Bound each step's work items independently at DEFAULT_PER_PAGE. Per-step
-    // paging links are coming in HARMONY-2354.
+    // paging links are coming
     const stepResults: StepWorkItems[] = await Promise.all(selectedSteps.map(async (step) => {
       const where: WorkItemQuery['where'] = { jobID, workflowStepIndex: step.stepIndex };
       if (q.status !== undefined) where.status = q.status;

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -283,7 +283,8 @@ function buildWorkItem(
   } else {
     outputFiles = outputCatalogs.urls.flatMap((url) => catalogHrefs.get(url) ?? []);
     if (outputCatalogs.omittedCount > 0) {
-      truncationWarning = `Not all stac catalogs resolved, there are ${outputCatalogs.omittedCount} unshown catalogs.`;
+      truncationWarning = `Not all output files are included. Only the outputs from the first ` +
+        `${outputCatalogs.urls.length} STAC catalogs were resolved, there are ${outputCatalogs.omittedCount} catalogs that were not resolved.`;
     }
   }
 
@@ -341,7 +342,7 @@ function buildSteps(
     };
     // workItems is capped at DEFAULT_PER_PAGE per step; flag steps with more.
     if (total > DEFAULT_PER_PAGE) {
-      jobStep.paging = { message: 'results paging not implemented' };
+      jobStep.paging = { message: `WorkItem results paging not implemented: ${workItems.length} work items shown out of ${total}.` };
     }
 
     result.push(jobStep);

--- a/services/harmony/app/markdown/docs.md
+++ b/services/harmony/app/markdown/docs.md
@@ -14,6 +14,8 @@
 
 !!!include(jobs.md)!!!
 
+!!!include(steps.md)!!!
+
 !!!include(labels.md)!!!
 
 !!!include(stac.md)!!!

--- a/services/harmony/app/markdown/endpoints.md
+++ b/services/harmony/app/markdown/endpoints.md
@@ -2,19 +2,20 @@
 
 All of the public endpoints for Harmony users other than the OGC Coverages, EDR, and WMS APIs are listed in the following table. The Coverages and WMS APIs are described in the [Using the Service APIs section](#using-the-service-apis).
 
-| route                  | description                                                                                       |
-|------------------------|---------------------------------------------------------------------------------------------------|
-| /                      | The Harmony landing page                                                                          |
-| /capabilities          | [Get harmony capabilities for the provided collection](#capabilities-details)                     |
-| /cloud-access          | [Generates AWS credentials for accessing processed data in S3](#cloud-access-details)             |
-| /docs                  | These documentation pages                                                                         |
-| /docs/api              | The Swagger documentation for the OGC Coverages API                                               |
-| /jobs                  | [The jobs API for getting job status, pausing/continuing/canceling jobs](#jobs-details)           |
-| /stac                  | [The API for retrieving STAC catalog and catalog items for processed data](#stac-details)         |
-| /staging-bucket-policy | [The policy generator for external (user) bucket storage](#user-owned-buckets-for-harmony-output) |
-| /versions              | [Returns JSON indicating the image and tag each deployed service is running](#versions-details)   |
-| /service-image-tag     | [The API for managing service image tags/versions](https://github.com/nasa/harmony/blob/main/docs/guides/managing-existing-services.md)|
-| /workflow-ui           | The Workflow UI for monitoring and interacting with running jobs                                  |
+| route                  | description                                                                                                                             |
+|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| /                      | The Harmony landing page                                                                                                                |
+| /capabilities          | [Get harmony capabilities for the provided collection](#capabilities-details)                                                           |
+| /cloud-access          | [Generates AWS credentials for accessing processed data in S3](#cloud-access-details)                                                   |
+| /docs                  | These documentation pages                                                                                                               |
+| /docs/api              | The Swagger documentation for the OGC Coverages API                                                                                     |
+| /jobs                  | [The jobs API for getting job status, pausing/continuing/canceling jobs](#jobs-details)                                                 |
+| /jobs/\<JobID\>/steps  | [The introspection service for understanding a jobs steps and intermediate results](#jobs-steps)                                        |
+| /stac                  | [The API for retrieving STAC catalog and catalog items for processed data](#stac-details)                                               |
+| /staging-bucket-policy | [The policy generator for external (user) bucket storage](#user-owned-buckets-for-harmony-output)                                       |
+| /versions              | [Returns JSON indicating the image and tag each deployed service is running](#versions-details)                                         |
+| /service-image-tag     | [The API for managing service image tags/versions](https://github.com/nasa/harmony/blob/main/docs/guides/managing-existing-services.md) |
+| /workflow-ui           | The Workflow UI for monitoring and interacting with running jobs                                                                        |
 ---
 **Table {{tableCounter}}** - Harmony routes other than OGC Coverages and WMS
 

--- a/services/harmony/app/markdown/jobs.md
+++ b/services/harmony/app/markdown/jobs.md
@@ -59,6 +59,9 @@ The returned JSON response list the details of the given job:
 | updatedAt        | Timestamp when the job was last updated in Harmony                                             |
 | dataExpiration   | Timestamp when the result data of the job will be cleaned up from Harmony                      |
 | links            | A list of JSON objects with links to STAC catalog and result data of the job                   |
+| labels           | An array of labels used when making the request                                                |
+| steps            | A link to the steps endpoint for this job-id                                                   |
+| serviceName      | the name of the service chain that was invoked by the request                                  |
 | request          | The original request url of the job                                                            |
 | numInputGranules | number of input granules in the job                                                            |
 | jobID            | ID of the job in Harmony                                                                       |

--- a/services/harmony/app/markdown/jobs.md
+++ b/services/harmony/app/markdown/jobs.md
@@ -65,6 +65,8 @@ The returned JSON response list the details of the given job:
 | request          | The original request url of the job                                                            |
 | numInputGranules | number of input granules in the job                                                            |
 | jobID            | ID of the job in Harmony                                                                       |
+| errors           | an array of error object that occured. Only shown when at least one error occurs.              |
+
 ---
 **Table {{tableCounter}}** - Harmony job response fields
 

--- a/services/harmony/app/markdown/steps.md
+++ b/services/harmony/app/markdown/steps.md
@@ -68,6 +68,8 @@ Each entry in a step's `workItems` list describes a single work item:
 | retryCount  | The number of times the work item has been retried                                                                                                                                        |
 | inputFiles  | A list of links to the input files for the work item, or `null` if the work item has no STAC input (e.g. the first query-cmr step).                                                       |
 | outputFiles | A list of links to the output files produced by the work item, or `null` if it produced no output. Files that cannot be turned into a public link are shown as `<private file location>`. |
+| warning     | Warning message displayed if the outputFiles array is incomplete                                                                                                                          |
+
 ---
 **Table {{tableCounter}}** - Harmony work item fields
 

--- a/services/harmony/app/markdown/steps.md
+++ b/services/harmony/app/markdown/steps.md
@@ -1,0 +1,75 @@
+### <a name="jobs-steps"></a>  Inspecting a Job's Steps with the Steps API
+
+The steps API provides introspection into the workflow steps that make up a job and the work items each step processed. It is useful for understanding how a request was broken down across services and for inspecting the inputs and outputs of each step.
+
+As with the jobs API, there are two sets of steps API endpoints with the same sub paths and parameters: one with path `jobs` to view the current user's own jobs; the other with `admin/jobs` path to view all users' jobs if the current user has admin permission to do so. For simplicity, we will only list the ones for a regular user below.
+
+#### Getting the steps for a job
+
+```
+
+{{root}}/jobs/<job-id>/steps
+
+```
+**Example {{exampleCounter}}** - Getting the steps for a job
+
+Returns the workflow steps for the given job, along with the work items processed by each step. By default, up to 50 work items are returned per step; steps with more work items than that include a `paging` note in the response.
+
+##### <a name="steps-query-parameters"></a> Query Parameters
+| parameter | description                                                                                                                                                                                  |
+|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| step      | Limit the response to the step with this stepIndex (a positive integer).                                                                                                                     |
+| status    | Filter the work items shown to those with this status. One of `ready`, `queued`, `running`, `successful`, `failed`, `canceled`, or `warning`. Steps with no matching work items are omitted. |
+| workItem  | Limit the work items shown to the one with this ID (a positive integer).                                                                                                                     |
+
+---
+**Table {{tableCounter}}** - Harmony steps endpoint parameters
+
+##### <a name="steps-response"></a> Response
+The returned JSON response describes the job and the list of its steps:
+
+| field            | description                                                                                           |
+|------------------|-------------------------------------------------------------------------------------------------------|
+| jobID            | ID of the job in Harmony                                                                              |
+| serviceName      | Name of the service that ran the job                                                                  |
+| status           | Status of the job                                                                                     |
+| progress         | Percentage of the job processing progress. `100` for a job that has been processed completely.        |
+| message          | Processing message of the job                                                                         |
+| username         | Username that owns the job                                                                            |
+| numInputGranules | Number of input granules in the job                                                                   |
+| request          | The original request url of the job                                                                   |
+| steps            | A list of JSON objects describing the workflow steps. For details, see [step fields](#step-response). |
+
+---
+**Table {{tableCounter}}** - Harmony steps response fields
+
+###### <a name="step-response"></a> Step fields
+Each entry in the `steps` list describes a single workflow step -- one service in a service chain:
+
+| field         | description                                                                                                                                |
+|---------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| serviceID     | The service image name and tag service that ran this step                                                                                  |
+| stepIndex     | The position of this step in the workflow, starting at `1`                                                                                 |
+| workItemCount | The total number of work items in this step                                                                                                |
+| statuses      | A map of work item status to the number of work items in that status for the whole step. Only statuses with at least one work item appear. |
+| workItems     | A list of JSON objects describing the work items for this step. For details, see [work item fields](#step-work-item-response).             |
+| paging        | Present only when the step has more work items than can be shown on a single page.                                                         |
+
+---
+**Table {{tableCounter}}** - Harmony step fields
+
+###### <a name="step-work-item-response"></a> Work item fields
+Each entry in a step's `workItems` list describes a single work item:
+
+| field       | description                                                                                                                                                                               |
+|-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| id          | ID of the work item in Harmony                                                                                                                                                            |
+| status      | Status of the work item                                                                                                                                                                   |
+| retryCount  | The number of times the work item has been retried                                                                                                                                        |
+| inputFiles  | A list of links to the input files for the work item, or `null` if the work item has no STAC input (e.g. the first query-cmr step).                                                       |
+| outputFiles | A list of links to the output files produced by the work item, or `null` if it produced no output. Files that cannot be turned into a public link are shown as `<private file location>`. |
+---
+**Table {{tableCounter}}** - Harmony work item fields
+
+<br/>
+<br/>

--- a/services/harmony/app/markdown/steps.md
+++ b/services/harmony/app/markdown/steps.md
@@ -68,7 +68,7 @@ Each entry in a step's `workItems` list describes a single work item:
 | retryCount  | The number of times the work item has been retried                                                                                                                                        |
 | inputFiles  | A list of links to the input files for the work item, or `null` if the work item has no STAC input (e.g. the first query-cmr step).                                                       |
 | outputFiles | A list of links to the output files produced by the work item, or `null` if it produced no output. Files that cannot be turned into a public link are shown as `<private file location>`. |
-| warning     | Warning message displayed if the outputFiles array is incomplete                                                                                                                          |
+| warning     | Warning message displayed if the outputFiles array is incomplete.                                                                                                                          |
 
 ---
 **Table {{tableCounter}}** - Harmony work item fields

--- a/services/harmony/app/models/job.ts
+++ b/services/harmony/app/models/job.ts
@@ -113,6 +113,10 @@ export class JobForDisplay {
 
   labels: string[];
 
+  serviceName?: string;
+
+  steps?: string;
+
   request: string;
 
   numInputGranules: number;
@@ -1189,6 +1193,8 @@ export class Job extends DBRecord implements JobRecord {
       dataExpiration: this.getDataExpiration(),
       links: this.links,
       labels: this.labels,
+      steps: this.getStepsUrl(urlRoot),
+      serviceName: this.service_name,
       request: this.request,
       numInputGranules: this.numInputGranules,
       jobID: this.jobID,
@@ -1233,6 +1239,16 @@ export class Job extends DBRecord implements JobRecord {
     }
 
     return result;
+  }
+
+  /**
+   * Return the link to the steps endpoint.
+   *
+   * @param urlRoot - The harmony root URL
+   * @returns link to steps endpoint.
+   */
+  getStepsUrl(urlRoot: string): string | undefined {
+    return urlRoot ? `${urlRoot}/jobs/${this.jobID}/steps` : undefined;
   }
 }
 

--- a/services/harmony/app/models/work-item-interface.ts
+++ b/services/harmony/app/models/work-item-interface.ts
@@ -86,6 +86,7 @@ export interface WorkItemQuery {
     id?: number;
     jobID?: string;
     status?: string;
+    workflowStepIndex?: number;
     createdAt?: number;
     updatedAt?: number;
   };

--- a/services/harmony/app/models/work-item.ts
+++ b/services/harmony/app/models/work-item.ts
@@ -727,6 +727,35 @@ export async function countOfWorkItemsByStepAndJobID(
 }
 
 /**
+ * Returns the per-status work item counts for each workflow step of a job, as a
+ * map of step index to  \{ statuses: count \}. Only statuses with at least one work
+ * item appear. The counts reflect the entire step.
+ *
+ * @param tx - the transaction to use for querying
+ * @param jobID - the ID of the job whose work items should be counted
+ * @returns a map of workflowStepIndex to a partial map of status: count
+ */
+export async function workItemStatusCountsForJob(
+  tx: Transaction,
+  jobID: string,
+): Promise<Map<number, { [K in WorkItemStatus]?: number }>> {
+  const rows = await tx(WorkItem.table)
+    .select('workflowStepIndex', 'status')
+    .count('id as count')
+    .where({ jobID })
+    .groupBy('workflowStepIndex', 'status');
+
+  const result = new Map<number, { [K in WorkItemStatus]?: number }>();
+  for (const row of rows) {
+    const stepIndex = Number(row.workflowStepIndex);
+    const counts = result.get(stepIndex) ?? {};
+    counts[row.status as WorkItemStatus] = Number(row.count);
+    result.set(stepIndex, counts);
+  }
+  return result;
+}
+
+/**
  *  Returns the number of work items that can be actively worked for the given service ID
  * @param tx - the transaction to use for querying
  * @param jobID - the ID of the job that created this work item

--- a/services/harmony/app/models/workflow-steps.ts
+++ b/services/harmony/app/models/workflow-steps.ts
@@ -9,7 +9,7 @@ import { Transaction } from '../util/db';
 import env from '../util/env';
 
 // The fields to save to the database
-const serializedFields = [
+export const serializedFields = [
   'id', 'jobID', 'serviceID', 'stepIndex',
   'workItemCount', 'operation', 'createdAt', 'updatedAt',
   'hasAggregatedOutput', 'isBatched', 'is_sequential', 'is_complete', 'maxBatchInputs',

--- a/services/harmony/app/routers/router.ts
+++ b/services/harmony/app/routers/router.ts
@@ -30,6 +30,7 @@ import {
 import { getServiceResult } from '../frontends/service-results';
 import { getStacCatalog, getStacItem } from '../frontends/stac';
 import { getStagingBucketPolicy } from '../frontends/staging-bucket-policy';
+import { getJobSteps } from '../frontends/steps';
 import getVersions from '../frontends/versions';
 import wmsFrontend from '../frontends/wms';
 import {
@@ -217,7 +218,7 @@ export default function router({ USE_EDL_CLIENT_APP = 'false' }: RouterConfig): 
   }
 
   // Routes and middleware not dealing with service requests
-  result.get('/service-results/:bucket/public/:jobId/:workItemId/:remainingPath(*)', asyncHandler(getServiceResult));
+  result.get('/service-results/:bucket/public/:jobId([0-9a-fA-F-]{36})/:workItemId/:remainingPath(*)', asyncHandler(getServiceResult));
   result.get('/service-results/:bucket/:remainingPath(*)', asyncHandler(getServiceResult));
 
   // Routes and middleware for handling service requests
@@ -266,8 +267,10 @@ export default function router({ USE_EDL_CLIENT_APP = 'false' }: RouterConfig): 
 
   result.get('/jobs', asyncHandler(getJobsListing));
   result.get('/jobs/:jobID', asyncHandler(getJobStatus));
+  result.get('/jobs/:jobID/steps', asyncHandler(getJobSteps));
   result.get('/admin/jobs', asyncHandler(getJobsListing));
   result.get('/admin/jobs/:jobID', asyncHandler(getJobStatus));
+  result.get('/admin/jobs/:jobID/steps', asyncHandler(getJobSteps));
 
   result.post('/jobs/:jobID/cancel', asyncHandler(cancelJob));
   result.post('/admin/jobs/:jobID/cancel', asyncHandler(cancelJob));

--- a/services/harmony/fixtures/uat.urs.earthdata.nasa.gov-443/177871848468386996
+++ b/services/harmony/fixtures/uat.urs.earthdata.nasa.gov-443/177871848468386996
@@ -1,0 +1,25 @@
+GET /api/user_groups/groups_for_user/stranger
+accept: application/json, text/plain, */*
+authorization: Bearer fake_access
+accept-encoding: gzip, compress, deflate, br
+
+HTTP/1.1 401 Unauthorized
+server: nginx/1.24.0
+date: Thu, 14 May 2026 00:28:04 GMT
+content-type: application/json; charset=utf-8
+transfer-encoding: chunked
+connection: keep-alive
+x-frame-options: SAMEORIGIN
+x-xss-protection: 0
+x-content-type-options: nosniff
+x-permitted-cross-domain-policies: none
+referrer-policy: strict-origin-when-cross-origin
+cache-control: no-store
+pragma: no-cache
+expires: Fri, 01 Jan 1990 00:00:00 GMT
+www-authenticate: Bearer realm="Earthdata Login",error="invalid_token"
+x-request-id: 2f11af67-2a8f-46d4-a449-dc5b77cde5e7
+x-runtime: 0.001534
+strict-transport-security: max-age=31536000
+
+{"error":"invalid_token"}

--- a/services/harmony/test/helpers/jobs.ts
+++ b/services/harmony/test/helpers/jobs.ts
@@ -18,7 +18,7 @@ export const adminUsername = 'adam';
 
 export const expectedJobKeys = [
   'username', 'status', 'message', 'progress', 'createdAt', 'updatedAt', 'dataExpiration',
-  'links', 'labels', 'request', 'numInputGranules', 'jobID',
+  'links', 'labels', 'steps', 'request', 'numInputGranules', 'jobID',
 ];
 
 const exampleProps = {

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -1,0 +1,490 @@
+import { expect } from 'chai';
+import { before, describe, it } from 'mocha';
+import request, { Test } from 'supertest';
+
+import { DEFAULT_PER_PAGE } from '../../app/frontends/steps';
+import { JobStatus } from '../../app/models/job';
+import WorkItem from '../../app/models/work-item';
+import { getStacLocation, WorkItemStatus } from '../../app/models/work-item-interface';
+import { serializedFields as workflowStepDbFields } from '../../app/models/workflow-steps';
+import { objectStoreForProtocol } from '../../app/util/object-store';
+import { auth } from '../helpers/auth';
+import { hookTransaction } from '../helpers/db';
+import { hookRequest } from '../helpers/hooks';
+import { adminUsername, buildJob } from '../helpers/jobs';
+import hookServersStartStop from '../helpers/servers';
+import { buildWorkItem } from '../helpers/work-items';
+import { buildWorkflowStep, validOperation } from '../helpers/workflow-steps';
+
+/**
+ * Issue a request to the steps endpoint. Mirrors the helpers/jobs.ts pattern
+ * for jobStatus / adminJobStatus so it can be bound via hookRequest.
+ */
+function jobSteps(app, { jobID, query }: { jobID: string; query?: object }): Test {
+  return request(app).get(`/jobs/${jobID}/steps`).query(query || {});
+}
+
+/**
+ * Issue a request to the admin steps endpoint.
+ */
+function adminJobSteps(app, { jobID, query }: { jobID: string; query?: object }): Test {
+  return request(app).get(`/admin/jobs/${jobID}/steps`).query(query || {});
+}
+
+const hookJobSteps = hookRequest.bind(this, jobSteps);
+const hookAdminJobSteps = hookRequest.bind(this, adminJobSteps);
+
+let wi2Id: number;
+
+const joeJob = buildJob({
+  username: 'joe',
+  status: JobStatus.FAILED,
+  message: 'Service failed',
+  service_name: 'harmony-best-service',
+  request: 'https://harmony.example/foo?bar=baz',
+});
+
+const runningJob = buildJob({
+  username: 'joe',
+  status: JobStatus.RUNNING,
+  request: 'https://harmony.example/running',
+});
+
+// Job exercising the batch-catalogs truncation path: a successful query-cmr WI
+// whose batch-catalogs.json lists more catalog files than MAX_BATCH_CATALOGS.
+const truncatedJob = buildJob({
+  username: 'joe',
+  status: JobStatus.SUCCESSFUL,
+  service_name: 'harmony-best-service',
+  request: 'https://harmony.example/truncated',
+});
+
+// Job written to a user-supplied destinationUrl bucket: its output catalog's
+// data asset is an s3:// href that createPublicPermalink can't sign (not under
+// /public/).
+const destBucketJob = buildJob({
+  username: 'joe',
+  status: JobStatus.SUCCESSFUL,
+  service_name: 'harmony-best-service',
+  request: 'https://harmony.example/dest',
+  destination_url: 's3://user-bucket/out',
+});
+
+// Job whose single step has more work items than DEFAULT_PER_PAGE (50), to
+// exercise the per-step bound and the placeholder paging block.
+const pagedJob = buildJob({
+  username: 'joe',
+  status: JobStatus.RUNNING,
+  service_name: 'harmony-best-service',
+  request: 'https://harmony.example/paged',
+});
+
+describe('GET /jobs/:jobID/steps', function () {
+  hookServersStartStop({ USE_EDL_CLIENT_APP: true });
+  hookTransaction();
+
+  before(async function () {
+    await joeJob.save(this.trx);
+    // Step 1: query-cmr with a single successful work item
+    const step1 = buildWorkflowStep({
+      jobID: joeJob.jobID,
+      stepIndex: 1,
+      serviceID: '123456789012.dkr.ecr.us-west-2.amazonaws.com/harmonyservices/query-cmr:latest',
+      workItemCount: 1,
+      operation: validOperation,
+    });
+    await step1.save(this.trx);
+    const wi1 = buildWorkItem({
+      jobID: joeJob.jobID,
+      workflowStepIndex: 1,
+      serviceID: 'harmonyservices/query-cmr:latest',
+      status: WorkItemStatus.SUCCESSFUL,
+      scrollID: 'fake-scroll-key',
+    });
+    await wi1.save(this.trx);
+
+    // Step 2: subsetter with a failed work item that has an input catalog from step 1
+    const step2 = buildWorkflowStep({
+      jobID: joeJob.jobID,
+      stepIndex: 2,
+      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      workItemCount: 1,
+      operation: validOperation,
+    });
+    await step2.save(this.trx);
+    const wi2 = buildWorkItem({
+      jobID: joeJob.jobID,
+      workflowStepIndex: 2,
+      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      status: WorkItemStatus.FAILED,
+      stacCatalogLocation: `s3://artifacts/${joeJob.jobID}/1/outputs/catalog.json`,
+    });
+    await wi2.save(this.trx);
+    wi2Id = wi2.id;
+
+    // A second job that's still running, with a single READY work item — used
+    // to verify that incomplete WIs surface as files: null and that no S3
+    // resolution is attempted on them.
+    await runningJob.save(this.trx);
+    const runningStep = buildWorkflowStep({
+      jobID: runningJob.jobID,
+      stepIndex: 1,
+      serviceID: 'harmonyservices/query-cmr:latest',
+      workItemCount: 1,
+      operation: validOperation,
+    });
+    await runningStep.save(this.trx);
+    const runningWi = buildWorkItem({
+      jobID: runningJob.jobID,
+      workflowStepIndex: 1,
+      serviceID: 'harmonyservices/query-cmr:latest',
+      status: WorkItemStatus.READY,
+    });
+    await runningWi.save(this.trx);
+
+    // A third job whose query-cmr WI has 105 catalog files listed in
+    // batch-catalogs.json — 5 over MAX_BATCH_CATALOGS (100). (The catalog
+    // files themselves are not staged.)
+    await truncatedJob.save(this.trx);
+    const truncatedStep = buildWorkflowStep({
+      jobID: truncatedJob.jobID,
+      stepIndex: 1,
+      serviceID: 'harmonyservices/query-cmr:latest',
+      workItemCount: 1,
+      operation: validOperation,
+    });
+    await truncatedStep.save(this.trx);
+    const truncatedWi = buildWorkItem({
+      jobID: truncatedJob.jobID,
+      workflowStepIndex: 1,
+      serviceID: 'harmonyservices/query-cmr:latest',
+      status: WorkItemStatus.SUCCESSFUL,
+      scrollID: 'fake-scroll-key',
+    });
+    await truncatedWi.save(this.trx);
+    const overCapCatalogList = Array.from({ length: 105 }, (_, i) => `catalog${i}.json`);
+    const batchUrl = getStacLocation(
+      { id: truncatedWi.id, jobID: truncatedJob.jobID },
+      'batch-catalogs.json',
+    );
+    await objectStoreForProtocol('s3').upload(
+      JSON.stringify(overCapCatalogList), batchUrl, null, 'application/json',
+    );
+
+    // A job with a destinationUrl with a data asset is an s3:// href in
+    // the user's destination bucket. Its single step has both a successful and
+    // a failed work item, so it also exercises the per-status step summary.
+    await destBucketJob.save(this.trx);
+    const destStep = buildWorkflowStep({
+      jobID: destBucketJob.jobID,
+      stepIndex: 1,
+      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      workItemCount: 2,
+      operation: validOperation,
+    });
+    await destStep.save(this.trx);
+    const destWi = buildWorkItem({
+      jobID: destBucketJob.jobID,
+      workflowStepIndex: 1,
+      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      status: WorkItemStatus.SUCCESSFUL,
+    });
+    await destWi.save(this.trx);
+    const destFailedWi = buildWorkItem({
+      jobID: destBucketJob.jobID,
+      workflowStepIndex: 1,
+      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      status: WorkItemStatus.FAILED,
+    });
+    await destFailedWi.save(this.trx);
+    const s3 = objectStoreForProtocol('s3');
+    const stacLoc = (f: string): string =>
+      getStacLocation({ id: destWi.id, jobID: destBucketJob.jobID }, f);
+    await s3.upload(JSON.stringify({
+      stac_version: '1.0.0', id: 'cat', description: 'c',
+      links: [{ rel: 'item', href: './item0.json' }],
+    }), stacLoc('catalog.json'), null, 'application/json');
+    await s3.upload(JSON.stringify({
+      stac_version: '1.0.0', id: 'item0', type: 'Feature',
+      geometry: null, properties: {}, links: [],
+      assets: {
+        'granule_reformatted.tif': {
+          href: 's3://user-bucket/out/granule_reformatted.tif',
+          type: 'image/tiff; application=geotiff; profile=cloud-optimized',
+          roles: ['visual'],
+        },
+      },
+    }), stacLoc('item0.json'), null, 'application/json');
+
+    // A job whose single step holds 51 READY work items — one over
+    // DEFAULT_PER_PAGE (50). READY items are skipped by catalog resolution, so
+    // this stays cheap while still exercising the per-step bound + paging block.
+    await pagedJob.save(this.trx);
+    const pagedStep = buildWorkflowStep({
+      jobID: pagedJob.jobID,
+      stepIndex: 1,
+      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      workItemCount: 51,
+      operation: validOperation,
+    });
+    await pagedStep.save(this.trx);
+    const pagedWorkItems = Array.from({ length: 51 }, () => buildWorkItem({
+      jobID: pagedJob.jobID,
+      workflowStepIndex: 1,
+      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      status: WorkItemStatus.READY,
+    }));
+    await WorkItem.insertBatch(this.trx, pagedWorkItems);
+
+    await this.trx.commit();
+  });
+
+  describe('For a user who is not logged in', function () {
+    hookJobSteps({ jobID: joeJob.jobID });
+    it('redirects to Earthdata Login', function () {
+      expect(this.res.statusCode).to.equal(303);
+    });
+  });
+
+  describe('For a non-owner who is not admin', function () {
+    hookJobSteps({ jobID: joeJob.jobID, username: 'stranger' });
+    it('denies access', function () {
+      expect(this.res.statusCode).to.equal(403);
+    });
+  });
+
+  describe('For the owner requesting the default steps response', function () {
+    hookJobSteps({ jobID: joeJob.jobID, username: 'joe' });
+
+    it('returns 200 with a steps document for the job', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      expect(body.jobID).to.equal(joeJob.jobID);
+      expect(body.status).to.equal('failed');
+      expect(body.username).to.equal('joe');
+      expect(body.serviceName).to.equal('harmony-best-service');
+      expect(body.request).to.equal('https://harmony.example/foo?bar=baz');
+    });
+
+    it('includes both workflow steps with expected keys', function () {
+      const body = JSON.parse(this.res.text);
+      expect(body.steps).to.have.lengthOf(2);
+      expect(body.steps[0].stepIndex).to.equal(1);
+      expect(body.steps[0].serviceID).to.equal('harmonyservices/query-cmr:latest');
+      expect(body.steps[0].workItemCount).to.equal(1);
+      expect(body.steps[1].stepIndex).to.equal(2);
+      expect(body.steps[1].serviceID).to.equal('nasa/harmony-opendap-subsetter:1.2.4');
+      expect(body.steps[1].workItemCount).to.equal(1);
+      expect(body.steps[1].workItems).to.have.length(1);
+    });
+
+    it('exposes correct step-level state on the response', function () {
+      const expectedKeys = ['serviceID', 'stepIndex', 'workItemCount', 'statuses', 'workItems'];
+      const unexposedKeys = workflowStepDbFields.filter((f) => !expectedKeys.includes(f));
+      const body = JSON.parse(this.res.text);
+      for (const step of body.steps) {
+        expect(step).to.not.have.any.keys(...unexposedKeys);
+        expect(step).to.have.keys(expectedKeys);
+      }
+    });
+
+    it('summarizes each step with per-status work item counts', function () {
+      const body = JSON.parse(this.res.text);
+      // Step 1: one successful query-cmr WI. Step 2: one failed subsetter WI.
+      // Only non-zero statuses appear, and the keys are WorkItemStatus values
+      // ('failed', not 'failure').
+      expect(body.steps[0].statuses).to.deep.equal({ successful: 1 });
+      expect(body.steps[1].statuses).to.deep.equal({ failed: 1 });
+    });
+
+    it('exposes inputFiles / outputFiles fields', function () {
+      const body = JSON.parse(this.res.text);
+      const wi1 = body.steps[0].workItems[0];
+      const wi2 = body.steps[1].workItems[0];
+      expect(wi1).to.have.property('inputFiles');
+      expect(wi1).to.have.property('outputFiles');
+      expect(wi1.inputFiles).to.be.null;
+      expect(wi1.outputFiles).to.be.an('array');
+      expect(wi2).to.have.property('inputFiles');
+      expect(wi2.inputFiles).to.be.an('array');
+      expect(wi2).to.have.property('outputFiles');
+    });
+
+  });
+
+  describe('Filtering with ?step=', function () {
+    hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { step: 2 } });
+    it('returns only the requested step', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      expect(body.steps).to.have.lengthOf(1);
+      expect(body.steps[0].stepIndex).to.equal(2);
+    });
+  });
+
+  describe('Filtering with ?status=failed', function () {
+    hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { status: 'failed' } });
+    it('keeps only work items in that status', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      for (const step of body.steps) {
+        for (const wi of step.workItems) {
+          expect(wi.status).to.equal('failed');
+        }
+      }
+      const stepsWithItems = body.steps.filter((s) => s.workItems.length > 0);
+      expect(stepsWithItems).to.have.lengthOf(1);
+      expect(stepsWithItems[0].stepIndex).to.equal(2);
+    });
+  });
+
+  describe('Top-level pagination has been removed', function () {
+    hookJobSteps({ jobID: joeJob.jobID, username: 'joe' });
+    it('does not include a top-level pagination object', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      expect(body).to.not.have.property('pagination');
+    });
+    it('does not add a paging block to steps under the per-step limit', function () {
+      const body = JSON.parse(this.res.text);
+      for (const step of body.steps) {
+        expect(step).to.not.have.property('paging');
+      }
+    });
+  });
+
+  describe('For a job whose work item is still incomplete', function () {
+    hookJobSteps({ jobID: runningJob.jobID, username: 'joe' });
+    it('leaves outputFiles as null and does not attempt resolution', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const wi = body.steps[0].workItems[0];
+      expect(wi.status).to.equal('ready');
+      expect(wi.outputFiles).to.equal(null);
+      expect(wi.inputFiles).to.equal(null);
+    });
+  });
+
+  describe('For an admin user fetching another user\'s job via /admin/jobs/:jobID/steps', function () {
+    hookAdminJobSteps({ jobID: joeJob.jobID, username: adminUsername });
+    it('returns 200 with the job\'s steps', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      expect(body.jobID).to.equal(joeJob.jobID);
+      expect(body.steps).to.have.lengthOf(2);
+    });
+  });
+
+  describe('For a jobID that does not exist', function () {
+    hookJobSteps({
+      jobID: '00000000-0000-4000-8000-000000000000',
+      username: 'joe',
+    });
+    it('returns 404', function () {
+      expect(this.res.statusCode).to.equal(404);
+    });
+  });
+
+  describe('Filtering with ?step= for an unknown step index', function () {
+    hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { step: 99 } });
+    it('returns 200 with an empty steps array', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      expect(body.steps).to.deep.equal([]);
+    });
+  });
+
+  describe('Filtering with ?workItem=<id>', function () {
+    // Custom before because hookJobSteps captures `query` at describe-load
+    // time, but wi2Id is only set by the outer `before` (after save).
+    before(async function () {
+      this.res = await jobSteps(
+        this.frontend,
+        { jobID: joeJob.jobID, query: { workItem: wi2Id } },
+      ).use(auth({ username: 'joe' }));
+    });
+    after(function () { delete this.res; });
+
+    it('returns only the requested work item, in its parent step', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      // The workItem filter + drop-empty-when-filtering means only step 2
+      // surfaces, with exactly the targeted work item.
+      expect(body.steps).to.have.lengthOf(1);
+      expect(body.steps[0].stepIndex).to.equal(2);
+      expect(body.steps[0].workItems).to.have.lengthOf(1);
+      expect(body.steps[0].workItems[0].id).to.equal(wi2Id);
+    });
+  });
+
+  describe('When batch-catalogs.json exceeds MAX_BATCH_CATALOGS', function () {
+    hookJobSteps({ jobID: truncatedJob.jobID, username: 'joe' });
+
+    it('appends a truncation sentinel to outputFiles naming the omitted count', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const { outputFiles } = body.steps[0].workItems[0];
+      expect(outputFiles).to.be.an('array');
+      // Last element [also the only element] is the sentinel; 105 staged - 100 cap = 5 omitted.
+      expect(outputFiles[outputFiles.length - 1]).to.equal(
+        'Not all files resolved, there are 5 more files not shown (HARMONY-2352)',
+      );
+    });
+  });
+
+  describe('For a job written to a user destinationUrl bucket', function () {
+    hookJobSteps({ jobID: destBucketJob.jobID, username: 'joe' });
+
+    it('displays a generic asset and passes the destination-bucket href through', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const { outputFiles } = body.steps[0].workItems[0];
+      expect(outputFiles).to.deep.equal(['s3://user-bucket/out/granule_reformatted.tif']);
+    });
+
+    it('summarizes both statuses present in the step', function () {
+      const body = JSON.parse(this.res.text);
+      expect(body.steps[0].statuses).to.deep.equal({ successful: 1, failed: 1 });
+    });
+  });
+
+  describe('For a mixed-status step filtered with ?status=failed', function () {
+    hookJobSteps({ jobID: destBucketJob.jobID, username: 'joe', query: { status: 'failed' } });
+
+    it('reports the whole-step summary when work items are filtered', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const step = body.steps[0];
+      expect(step.workItems).to.have.lengthOf(1);
+      expect(step.workItems[0].status).to.equal('failed');
+      expect(step.statuses).to.deep.equal({ successful: 1, failed: 1 });
+    });
+  });
+
+  describe('For a step with more work items than the per-step limit', function () {
+    hookJobSteps({ jobID: pagedJob.jobID, username: 'joe' });
+
+    it('caps the work items at DEFAULT_PER_PAGE and adds a paging note', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const step = body.steps[0];
+      // 51 work items exist, but the step is bounded to the per-page limit.
+      expect(step.workItems).to.have.lengthOf(DEFAULT_PER_PAGE);
+      expect(step.paging).to.deep.equal({
+        message: 'Paging of results available with HARMONY-2354',
+      });
+      // The status summary for whole step.
+      expect(step.statuses).to.deep.equal({ ready: 51 });
+    });
+  });
+
+  describe('Validation errors', function () {
+    describe('?status=bogus', function () {
+      hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { status: 'bogus' } });
+      it('returns 400', function () {
+        expect(this.res.statusCode).to.equal(400);
+      });
+    });
+
+  });
+});

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -143,7 +143,7 @@ describe('GET /jobs/:jobID/steps', function () {
     await runningWi.save(this.trx);
 
     // A third job whose query-cmr WI has 105 catalog files listed in
-    // batch-catalogs.json — 5 over MAX_BATCH_CATALOGS (100). (The catalog
+    // batch-catalogs.json — 5 over MAX_BATCH_CATALOGS (5). (The catalog
     // files themselves are not staged.)
     await truncatedJob.save(this.trx);
     const truncatedStep = buildWorkflowStep({
@@ -162,7 +162,7 @@ describe('GET /jobs/:jobID/steps', function () {
       scrollID: 'fake-scroll-key',
     });
     await truncatedWi.save(this.trx);
-    const overCapCatalogList = Array.from({ length: 105 }, (_, i) => `catalog${i}.json`);
+    const overCapCatalogList = Array.from({ length: 100 }, (_, i) => `catalog${i}.json`);
     const batchUrl = getStacLocation(
       { id: truncatedWi.id, jobID: truncatedJob.jobID },
       'batch-catalogs.json',
@@ -425,9 +425,9 @@ describe('GET /jobs/:jobID/steps', function () {
       const body = JSON.parse(this.res.text);
       const { outputFiles } = body.steps[0].workItems[0];
       expect(outputFiles).to.be.an('array');
-      // Last element [also the only element] is the sentinel; 105 staged - 100 cap = 5 omitted.
+      // Last element [also the only element] is the sentinel; 100 staged - 5 cap = 95 omitted.
       expect(outputFiles[outputFiles.length - 1]).to.equal(
-        'Not all files resolved, there are 5 more files not shown (HARMONY-2352)',
+        'Not all files resolved, there are 95 more files not shown.',
       );
     });
   });
@@ -471,7 +471,7 @@ describe('GET /jobs/:jobID/steps', function () {
       // 51 work items exist, but the step is bounded to the per-page limit.
       expect(step.workItems).to.have.lengthOf(DEFAULT_PER_PAGE);
       expect(step.paging).to.deep.equal({
-        message: 'Paging of results available with HARMONY-2354',
+        message: 'results paging not implemented',
       });
       // The status summary for whole step.
       expect(step.statuses).to.deep.equal({ ready: 51 });

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -420,15 +420,12 @@ describe('GET /jobs/:jobID/steps', function () {
   describe('When batch-catalogs.json exceeds MAX_BATCH_CATALOGS', function () {
     hookJobSteps({ jobID: truncatedJob.jobID, username: 'joe' });
 
-    it('appends a truncation sentinel to outputFiles naming the omitted count', function () {
+    it('includes a truncation warning when outputFiles in incomplete', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
-      const { outputFiles } = body.steps[0].workItems[0];
+      const { outputFiles, warning } = body.steps[0].workItems[0];
       expect(outputFiles).to.be.an('array');
-      // Last element [also the only element] is the sentinel; 100 staged - 5 cap = 95 omitted.
-      expect(outputFiles[outputFiles.length - 1]).to.equal(
-        'Not all files resolved, there are 95 more files not shown.',
-      );
+      expect(warning).to.equal('Not all stac catalogs resolved, there are 95 unshown catalogs.');
     });
   });
 
@@ -438,8 +435,9 @@ describe('GET /jobs/:jobID/steps', function () {
     it('displays a generic asset and passes the destination-bucket href through', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
-      const { outputFiles } = body.steps[0].workItems[0];
+      const { outputFiles, warning } = body.steps[0].workItems[0];
       expect(outputFiles).to.deep.equal(['s3://user-bucket/out/granule_reformatted.tif']);
+      expect(warning).not.to.exist;
     });
 
     it('summarizes both statuses present in the step', function () {

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -425,7 +425,8 @@ describe('GET /jobs/:jobID/steps', function () {
       const body = JSON.parse(this.res.text);
       const { outputFiles, warning } = body.steps[0].workItems[0];
       expect(outputFiles).to.be.an('array');
-      expect(warning).to.equal('Not all stac catalogs resolved, there are 95 unshown catalogs.');
+      expect(warning).to.equal('Not all output files are included. Only the outputs from the first ' +
+        '5 STAC catalogs were resolved, there are 95 catalogs that were not resolved.');
     });
   });
 
@@ -469,7 +470,7 @@ describe('GET /jobs/:jobID/steps', function () {
       // 51 work items exist, but the step is bounded to the per-page limit.
       expect(step.workItems).to.have.lengthOf(DEFAULT_PER_PAGE);
       expect(step.paging).to.deep.equal({
-        message: 'results paging not implemented',
+        message: 'WorkItem results paging not implemented: 50 work items shown out of 51.',
       });
       // The status summary for whole step.
       expect(step.statuses).to.deep.equal({ ready: 51 });

--- a/services/harmony/test/jobs/steps-helpers.ts
+++ b/services/harmony/test/jobs/steps-helpers.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { safePublicLink } from '../../app/frontends/steps';
+
+const FRONTEND_ROOT = 'https://harmony.example';
+const PRIVATE_FILE_PLACEHOLDER = '<private file location>';
+
+describe('safePublicLink', function () {
+  describe('for an href createPublicPermalink can sign (s3 .../public/...)', function () {
+    it('returns a Harmony permalink and ignores the destination bucket', function () {
+      const href = 's3://staging-bucket/public/abc/granule.nc4';
+      const link = safePublicLink(href, FRONTEND_ROOT, 'user-bucket');
+      expect(link).to.equal(
+        'https://harmony.example/service-results/staging-bucket/public/abc/granule.nc4',
+      );
+    });
+  });
+
+  describe('for an unsignable s3 href (not under /public/)', function () {
+    it('passes the href through when it is in the job destination bucket', function () {
+      const href = 's3://user-bucket/out/granule.nc4';
+      expect(safePublicLink(href, FRONTEND_ROOT, 'user-bucket')).to.equal(href);
+    });
+
+    it('hides the href behind the placeholder when it is in a different bucket', function () {
+      const href = 's3://someone-else/out/granule.nc4';
+      expect(safePublicLink(href, FRONTEND_ROOT, 'user-bucket')).to.equal(PRIVATE_FILE_PLACEHOLDER);
+    });
+
+    it('does not treat a bucket-name prefix as a match', function () {
+      const href = 's3://user-bucket-nefarious/out/granule.nc4';
+      expect(safePublicLink(href, FRONTEND_ROOT, 'user-bucket')).to.equal(PRIVATE_FILE_PLACEHOLDER);
+    });
+
+    it('hides the href behind the placeholder when the job has no destinationUrl', function () {
+      const href = 's3://artifacts/123/1/outputs/catalog.json';
+      expect(safePublicLink(href, FRONTEND_ROOT, undefined)).to.equal(PRIVATE_FILE_PLACEHOLDER);
+    });
+  });
+
+  describe('for a non-s3 href that createPublicPermalink passes through', function () {
+    it('returns an https href unchanged, ignoring the destination bucket', function () {
+      const href = 'https://example.com/data/granule.nc4';
+      expect(safePublicLink(href, FRONTEND_ROOT, 'user-bucket')).to.equal(href);
+    });
+
+    it('returns an ftp href unchanged', function () {
+      const href = 'ftp://example.com/data/granule.nc4';
+      expect(safePublicLink(href, FRONTEND_ROOT, undefined)).to.equal(href);
+    });
+  });
+
+  describe('for an href createPublicPermalink cannot handle at all', function () {
+    it('hides an unsupported-scheme href behind the placeholder', function () {
+      const href = 'file:///etc/passwd';
+      expect(safePublicLink(href, FRONTEND_ROOT, 'user-bucket')).to.equal(PRIVATE_FILE_PLACEHOLDER);
+    });
+
+    it('hides a non-URL string behind the placeholder', function () {
+      expect(safePublicLink('not-a-url', FRONTEND_ROOT, undefined)).to.equal(PRIVATE_FILE_PLACEHOLDER);
+    });
+  });
+});

--- a/services/harmony/test/service-results.ts
+++ b/services/harmony/test/service-results.ts
@@ -1,11 +1,15 @@
 import { expect } from 'chai';
 import { describe, it } from 'mocha';
 import sinon, { stub } from 'sinon';
+import { v4 as uuid } from 'uuid';
 
 import { hookUrl } from './helpers/hooks';
 import hookServersStartStop from './helpers/servers';
 import { createPublicPermalink, providerCollectionCache } from '../app/frontends/service-results';
 import { FileStore } from '../app/util/object-store/file-store';
+
+const someJobID = uuid();
+const someWorkItemID = '12345';
 
 describe('service-results', function () {
   hookServersStartStop({ USE_EDL_CLIENT_APP: true });
@@ -77,7 +81,7 @@ describe('service-results', function () {
         providerCollectionIdCacheStub.restore();
       });
 
-      hookUrl('/service-results/some-bucket/public/some-job-id/some-work-item-id/some-path.tif', 'jdoe');
+      hookUrl(`/service-results/some-bucket/public/${someJobID}/${someWorkItemID}/some-path.tif`, 'jdoe');
       it('passes the user\'s Earthdata Login username to the signing function for tracking', function () {
         expect(this.res.headers.location).to.include('A-userid=jdoe');
         expect(this.res.headers.location).to.include('A-provider=EEDTEST');
@@ -86,11 +90,11 @@ describe('service-results', function () {
 
       it('redirects temporarily to a presigned URL', function () {
         expect(this.res.statusCode).to.equal(307);
-        expect(this.res.headers.location).to.include('some-bucket/public/some-job-id/some-work-item-id/some-path.tif');
+        expect(this.res.headers.location).to.include(`some-bucket/public/${someJobID}/${someWorkItemID}/some-path.tif`);
       });
 
       it('includes an api_request_id field', function () {
-        expect(this.res.headers.location).to.include('A-api-request-uuid=some-job-id');
+        expect(this.res.headers.location).to.include(`A-api-request-uuid=${someJobID}`);
       });
 
       it('includes a provider field', function () {
@@ -107,7 +111,7 @@ describe('service-results', function () {
       before(function () {
         stubObject = stub(FileStore.prototype, 'signGetObject').throws();
       });
-      hookUrl('/service-results/some-bucket/public/some-job-id/some-work-item-id/some-path.tif', 'jdoe');
+      hookUrl(`/service-results/some-bucket/public/${someJobID}/${someWorkItemID}/some-path.tif`, 'jdoe');
       after(function () {
         stubObject.restore();
       });


### PR DESCRIPTION
## Jira Issue ID


[HARMONY-2312](https://bugs.earthdata.nasa.gov/browse/HARMONY-2312)

## Description

Implements MVP for steps endpoint.

- new `steps` endpoint allowing a user to interrogate the intermediate steps of a job.
- link to steps added to the `job/:jobId` response
- service chain name added to `job/:jobId` response
- documentation added.
- Query CMR steps limited to reading 100 local stac catalogs with indicator of how many files are not shown.
- Workflow items limited to first 50 and a paging indicator is displayed if there are more that cannot be reached (to be done HARMONY-2354)


## Local Test Steps

Pull this branch and run against local Harmony-In-A-Box.

here are some sample requests to try.

Request that goes into a destination bucket: (to test that S3 refs are revealed to the end user directly)
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=PNG&destinationUrl=s3%3A%2F%2Flocal-upload-bucket&subset=time(%222002-09-15T00%3A00%3A00.000Z%22%3A%222022-09-25T00%3A00%3A00Z%22)&label=HARMONY-2312-destination-bucket

Request that has a HOSS failure.
http://localhost:3000/C1268429762-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&subset=lat(41.73504%3A43.2472)&subset=lon(5.0196%3A7.91089)&subset=time(%222015-03-31T17%3A06%3A00Z%22%3A%222015-03-31T17%3A10%3A00Z%22)&label=HARMONY-2312-errors&format=image%2Ftiff&variable=Soil_Moisture_Retrieval_Data_1km%2Fretrieval_qual_flag_1km&variable=Soil_Moisture_Retrieval_Data_1km%2Fretrieval_qual_flag_apm_1km&variable=Soil_Moisture_Retrieval_Data_1km%2Fsoil_moisture_1km&variable=Soil_Moisture_Retrieval_Data_1km%2Fsoil_moisture_apm_1km


Request to verify net2cog output files.
http://localhost:3000/C1268429309-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&granuleId=G1281797307-EEDTEST&format=image%2Ftiff&variable=Soil_Moisture_Retrieval_Data%2Flandcover_class_fraction&label=HARMONY-2312-net2cog


Request to demonstrate paging:
http://localhost:3000/C1234088182-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?format=image%2Ftiff&label=HARMONY-2312-paging

Request with batch-catalog stac files (batchee)

http://localhost:3000/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-70%3A30)&subset=lon(-157.5%3A-10)&concatenate=true&maxResults=8&extend=true&serviceId=l2-subsetter-batchee-stitchee-concise

Follow the job page to the steps page and verify the outputs look like what we want.


I did also deploy to mhs sandbox and you can pull that information from the sandbox account and see some outputs running there (including the 110000 granule request for C1234724470-POCLOUD [this one is actually slow 2s because of the bunches of query cmrs that are kicked off but each 2000 granule output list is still bounded at 100 catalogs]) 

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)
* [X] Harmony in a Box tested (if changes made to microservices or new dependencies added)
