### PR TITLE
HARMONY-2364: Make sure as work item updates are actively being worked SQS messages are not redelivered

### DIFF
--- a/services/harmony/app/util/queue/queue.ts
+++ b/services/harmony/app/util/queue/queue.ts
@@ -18,4 +18,10 @@ export abstract class Queue {
   abstract deleteMessage(receipt: string): Promise<void>;
   abstract deleteMessages(receipts: string[]): Promise<void>;
   abstract purge(): Promise<void>;
+  abstract changeMessageVisibility(
+    receipt: string, visibilityTimeoutSeconds: number
+  ): Promise<void>;
+  abstract changeMessageVisibilities(
+    receipts: string[], visibilityTimeoutSeconds: number
+  ): Promise<void>;
 }

--- a/services/harmony/app/util/queue/sqs-queue.ts
+++ b/services/harmony/app/util/queue/sqs-queue.ts
@@ -1,10 +1,14 @@
 import {
+  ChangeMessageVisibilityBatchCommand,
+  ChangeMessageVisibilityCommand,
   DeleteMessageBatchCommand, DeleteMessageCommand, GetQueueAttributesCommand, PurgeQueueCommand,
   ReceiveMessageCommand, SendMessageCommand, SendMessageCommandInput, SQSClient, SQSClientConfig,
 } from '@aws-sdk/client-sqs';
 
 import env from '../env';
 import { Queue, ReceivedMessage } from './queue';
