### PR TITLE
HARMONY-2354: Implements per-step paging on the steps endpoint.

### DIFF
--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -340,8 +340,8 @@ function buildSteps(
   const result: JobStep[] = [];
   const filtering = q.status !== undefined || q.workItem !== undefined;
   for (const { step, workItems, pagination } of stepResults) {
-    // Don't show steps without workitems.
-    if (filtering && workItems.length === 0) continue;
+    // Drop steps with no matching work items at all
+    if (filtering && pagination.total === 0) continue;
 
     const jobStep: JobStep = {
       serviceID: sanitizeImage(step.serviceID),
@@ -350,11 +350,12 @@ function buildSteps(
       statuses: statusCounts.get(step.stepIndex) ?? {},
       workItems: workItems.map((wi) => buildWorkItem(wi, resolved)),
     };
-    if (pagination.lastPage > 1) {
+    const { currentPage, lastPage, total } = pagination;
+    if (lastPage > 1 || currentPage > Math.max(lastPage, 1)) {
       jobStep.paging = {
-        currentPage: pagination.currentPage,
-        lastPage: pagination.lastPage,
-        total: pagination.total,
+        currentPage,
+        lastPage,
+        total,
         links: getPagingLinks(req, pagination, true, `step${step.stepIndex}Page`),
       };
     }

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -22,7 +22,7 @@ import { getPagingLinks, parseIntegerParam } from '../util/pagination';
 import { readCatalogItems, StacItem } from '../util/stac';
 import { getRequestRoot } from '../util/url';
 
-export const DEFAULT_PER_PAGE = 50;
+const DEFAULT_PER_PAGE = 50;
 const MAX_STEP_PAGE_SIZE = 1000;
 const MAX_BATCH_CATALOGS = 5;
 const VALID_STATUSES = Object.values(WorkItemStatus);
@@ -308,8 +308,7 @@ function buildWorkItem(
 }
 
 
-// A workflow step paired with its requested page of work items and that page's
-// pagination info (used to build the step's paging links).
+// A workflow step, its page of work items and the pagination info.
 interface StepWorkItems {
   step: WorkflowStep;
   workItems: WorkItem[];
@@ -340,7 +339,7 @@ function buildSteps(
   const result: JobStep[] = [];
   const filtering = q.status !== undefined || q.workItem !== undefined;
   for (const { step, workItems, pagination } of stepResults) {
-    // Drop steps with no matching work items at all
+    // Don't show steps having no matching work items.
     if (filtering && pagination.total === 0) continue;
 
     const jobStep: JobStep = {
@@ -394,8 +393,8 @@ export async function getJobSteps(
       ? steps.filter((s) => s.stepIndex === q.step)
       : steps;
 
-    // One shared page size across steps; each step is paged independently via
-    // its own step<stepIndex>Page parameter.
+    // Bound every page result by 'limit' and page each step independently
+    // via step<stepIndex>Page parameter.
     const limit = parseIntegerParam(req, 'limit', DEFAULT_PER_PAGE, 1, MAX_STEP_PAGE_SIZE, true, true);
     const stepResults: StepWorkItems[] = await Promise.all(selectedSteps.map(async (step) => {
       const where: WorkItemQuery['where'] = { jobID, workflowStepIndex: step.stepIndex };

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -1,4 +1,4 @@
-import { NextFunction, Request, Response } from 'express';
+import { NextFunction, Response } from 'express';
 import { ILengthAwarePagination } from 'knex-paginate';
 
 import { sanitizeImage } from '@harmony/util/string';
@@ -402,7 +402,7 @@ export async function getJobSteps(
       const where: WorkItemQuery['where'] = { jobID, workflowStepIndex: step.stepIndex };
       if (q.status !== undefined) where.status = q.status;
       if (q.workItem !== undefined) where.id = q.workItem;
-      const page = parseIntegerParam(req, `step${step.stepIndex}page`, 1, 1, null, false, true);
+      const page = parseIntegerParam(req, `step${step.stepIndex}page`, 1, 1);
       const query = { where, orderBy: { field: 'id', value: 'asc' } };
       let { workItems, pagination } = await queryWorkItems(db, query, page, limit);
       // reload last page for this step if we're off the end.

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -321,7 +321,7 @@ interface StepWorkItems {
  * A step with more than one page of matching work items gets a `paging` block
  * whose links page that step via its own `step<stepIndex>Page` query parameter.
  * When a status/workItem filter is active, steps with no matching work items are
- * omitted unless they are missing because the page is invalid page.
+ * omitted.
  *
  * @param req - the Express request, used to build per-step paging links
  * @param stepResults - each workflow step with its page of work items and pagination
@@ -331,7 +331,7 @@ interface StepWorkItems {
  * @returns the steps with their work items, status summary, and any paging links
  */
 function buildSteps(
-  req: Request,
+  req: HarmonyRequest,
   stepResults: StepWorkItems[],
   resolved: ResolvedCatalogs,
   statusCounts: Map<number, Partial<Record<WorkItemStatus, number>>>,
@@ -351,7 +351,7 @@ function buildSteps(
       workItems: workItems.map((wi) => buildWorkItem(wi, resolved)),
     };
     const { currentPage, lastPage, total } = pagination;
-    if (lastPage > 1 || currentPage > Math.max(lastPage, 1)) {
+    if (lastPage > 1) {
       jobStep.paging = {
         currentPage,
         lastPage,
@@ -403,9 +403,12 @@ export async function getJobSteps(
       if (q.status !== undefined) where.status = q.status;
       if (q.workItem !== undefined) where.id = q.workItem;
       const page = parseIntegerParam(req, `step${step.stepIndex}page`, 1, 1, null, false, true);
-      const { workItems, pagination } = await queryWorkItems(
-        db, { where, orderBy: { field: 'id', value: 'asc' } }, page, limit,
-      );
+      const query = { where, orderBy: { field: 'id', value: 'asc' } };
+      let { workItems, pagination } = await queryWorkItems(db, query, page, limit);
+      // reload last page for this step if we're off the end.
+      if (pagination.lastPage >= 1 && page > pagination.lastPage) {
+        ({ workItems, pagination } = await queryWorkItems(db, query, pagination.lastPage, limit));
+      }
       return { step, workItems, pagination };
     }));
 

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -17,6 +17,7 @@ import { isAdminUser } from '../util/edl-api';
 import { RequestValidationError } from '../util/errors';
 import { getJobIfAllowed } from '../util/job';
 import { Link } from '../util/links';
+import { keysToLowerCase } from '../util/object';
 import { defaultObjectStore } from '../util/object-store';
 import { getPagingLinks, parseIntegerParam } from '../util/pagination';
 import { readCatalogItems, StacItem } from '../util/stac';
@@ -85,8 +86,8 @@ function parseQuery(query: Record<string, unknown>): StepsQueryParams {
     out.status = s;
   }
 
-  if (query.workItem !== undefined) {
-    const n = Number(query.workItem);
+  if (query.workitem !== undefined) {
+    const n = Number(query.workitem);
     if (!Number.isInteger(n) || n < 1) {
       throw new RequestValidationError('workItem must be a positive integer');
     }
@@ -355,7 +356,7 @@ function buildSteps(
         currentPage,
         lastPage,
         total,
-        links: getPagingLinks(req, pagination, true, `step${step.stepIndex}Page`),
+        links: getPagingLinks(req, pagination, true, `step${step.stepIndex}page`),
       };
     }
 
@@ -380,6 +381,7 @@ export async function getJobSteps(
 ): Promise<void> {
   const { jobID } = req.params;
   try {
+    req.query = keysToLowerCase(req.query);
     const q = parseQuery(req.query as Record<string, unknown>);
 
     const isAdmin = await isAdminUser(req);
@@ -400,7 +402,7 @@ export async function getJobSteps(
       const where: WorkItemQuery['where'] = { jobID, workflowStepIndex: step.stepIndex };
       if (q.status !== undefined) where.status = q.status;
       if (q.workItem !== undefined) where.id = q.workItem;
-      const page = parseIntegerParam(req, `step${step.stepIndex}Page`, 1, 1, null, false, true);
+      const page = parseIntegerParam(req, `step${step.stepIndex}page`, 1, 1, null, false, true);
       const { workItems, pagination } = await queryWorkItems(
         db, { where, orderBy: { field: 'id', value: 'asc' } }, page, limit,
       );

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -1,4 +1,5 @@
-import { NextFunction, Response } from 'express';
+import { NextFunction, Request, Response } from 'express';
+import { ILengthAwarePagination } from 'knex-paginate';
 
 import { sanitizeImage } from '@harmony/util/string';
 
@@ -15,11 +16,14 @@ import db from '../util/db';
 import { isAdminUser } from '../util/edl-api';
 import { RequestValidationError } from '../util/errors';
 import { getJobIfAllowed } from '../util/job';
+import { Link } from '../util/links';
 import { defaultObjectStore } from '../util/object-store';
+import { getPagingLinks, parseIntegerParam } from '../util/pagination';
 import { readCatalogItems, StacItem } from '../util/stac';
 import { getRequestRoot } from '../util/url';
 
 export const DEFAULT_PER_PAGE = 50;
+const MAX_STEP_PAGE_SIZE = 1000;
 const MAX_BATCH_CATALOGS = 5;
 const VALID_STATUSES = Object.values(WorkItemStatus);
 
@@ -49,7 +53,10 @@ interface JobStep {
 }
 
 interface StepPaging {
-  message: string;
+  currentPage: number;
+  lastPage: number;
+  total: number;
+  links: Link[];
 }
 
 /**
@@ -301,27 +308,30 @@ function buildWorkItem(
 }
 
 
-// A workflow step paired with its bounded page of work items and the total
-// number of work items that matched (used to decide whether to page).
+// A workflow step paired with its requested page of work items and that page's
+// pagination info (used to build the step's paging links).
 interface StepWorkItems {
   step: WorkflowStep;
   workItems: WorkItem[];
-  total: number;
+  pagination: ILengthAwarePagination;
 }
 
 /**
- * Build the full step list from each step's already-bounded page of work items.
- * A step whose total matching work item count exceeds DEFAULT_PER_PAGE gets a
- * placeholder `paging` block. When a status/workItem filter is active, steps
- * with no matching work items are omitted.
+ * Build the full step list from each step's requested page of work items.
+ * A step with more than one page of matching work items gets a `paging` block
+ * whose links page that step via its own `step<stepIndex>Page` query parameter.
+ * When a status/workItem filter is active, steps with no matching work items are
+ * omitted.
  *
- * @param stepResults - each workflow step with its bounded work items and total
+ * @param req - the Express request, used to build per-step paging links
+ * @param stepResults - each workflow step with its page of work items and pagination
  * @param resolved - resolved-catalog data from resolveAllCatalogs
  * @param statusCounts - per-step, per-status work item counts for the whole job
  * @param q - the parsed steps query, used to honor the status/workItem filters
- * @returns the steps with their work items, status summary, and any paging note
+ * @returns the steps with their work items, status summary, and any paging links
  */
 function buildSteps(
+  req: Request,
   stepResults: StepWorkItems[],
   resolved: ResolvedCatalogs,
   statusCounts: Map<number, Partial<Record<WorkItemStatus, number>>>,
@@ -329,7 +339,7 @@ function buildSteps(
 ): JobStep[] {
   const result: JobStep[] = [];
   const filtering = q.status !== undefined || q.workItem !== undefined;
-  for (const { step, workItems, total } of stepResults) {
+  for (const { step, workItems, pagination } of stepResults) {
     // Don't show steps without workitems.
     if (filtering && workItems.length === 0) continue;
 
@@ -340,9 +350,13 @@ function buildSteps(
       statuses: statusCounts.get(step.stepIndex) ?? {},
       workItems: workItems.map((wi) => buildWorkItem(wi, resolved)),
     };
-    // workItems is capped at DEFAULT_PER_PAGE per step; flag steps with more.
-    if (total > DEFAULT_PER_PAGE) {
-      jobStep.paging = { message: `WorkItem results paging not implemented: ${workItems.length} work items shown out of ${total}.` };
+    if (pagination.lastPage > 1) {
+      jobStep.paging = {
+        currentPage: pagination.currentPage,
+        lastPage: pagination.lastPage,
+        total: pagination.total,
+        links: getPagingLinks(req, pagination, true, `step${step.stepIndex}Page`),
+      };
     }
 
     result.push(jobStep);
@@ -379,22 +393,24 @@ export async function getJobSteps(
       ? steps.filter((s) => s.stepIndex === q.step)
       : steps;
 
-    // Bound each step's work items independently at DEFAULT_PER_PAGE. Per-step
-    // paging links are coming
+    // One shared page size across steps; each step is paged independently via
+    // its own step<stepIndex>Page parameter.
+    const limit = parseIntegerParam(req, 'limit', DEFAULT_PER_PAGE, 1, MAX_STEP_PAGE_SIZE, true, true);
     const stepResults: StepWorkItems[] = await Promise.all(selectedSteps.map(async (step) => {
       const where: WorkItemQuery['where'] = { jobID, workflowStepIndex: step.stepIndex };
       if (q.status !== undefined) where.status = q.status;
       if (q.workItem !== undefined) where.id = q.workItem;
+      const page = parseIntegerParam(req, `step${step.stepIndex}Page`, 1, 1, null, false, true);
       const { workItems, pagination } = await queryWorkItems(
-        db, { where, orderBy: { field: 'id', value: 'asc' } }, 1, DEFAULT_PER_PAGE,
+        db, { where, orderBy: { field: 'id', value: 'asc' } }, page, limit,
       );
-      return { step, workItems, total: pagination.total };
+      return { step, workItems, pagination };
     }));
 
     const frontendRoot = getRequestRoot(req);
     const allWorkItems = stepResults.flatMap((r) => r.workItems);
     const resolvedCatalogs = await resolveAllCatalogs(allWorkItems, frontendRoot, destinationBucket);
-    const jobSteps = buildSteps(stepResults, resolvedCatalogs, statusCounts, q);
+    const jobSteps = buildSteps(req, stepResults, resolvedCatalogs, statusCounts, q);
 
     const responseBody = {
       jobID: job.jobID,

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -321,7 +321,7 @@ interface StepWorkItems {
  * A step with more than one page of matching work items gets a `paging` block
  * whose links page that step via its own `step<stepIndex>Page` query parameter.
  * When a status/workItem filter is active, steps with no matching work items are
- * omitted.
+ * omitted unless they are missing because the page is invalid page.
  *
  * @param req - the Express request, used to build per-step paging links
  * @param stepResults - each workflow step with its page of work items and pagination

--- a/services/harmony/app/markdown/steps.md
+++ b/services/harmony/app/markdown/steps.md
@@ -13,14 +13,16 @@ As with the jobs API, there are two sets of steps API endpoints with the same su
 ```
 **Example {{exampleCounter}}** - Getting the steps for a job
 
-Returns the workflow steps for the given job, along with the work items processed by each step. By default, up to 50 work items are returned per step; steps with more work items than that include a `paging` note in the response.
+Returns the workflow steps for the given job, along with the work items processed by each step. Each step's work items are paged independently: by default up to 50 are shown per step (configurable with `limit`), and each step is navigated with its own `step<stepIndex>Page` parameter. A step with more than one page of work items includes a `paging` object with links to the other pages.
 
 ##### <a name="steps-query-parameters"></a> Query Parameters
-| parameter | description                                                                                                                                                                                  |
-|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| step      | Limit the response to the step with this stepIndex (a positive integer).                                                                                                                     |
-| status    | Filter the work items shown to those with this status. One of `ready`, `queued`, `running`, `successful`, `failed`, `canceled`, or `warning`. Steps with no matching work items are omitted. |
-| workItem  | Limit the work items shown to the one with this ID (a positive integer).                                                                                                                     |
+| parameter           | description                                                                                                                                                                                  |
+|---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| step                | Limit the response to the step with this stepIndex (a positive integer).                                                                                                                     |
+| status              | Filter the work items shown to those with this status. One of `ready`, `queued`, `running`, `successful`, `failed`, `canceled`, or `warning`. Steps with no matching work items are omitted. |
+| workItem            | Limit the work items shown to the one with this ID (a positive integer).                                                                                                                     |
+| limit               | The number of work items to show per page for each step. Defaults to 50, maximum 1000.
+| step\<stepIndex\>Page | The page of work items to show for the step with the given stepIndex, e.g. `step2Page=3`. A positive integer that defaults to 1. Each step pages independently, so multiple may be supplied. |
 
 ---
 **Table {{tableCounter}}** - Harmony steps endpoint parameters
@@ -53,10 +55,23 @@ Each entry in the `steps` list describes a single workflow step -- one service i
 | workItemCount | The total number of work items in this step                                                                                                |
 | statuses      | A map of work item status to the number of work items in that status for the whole step. Only statuses with at least one work item appear. |
 | workItems     | A list of JSON objects describing the work items for this step. For details, see [work item fields](#step-work-item-response).             |
-| paging        | Present only when the step has more work items than can be shown on a single page.                                                         |
+| paging        | Present when the step has more than one page of work items. For details, see [paging fields](#step-paging-response). |
 
 ---
 **Table {{tableCounter}}** - Harmony step fields
+
+###### <a name="step-paging-response"></a> Paging fields
+The `paging` object lets you navigate a step's work items one page at a time:
+
+| field       | description                                                                                                                                                                                                |
+|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| currentPage | The page of work items currently shown for this step.                                                                                                                                                     |
+| lastPage    | The index of the last available page.                                                                                                                                                                     |
+| total       | The total number of work items for this step, after any `status` or `workItem` filter.                                                                                                                    |
+| links       | Navigation links, each with `rel` (one of `first`, `prev`, `self`, `next`, `last`), `href`, `title`, and `type`. Links that do not apply (e.g. `next` on the last page) are omitted.                       |
+
+---
+**Table {{tableCounter}}** - Harmony step paging fields
 
 ###### <a name="step-work-item-response"></a> Work item fields
 Each entry in a step's `workItems` list describes a single work item:

--- a/services/harmony/app/markdown/steps.md
+++ b/services/harmony/app/markdown/steps.md
@@ -24,7 +24,7 @@ Parameter names are case-insensitive (e.g. `step2Page`, `Step2Page`, and `STEP2P
 | status              | Filter the work items shown to those with this status. One of `ready`, `queued`, `running`, `successful`, `failed`, `canceled`, or `warning`. Steps with no matching work items are omitted. |
 | workItem            | Limit the work items shown to the one with this ID (a positive integer).                                                                                                                     |
 | limit               | The number of work items to show per page for each step. Defaults to 50, maximum 1000.
-| step\<stepIndex\>Page | The page of work items to show for the step with the given stepIndex, e.g. `step2Page=3`. A positive integer that defaults to 1. Each step pages independently, so multiple may be supplied. |
+| step\<stepIndex\>Page | The page of work items to show for the step with the given stepIndex, e.g. `step2Page=3`. A positive integer that defaults to 1; a page beyond the last page returns the last page. Each step pages independently, so multiple may be supplied. |
 
 ---
 **Table {{tableCounter}}** - Harmony steps endpoint parameters

--- a/services/harmony/app/markdown/steps.md
+++ b/services/harmony/app/markdown/steps.md
@@ -16,6 +16,8 @@ As with the jobs API, there are two sets of steps API endpoints with the same su
 Returns the workflow steps for the given job, along with the work items processed by each step. Each step's work items are paged independently: by default up to 50 are shown per step (configurable with `limit`), and each step is navigated with its own `step<stepIndex>Page` parameter. A step with more than one page of work items includes a `paging` object with links to the other pages.
 
 ##### <a name="steps-query-parameters"></a> Query Parameters
+Parameter names are case-insensitive (e.g. `step2Page`, `Step2Page`, and `STEP2PAGE` are equivalent).
+
 | parameter           | description                                                                                                                                                                                  |
 |---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | step                | Limit the response to the step with this stepIndex (a positive integer).                                                                                                                     |

--- a/services/harmony/app/middleware/parameter-validation.ts
+++ b/services/harmony/app/middleware/parameter-validation.ts
@@ -21,6 +21,7 @@ const { awsDefaultRegion } = env;
 
 const RANGESET_ROUTE_REGEX = /^\/.*\/ogc-api-coverages\/.*\/collections\/.*\/coverage\/rangeset/;
 const EDR_ROUTE_REGEX = /^\/ogc-api-edr\/.*\/collections\/.*\/(cube|area|position|trajectory)/;
+const STEPS_ROUTE_REGEX = /^\/(admin\/)?jobs\/[^/]+\/steps/;
 
 /**
  * The accepted values for the `linkType` parameter for job status requests
@@ -225,6 +226,24 @@ function validateEdrParameterNames(req: HarmonyRequest): void {
   validateParameterNames(requestedParams, getEdrParameters(action));
 }
 
+
+/**
+ * Validate that the steps endpoint query parameter names are allowed. The
+ * per-step `step<stepIndex>Page` paging parameters are accepted alongside the
+ * fixed steps parameters.
+ *
+ * @param req - The client request
+ * @throws RequestValidationError - if disallowed parameters are detected
+ */
+export function validateStepsParameterNames(req: HarmonyRequest): void {
+  const stepsAllowedParams = ['step', 'status', 'workItem', 'limit'];
+  const stepPageParamRegex = /^step\d+page$/;
+
+  const requestedParams = Object.keys(req.query)
+    .filter((param) => !stepPageParamRegex.test(param.toLowerCase()));
+  validateParameterNames(requestedParams, stepsAllowedParams);
+}
+
 /**
  * Express.js middleware to validate parameters. This must be installed after the error handler
  * middleware.
@@ -246,6 +265,9 @@ export default async function parameterValidation(
     }
     if (req.url.match(EDR_ROUTE_REGEX)) {
       validateEdrParameterNames(req);
+    }
+    if (req.url.match(STEPS_ROUTE_REGEX)) {
+      validateStepsParameterNames(req);
     }
     validateLabelParameter(req);
   } catch (e) {

--- a/services/harmony/app/util/pagination.ts
+++ b/services/harmony/app/util/pagination.ts
@@ -40,7 +40,7 @@ function buildIntegerParseError(min: number, max: number, paramName: string): Re
  * @returns The numeric value of the parameter
  * @throws {@link RequestValidationError} If the passed value is not a positive integer
  */
-function parseIntegerParam(
+export function parseIntegerParam(
   req: Request,
   paramName: string,
   defaultValue: number,
@@ -106,6 +106,7 @@ export function getPagingParams(
  * @param page - the page number for the link
  * @param rel - the name of the link relation
  * @param relName - the name of the link relation
+ * @param pageParamName - the query parameter the link should set the page on
  * @returns the generated link
  */
 function getPagingLink(
@@ -114,12 +115,13 @@ function getPagingLink(
   page: number,
   rel: string,
   relName: string = rel,
+  pageParamName = 'page',
 ): Link {
   const { lastPage, perPage } = pagination;
   const suffix = (lastPage <= 1 && page === 1) || perPage === 0 ? '' : ` (${page} of ${lastPage})`;
   return {
     title: `The ${relName} page${suffix}`,
-    href: getRequestUrl(req, true, { page, limit: perPage }),
+    href: getRequestUrl(req, true, { [pageParamName]: page, limit: perPage }),
     rel,
     type: 'application/json',
   };
@@ -131,17 +133,19 @@ function getPagingLink(
  * @param pagination - the pagination information as returned by, e.g. knex-paginate
  * @param includeExtraneous - include first and last links even when first and last are the
  * previous and next pages respectively
+ * @param pageParamName - the query parameter the links should set the page on
  * @returns the links to paginate
  */
-export function getPagingLinks(req: Request, pagination: ILengthAwarePagination, includeExtraneous = false): Link[] {
+export function getPagingLinks(
+  req: Request, pagination: ILengthAwarePagination, includeExtraneous = false, pageParamName = 'page',
+): Link[] {
   const result = [];
   const { currentPage, lastPage, perPage } = pagination;
-  // const { currentPage, lastPage, perPage } = pagination as unknown as { lastPage: number; perPage; number; currentPage: number; total: number; };
-  if (perPage > 0 && currentPage > (includeExtraneous ? 1 : 2)) result.push(getPagingLink(req, pagination, 1, 'first'));
-  if (perPage > 0 && currentPage > 1) result.push(getPagingLink(req, pagination, currentPage - 1, 'prev', 'previous'));
-  result.push(getPagingLink(req, pagination, currentPage, 'self', 'current'));
-  if (perPage > 0 && currentPage < lastPage) result.push(getPagingLink(req, pagination, currentPage + 1, 'next'));
-  if (perPage > 0 && currentPage < (includeExtraneous ? lastPage : lastPage - 1)) result.push(getPagingLink(req, pagination, lastPage, 'last'));
+  if (perPage > 0 && currentPage > (includeExtraneous ? 1 : 2)) result.push(getPagingLink(req, pagination, 1, 'first', 'first', pageParamName));
+  if (perPage > 0 && currentPage > 1) result.push(getPagingLink(req, pagination, currentPage - 1, 'prev', 'previous', pageParamName));
+  result.push(getPagingLink(req, pagination, currentPage, 'self', 'current', pageParamName));
+  if (perPage > 0 && currentPage < lastPage) result.push(getPagingLink(req, pagination, currentPage + 1, 'next', 'next', pageParamName));
+  if (perPage > 0 && currentPage < (includeExtraneous ? lastPage : lastPage - 1)) result.push(getPagingLink(req, pagination, lastPage, 'last', 'last', pageParamName));
   return result;
 }
 

--- a/services/harmony/app/util/pagination.ts
+++ b/services/harmony/app/util/pagination.ts
@@ -141,6 +141,13 @@ export function getPagingLinks(
 ): Link[] {
   const result = [];
   const { currentPage, lastPage, perPage } = pagination;
+  if (perPage > 0 && currentPage > lastPage && lastPage >= 1) {
+    // this request was for a page beyond the last, just give them a first and last link.
+    if (lastPage > 1) result.push(getPagingLink(req, pagination, 1, 'first', 'first', pageParamName));
+    result.push(getPagingLink(req, pagination, currentPage, 'self', 'current', pageParamName));
+    result.push(getPagingLink(req, pagination, lastPage, 'last', 'last', pageParamName));
+    return result;
+  }
   if (perPage > 0 && currentPage > (includeExtraneous ? 1 : 2)) result.push(getPagingLink(req, pagination, 1, 'first', 'first', pageParamName));
   if (perPage > 0 && currentPage > 1) result.push(getPagingLink(req, pagination, currentPage - 1, 'prev', 'previous', pageParamName));
   result.push(getPagingLink(req, pagination, currentPage, 'self', 'current', pageParamName));

--- a/services/harmony/test/jobs/job-status-pagination.ts
+++ b/services/harmony/test/jobs/job-status-pagination.ts
@@ -193,7 +193,7 @@ describe('Individual job status route - pagination', function () {
         const dataLinks = JSON.parse(this.res.text).links.filter((link) => link.rel === 'data');
         expect(dataLinks.length).to.equal(0);
       });
-      itIncludesPagingRelations(5, `jobs/${jobID}`, { first: 1, prev: 5, self: 6, next: null, last: null });
+      itIncludesPagingRelations(5, `jobs/${jobID}`, { first: 1, prev: null, self: 6, next: null, last: 5 });
     });
 
     describe('on a page that is both first and last (the only page)', function () {

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import { before, describe, it } from 'mocha';
 import request, { Test } from 'supertest';
 
-import { DEFAULT_PER_PAGE } from '../../app/frontends/steps';
 import { JobStatus } from '../../app/models/job';
 import WorkItem from '../../app/models/work-item';
 import { getStacLocation, WorkItemStatus } from '../../app/models/work-item-interface';
@@ -77,6 +76,16 @@ const pagedJob = buildJob({
   status: JobStatus.RUNNING,
   service_name: 'harmony-best-service',
   request: 'https://harmony.example/paged',
+});
+
+// Job whose single step holds one more work item than MAX_STEP_PAGE_SIZE, so a
+// limit above the max defaults to MAX_STEP_PAGE_SIZE
+const BIG_STEP_WORKITEMS = 1001;
+const bigStepJob = buildJob({
+  username: 'joe',
+  status: JobStatus.RUNNING,
+  service_name: 'harmony-best-service',
+  request: 'https://harmony.example/big-step',
 });
 
 // Job with two steps each holding more than DEFAULT_PER_PAGE work items, to
@@ -244,6 +253,27 @@ describe('GET /jobs/:jobID/steps', function () {
       status: WorkItemStatus.READY,
     }));
     await WorkItem.insertBatch(this.trx, pagedWorkItems);
+
+    // A job whose single step holds one more than MAX_STEP_PAGE_SIZE READY work
+    // items, used to show a limit above the MAX_STEP_PAGE_SIZE defaults to MAX_STEP_PAGE_SIZE.
+    await bigStepJob.save(this.trx);
+    const bigStep = buildWorkflowStep({
+      jobID: bigStepJob.jobID,
+      stepIndex: 1,
+      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      workItemCount: BIG_STEP_WORKITEMS,
+      operation: validOperation,
+    });
+    await bigStep.save(this.trx);
+    const bigStepWorkItems = Array.from({ length: BIG_STEP_WORKITEMS }, () => buildWorkItem({
+      jobID: bigStepJob.jobID,
+      workflowStepIndex: 1,
+      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      status: WorkItemStatus.READY,
+    }));
+    for (let i = 0; i < bigStepWorkItems.length; i += 500) {
+      await WorkItem.insertBatch(this.trx, bigStepWorkItems.slice(i, i + 500));
+    }
 
     // A job with two steps (1 and 2), each holding 51 READY work items, used to
     // verify the two steps page independently of each other.
@@ -511,7 +541,7 @@ describe('GET /jobs/:jobID/steps', function () {
       const body = JSON.parse(this.res.text);
       const step = body.steps[0];
       // 51 work items exist, but the page is bounded to the per-page limit.
-      expect(step.workItems).to.have.lengthOf(DEFAULT_PER_PAGE);
+      expect(step.workItems).to.have.lengthOf(50);
       expect(step.paging.currentPage).to.equal(1);
       expect(step.paging.lastPage).to.equal(2);
       expect(step.paging.total).to.equal(51);
@@ -551,14 +581,19 @@ describe('GET /jobs/:jobID/steps', function () {
   });
 
   describe('When ?limit= exceeds the maximum page size', function () {
-    hookJobSteps({ jobID: pagedJob.jobID, username: 'joe', query: { limit: 99999 } });
+    hookJobSteps({ jobID: bigStepJob.jobID, username: 'joe', query: { limit: 99999 } });
 
-    it('clamps the limit instead of erroring (all 51 fit on one page)', function () {
+    it('clamps the limit to MAX_STEP_PAGE_SIZE and pages the remainder', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const step = body.steps[0];
-      expect(step.workItems).to.have.lengthOf(51);
-      expect(step).to.not.have.property('paging');
+      // The limit clamps to the max, so page 1 holds MAX_STEP_PAGE_SIZE items and
+      // the one extra work item spills onto a second page.
+      expect(step.workItems).to.have.lengthOf(1000);
+      expect(step.paging.currentPage).to.equal(1);
+      expect(step.paging.lastPage).to.equal(2);
+      expect(step.paging.total).to.equal(1001);
+      expect(step.paging.links.find((l) => l.rel === 'next').href).to.include('step1Page=2');
     });
   });
 
@@ -607,7 +642,7 @@ describe('GET /jobs/:jobID/steps', function () {
       // Step 1 advanced to page 2 (1 item), step 2 stayed on page 1 (50 items).
       expect(step1.workItems).to.have.lengthOf(1);
       expect(step1.paging.currentPage).to.equal(2);
-      expect(step2.workItems).to.have.lengthOf(DEFAULT_PER_PAGE);
+      expect(step2.workItems).to.have.lengthOf(50);
       expect(step2.paging.currentPage).to.equal(1);
       // Step 2's next link preserves step 1's page; step 1's prev preserves step 2's.
       expect(step2.paging.links.find((l) => l.rel === 'next').href).to.include('step1Page=2');

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -548,6 +548,40 @@ describe('GET /jobs/:jobID/steps', function () {
     });
   });
 
+  describe('Requesting a page past the last page without filtering', function () {
+    hookJobSteps({ jobID: pagedJob.jobID, username: 'joe', query: { step1Page: 4 } });
+
+    it('still emits a paging block with a way back even with no items on the page', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const step = body.steps[0];
+      expect(step.workItems).to.have.lengthOf(0);
+      expect(step.paging.currentPage).to.equal(4);
+      expect(step.paging.lastPage).to.equal(2);
+      expect(step.paging.total).to.equal(51);
+      expect(step.paging.links.find((l) => l.rel === 'first').href).to.include('step1Page=1');
+      expect(step.paging.links.find((l) => l.rel === 'next')).to.be.undefined;
+    });
+  });
+
+  describe('When a status filter and page query go beyond last page', function () {
+    hookJobSteps({
+      jobID: destBucketJob.jobID, username: 'joe', query: { status: 'successful', step1Page: 4 },
+    });
+
+    it('keeps the step and emits an paging block with first page', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      expect(body.steps).to.have.lengthOf(1);
+      const step = body.steps[0];
+      expect(step.workItems).to.have.lengthOf(0);
+      expect(step.paging.currentPage).to.equal(4);
+      expect(step.paging.lastPage).to.equal(1);
+      expect(step.paging.total).to.equal(1);
+      expect(step.paging.links.find((l) => l.rel === 'first').href).to.include('step1Page=1');
+    });
+  });
+
   describe('For a job with two independently pageable steps', function () {
     hookJobSteps({ jobID: twoPagedJob.jobID, username: 'joe', query: { step1Page: 2 } });
 

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -79,7 +79,7 @@ const pagedJob = buildJob({
 });
 
 // Job whose single step holds one more work item than MAX_STEP_PAGE_SIZE, so a
-// limit above the max defaults to MAX_STEP_PAGE_SIZE
+// limit above the max defaults to MAX_STEP_PAGE_SIZE (1000)
 const BIG_STEP_WORKITEMS = 1001;
 const bigStepJob = buildJob({
   username: 'joe',
@@ -88,7 +88,7 @@ const bigStepJob = buildJob({
   request: 'https://harmony.example/big-step',
 });
 
-// Job with two steps each holding more than DEFAULT_PER_PAGE work items, to
+// Job with two steps each holding more than DEFAULT_PER_PAGE (50) work items, to
 // exercise that each step pages independently via its own step<idx>Page param.
 const twoPagedJob = buildJob({
   username: 'joe',
@@ -254,7 +254,7 @@ describe('GET /jobs/:jobID/steps', function () {
     }));
     await WorkItem.insertBatch(this.trx, pagedWorkItems);
 
-    // A job whose single step holds one more than MAX_STEP_PAGE_SIZE READY work
+    // A job whose single step holds one more than MAX_STEP_PAGE_SIZE (1000) READY work
     // items, used to show a limit above the MAX_STEP_PAGE_SIZE defaults to MAX_STEP_PAGE_SIZE.
     await bigStepJob.save(this.trx);
     const bigStep = buildWorkflowStep({
@@ -540,7 +540,7 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const step = body.steps[0];
-      // 51 work items exist, but the page is bounded to the per-page limit.
+      // 51 work items exist, but the page is bounded to the default per-page limit.
       expect(step.workItems).to.have.lengthOf(50);
       expect(step.paging.currentPage).to.equal(1);
       expect(step.paging.lastPage).to.equal(2);
@@ -583,12 +583,10 @@ describe('GET /jobs/:jobID/steps', function () {
   describe('When ?limit= exceeds the maximum page size', function () {
     hookJobSteps({ jobID: bigStepJob.jobID, username: 'joe', query: { limit: 99999 } });
 
-    it('clamps the limit to MAX_STEP_PAGE_SIZE and pages the remainder', function () {
+    it('defaults limit to MAX_STEP_PAGE_SIZE and pages', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const step = body.steps[0];
-      // The limit clamps to the max, so page 1 holds MAX_STEP_PAGE_SIZE items and
-      // the one extra work item spills onto a second page.
       expect(step.workItems).to.have.lengthOf(1000);
       expect(step.paging.currentPage).to.equal(1);
       expect(step.paging.lastPage).to.equal(2);
@@ -644,7 +642,7 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(step1.paging.currentPage).to.equal(2);
       expect(step2.workItems).to.have.lengthOf(50);
       expect(step2.paging.currentPage).to.equal(1);
-      // Step 2's next link preserves step 1's page; step 1's prev preserves step 2's.
+      // Step 2's next link preserves step 1's page
       expect(step2.paging.links.find((l) => l.rel === 'next').href).to.include('step1Page=2');
       expect(step2.paging.links.find((l) => l.rel === 'next').href).to.include('step2Page=2');
       expect(step1.paging.links.find((l) => l.rel === 'prev').href).to.include('step1Page=1');

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -672,5 +672,35 @@ describe('GET /jobs/:jobID/steps', function () {
       });
     });
 
+    describe('?step1Page=0', function () {
+      hookJobSteps({ jobID: pagedJob.jobID, username: 'joe', query: { step1Page: 0 } });
+      it('returns 400', function () {
+        expect(this.res.statusCode).to.equal(400);
+      });
+
+      it('returns a JSON error response', function () {
+        const response = JSON.parse(this.res.text);
+        expect(response).to.eql({
+          code: 'harmony.RequestValidationError',
+          description: 'Error: Parameter "step1page" is invalid. Must be an integer greater than or equal to 1.',
+        });
+      });
+    });
+
+    describe('an unrecognized parameter name', function () {
+      hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { staus: 'failed' } });
+      it('returns 400', function () {
+        expect(this.res.statusCode).to.equal(400);
+      });
+
+      it('returns a JSON error listing the invalid parameter', function () {
+        const response = JSON.parse(this.res.text);
+        expect(response).to.eql({
+          code: 'harmony.RequestValidationError',
+          description: 'Error: Invalid parameter(s): staus. Allowed parameters are: step, status, workItem, and limit.',
+        });
+      });
+    });
+
   });
 });

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -546,7 +546,7 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(step.paging.lastPage).to.equal(2);
       expect(step.paging.total).to.equal(51);
       const next = step.paging.links.find((l) => l.rel === 'next');
-      expect(next.href).to.include('step1Page=2');
+      expect(next.href).to.include('step1page=2');
       // First page has no prev link.
       expect(step.paging.links.find((l) => l.rel === 'prev')).to.be.undefined;
       // The status summary for whole step.
@@ -563,7 +563,7 @@ describe('GET /jobs/:jobID/steps', function () {
       const step = body.steps[0];
       expect(step.workItems).to.have.lengthOf(1);
       expect(step.paging.currentPage).to.equal(2);
-      expect(step.paging.links.find((l) => l.rel === 'prev').href).to.include('step1Page=1');
+      expect(step.paging.links.find((l) => l.rel === 'prev').href).to.include('step1page=1');
       expect(step.paging.links.find((l) => l.rel === 'next')).to.be.undefined;
     });
   });
@@ -591,7 +591,7 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(step.paging.currentPage).to.equal(1);
       expect(step.paging.lastPage).to.equal(2);
       expect(step.paging.total).to.equal(1001);
-      expect(step.paging.links.find((l) => l.rel === 'next').href).to.include('step1Page=2');
+      expect(step.paging.links.find((l) => l.rel === 'next').href).to.include('step1page=2');
     });
   });
 
@@ -606,7 +606,7 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(step.paging.currentPage).to.equal(4);
       expect(step.paging.lastPage).to.equal(2);
       expect(step.paging.total).to.equal(51);
-      expect(step.paging.links.find((l) => l.rel === 'first').href).to.include('step1Page=1');
+      expect(step.paging.links.find((l) => l.rel === 'first').href).to.include('step1page=1');
       expect(step.paging.links.find((l) => l.rel === 'next')).to.be.undefined;
     });
   });
@@ -625,7 +625,7 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(step.paging.currentPage).to.equal(4);
       expect(step.paging.lastPage).to.equal(1);
       expect(step.paging.total).to.equal(1);
-      expect(step.paging.links.find((l) => l.rel === 'first').href).to.include('step1Page=1');
+      expect(step.paging.links.find((l) => l.rel === 'first').href).to.include('step1page=1');
     });
   });
 
@@ -643,9 +643,24 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(step2.workItems).to.have.lengthOf(50);
       expect(step2.paging.currentPage).to.equal(1);
       // Step 2's next link preserves step 1's page
-      expect(step2.paging.links.find((l) => l.rel === 'next').href).to.include('step1Page=2');
-      expect(step2.paging.links.find((l) => l.rel === 'next').href).to.include('step2Page=2');
-      expect(step1.paging.links.find((l) => l.rel === 'prev').href).to.include('step1Page=1');
+      expect(step2.paging.links.find((l) => l.rel === 'next').href).to.include('step1page=2');
+      expect(step2.paging.links.find((l) => l.rel === 'next').href).to.include('step2page=2');
+      expect(step1.paging.links.find((l) => l.rel === 'prev').href).to.include('step1page=1');
+    });
+  });
+
+  describe('Query parameter names are case-insensitive', function () {
+    hookJobSteps({ jobID: pagedJob.jobID, username: 'joe', query: { LIMIT: 25, STEP1PAGE: 2 } });
+
+    it('parses upper-cased parameter names the same as lower-cased ones', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const step = body.steps[0];
+      // ?LIMIT=25&STEP1PAGE=2 -> page 2 of 25-item pages over 51 items (26 left).
+      expect(step.workItems).to.have.lengthOf(25);
+      expect(step.paging.currentPage).to.equal(2);
+      expect(step.paging.lastPage).to.equal(3);
+      expect(step.paging.links.find((l) => l.rel === 'prev').href).to.include('step1page=1');
     });
   });
 

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -248,22 +248,36 @@ describe('GET /jobs/:jobID/steps', function () {
     // A job with two steps (1 and 2), each holding 51 READY work items, used to
     // verify the two steps page independently of each other.
     await twoPagedJob.save(this.trx);
-    for (const stepIndex of [1, 2]) {
-      const step = buildWorkflowStep({
-        jobID: twoPagedJob.jobID,
-        stepIndex,
-        serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
-        workItemCount: 51,
-        operation: validOperation,
-      });
-      await step.save(this.trx);
-      await WorkItem.insertBatch(this.trx, Array.from({ length: 51 }, () => buildWorkItem({
-        jobID: twoPagedJob.jobID,
-        workflowStepIndex: stepIndex,
-        serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
-        status: WorkItemStatus.READY,
-      })));
-    }
+
+    const step2a = buildWorkflowStep({
+      jobID: twoPagedJob.jobID,
+      stepIndex: 1,
+      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      workItemCount: 51,
+      operation: validOperation,
+    });
+    await step2a.save(this.trx);
+    await WorkItem.insertBatch(this.trx, Array.from({ length: 51 }, () => buildWorkItem({
+      jobID: twoPagedJob.jobID,
+      workflowStepIndex: 1,
+      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      status: WorkItemStatus.READY,
+    })));
+    const step2b = buildWorkflowStep({
+      jobID: twoPagedJob.jobID,
+      stepIndex: 2,
+      serviceID: 'sds/harmony-metadata-annotator:latest',
+      workItemCount: 51,
+      operation: validOperation,
+    });
+    await step2b.save(this.trx);
+    await WorkItem.insertBatch(this.trx, Array.from({ length: 51 }, () => buildWorkItem({
+      jobID: twoPagedJob.jobID,
+      workflowStepIndex: 2,
+      serviceID: 'sds/harmony-metadata-annotator:latest',
+      status: WorkItemStatus.READY,
+    })));
+
 
     await this.trx.commit();
   });

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -71,12 +71,21 @@ const destBucketJob = buildJob({
 });
 
 // Job whose single step has more work items than DEFAULT_PER_PAGE (50), to
-// exercise the per-step bound and the placeholder paging block.
+// exercise per-step paging and the paging links block.
 const pagedJob = buildJob({
   username: 'joe',
   status: JobStatus.RUNNING,
   service_name: 'harmony-best-service',
   request: 'https://harmony.example/paged',
+});
+
+// Job with two steps each holding more than DEFAULT_PER_PAGE work items, to
+// exercise that each step pages independently via its own step<idx>Page param.
+const twoPagedJob = buildJob({
+  username: 'joe',
+  status: JobStatus.RUNNING,
+  service_name: 'harmony-best-service',
+  request: 'https://harmony.example/two-paged',
 });
 
 describe('GET /jobs/:jobID/steps', function () {
@@ -235,6 +244,26 @@ describe('GET /jobs/:jobID/steps', function () {
       status: WorkItemStatus.READY,
     }));
     await WorkItem.insertBatch(this.trx, pagedWorkItems);
+
+    // A job with two steps (1 and 2), each holding 51 READY work items, used to
+    // verify the two steps page independently of each other.
+    await twoPagedJob.save(this.trx);
+    for (const stepIndex of [1, 2]) {
+      const step = buildWorkflowStep({
+        jobID: twoPagedJob.jobID,
+        stepIndex,
+        serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+        workItemCount: 51,
+        operation: validOperation,
+      });
+      await step.save(this.trx);
+      await WorkItem.insertBatch(this.trx, Array.from({ length: 51 }, () => buildWorkItem({
+        jobID: twoPagedJob.jobID,
+        workflowStepIndex: stepIndex,
+        serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+        status: WorkItemStatus.READY,
+      })));
+    }
 
     await this.trx.commit();
   });
@@ -463,17 +492,79 @@ describe('GET /jobs/:jobID/steps', function () {
   describe('For a step with more work items than the per-step limit', function () {
     hookJobSteps({ jobID: pagedJob.jobID, username: 'joe' });
 
-    it('caps the work items at DEFAULT_PER_PAGE and adds a paging note', function () {
+    it('caps the work items at DEFAULT_PER_PAGE and adds a paging block with links', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const step = body.steps[0];
-      // 51 work items exist, but the step is bounded to the per-page limit.
+      // 51 work items exist, but the page is bounded to the per-page limit.
       expect(step.workItems).to.have.lengthOf(DEFAULT_PER_PAGE);
-      expect(step.paging).to.deep.equal({
-        message: 'WorkItem results paging not implemented: 50 work items shown out of 51.',
-      });
+      expect(step.paging.currentPage).to.equal(1);
+      expect(step.paging.lastPage).to.equal(2);
+      expect(step.paging.total).to.equal(51);
+      const next = step.paging.links.find((l) => l.rel === 'next');
+      expect(next.href).to.include('step1Page=2');
+      // First page has no prev link.
+      expect(step.paging.links.find((l) => l.rel === 'prev')).to.be.undefined;
       // The status summary for whole step.
       expect(step.statuses).to.deep.equal({ ready: 51 });
+    });
+  });
+
+  describe('Requesting the last page of a step with ?step<idx>Page=', function () {
+    hookJobSteps({ jobID: pagedJob.jobID, username: 'joe', query: { step1Page: 2 } });
+
+    it('returns the remaining work items with prev/first links and no next', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const step = body.steps[0];
+      expect(step.workItems).to.have.lengthOf(1);
+      expect(step.paging.currentPage).to.equal(2);
+      expect(step.paging.links.find((l) => l.rel === 'prev').href).to.include('step1Page=1');
+      expect(step.paging.links.find((l) => l.rel === 'next')).to.be.undefined;
+    });
+  });
+
+  describe('Setting the shared page size with ?limit=', function () {
+    hookJobSteps({ jobID: pagedJob.jobID, username: 'joe', query: { limit: 25 } });
+
+    it('uses the limit as the per-step page size', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const step = body.steps[0];
+      expect(step.workItems).to.have.lengthOf(25);
+      expect(step.paging.lastPage).to.equal(3); // ceil(51 / 25)
+    });
+  });
+
+  describe('When ?limit= exceeds the maximum page size', function () {
+    hookJobSteps({ jobID: pagedJob.jobID, username: 'joe', query: { limit: 99999 } });
+
+    it('clamps the limit instead of erroring (all 51 fit on one page)', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const step = body.steps[0];
+      expect(step.workItems).to.have.lengthOf(51);
+      expect(step).to.not.have.property('paging');
+    });
+  });
+
+  describe('For a job with two independently pageable steps', function () {
+    hookJobSteps({ jobID: twoPagedJob.jobID, username: 'joe', query: { step1Page: 2 } });
+
+    it('pages the requested step without affecting the other', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const step1 = body.steps.find((s) => s.stepIndex === 1);
+      const step2 = body.steps.find((s) => s.stepIndex === 2);
+      // Step 1 advanced to page 2 (1 item), step 2 stayed on page 1 (50 items).
+      expect(step1.workItems).to.have.lengthOf(1);
+      expect(step1.paging.currentPage).to.equal(2);
+      expect(step2.workItems).to.have.lengthOf(DEFAULT_PER_PAGE);
+      expect(step2.paging.currentPage).to.equal(1);
+      // Step 2's next link preserves step 1's page; step 1's prev preserves step 2's.
+      expect(step2.paging.links.find((l) => l.rel === 'next').href).to.include('step1Page=2');
+      expect(step2.paging.links.find((l) => l.rel === 'next').href).to.include('step2Page=2');
+      expect(step1.paging.links.find((l) => l.rel === 'prev').href).to.include('step1Page=1');
     });
   });
 

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -598,34 +598,34 @@ describe('GET /jobs/:jobID/steps', function () {
   describe('Requesting a page past the last page without filtering', function () {
     hookJobSteps({ jobID: pagedJob.jobID, username: 'joe', query: { step1Page: 4 } });
 
-    it('still emits a paging block with a way back even with no items on the page', function () {
+    it('returns the last page of work items instead of an empty page', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const step = body.steps[0];
-      expect(step.workItems).to.have.lengthOf(0);
-      expect(step.paging.currentPage).to.equal(4);
+      // 51 items over a 50-item page: page 4 is limited to the last page (2)
+      // with one item.
+      expect(step.workItems).to.have.lengthOf(1);
+      expect(step.paging.currentPage).to.equal(2);
       expect(step.paging.lastPage).to.equal(2);
       expect(step.paging.total).to.equal(51);
-      expect(step.paging.links.find((l) => l.rel === 'first').href).to.include('step1page=1');
+      expect(step.paging.links.find((l) => l.rel === 'prev').href).to.include('step1page=1');
       expect(step.paging.links.find((l) => l.rel === 'next')).to.be.undefined;
     });
   });
 
-  describe('When a status filter and page query go beyond last page', function () {
+  describe('When a status filter and page query go beyond the last page', function () {
     hookJobSteps({
       jobID: destBucketJob.jobID, username: 'joe', query: { status: 'successful', step1Page: 4 },
     });
 
-    it('keeps the step and emits an paging block with first page', function () {
+    it('keeps the step and returns the last page of matching work items', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       expect(body.steps).to.have.lengthOf(1);
       const step = body.steps[0];
-      expect(step.workItems).to.have.lengthOf(0);
-      expect(step.paging.currentPage).to.equal(4);
-      expect(step.paging.lastPage).to.equal(1);
-      expect(step.paging.total).to.equal(1);
-      expect(step.paging.links.find((l) => l.rel === 'first').href).to.include('step1page=1');
+      // The single matching item fits on one page, so there is no paging block.
+      expect(step.workItems).to.have.lengthOf(1);
+      expect(step.paging).to.be.undefined;
     });
   });
 


### PR DESCRIPTION
## Jira Issue ID

[HARMONY-2354](https://bugs.earthdata.nasa.gov/browse/HARMONY-2354)

## Description

Adds per-step paging to the steps endpoint:

Each step is paged independently via its `step<stepIndex>Page` query param  (e.g. `?step1Page=2&step2Page=1`)

`limit` is used as the page size for all steps

Each step's `paging` block is now `{ currentPage, lastPage, total, links }`  with `links` reusing `getPagingLinks`.

The block is shown when a step has more than one page or the requested page is  past the end (so paging off the end after a filter still links back)


## Local Test Steps

check out this branch and run the tests.
```
npm run test
```

deploy to Harmony-In-A-Box

Run a command that generates a number of pages, to test independent paging, we'll use the `limit` query param.

This request will find 7 granules and 6 that will complete.

http://localhost:3000/C1268429762-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&subset=lat(11.73504%3A43.2472)&subset=lon(5.0196%3A79.91089)&subset=time(%222015-03-31T17%3A06%3A00Z%22%3A%222015-03-31T17%3A10%3A00Z%22)&label=harmony-py&label=HARMONY-2254-verify&label=HARMONY-2254&format=image%2Ftiff&variable=Soil_Moisture_Retrieval_Data_1km%2Fretrieval_qual_flag_1km&variable=Soil_Moisture_Retrieval_Data_1km%2Fretrieval_qual_flag_apm_1km&variable=Soil_Moisture_Retrieval_Data_1km%2Fsoil_moisture_1km&variable=Soil_Moisture_Retrieval_Data_1km%2Fsoil_moisture_apm_1km&maxResults=20

(use your UUID:)
`> export UUID=77cc875f-4fd0-4c20-87ba-184f25718094`

Visualize all of the outputs you won't see any paging or paging objects.
`> open http://localhost:3000/jobs/${UUID}/steps`

default to limit=3
`> open "http://localhost:3000/jobs/${UUID}/steps?limit=3"`


open the metadata-annotator's second page:
`> open "http://localhost:3000/jobs/${UUID}/steps?limit=3&step3Page=2"`

Navigate around, verifying that only the step that was changed updates and the rest of the pages stay as they are (but also that the next/previous values on other steps have the correct pages to preserve other steps locations).

Change the page length and open metadata-annotator's second page, and HOSS's 10th:
This shows you that you can page multiple steps and that if you are beyond the last page, the last page is loaded for you and the page object will exist that has normal paging for HOSS step2 (current, previous, first) and the same for metadata annotator, step3

Old behavior was: ~you can still get back to results (HOSS shows a `first` link that will take you back to results, `previous` and `current` (that are both still beyond the bounds)~
`> open "http://localhost:3000/jobs/${UUID}/steps?limit=5&step3Page=2&step2Page=10"`


For more fun, you can just pop open a request that will generate 177 workItems:

http://localhost:3000/C1234088182-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?format=image%2Ftiff

go to the steps endpoint for the job, verify the default of 50 workitems and that the paging works as expected.

  ## PR Acceptance Checklist
  * [X] Acceptance criteria met
  * [X] Tests added/updated (if needed) and passing
  * [X] Documentation updated (if needed)
  * [X] Harmony in a Box tested
