### PR TITLE
HARMONY-2355: Implements multiple value query params.

### DIFF
--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -20,6 +20,7 @@ import { Link } from '../util/links';
 import { keysToLowerCase } from '../util/object';
 import { defaultObjectStore } from '../util/object-store';
 import { getPagingLinks, parseIntegerParam } from '../util/pagination';
+import { parseMultiValueParameter } from '../util/parameter-parsing-helpers';
 import { readCatalogItems, StacItem } from '../util/stac';
 import { getRequestRoot } from '../util/url';
 
@@ -30,9 +31,9 @@ const VALID_STATUSES = Object.values(WorkItemStatus);
 
 
 interface StepsQueryParams {
-  step?: number;
-  status?: WorkItemStatus;
-  workItem?: number;
+  steps?: number[];
+  statuses?: WorkItemStatus[];
+  workItems?: number[];
 }
 
 interface StepWorkItem {
@@ -71,27 +72,36 @@ function parseQuery(query: Record<string, unknown>): StepsQueryParams {
   const out: StepsQueryParams = {};
 
   if (query.step !== undefined) {
-    const n = Number(query.step);
-    if (!Number.isInteger(n) || n < 1) {
-      throw new RequestValidationError('step must be a positive integer');
-    }
-    out.step = n;
+    const queryStepsArray = parseMultiValueParameter(query.step as string | string[]);
+    out.steps = queryStepsArray.map((v) => {
+      const n = Number(v);
+      if (!Number.isInteger(n) || n < 1) {
+        throw new RequestValidationError('step must be a positive integer');
+      }
+      return n;
+    });
   }
 
   if (query.status !== undefined) {
-    const s = String(query.status) as WorkItemStatus;
-    if (!VALID_STATUSES.includes(s)) {
-      throw new RequestValidationError(`status must be one of: ${VALID_STATUSES.join(', ')}`);
-    }
-    out.status = s;
+    const queryStatusArray = parseMultiValueParameter(query.status as string | string[]);
+    out.statuses = queryStatusArray.map((v) => {
+      const s = v as WorkItemStatus;
+      if (!VALID_STATUSES.includes(s)) {
+        throw new RequestValidationError(`status must be one of: ${VALID_STATUSES.join(', ')}`);
+      }
+      return s;
+    });
   }
 
   if (query.workitem !== undefined) {
-    const n = Number(query.workitem);
-    if (!Number.isInteger(n) || n < 1) {
-      throw new RequestValidationError('workItem must be a positive integer');
-    }
-    out.workItem = n;
+    const queryWorkItemArray = parseMultiValueParameter(query.workitem as string | string[]);
+    out.workItems = queryWorkItemArray.map((v) => {
+      const n = Number(v);
+      if (!Number.isInteger(n) || n < 1) {
+        throw new RequestValidationError('workItem must be a positive integer');
+      }
+      return n;
+    });
   }
 
   return out;
@@ -338,7 +348,7 @@ function buildSteps(
   q: StepsQueryParams,
 ): JobStep[] {
   const result: JobStep[] = [];
-  const filtering = q.status !== undefined || q.workItem !== undefined;
+  const filtering = q.statuses !== undefined || q.workItems !== undefined;
   for (const { step, workItems, pagination } of stepResults) {
     // Don't show steps having no matching work items.
     if (filtering && pagination.total === 0) continue;
@@ -391,8 +401,8 @@ export async function getJobSteps(
     const steps = await getWorkflowStepsByJobId(db, jobID);
     const statusCounts = await workItemStatusCountsForJob(db, jobID);
 
-    const selectedSteps = q.step !== undefined
-      ? steps.filter((s) => s.stepIndex === q.step)
+    const selectedSteps = q.steps !== undefined
+      ? steps.filter((s) => q.steps.includes(s.stepIndex))
       : steps;
 
     // Bound every page result by 'limit' and page each step independently
@@ -400,10 +410,13 @@ export async function getJobSteps(
     const limit = parseIntegerParam(req, 'limit', DEFAULT_PER_PAGE, 1, MAX_STEP_PAGE_SIZE, true, true);
     const stepResults: StepWorkItems[] = await Promise.all(selectedSteps.map(async (step) => {
       const where: WorkItemQuery['where'] = { jobID, workflowStepIndex: step.stepIndex };
-      if (q.status !== undefined) where.status = q.status;
-      if (q.workItem !== undefined) where.id = q.workItem;
+      const whereIn: WorkItemQuery['whereIn'] = {};
+      if (q.statuses !== undefined) whereIn.status = { in: true, values: q.statuses };
+      if (q.workItems !== undefined) whereIn.id = { in: true, values: q.workItems };
       const page = parseIntegerParam(req, `step${step.stepIndex}page`, 1, 1);
-      const query = { where, orderBy: { field: 'id', value: 'asc' } };
+      const query: WorkItemQuery = {
+        where, whereIn, orderBy: { field: 'id', value: 'asc' },
+      };
       let { workItems, pagination } = await queryWorkItems(db, query, page, limit);
       // reload last page for this step if we're off the end.
       if (pagination.lastPage >= 1 && page > pagination.lastPage) {

--- a/services/harmony/app/markdown/steps.md
+++ b/services/harmony/app/markdown/steps.md
@@ -20,9 +20,9 @@ Parameter names are case-insensitive (e.g. `step2Page`, `Step2Page`, and `STEP2P
 
 | parameter           | description                                                                                                                                                                                  |
 |---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| step                | Limit the response to the step with this stepIndex (a positive integer).                                                                                                                     |
-| status              | Filter the work items shown to those with this status. One of `ready`, `queued`, `running`, `successful`, `failed`, `canceled`, or `warning`. Steps with no matching work items are omitted. |
-| workItem            | Limit the work items shown to the one with this ID (a positive integer).                                                                                                                     |
+| step                | Limit the response to one or more steps by stepIndex, comma-separated (e.g. `step=1,2`). Each a positive integer.                                                                             |
+| status              | Filter the work items shown to one or more statuses, comma-separated (e.g. `status=failed,warning`). Each one of `ready`, `queued`, `running`, `successful`, `failed`, `canceled`, or `warning`. Steps with no matching work items are omitted. |
+| workItem            | Limit the work items shown to one or more IDs, comma-separated (e.g. `workItem=123,124`). Each a positive integer.                                                                            |
 | limit               | The number of work items to show per page for each step. Defaults to 50, maximum 1000.
 | step\<stepIndex\>Page | The page of work items to show for the step with the given stepIndex, e.g. `step2Page=3`. A positive integer that defaults to 1; a page beyond the last page returns the last page. Each step pages independently, so multiple may be supplied. |
 

--- a/services/harmony/app/models/work-item-interface.ts
+++ b/services/harmony/app/models/work-item-interface.ts
@@ -91,6 +91,7 @@ export interface WorkItemQuery {
     updatedAt?: number;
   };
   whereIn?: {
+    id?: { in: boolean, values: number[] };
     status?: { in: boolean, values: string[] };
     message_category?: { in: boolean, values: string[] };
   };

--- a/services/harmony/package-lock.json
+++ b/services/harmony/package-lock.json
@@ -5413,6 +5413,18 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@hapi/boom": {
       "version": "10.0.1",
       "license": "BSD-3-Clause",
@@ -5424,20 +5436,39 @@
       "version": "3.0.0",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@hapi/hoek": {
       "version": "11.0.7",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@hapi/topo": {
-      "version": "5.1.0",
+    "node_modules/@hapi/pinpoint": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
+      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.7.tgz",
+      "integrity": "sha512-MgNjRwy9Ti92yVAixLmDc8dd1bJIKwO9qlWCfFQRwRmUEDPQHYn4G6hwPFvFGUTzAa0FsS+inMjLin7GnyBRhA==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
-    "node_modules/@hapi/topo/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "license": "BSD-3-Clause"
+    "node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      }
     },
     "node_modules/@hapi/wreck": {
       "version": "18.1.2",
@@ -5900,25 +5931,6 @@
       "version": "1.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@sideway/address": {
-      "version": "4.1.5",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/address/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@sindresorhus/fnv1a": {
       "version": "2.0.1",
@@ -6720,6 +6732,12 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@tmcw/togeojson": {
       "version": "5.8.1",
@@ -10804,19 +10822,22 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
-    },
-    "node_modules/joi/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "license": "BSD-3-Clause"
     },
     "node_modules/js-string-escape": {
       "version": "1.0.1",

--- a/services/harmony/package.json
+++ b/services/harmony/package.json
@@ -226,6 +226,7 @@
     "fast-json-patch": "3.1.1",
     "fast-xml-parser": "5.5.12",
     "ip-address": "10.1.1",
+    "joi": "^18.2.1",
     "jsonpath-plus": "^10.0.7",
     "semver": "^7.6.2",
     "tar": "^7.5.8",

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -406,6 +406,21 @@ describe('GET /jobs/:jobID/steps', function () {
     });
   });
 
+  describe('?step=1&step=2 (repeated param) matches ?step=1,2', function () {
+    before(async function () {
+      this.repeated = await jobSteps(this.frontend,
+        { jobID: joeJob.jobID, query: { step: [1, 2] } }).use(auth({ username: 'joe' }));
+      this.comma = await jobSteps(this.frontend,
+        { jobID: joeJob.jobID, query: { step: '1,2' } }).use(auth({ username: 'joe' }));
+    });
+    after(function () { delete this.repeated; delete this.comma; });
+
+    it('produces the same steps', function () {
+      expect(this.repeated.statusCode).to.equal(200);
+      expect(this.repeated.text).to.equal(this.comma.text);
+    });
+  });
+
   describe('Filtering with ?status=failed,successful multiple status params', function () {
     hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { status: 'failed,successful' } });
     it('keeps work items in any of the requested statuses', function () {

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -33,6 +33,7 @@ function adminJobSteps(app, { jobID, query }: { jobID: string; query?: object })
 const hookJobSteps = hookRequest.bind(this, jobSteps);
 const hookAdminJobSteps = hookRequest.bind(this, adminJobSteps);
 
+let wi1Id: number;
 let wi2Id: number;
 
 const joeJob = buildJob({
@@ -120,6 +121,7 @@ describe('GET /jobs/:jobID/steps', function () {
       scrollID: 'fake-scroll-key',
     });
     await wi1.save(this.trx);
+    wi1Id = wi1.id;
 
     // Step 2: subsetter with a failed work item that has an input catalog from step 1
     const step2 = buildWorkflowStep({
@@ -395,6 +397,29 @@ describe('GET /jobs/:jobID/steps', function () {
     });
   });
 
+  describe('Filtering with ?step=1,2 multiple step params', function () {
+    hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { step: '1,2' } });
+    it('returns each requested step', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      expect(body.steps.map((s) => s.stepIndex)).to.deep.equal([1, 2]);
+    });
+  });
+
+  describe('Filtering with ?status=failed,successful multiple status params', function () {
+    hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { status: 'failed,successful' } });
+    it('keeps work items in any of the requested statuses', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      expect(body.steps).to.have.lengthOf(2);
+      for (const step of body.steps) {
+        for (const wi of step.workItems) {
+          expect(wi.status).to.be.oneOf(['failed', 'successful']);
+        }
+      }
+    });
+  });
+
   describe('Filtering with ?status=failed', function () {
     hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { status: 'failed' } });
     it('keeps only work items in that status', function () {
@@ -487,6 +512,24 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(body.steps[0].stepIndex).to.equal(2);
       expect(body.steps[0].workItems).to.have.lengthOf(1);
       expect(body.steps[0].workItems[0].id).to.equal(wi2Id);
+    });
+  });
+
+  describe('Filtering with ?workItem=<id1>,<id2> multiple workitem params', function () {
+    before(async function () {
+      this.res = await jobSteps(
+        this.frontend,
+        { jobID: joeJob.jobID, query: { workItem: `${wi1Id},${wi2Id}` } },
+      ).use(auth({ username: 'joe' }));
+    });
+    after(function () { delete this.res; });
+
+    it('returns each requested work item in its parent step', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      expect(body.steps).to.have.lengthOf(2);
+      const ids = body.steps.flatMap((s) => s.workItems.map((wi) => wi.id));
+      expect(ids).to.have.members([wi1Id, wi2Id]);
     });
   });
 
@@ -667,6 +710,27 @@ describe('GET /jobs/:jobID/steps', function () {
   describe('Validation errors', function () {
     describe('?status=bogus', function () {
       hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { status: 'bogus' } });
+      it('returns 400', function () {
+        expect(this.res.statusCode).to.equal(400);
+      });
+    });
+
+    describe('?status=failed,bogus (one invalid value in a list)', function () {
+      hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { status: 'failed,bogus' } });
+      it('returns 400', function () {
+        expect(this.res.statusCode).to.equal(400);
+      });
+    });
+
+    describe('?step=1,abc (one non-integer value in a list)', function () {
+      hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { step: '1,abc' } });
+      it('returns 400', function () {
+        expect(this.res.statusCode).to.equal(400);
+      });
+    });
+
+    describe('?workItem=1,-2 (one non-positive value in a list)', function () {
+      hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { workItem: '1,-2' } });
       it('returns 400', function () {
         expect(this.res.statusCode).to.equal(400);
       });


### PR DESCRIPTION
## Jira Issue ID

[HARMONY-2355](https://bugs.earthdata.nasa.gov/browse/HARMONY-2355) 

## Description

Update query parameters to handle multiple comma separated values. 
e.g. `?step=1,2`
Also, multiple repeated values are supported 
`?step=1&step=2`

## Local Test Steps

Pull and deploy this to Harmony-In-A-Box.

Run a request that will generate multiple pages of steps and will pause so you have multiple statuses.


http://localhost:3000/C1234088182-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?format=image%2Ftiff

visit the endpoint and compare the outputs of: verify they don't error

http://localhost:3000/jobs/{:UUID}/steps
http://localhost:3000/jobs/{:UUID}/steps?status=ready
http://localhost:3000/jobs/{:UUID}/steps?status=ready,successful



## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)
* [X] Harmony in a Box tested (if changes made to microservices or new dependencies added)