+
+const MAX_BATCH_SIZE = 10;
 
 export class SqsQueue extends Queue {
   queueUrl: string;
@@ -91,10 +95,9 @@ export class SqsQueue extends Queue {
   }
 
   async deleteMessages(receipts: string[]): Promise<void> {
-    // SQS only allows deleting up to 10 at a time so we need to batch the deletes
-    const MAX_BATCH_SIZE = 10;
     const promises = [];
 
+    // SQS only allows deleting up to 10 at a time so we need to batch the deletes
     for (let i = 0; i < receipts.length; i += MAX_BATCH_SIZE) {
       const batch = receipts.slice(i, i + MAX_BATCH_SIZE);
       const entries = batch.map((receipt, index) => ({
@@ -107,6 +110,45 @@ export class SqsQueue extends Queue {
           new DeleteMessageBatchCommand({
             QueueUrl: this.queueUrl,
             Entries: entries,
+          }),
+        ),
+      );
+    }
+
+    await Promise.all(promises);
+  }
+
+  async changeMessageVisibility(
+    receipt: string,
+    visibilityTimeoutSeconds: number,
+  ): Promise<void> {
+    const command = new ChangeMessageVisibilityCommand({
+      QueueUrl: this.queueUrl,
+      ReceiptHandle: receipt,
+      VisibilityTimeout: visibilityTimeoutSeconds,
+    });
+
+    await this.sqs.send(command);
+  }
+
+  async changeMessageVisibilities(
+    receipts: string[],
+    visibilityTimeoutSeconds: number,
+  ): Promise<void> {
+    const promises = [];
+
+    for (let i = 0; i < receipts.length; i += MAX_BATCH_SIZE) {
+      const batch = receipts.slice(i, i + MAX_BATCH_SIZE);
+
+      promises.push(
+        this.sqs.send(
+          new ChangeMessageVisibilityBatchCommand({
+            QueueUrl: this.queueUrl,
+            Entries: batch.map((receipt, index) => ({
+              Id: index.toString(),
+              ReceiptHandle: receipt,
+              VisibilityTimeout: visibilityTimeoutSeconds,
+            })),
           }),
         ),
       );

--- a/services/harmony/test/helpers/memory-queue.ts
+++ b/services/harmony/test/helpers/memory-queue.ts
@@ -74,4 +74,17 @@ export class MemoryQueue extends Queue {
   async purge(): Promise<void> {
     this.messages = [];
   }
+
+  async changeMessageVisibility(
+    _receipt: string, _visibilityTimeoutSeconds: number,
+  ): Promise<void> {
+    // Memory queue ignores visibility timeout
+  }
+
+  async changeMessageVisibilities(
+    _receipts: string[], _visibilityTimeoutSeconds: number,
+  ): Promise<void> {
+    // Memory queue ignores visibility timeout
+  }
+
 }

--- a/services/work-updater/app/workers/updater.ts
+++ b/services/work-updater/app/workers/updater.ts
@@ -6,7 +6,7 @@ import {
 import { getJobStatusForJobID, terminalStates } from '../../../harmony/app/models/job';
 import { getJobIdForWorkItem } from '../../../harmony/app/models/work-item';
 import { default as defaultLogger } from '../../../harmony/app/util/log';
-import { WorkItemQueueType } from '../../../harmony/app/util/queue/queue';
+import { Queue, WorkItemQueueType } from '../../../harmony/app/util/queue/queue';
 import { getQueueForType } from '../../../harmony/app/util/queue/queue-factory';
 import sleep from '../../../harmony/app/util/sleep';
 import { Worker } from '../../../harmony/app/workers/worker';
@@ -58,6 +58,57 @@ export async function handleBatchWorkItemUpdates(
 }
 
 /**
+ * Starts periodically extending message visibility.
+ *
+ * After an initial delay, sets the visibility timeout and continues refreshing
+ * it at the specified interval until the returned cleanup function is called.
+ *
+ * @param queue - Queue being processed
+ * @param receipts - Receipt handles to extend
+ * @param initialDelaySeconds - Delay before starting visibility extensions
+ * @param refreshIntervalSeconds - Interval between visibility extensions
+ * @param visibilityTimeoutSeconds - Visibility timeout to set on each extension
+ * @returns Cleanup function
+ */
+export function startVisibilityHeartbeat(
+  queue: Queue,
+  receipts: string[],
+  initialDelaySeconds = 15,
+  refreshIntervalSeconds = 30,
+  visibilityTimeoutSeconds = 60,
+): () => void {
+  const extendVisibility = async (): Promise<void> => {
+    try {
+      defaultLogger.warn(`Extending message visibility by ${visibilityTimeoutSeconds} seconds`);
+      await queue.changeMessageVisibilities(
+        receipts,
+        visibilityTimeoutSeconds,
+      );
+    } catch (e) {
+      defaultLogger.error(`Error extending message visibility timeout: ${e}`);
+    }
+  };
+
+  let visibilityInterval: NodeJS.Timeout | undefined;
+
+  const visibilityStartTimeout = setTimeout(() => {
+    void extendVisibility();
+
+    visibilityInterval = setInterval(() => {
+      void extendVisibility();
+    }, refreshIntervalSeconds * 1000);
+  }, initialDelaySeconds * 1000);
+
+  return (): void => {
+    clearTimeout(visibilityStartTimeout);
+
+    if (visibilityInterval) {
+      clearInterval(visibilityInterval);
+    }
+  };
+}
+
+/**
  * This function processes a batch of work item updates from the queue.
  * @param queueType - Type of the queue to read from
  */
@@ -78,39 +129,49 @@ export async function batchProcessQueue(queueType: WorkItemQueueType): Promise<v
 
   defaultLogger.debug(`Processing ${messages.length} work item updates from queue`);
 
-  if (queueType === WorkItemQueueType.LARGE_ITEM_UPDATE) {
-    // process each message individually
-    for (const msg of messages) {
-      try {
-        const updateItem: WorkItemUpdateQueueItem = JSON.parse(msg.body);
-        defaultLogger.debug(`Processing work item update from queue for work item ${updateItem.update.workItemID} and status ${updateItem.update.status}`);
-        await exports.handleBatchWorkItemUpdates([updateItem], defaultLogger);
-      } catch (e) {
-        defaultLogger.error(`Error processing work item update from queue: ${e}`);
+  const stopVisibilityHeartbeat = startVisibilityHeartbeat(
+    queue,
+    messages.map((msg) => msg.receipt),
+  );
+
+  try {
+    if (queueType === WorkItemQueueType.LARGE_ITEM_UPDATE) {
+      // process each message individually
+      for (const msg of messages) {
+        try {
+          const updateItem: WorkItemUpdateQueueItem = JSON.parse(msg.body);
+          defaultLogger.debug(`Processing work item update from queue for work item ${updateItem.update.workItemID} and status ${updateItem.update.status}`);
+          await exports.handleBatchWorkItemUpdates([updateItem], defaultLogger);
+        } catch (e) {
+          defaultLogger.error(`Error processing work item update from queue: ${e}`);
+        }
+        try {
+          // delete the message from the queue even if there was an error updating the work-item
+          // so that we don't keep processing the same message over and over
+          await queue.deleteMessage(msg.receipt);
+        } catch (e) {
+          defaultLogger.error(`Error deleting work item update from queue: ${e}`);
+        }
       }
+    } else {
+      // process all the messages at once
+      const updates: WorkItemUpdateQueueItem[] = messages.map((msg) => JSON.parse(msg.body));
       try {
-        // delete the message from the queue even if there was an error updating the work-item
-        // so that we don't keep processing the same message over and over
-        await queue.deleteMessage(msg.receipt);
+        await exports.handleBatchWorkItemUpdates(updates, defaultLogger);
       } catch (e) {
-        defaultLogger.error(`Error deleting work item update from queue: ${e}`);
+        defaultLogger.error(`Error processing work item updates from queue: ${e}`);
+      }
+      // delete all the messages from the queue at once (slightly more efficient)
+      try {
+        await queue.deleteMessages(messages.map((msg) => msg.receipt));
+      } catch (e) {
+        defaultLogger.error(`Error deleting work item updates from queue: ${e}`);
       }
     }
-  } else {
-    // process all the messages at once
-    const updates: WorkItemUpdateQueueItem[] = messages.map((msg) => JSON.parse(msg.body));
-    try {
-      await exports.handleBatchWorkItemUpdates(updates, defaultLogger);
-    } catch (e) {
-      defaultLogger.error(`Error processing work item updates from queue: ${e}`);
-    }
-    // delete all the messages from the queue at once (slightly more efficient)
-    try {
-      await queue.deleteMessages(messages.map((msg) => msg.receipt));
-    } catch (e) {
-      defaultLogger.error(`Error deleting work item updates from queue: ${e}`);
-    }
+  } finally {
+    stopVisibilityHeartbeat();
   }
+
   const endTime = Date.now();
   defaultLogger.debug(`Processed ${messages.length} work item updates from queue in ${endTime - startTime} ms`);
 }

--- a/services/work-updater/test/updater.ts
+++ b/services/work-updater/test/updater.ts
@@ -7,7 +7,7 @@ import * as jobModel from '../../harmony/app/models/job';
 import * as wi from '../../harmony/app/models/work-item';
 import { WorkItemStatus } from '../../harmony/app/models/work-item-interface';
 import logger from '../../harmony/app/util/log';
-import { WorkItemQueueType } from '../../harmony/app/util/queue/queue';
+import { Queue, WorkItemQueueType } from '../../harmony/app/util/queue/queue';
 import * as queueFactory from '../../harmony/app/util/queue/queue-factory';
 import { MemoryQueue } from '../../harmony/test/helpers/memory-queue';
 import * as updater from '../app/workers/updater';
@@ -127,6 +127,158 @@ describe('Updater Worker', function () {
       await updater.handleBatchWorkItemUpdates(updates, logger);
 
       expect(handleBatchWorkItemUpdatesWithJobIdStub.callCount).to.equal(0);
+    });
+  });
+
+  describe('startVisibilityHeartbeat', function () {
+    let clock: sinon.SinonFakeTimers;
+
+    beforeEach(function () {
+      clock = sinon.useFakeTimers();
+    });
+
+    afterEach(function () {
+      clock.restore();
+    });
+
+    it('should not extend visibility before the initial delay', async function () {
+      const queue = {
+        changeMessageVisibilities: sinon.stub().resolves(),
+      } as unknown as Queue;
+
+      const stop = updater.startVisibilityHeartbeat(
+        queue,
+        ['receipt1'],
+        15,
+        30,
+        60,
+      );
+
+      await clock.tickAsync(14999);
+
+      expect(
+        (queue.changeMessageVisibilities as sinon.SinonStub).called,
+      ).to.be.false;
+
+      stop();
+    });
+
+    it('should extend visibility after the initial delay', async function () {
+      const queue = {
+        changeMessageVisibilities: sinon.stub().resolves(),
+      } as unknown as Queue;
+
+      const stop = updater.startVisibilityHeartbeat(
+        queue,
+        ['receipt1', 'receipt2'],
+        15,
+        30,
+        60,
+      );
+
+      await clock.tickAsync(15000);
+
+      const stub = queue.changeMessageVisibilities as sinon.SinonStub;
+
+      expect(stub.calledOnce).to.be.true;
+      expect(stub.firstCall.args).to.deep.equal([
+        ['receipt1', 'receipt2'],
+        60,
+      ]);
+
+      stop();
+    });
+
+    it('should continue extending visibility at the refresh interval', async function () {
+      const queue = {
+        changeMessageVisibilities: sinon.stub().resolves(),
+      } as unknown as Queue;
+
+      const stop = updater.startVisibilityHeartbeat(
+        queue,
+        ['receipt1'],
+        15,
+        30,
+        60,
+      );
+
+      const stub = queue.changeMessageVisibilities as sinon.SinonStub;
+
+      await clock.tickAsync(15000);
+      expect(stub.callCount).to.equal(1);
+
+      await clock.tickAsync(30000);
+      expect(stub.callCount).to.equal(2);
+
+      await clock.tickAsync(30000);
+      expect(stub.callCount).to.equal(3);
+
+      stop();
+    });
+
+    it('should stop extending visibility after cleanup', async function () {
+      const queue = {
+        changeMessageVisibilities: sinon.stub().resolves(),
+      } as unknown as Queue;
+
+      const stop = updater.startVisibilityHeartbeat(
+        queue,
+        ['receipt1'],
+        15,
+        30,
+        60,
+      );
+
+      const stub = queue.changeMessageVisibilities as sinon.SinonStub;
+
+      await clock.tickAsync(15000);
+      expect(stub.callCount).to.equal(1);
+
+      stop();
+
+      await clock.tickAsync(120000);
+
+      expect(stub.callCount).to.equal(1);
+    });
+
+    it('should extend visibility while processing a long running batch', async function () {
+      const queue = new MemoryQueue();
+
+      const visibilityStub = sinon.stub(queue, 'changeMessageVisibilities').resolves();
+
+      getQueueForTypeStub.callsFake(function () {
+        return queue;
+      });
+
+      await queue.sendMessage(
+        JSON.stringify({
+          update: {
+            workItemID: 1,
+            status: WorkItemStatus.RUNNING,
+          },
+        }),
+        '',
+        false,
+      );
+
+      handleBatchWorkItemUpdatesSpy.restore();
+
+      const processingStub = sinon.stub(updater, 'handleBatchWorkItemUpdates')
+        .callsFake(async () => {
+          await clock.tickAsync(20000);
+        });
+
+      const processingPromise = updater.batchProcessQueue(
+        WorkItemQueueType.SMALL_ITEM_UPDATE,
+      );
+
+      await clock.tickAsync(15000);
+
+      expect(visibilityStub.calledOnce).to.be.true;
+
+      await processingPromise;
+
+      processingStub.restore();
     });
   });
 });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2364

## Description
Make sure as work item updates are actively being worked SQS messages are not redelivered. The root cause of the bug for HARMONY-2364 is that the work item updates for the Geoloco work items in the request took over 100 seconds to process and the messages were being redelivered every 30 seconds because the message had not been deleted from the queue. When the message is redelivered because of the design of SQS the original worker is not able to delete the message from the queue (the only valid receipt handle that can delete the message is the last worker that received the message).

With this change the worker will extend the visibility timeout every 30 seconds to prevent the message from being redelivered.

## Local Test Steps
I built and pushed the work-updater image to sandbox and then tested in sandbox pointed against production using {root}/C1379758607-LAADS/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lon(77.19259999%3A77.19260000999999)&subset=lat(28.54499999%3A28.545000010000003)&format=application%2Fx-hdf&maxResults=100&skipPreview=true

I verified the message was logged every 30 seconds: 
```
{"env_name":"harmony-cdd-sandbox","level":"warn","message":"Extending message visibility by 60 seconds","timestamp":"2026-06-04T15:05:00.732Z"}
```

I saw work items completed successfully in the workflow-ui and no messages were added to the dead letter queue.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)