### PR TITLE
HARMONY-2352 step allows paged access to all intermediate files

### DIFF
--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -28,7 +28,7 @@ const DEFAULT_WORKITEMS_PER_PAGE = 50;
 const MAX_WORKITEMS_PER_PAGE = 1000;
 
 // Default number of a work item's input items / output catalogs resolved per page,
-// navigated with the per-work-item `workItem<id>InputPage` / `workItem<id>Page`
+// navigated with the per-work-item `workItem<id>InputPage` / `workItem<id>OutputPage`
 // parameters and overridable via the `wiLimit` query parameter. Bounds the S3 reads
 // each resolved page costs.
 const CATALOG_PAGE_SIZE = 50;
@@ -370,13 +370,13 @@ async function resolveOutputFiles(
   const perPage = parseIntegerParam(req, 'wilimit', CATALOG_PAGE_SIZE, 1, MAX_WI_PAGE_SIZE, true, true);
   const outputDir = getStacLocation({ id: wi.id, jobID: wi.jobID });
   const allCatalogUrls = await getAllOutputCatalogFilenames(outputDir);
-  const requestedPage = parseIntegerParam(req, `workitem${wi.id}page`, 1, 1);
+  const requestedPage = parseIntegerParam(req, `workitem${wi.id}outputpage`, 1, 1);
   const pagination = catalogPagination(allCatalogUrls.length, requestedPage, perPage);
   const start = (pagination.currentPage - 1) * perPage;
   const pageUrls = allCatalogUrls.slice(start, start + perPage);
   const hrefArrays = await Promise.all(pageUrls.map((url) => resolveDataHrefs(url)));
   const files = hrefArrays.flat().map((h) => safePublicLink(h, frontendRoot, destinationBucket));
-  return { files, paging: buildFilesPaging(req, pagination, `workitem${wi.id}page`) };
+  return { files, paging: buildFilesPaging(req, pagination, `workitem${wi.id}outputpage`) };
 }
 
 /**
@@ -422,7 +422,7 @@ async function resolveSelectedWorkItemFiles(
  *
  * In resolve mode the requested kind's files are populated inline from the
  * precomputed `resolved` map, with an `inputFilesPaging` / `outputFilesPaging`
- * block (navigated via the `workItem<id>InputPage` / `workItem<id>Page`
+ * block (navigated via the `workItem<id>InputPage` / `workItem<id>OutputPage`
  * parameter) when there is more than one page.
  *
  * @param req - the Express request, used to build links

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -26,7 +26,14 @@ import { getRequestRoot } from '../util/url';
 
 const DEFAULT_PER_PAGE = 50;
 const MAX_STEP_PAGE_SIZE = 1000;
-const MAX_BATCH_CATALOGS = 5;
+// Number of a work item's output catalogs resolved per page, navigated with the
+// per-work-item `workItem<id>Page` parameter. Bounds the S3 reads each page costs.
+const CATALOG_PAGE_SIZE = 10;
+// Upper bound on the number of items resolved from a single work item's input
+// catalog. A work item has one input catalog, but for an aggregating service that
+// catalog can list a huge number of items; this keeps the read bounded. Full
+// input pagination is a possible follow-up.
+const MAX_INPUT_CATALOG_ITEMS = 100;
 const VALID_STATUSES = Object.values(WorkItemStatus);
 
 
@@ -42,7 +49,7 @@ interface StepWorkItem {
   retryCount: number;
   inputFiles: string[] | null;
   outputFiles: string[] | null;
-  warning?: string;
+  outputFilesPaging?: StepPaging;
 }
 
 interface JobStep {
@@ -128,13 +135,15 @@ function getAllAssetHrefs(items: StacItem[]): string[] {
  * Read a STAC catalog and return every asset href it references.
  *
  * @param catalogUrl - the location of the STAC catalog to read
+ * @param maxItems - if provided, read at most this many items from the catalog
+ *   (bounds the number of S3 reads)
  * @returns the asset hrefs from the catalog, or an empty array if the catalog
  *   cannot be read (e.g. the service failed before producing it, or the
  *   catalog has no assets)
  */
-async function resolveDataHrefs(catalogUrl: string): Promise<string[]> {
+async function resolveDataHrefs(catalogUrl: string, maxItems?: number): Promise<string[]> {
   try {
-    const items = await readCatalogItems(catalogUrl);
+    const items = await readCatalogItems(catalogUrl, maxItems);
     return getAllAssetHrefs(items);
   } catch {
     return [];
@@ -169,18 +178,20 @@ export function safePublicLink(href: string, frontendRoot: string, destinationBu
   }
 }
 
-// Per-WI output catalog list, plus how many additional catalog files (if any)
-// were dropped to keep the S3 fan-out bounded.
-interface WiOutputCatalogs {
+// A work item's output catalogs for the requested page, plus the pagination
+// describing where that page sits in the full (catalog-level) result set.
+interface WiOutputPage {
+  // The output catalog URLs for the current page only.
   urls: string[];
-  omittedCount: number;
+  // Catalog-level pagination over the work item's full output catalog list.
+  pagination: ILengthAwarePagination;
 }
 
 interface ResolvedCatalogs {
   // Map of local catalog.json location -> Array of public links to file.
   catalogHrefs: Map<string, string[]>;
-  // Map of work item id to its output catalog.json list (plus the omitted count).
-  wiOutputCatalogs: Map<number, WiOutputCatalogs>;
+  // Map of work item id to its current page of output catalogs + pagination.
+  wiOutputPages: Map<number, WiOutputPage>;
 }
 
 /**
@@ -204,14 +215,13 @@ function catalogIndex(filename: string): number {
  *   - otherwise list the `catalog*.json` files in the outputs directory, which
  *     covers both the common single `catalog.json` and services that might write
  *     several `catalogN.json` files without an index.
- * The result is capped at MAX_BATCH_CATALOGS to bound the downstream S3 reads;
- * any extras are reported as omittedCount.
+ * The full ordered list is returned; the caller paginates it (its length is the
+ * work item's output catalog total).
  *
  * @param outputDir - the WI's outputs directory URL
- * @returns the (capped) catalog URLs and the count of additional catalog
- *   files that were not included
+ * @returns the ordered output catalog URLs
  */
-async function readOutputCatalogs(outputDir: string): Promise<WiOutputCatalogs> {
+async function readOutputCatalogs(outputDir: string): Promise<string[]> {
   const store = defaultObjectStore();
   const batchCatalogsUrl = `${outputDir}batch-catalogs.json`;
 
@@ -220,7 +230,7 @@ async function readOutputCatalogs(outputDir: string): Promise<WiOutputCatalogs> 
     try {
       filenames = await store.getObjectJson(batchCatalogsUrl) as string[];
     } catch {
-      return { urls: [], omittedCount: 0 };
+      return [];
     }
   } else {
     const keys = await store.listObjectKeys(outputDir);
@@ -230,79 +240,125 @@ async function readOutputCatalogs(outputDir: string): Promise<WiOutputCatalogs> 
       .sort((a, b) => catalogIndex(a) - catalogIndex(b));
   }
 
-  const capped = filenames.slice(0, MAX_BATCH_CATALOGS);
+  return filenames.map((f) => `${outputDir}${f}`);
+}
+
+/**
+ * Build a catalog-level pagination object for a work item's output catalogs,
+ * mirroring the shape knex-paginate produces so getPagingLinks can consume it.
+ * The requested page is clamped to the last page when it is beyond the end,
+ * matching the per-step paging behavior.
+ *
+ * @param total - the work item's total number of output catalogs
+ * @param requestedPage - the page requested via the work item's page parameter
+ * @returns the pagination describing the (clamped) current page
+ */
+function catalogPagination(total: number, requestedPage: number): ILengthAwarePagination {
+  const perPage = CATALOG_PAGE_SIZE;
+  const lastPage = Math.max(1, Math.ceil(total / perPage));
+  const currentPage = Math.min(requestedPage, lastPage);
+  const from = total === 0 ? 0 : (currentPage - 1) * perPage + 1;
+  const to = Math.min(currentPage * perPage, total);
   return {
-    urls: capped.map((f) => `${outputDir}${f}`),
-    omittedCount: Math.max(0, filenames.length - MAX_BATCH_CATALOGS),
+    total, lastPage, perPage, currentPage, from, to,
+    prevPage: currentPage > 1 ? currentPage - 1 : null,
+    nextPage: currentPage < lastPage ? currentPage + 1 : null,
   };
 }
 
 /**
- * For every completed work item, determine its output catalog file URLs, then
- * resolve each unique catalog URL (inputs + outputs) to public-facing data
- * hrefs.
+ * For every completed work item, determine the requested page of its output
+ * catalog file URLs, then resolve the catalogs needed for the response to
+ * public-facing data hrefs. Only the current page of each work item's output
+ * catalogs is resolved (full), and each work item's single input catalog is
+ * resolved with a bounded number of items, so the S3 reads stay bounded
+ * regardless of the size of the fan-out.
  *
+ * @param req - the Express request, used to read each work item's page parameter
  * @param workItems - the page of work items whose catalogs should be resolved
  * @param frontendRoot - the root URL to use when producing Harmony permalinks
- * @returns the per-catalog to  hrefs map and per-WI output to catalog list (see
- *   ResolvedCatalogs)
+ * @param destinationBucket - the job's destinationUrl bucket name, or undefined
+ * @returns the per-catalog hrefs map and per-WI output page (see ResolvedCatalogs)
  */
 async function resolveAllCatalogs(
+  req: HarmonyRequest,
   workItems: WorkItem[],
   frontendRoot: string,
   destinationBucket: string = undefined,
 ): Promise<ResolvedCatalogs> {
   const completed_workitems = workItems.filter((wi) => COMPLETED_WORK_ITEM_STATUSES.includes(wi.status));
 
-  // Determine each completed WI's *output* catalog file URLs
-  const wiOutputCatalogs = new Map<number, WiOutputCatalogs>();
+  // Determine each completed WI's current page of *output* catalog file URLs.
+  const wiOutputPages = new Map<number, WiOutputPage>();
   await Promise.all(completed_workitems.map(async (wi) => {
     const outputDir = getStacLocation({ id: wi.id, jobID: wi.jobID });
-    wiOutputCatalogs.set(wi.id, await readOutputCatalogs(outputDir));
+    const allUrls = await readOutputCatalogs(outputDir);
+    const requestedPage = parseIntegerParam(req, `workitem${wi.id}page`, 1, 1);
+    const pagination = catalogPagination(allUrls.length, requestedPage);
+    const start = (pagination.currentPage - 1) * CATALOG_PAGE_SIZE;
+    const urls = allUrls.slice(start, start + CATALOG_PAGE_SIZE);
+    wiOutputPages.set(wi.id, { urls, pagination });
   }));
-
-  // Collect every unique catalog file URL: each completed WI's
-  // input (stacCatalogLocation) plus every output catalog file.
-  const allCatalogUrls = new Set<string>();
-  for (const wi of completed_workitems) {
-    if (wi.stacCatalogLocation) allCatalogUrls.add(wi.stacCatalogLocation);
-    for (const url of wiOutputCatalogs.get(wi.id)?.urls ?? []) allCatalogUrls.add(url);
-  }
 
   const catalogHrefs = new Map<string, string[]>();
-  await Promise.all(Array.from(allCatalogUrls).map(async (url) => {
-    const rawHrefs = await resolveDataHrefs(url);
+  const resolve = async (url: string, maxItems?: number): Promise<void> => {
+    if (catalogHrefs.has(url)) return;
+    const rawHrefs = await resolveDataHrefs(url, maxItems);
     catalogHrefs.set(url, rawHrefs.map((h) => safePublicLink(h, frontendRoot, destinationBucket)));
-  }));
+  };
 
-  return { catalogHrefs, wiOutputCatalogs };
+  // Resolve the current page of output catalogs (full), then each WI's single
+  // input catalog (bounded). Outputs first so a URL that is both keeps the
+  // full output resolution.
+  const outputUrls = new Set<string>();
+  for (const wi of completed_workitems) {
+    for (const url of wiOutputPages.get(wi.id)?.urls ?? []) outputUrls.add(url);
+  }
+  await Promise.all(Array.from(outputUrls).map((url) => resolve(url)));
+
+  const inputUrls = new Set<string>();
+  for (const wi of completed_workitems) {
+    if (wi.stacCatalogLocation) inputUrls.add(wi.stacCatalogLocation);
+  }
+  await Promise.all(Array.from(inputUrls).map((url) => resolve(url, MAX_INPUT_CATALOG_ITEMS)));
+
+  return { catalogHrefs, wiOutputPages };
 }
 
 /**
  * Build the work item portion of the response. inputFiles / outputFiles are
  * populated from the precomputed `resolved` maps; a WI absent from
- * `wiOutputCatalogs` displays `outputFiles: null`. WIs that never have a STAC
- * input (e.g.  query-cmr step 1) always report `inputFiles: null`.
+ * `wiOutputPages` displays `outputFiles: null`. WIs that never have a STAC
+ * input (e.g.  query-cmr step 1) always report `inputFiles: null`. When a work
+ * item has more than one page of output catalogs, an `outputFilesPaging` block
+ * with navigation links (via the `workItem<id>Page` parameter) is included.
  *
+ * @param req - the Express request, used to build per-work-item paging links
  * @param wi - the work item to serialize
- * @param resolved - the catalog hrefs map + per-WI output catalog list
+ * @param resolved - the catalog hrefs map + per-WI output page
  * @returns the work item shaped for the steps response
  */
 function buildWorkItem(
+  req: HarmonyRequest,
   wi: WorkItem,
   resolved: ResolvedCatalogs,
 ): StepWorkItem {
-  const { catalogHrefs, wiOutputCatalogs } = resolved;
-  const outputCatalogs = wiOutputCatalogs.get(wi.id);
+  const { catalogHrefs, wiOutputPages } = resolved;
+  const outputPage = wiOutputPages.get(wi.id);
   let outputFiles: string[] | null;
-  let truncationWarning: string | undefined = undefined;
-  if (outputCatalogs === undefined) {
+  let outputFilesPaging: StepPaging | undefined = undefined;
+  if (outputPage === undefined) {
     outputFiles = null;
   } else {
-    outputFiles = outputCatalogs.urls.flatMap((url) => catalogHrefs.get(url) ?? []);
-    if (outputCatalogs.omittedCount > 0) {
-      truncationWarning = 'Not all output files are included. Only the outputs from the first ' +
-        `${outputCatalogs.urls.length} STAC catalogs were resolved, there are ${outputCatalogs.omittedCount} catalogs that were not resolved.`;
+    outputFiles = outputPage.urls.flatMap((url) => catalogHrefs.get(url) ?? []);
+    const { currentPage, lastPage, total } = outputPage.pagination;
+    if (lastPage > 1) {
+      outputFilesPaging = {
+        currentPage,
+        lastPage,
+        total,
+        links: getPagingLinks(req, outputPage.pagination, true, `workitem${wi.id}page`),
+      };
     }
   }
 
@@ -314,7 +370,7 @@ function buildWorkItem(
       ? (catalogHrefs.get(wi.stacCatalogLocation) ?? null)
       : null,
     outputFiles,
-    ...(truncationWarning !== undefined && { warning: truncationWarning }),
+    ...(outputFilesPaging !== undefined && { outputFilesPaging }),
   };
 }
 
@@ -358,7 +414,7 @@ function buildSteps(
       stepIndex: step.stepIndex,
       workItemCount: step.workItemCount,
       statuses: statusCounts.get(step.stepIndex) ?? {},
-      workItems: workItems.map((wi) => buildWorkItem(wi, resolved)),
+      workItems: workItems.map((wi) => buildWorkItem(req, wi, resolved)),
     };
     const { currentPage, lastPage, total } = pagination;
     if (lastPage > 1) {
@@ -427,7 +483,7 @@ export async function getJobSteps(
 
     const frontendRoot = getRequestRoot(req);
     const allWorkItems = stepResults.flatMap((r) => r.workItems);
-    const resolvedCatalogs = await resolveAllCatalogs(allWorkItems, frontendRoot, destinationBucket);
+    const resolvedCatalogs = await resolveAllCatalogs(req, allWorkItems, frontendRoot, destinationBucket);
     const jobSteps = buildSteps(req, stepResults, resolvedCatalogs, statusCounts, q);
 
     const responseBody = {

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -22,36 +22,50 @@ import { keysToLowerCase } from '../util/object';
 import { defaultObjectStore } from '../util/object-store';
 import { getPagingLinks, parseIntegerParam } from '../util/pagination';
 import { parseMultiValueParameter } from '../util/parameter-parsing-helpers';
-import { readCatalogItems, StacItem } from '../util/stac';
+import { readCatalogItems, readCatalogItemsPage, StacItem } from '../util/stac';
 import { getRequestRoot } from '../util/url';
 
 const DEFAULT_WORKITEMS_PER_PAGE = 50;
 const MAX_WORKITEMS_PER_PAGE = 1000;
 
-// Default number of a work item's output catalogs resolved per page, navigated with the
-// per-work-item `workItem<id>Page` parameter and overridable via the `wiLimit` query
-// parameter. Bounds the S3 reads each page costs.
+// Default number of a work item's input items / output catalogs resolved per page,
+// navigated with the per-work-item `workItem<id>InputPage` / `workItem<id>Page`
+// parameters and overridable via the `wiLimit` query parameter. Bounds the S3 reads
+// each resolved page costs.
 const CATALOG_PAGE_SIZE = 10;
-// Upper bound on the number of items resolved from a single work item's input
-// catalog. A work item has one input catalog, but for an aggregating service that
-// catalog can list a huge number of items; this keeps the read bounded. Full
-// input pagination is a possible follow-up.
-const MAX_INPUT_CATALOG_ITEMS = 100;
+// Upper bound on `wiLimit`: the largest page of input items / output catalogs that
+// may be resolved in a single request. A work item's input catalog can list a huge
+// number of items (e.g. an aggregating service), so this caps the per-page read cost.
+const MAX_WI_PAGE_SIZE = 100;
 const VALID_STATUSES = Object.values(WorkItemStatus);
+
+// Which side of a single work item's files a resolve request is asking for.
+type ResolveKind = 'input' | 'output';
+const VALID_RESOLVE_KINDS: ResolveKind[] = ['input', 'output'];
 
 
 interface StepsQueryParams {
   steps?: number[];
   statuses?: WorkItemStatus[];
   workItems?: number[];
+  // When set, the request resolves a single work item's input or output files
+  // inline (rather than returning the link-only overview).
+  resolveFiles?: ResolveKind;
 }
 
 interface StepWorkItem {
   id: number;
   status: WorkItemStatus;
   retryCount: number;
-  inputFiles: string[] | null;
-  outputFiles: string[] | null;
+  // Overview mode: links back to the steps endpoint that resolve this work item's
+  // input / output files (null when the work item has no input / no outputs yet).
+  inputFilesUrl?: string | null;
+  outputFilesUrl?: string | null;
+  // Resolve mode: the requested page of files for the requested kind, plus paging
+  // when there is more than one page. Only the requested kind is populated.
+  inputFiles?: string[] | null;
+  inputFilesPaging?: StepPaging;
+  outputFiles?: string[] | null;
   outputFilesPaging?: StepPaging;
 }
 
@@ -114,6 +128,14 @@ function parseQuery(query: Record<string, unknown>): StepsQueryParams {
     });
   }
 
+  if (query.resolvefiles !== undefined) {
+    const kind = query.resolvefiles as ResolveKind;
+    if (!VALID_RESOLVE_KINDS.includes(kind)) {
+      throw new RequestValidationError(`resolveFiles must be one of: ${VALID_RESOLVE_KINDS.join(', ')}`);
+    }
+    out.resolveFiles = kind;
+  }
+
   return out;
 }
 
@@ -135,20 +157,19 @@ function getAllAssetHrefs(items: StacItem[]): string[] {
 }
 
 /**
- * Read a STAC catalog and return every asset href it references.
+ * Read a STAC catalog and return every asset href it references. Used to resolve
+ * a single output catalog (one page of a work item's outputs); input catalogs,
+ * which can list a huge number of items, are read a page at a time via
+ * `resolveInputFiles` instead.
  *
  * @param catalogUrl - the location of the STAC catalog to read
- * @param maxItems - if provided, read at most this many items from the catalog
- *   (bounds the number of S3 reads)
  * @returns the asset hrefs from the catalog, or an empty array if the catalog
  *   cannot be read (e.g. the service failed before producing it, or the
  *   catalog has no assets)
  */
-async function resolveDataHrefs(catalogUrl: string, maxItems?: number, logger?: Logger): Promise<string[]> {
+async function resolveDataHrefs(catalogUrl: string, logger?: Logger): Promise<string[]> {
   try {
-    // TODO [MHS, 06/16/2026]  this will need to be a paged read somehow..
-    // the catalogURL can point
-    const items = await readCatalogItems(catalogUrl, maxItems, logger);
+    const items = await readCatalogItems(catalogUrl, undefined, logger);
     return getAllAssetHrefs(items);
   } catch {
     return [];
@@ -183,20 +204,48 @@ export function safePublicLink(href: string, frontendRoot: string, destinationBu
   }
 }
 
-// A work item's output catalogs for the requested page, plus the pagination
-// describing where that page sits in the full (catalog-level) result set.
-interface WiOutputPage {
-  // The output catalog URLs for the current page only.
-  urls: string[];
-  // Catalog-level pagination over the work item's full output catalog list.
-  pagination: ILengthAwarePagination;
+// A single work item's resolved page of files plus its paging (paging is omitted
+// when there is only one page).
+interface WiResolvedFiles {
+  files: string[];
+  paging?: StepPaging;
 }
 
-interface ResolvedCatalogs {
-  // Map of local catalog.json location -> Array of public links to file.
-  catalogHrefs: Map<string, string[]>;
-  // Map of work item id to its current page of output catalogs + pagination.
-  wiOutputPages: Map<number, WiOutputPage>;
+// Map of work item id -> its resolved page of files (only populated in resolve mode).
+type ResolvedFiles = Map<number, WiResolvedFiles>;
+
+/**
+ * Build the link, back to this same steps endpoint, that resolves a single work
+ * item's input or output files inline.
+ *
+ * @param req - the Express request, used for the host and current path
+ * @param wiId - the work item id to scope the link to
+ * @param kind - whether the link resolves input or output files
+ * @returns the absolute URL that resolves that work item's files
+ */
+function workItemFilesUrl(req: HarmonyRequest, wiId: number, kind: ResolveKind): string {
+  const path = req.originalUrl.split('?')[0];
+  return `${getRequestRoot(req)}${path}?workitem=${wiId}&resolvefiles=${kind}`;
+}
+
+/**
+ * Build the paging block for a resolved page of a work item's files, or undefined
+ * when the files fit on a single page.
+ *
+ * @param req - the Express request, used to build the paging links
+ * @param pagination - the catalog-level pagination for the work item's files
+ * @param pageParamName - the per-work-item page query parameter the links should set
+ * @returns the paging block, or undefined when there is only one page
+ */
+function buildFilesPaging(
+  req: HarmonyRequest, pagination: ILengthAwarePagination, pageParamName: string,
+): StepPaging | undefined {
+  const { currentPage, lastPage, total } = pagination;
+  if (lastPage <= 1) return undefined;
+  return {
+    currentPage, lastPage, total,
+    links: getPagingLinks(req, pagination, true, pageParamName, 'wilimit'),
+  };
 }
 
 /**
@@ -226,7 +275,7 @@ function catalogIndex(filename: string): number {
  * @param outputDir - the WI's outputs directory URL
  * @returns the ordered output catalog URLs
  */
-async function readOutputCatalogs(outputDir: string): Promise<string[]> {
+async function getAllOutputCatalogFilenames(outputDir: string): Promise<string[]> {
   const store = defaultObjectStore();
   const batchCatalogsUrl = `${outputDir}batch-catalogs.json`;
 
@@ -271,115 +320,141 @@ function catalogPagination(total: number, requestedPage: number, perPage: number
 }
 
 /**
- * For every completed work item, determine the requested page of its output
- * catalog file URLs, then resolve the catalogs needed for the response to
- * public-facing data hrefs. Only the current page of each work item's output
- * catalogs is resolved (full), and each work item's single input catalog is
- * resolved with a bounded number of items, so the S3 reads stay bounded
- * regardless of the size of the fan-out.
+ * Resolve one page of a work item's input files. The work item's single input
+ * catalog can reference a huge number of items (e.g. an aggregating service), so
+ * the catalog is enumerated once and only the requested page of items is read,
+ * keeping the S3 reads bounded by `wiLimit`.
  *
- * @param req - the Express request, used to read each work item's page parameter
- * @param workItems - the page of work items whose catalogs should be resolved
+ * @param req - the Express request, used to read the input page / wiLimit params
+ * @param wi - the work item whose input catalog should be resolved
  * @param frontendRoot - the root URL to use when producing Harmony permalinks
  * @param destinationBucket - the job's destinationUrl bucket name, or undefined
- * @returns the per-catalog hrefs map and per-WI output page (see ResolvedCatalogs)
+ * @returns the page of public file links plus paging (paging omitted for one page)
  */
-async function resolveAllCatalogs(
-  req: HarmonyRequest,
-  workItems: WorkItem[],
-  frontendRoot: string,
-  destinationBucket: string = undefined,
-): Promise<ResolvedCatalogs> {
-  const startTime = new Date().getTime();
-  const completed_workitems = workItems.filter((wi) => COMPLETED_WORK_ITEM_STATUSES.includes(wi.status));
-
-  // Determine each completed WI's current page of *output* catalog file URLs.
-  const wiPageSize = parseIntegerParam(req, 'wilimit', CATALOG_PAGE_SIZE, 1, MAX_INPUT_CATALOG_ITEMS, true, true);
-  const wiOutputPages = new Map<number, WiOutputPage>();
-  await Promise.all(completed_workitems.map(async (wi) => {
-    const outputDir = getStacLocation({ id: wi.id, jobID: wi.jobID });
-    const allUrls = await readOutputCatalogs(outputDir);
-    const requestedPage = parseIntegerParam(req, `workitem${wi.id}page`, 1, 1);
-    const pagination = catalogPagination(allUrls.length, requestedPage, wiPageSize);
-    const start = (pagination.currentPage - 1) * wiPageSize;
-    const urls = allUrls.slice(start, start + wiPageSize);
-    wiOutputPages.set(wi.id, { urls, pagination });
-  }));
-
-  const catalogHrefs = new Map<string, string[]>();
-  const resolve = async (url: string, maxItems?: number): Promise<void> => {
-    if (catalogHrefs.has(url)) return;
-    const rawHrefs = await resolveDataHrefs(url, maxItems, req.context.logger);
-    catalogHrefs.set(url, rawHrefs.map((h) => safePublicLink(h, frontendRoot, destinationBucket)));
-  };
-
-  // Resolve the current page of output catalogs (full), then each WI's single
-  // input catalog (bounded). Outputs first so a URL that is both keeps the
-  // full output resolution.
-  const outputUrls = new Set<string>();
-  for (const wi of completed_workitems) {
-    for (const url of wiOutputPages.get(wi.id)?.urls ?? []) outputUrls.add(url);
+async function resolveInputFiles(
+  req: HarmonyRequest, wi: WorkItem, frontendRoot: string, destinationBucket: string | undefined,
+): Promise<WiResolvedFiles> {
+  if (!wi.stacCatalogLocation) return { files: [] };
+  const perPage = parseIntegerParam(req, 'wilimit', CATALOG_PAGE_SIZE, 1, MAX_WI_PAGE_SIZE, true, true);
+  const requestedPage = parseIntegerParam(req, `workitem${wi.id}inputpage`, 1, 1);
+  try {
+    const first = await readCatalogItemsPage(
+      wi.stacCatalogLocation, (requestedPage - 1) * perPage, perPage, req.context.logger);
+    const pagination = catalogPagination(first.total, requestedPage, perPage);
+    // Re-read the clamped page when the requested page was beyond the last.
+    let { items } = first;
+    if (pagination.currentPage !== requestedPage) {
+      ({ items } = await readCatalogItemsPage(
+        wi.stacCatalogLocation, (pagination.currentPage - 1) * perPage, perPage, req.context.logger));
+    }
+    const files = getAllAssetHrefs(items).map((h) => safePublicLink(h, frontendRoot, destinationBucket));
+    return { files, paging: buildFilesPaging(req, pagination, `workitem${wi.id}inputpage`) };
+  } catch {
+    return { files: [] };
   }
-  await Promise.all(Array.from(outputUrls).map((url) => resolve(url)));
-
-  const inputUrls = new Set<string>();
-  for (const wi of completed_workitems) {
-    if (wi.stacCatalogLocation) inputUrls.add(wi.stacCatalogLocation);
-  }
-  await Promise.all(Array.from(inputUrls).map((url) => resolve(url, MAX_INPUT_CATALOG_ITEMS)));
-
-  const durationMs = new Date().getTime() - startTime;
-  req.context.logger.info('Finished steps:resolveAllCatalogs', { durationMs });
-  return { catalogHrefs, wiOutputPages };
 }
 
 /**
- * Build the work item portion of the response. inputFiles / outputFiles are
- * populated from the precomputed `resolved` maps; a WI absent from
- * `wiOutputPages` displays `outputFiles: null`. WIs that never have a STAC
- * input (e.g.  query-cmr step 1) always report `inputFiles: null`. When a work
- * item has more than one page of output catalogs, an `outputFilesPaging` block
- * with navigation links (via the `workItem<id>Page` parameter) is included.
+ * Resolve one page of a work item's output files. A work item's outputs are a list
+ * of catalog files; only the requested page of those catalogs is read (each fully)
+ * so the S3 reads stay bounded by `wiLimit`.
  *
- * @param req - the Express request, used to build per-work-item paging links
+ * @param req - the Express request, used to read the output page / wiLimit params
+ * @param wi - the work item whose output catalogs should be resolved
+ * @param frontendRoot - the root URL to use when producing Harmony permalinks
+ * @param destinationBucket - the job's destinationUrl bucket name, or undefined
+ * @returns the page of public file links plus paging (paging omitted for one page)
+ */
+async function resolveOutputFiles(
+  req: HarmonyRequest, wi: WorkItem, frontendRoot: string, destinationBucket: string | undefined,
+): Promise<WiResolvedFiles> {
+  if (!COMPLETED_WORK_ITEM_STATUSES.includes(wi.status)) return { files: [] };
+  const perPage = parseIntegerParam(req, 'wilimit', CATALOG_PAGE_SIZE, 1, MAX_WI_PAGE_SIZE, true, true);
+  const outputDir = getStacLocation({ id: wi.id, jobID: wi.jobID });
+  const allUrls = await getAllOutputCatalogFilenames(outputDir);
+  const requestedPage = parseIntegerParam(req, `workitem${wi.id}page`, 1, 1);
+  const pagination = catalogPagination(allUrls.length, requestedPage, perPage);
+  const start = (pagination.currentPage - 1) * perPage;
+  const pageUrls = allUrls.slice(start, start + perPage);
+  const hrefArrays = await Promise.all(pageUrls.map((url) => resolveDataHrefs(url, req.context.logger)));
+  const files = hrefArrays.flat().map((h) => safePublicLink(h, frontendRoot, destinationBucket));
+  return { files, paging: buildFilesPaging(req, pagination, `workitem${wi.id}page`) };
+}
+
+/**
+ * Resolve the requested kind (input or output) of files for the given work items
+ * inline. Only invoked in resolve mode, which is scoped to a single work item, so
+ * the S3 reads are bounded to that one work item's requested page.
+ *
+ * @param req - the Express request
+ * @param workItems - the work items to resolve (a single item in resolve mode)
+ * @param kind - whether to resolve input or output files
+ * @param frontendRoot - the root URL to use when producing Harmony permalinks
+ * @param destinationBucket - the job's destinationUrl bucket name, or undefined
+ * @returns map of work item id to its resolved page of files
+ */
+async function resolveSelectedWorkItemFiles(
+  req: HarmonyRequest,
+  workItems: WorkItem[],
+  kind: ResolveKind,
+  frontendRoot: string,
+  destinationBucket: string | undefined,
+): Promise<ResolvedFiles> {
+  const startTime = new Date().getTime();
+  const resolved: ResolvedFiles = new Map();
+  await Promise.all(workItems.map(async (wi) => {
+    const result = kind === 'input'
+      ? await resolveInputFiles(req, wi, frontendRoot, destinationBucket)
+      : await resolveOutputFiles(req, wi, frontendRoot, destinationBucket);
+    resolved.set(wi.id, result);
+  }));
+  const durationMs = new Date().getTime() - startTime;
+  req.context.logger.info('Finished steps:resolveSelectedWorkItemFiles', { durationMs });
+  return resolved;
+}
+
+/**
+ * Build the work item portion of the response.
+ *
+ * In overview mode (no `resolveFiles`) the work item carries `inputFilesUrl` /
+ * `outputFilesUrl` links back to this endpoint that resolve its files on demand,
+ * doing no S3 reads here: `inputFilesUrl` is null when the work item has no STAC
+ * input (e.g. query-cmr step 1) and `outputFilesUrl` is null until the work item
+ * completes.
+ *
+ * In resolve mode the requested kind's files are populated inline from the
+ * precomputed `resolved` map, with an `inputFilesPaging` / `outputFilesPaging`
+ * block (navigated via the `workItem<id>InputPage` / `workItem<id>Page`
+ * parameter) when there is more than one page.
+ *
+ * @param req - the Express request, used to build links
  * @param wi - the work item to serialize
- * @param resolved - the catalog hrefs map + per-WI output page
+ * @param q - the parsed steps query (determines overview vs resolve mode)
+ * @param resolved - the per-WI resolved files map (resolve mode only)
  * @returns the work item shaped for the steps response
  */
 function buildWorkItem(
   req: HarmonyRequest,
   wi: WorkItem,
-  resolved: ResolvedCatalogs,
+  q: StepsQueryParams,
+  resolved?: ResolvedFiles,
 ): StepWorkItem {
-  const { catalogHrefs, wiOutputPages } = resolved;
-  const outputPage = wiOutputPages.get(wi.id);
-  let outputFiles: string[] | null;
-  let outputFilesPaging: StepPaging | undefined = undefined;
-  if (outputPage === undefined) {
-    outputFiles = null;
-  } else {
-    outputFiles = outputPage.urls.flatMap((url) => catalogHrefs.get(url) ?? []);
-    const { currentPage, lastPage, total } = outputPage.pagination;
-    if (lastPage > 1) {
-      outputFilesPaging = {
-        currentPage,
-        lastPage,
-        total,
-        links: getPagingLinks(req, outputPage.pagination, true, `workitem${wi.id}page`, 'wilimit'),
-      };
-    }
+  const base = { id: wi.id, status: wi.status, retryCount: wi.retryCount };
+
+  if (q.resolveFiles === undefined) {
+    return {
+      ...base,
+      inputFilesUrl: wi.stacCatalogLocation ? workItemFilesUrl(req, wi.id, 'input') : null,
+      outputFilesUrl: COMPLETED_WORK_ITEM_STATUSES.includes(wi.status)
+        ? workItemFilesUrl(req, wi.id, 'output') : null,
+    };
   }
 
-  return {
-    id: wi.id,
-    status: wi.status,
-    retryCount: wi.retryCount,
-    inputFiles: wi.stacCatalogLocation
-      ? (catalogHrefs.get(wi.stacCatalogLocation) ?? null)
-      : null,
-    outputFiles,
-    ...(outputFilesPaging !== undefined && { outputFilesPaging }),
-  };
+  const { files, paging } = resolved?.get(wi.id) ?? { files: [] };
+  if (q.resolveFiles === 'input') {
+    return { ...base, inputFiles: files, ...(paging !== undefined && { inputFilesPaging: paging }) };
+  }
+  return { ...base, outputFiles: files, ...(paging !== undefined && { outputFilesPaging: paging }) };
 }
 
 
@@ -399,17 +474,17 @@ interface StepWorkItems {
  *
  * @param req - the Express request, used to build per-step paging links
  * @param stepResults - each workflow step with its page of work items and pagination
- * @param resolved - resolved-catalog data from resolveAllCatalogs
  * @param statusCounts - per-step, per-status work item counts for the whole job
  * @param q - the parsed steps query, used to honor the status/workItem filters
+ * @param resolved - per-WI resolved files map (resolve mode only)
  * @returns the steps with their work items, status summary, and any paging links
  */
 function buildSteps(
   req: HarmonyRequest,
   stepResults: StepWorkItems[],
-  resolved: ResolvedCatalogs,
   statusCounts: Map<number, Partial<Record<WorkItemStatus, number>>>,
   q: StepsQueryParams,
+  resolved?: ResolvedFiles,
 ): JobStep[] {
   const result: JobStep[] = [];
   const filtering = q.statuses !== undefined || q.workItems !== undefined;
@@ -422,7 +497,7 @@ function buildSteps(
       stepIndex: step.stepIndex,
       workItemCount: step.workItemCount,
       statuses: statusCounts.get(step.stepIndex) ?? {},
-      workItems: workItems.map((wi) => buildWorkItem(req, wi, resolved)),
+      workItems: workItems.map((wi) => buildWorkItem(req, wi, q, resolved)),
     };
     const { currentPage, lastPage, total } = pagination;
     if (lastPage > 1) {
@@ -492,8 +567,17 @@ export async function getJobSteps(
 
     const frontendRoot = getRequestRoot(req);
     const allWorkItems = stepResults.flatMap((r) => r.workItems);
-    const resolvedCatalogs = await resolveAllCatalogs(req, allWorkItems, frontendRoot, destinationBucket);
-    const jobSteps = buildSteps(req, stepResults, resolvedCatalogs, statusCounts, q);
+
+    // Resolve mode resolves a single work item's files inline; the default
+    // overview does no S3 reads and returns links to resolve them on demand.
+    let resolved: ResolvedFiles | undefined;
+    if (q.resolveFiles !== undefined) {
+      if (q.workItems === undefined || q.workItems.length !== 1) {
+        throw new RequestValidationError('resolveFiles requires exactly one workItem');
+      }
+      resolved = await resolveSelectedWorkItemFiles(req, allWorkItems, q.resolveFiles, frontendRoot, destinationBucket);
+    }
+    const jobSteps = buildSteps(req, stepResults, statusCounts, q, resolved);
 
     const responseBody = {
       jobID: job.jobID,

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -427,16 +427,12 @@ async function resolveWorkItemFiles(
 /**
  * Build the workItem portion of the response.
  *
- * In overview mode (no `resolveFiles`) the workItem carries `inputFilesUrl` /
- * `outputFilesUrl` links back to this endpoint that resolve its files on demand,
- * doing no S3 reads here: `inputFilesUrl` is null when the workItem has no STAC
- * input (e.g. query-cmr step 1) and `outputFilesUrl` is null until the workItem
- * completes.
+ * In overview mode a workItem carries `inputFilesUrl` / `outputFilesUrl` links
+ * doing no S3 reads here.
  *
- * In resolve mode the requested kind's files are populated inline from the
+ * In resolve mode either input or output files are populated inline from the
  * precomputed `resolved` map, with an `inputFilesPaging` / `outputFilesPaging`
- * block (navigated via the `workItem<id>InputPage` / `workItem<id>OutputPage`
- * parameter) when there is more than one page.
+ * block when necessary.
  *
  * @param req - the Express request, used to build links
  * @param wi - the workItem to serialize

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -24,8 +24,9 @@ import { parseMultiValueParameter } from '../util/parameter-parsing-helpers';
 import { readCatalogItems, StacItem } from '../util/stac';
 import { getRequestRoot } from '../util/url';
 
-const DEFAULT_PER_PAGE = 50;
-const MAX_STEP_PAGE_SIZE = 1000;
+const DEFAULT_WORKITEMS_PER_PAGE = 50;
+const MAX_WORKITEMS_PER_PAGE = 1000;
+
 // Number of a work item's output catalogs resolved per page, navigated with the
 // per-work-item `workItem<id>Page` parameter. Bounds the S3 reads each page costs.
 const CATALOG_PAGE_SIZE = 10;
@@ -467,7 +468,7 @@ export async function getJobSteps(
 
     // Bound every page result by 'limit' and page each step independently
     // via step<stepIndex>Page parameter.
-    const limit = parseIntegerParam(req, 'limit', DEFAULT_PER_PAGE, 1, MAX_STEP_PAGE_SIZE, true, true);
+    const limit = parseIntegerParam(req, 'limit', DEFAULT_WORKITEMS_PER_PAGE, 1, MAX_WORKITEMS_PER_PAGE, true, true);
     const stepResults: StepWorkItems[] = await Promise.all(selectedSteps.map(async (step) => {
       const where: WorkItemQuery['where'] = { jobID, workflowStepIndex: step.stepIndex };
       const whereIn: WorkItemQuery['whereIn'] = {};

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -24,18 +24,17 @@ import { parseMultiValueParameter } from '../util/parameter-parsing-helpers';
 import { getCatalogItemUrls, readCatalogItems, readItemsAtUrls, StacItem } from '../util/stac';
 import { getRequestRoot } from '../util/url';
 
+// Default and max 'limit': the number of workitems in a step that are shown to a user.
 const DEFAULT_WORKITEMS_PER_PAGE = 50;
 const MAX_WORKITEMS_PER_PAGE = 1000;
 
-// Default `wiLimit`: the number of a work item's input items / output catalogs
+// Default and max `wiLimit`: the number of a workitem's input items / output catalogs
 // resolved per page. This confusingly will not always result in
 // DEFAULT_WI_LIMIT items in the output. For input catalogs we are reading
 // items inside a single catalog, a single item file with perhaps many
 // items. and for output catalogs, we're reading 1 batch catalog and all of
 // its files.
 const DEFAULT_WI_LIMIT = 50;
-// Upper bound on `wiLimit`: the largest page of input items / output catalogs that
-// may be resolved in a single request.
 const MAX_WI_LIMIT = 100;
 
 const VALID_STATUSES = Object.values(WorkItemStatus);
@@ -54,12 +53,11 @@ interface StepWorkItem {
   id: number;
   status: WorkItemStatus;
   retryCount: number;
-  // Overview mode: links back to the steps endpoint that resolve this work item's
+  // Overview mode: links back to the steps endpoint that resolve this workItem's
   // input / output files
   inputFilesUrl?: string | null;
   outputFilesUrl?: string | null;
-  // Resolve mode: the requested page of files for the requested kind, plus paging
-  // when there is more than one page. Only the requested kind is populated.
+  // Resolve mode: the requested page of input or output files.
   inputFiles?: string[] | null;
   inputFilesPaging?: StepPaging;
   outputFiles?: string[] | null;
@@ -155,7 +153,7 @@ function getAllAssetHrefs(items: StacItem[]): string[] {
 
 /**
  * Read a single STAC output catalog in full (all of its items) and return every
- * asset href it references. A work item's outputs are a list of such catalogs;
+ * asset href it references. A workItem's outputs are a list of such catalogs;
  * `resolveOutputFiles` calls this once per catalog on the requested page. Input
  * catalogs, which can list a huge number of items, are instead read a page of
  * items at a time via `resolveInputFiles`.
@@ -176,6 +174,7 @@ async function resolveDataHrefs(catalogUrl: string): Promise<string[]> {
 
 // Placeholder used in inputFiles / outputFiles when a STAC asset href cannot
 // be turned into a public/valid link.
+// [Not sure this is ever used, but here for safety.]
 const PRIVATE_FILE_PLACEHOLDER = '<private file location>';
 
 /**
@@ -202,14 +201,13 @@ export function safePublicLink(href: string, frontendRoot: string, destinationBu
   }
 }
 
-// A single work item's resolved page of files plus its paging (paging is omitted
-// when there is only one page).
+// A single workItem's resolved page of files plus its paging if needed
 interface WiResolvedFiles {
   files: string[];
   paging?: StepPaging;
 }
 
-// Map of work item id -> its resolved page of files (only populated in resolve mode).
+// Map of workItem id -> its resolved page of files
 type ResolvedFiles = Map<number, WiResolvedFiles>;
 
 /**
@@ -217,9 +215,9 @@ type ResolvedFiles = Map<number, WiResolvedFiles>;
  * item's input or output files inline.
  *
  * @param req - the Express request, used for the host and current path
- * @param wiId - the work item id to scope the link to
+ * @param wiId - the workItem id to scope the link to
  * @param kind - whether the link resolves input or output files
- * @returns the absolute URL that resolves that work item's files
+ * @returns the absolute URL that resolves that workItem's files
  */
 function workItemFilesUrl(req: HarmonyRequest, wiId: number, kind: ResolveKind): string {
   const path = req.originalUrl.split('?')[0];
@@ -227,11 +225,11 @@ function workItemFilesUrl(req: HarmonyRequest, wiId: number, kind: ResolveKind):
 }
 
 /**
- * Build the paging block for a resolved page of a work item's files, or undefined
+ * Build the paging block for a resolved page of a workItem's files, or undefined
  * when the files fit on a single page.
  *
  * @param req - the Express request, used to build the paging links
- * @param pagination - the catalog-level pagination for the work item's files
+ * @param pagination - the catalog-level pagination for the workItem's files
  * @param pageParamName - the per-work-item page query parameter the links should set
  * @returns the paging block, or undefined when there is only one page
  */
@@ -247,8 +245,7 @@ function buildFilesPaging(
 }
 
 /**
- * Sorting function to return the catalogs in the order they are presumed to be
- * generated.
+ * Sorting function to order catalogs in the presumed generation order
  *
  * @param filename - a `catalog.json` / `catalogN.json` basename
  * @returns the numeric index, or -1 if the filename has none
@@ -259,16 +256,15 @@ function catalogIndex(filename: string): number {
 }
 
 /**
- * Determine a completed work item's output catalog file URLs, mirroring
+ * Determine a completed workItem's output catalog file URLs, mirroring
  * service-runner's `_getStacCatalogs` discovery so that every catalog a service
  * writes is found:
- *   - if the work item wrote a `batch-catalogs.json` (query-cmr, and aggregating
+ *   - if the workItem wrote a `batch-catalogs.json` (query-cmr, and aggregating
  *     services such as batchee/stitchee), use the catalogN.json files it lists;
  *   - otherwise list the `catalog*.json` files in the outputs directory, which
  *     covers both the common single `catalog.json` and services that might write
  *     several `catalogN.json` files without an index.
- * The full ordered list is returned; the caller paginates it (its length is the
- * work item's output catalog total).
+ * The full ordered list is returned.
  *
  * @param outputDir - the WI's outputs directory URL
  * @returns the ordered output catalog URLs
@@ -296,14 +292,12 @@ async function getAllOutputCatalogFilenames(outputDir: string): Promise<string[]
 }
 
 /**
- * Build a catalog-level pagination object for a work item's output catalogs,
- * mirroring the shape knex-paginate produces so getPagingLinks can consume it.
- * The requested page is clamped to the last page when it is beyond the end,
- * matching the per-step paging behavior.
+ * Build a catalog-level pagination object for a workItem's output catalogs.
+ * The requested page is set to the last page when it is beyond the end.
  *
- * @param total - the work item's total number of output catalogs
- * @param requestedPage - the page requested via the work item's page parameter
- * @returns the pagination describing the (clamped) current page
+ * @param total - the workItem's total number of output catalogs
+ * @param requestedPage - the page requested via the workItem's page parameter
+ * @returns a pagination object describing the page.
  */
 function catalogPagination(total: number, requestedPage: number, perPage: number): ILengthAwarePagination {
   const lastPage = Math.max(1, Math.ceil(total / perPage));
@@ -318,17 +312,15 @@ function catalogPagination(total: number, requestedPage: number, perPage: number
 }
 
 /**
- * Resolve one page of a work item's files. The full list of paginated "units"
+ * Resolve one page of a workItem's files. The full list of paginated source URLs
  * (input item URLs within a single catalog, or output catalog URLs) is loaded,
  * the requested page is sliced out, and only that slice is read into asset
- * hrefs — keeping the S3 reads bounded by `wiLimit`. Validation errors on the
- * `wilimit`/page parameters propagate (failing the request); I/O errors while
- * loading or reading the page resolve to an empty file list.
+ * hrefs — keeping the S3 reads bounded by `wiLimit`.
  *
  * @param req - the Express request, used to read the page / wiLimit params
- * @param pageParam - the per-work-item page query parameter for this kind
- * @param loadUnits - loads the full ordered list of paginated units
- * @param readPage - reads one page's slice of units into raw asset hrefs
+ * @param pageParam - the per-work-item page query parameter for this kind (in/out)
+ * @param loadSourceUrls - loads the full ordered list of paginated source URLs
+ * @param readPage - reads one page's slice of source URLs into raw asset hrefs
  * @param frontendRoot - the root URL to use when producing Harmony permalinks
  * @param destinationBucket - the job's destinationUrl bucket name, or undefined
  * @returns the page of public file links plus paging (paging omitted for one page)
@@ -336,18 +328,18 @@ function catalogPagination(total: number, requestedPage: number, perPage: number
 async function resolvePagedFiles(
   req: HarmonyRequest,
   pageParam: string,
-  loadUnits: () => Promise<string[]>,
-  readPage: (pageUnits: string[]) => Promise<string[]>,
+  loadSourceUrls: () => Promise<string[]>,
+  readPage: (pageSourceUrls: string[]) => Promise<string[]>,
   frontendRoot: string,
   destinationBucket: string | undefined,
 ): Promise<WiResolvedFiles> {
   const perPage = parseIntegerParam(req, 'wilimit', DEFAULT_WI_LIMIT, 1, MAX_WI_LIMIT, true, true);
   const requestedPage = parseIntegerParam(req, pageParam, 1, 1);
   try {
-    const units = await loadUnits();
-    const pagination = catalogPagination(units.length, requestedPage, perPage);
+    const sourceUrls = await loadSourceUrls();
+    const pagination = catalogPagination(sourceUrls.length, requestedPage, perPage);
     const start = (pagination.currentPage - 1) * perPage;
-    const hrefs = await readPage(units.slice(start, start + perPage));
+    const hrefs = await readPage(sourceUrls.slice(start, start + perPage));
     const files = hrefs.map((h) => safePublicLink(h, frontendRoot, destinationBucket));
     return { files, paging: buildFilesPaging(req, pagination, pageParam) };
   } catch {
@@ -356,13 +348,13 @@ async function resolvePagedFiles(
 }
 
 /**
- * Resolve one page of a work item's input files. The work item's single input
+ * Resolve one page of a workItem's input files. The workItem's single input
  * catalog can reference a huge number of items (e.g. an aggregating service), so
  * the catalog's item URLs are read once and only the requested page of items is
  * read, keeping the S3 reads bounded by `wiLimit`.
  *
  * @param req - the Express request, used to read the input page / wiLimit params
- * @param wi - the work item whose input catalog should be resolved
+ * @param wi - the workItem whose input catalog should be resolved
  * @param frontendRoot - the root URL to use when producing Harmony permalinks
  * @param destinationBucket - the job's destinationUrl bucket name, or undefined
  * @returns the page of public file links plus paging (paging omitted for one page)
@@ -380,13 +372,13 @@ async function resolveInputFiles(
 }
 
 /**
- * Resolve one page of a work item's output files. A work item's outputs are a list
+ * Resolve one page of a workItem's output files. A workItem's outputs are a list
  * of catalog files; only the requested page of those catalogs is read completely
  * so the S3 reads stay bounded by `wiLimit`, but the number of output files
  * may exceed `wilimit`.
  *
  * @param req - the Express request, used to read the output page / wiLimit params
- * @param wi - the work item whose output catalogs should be resolved
+ * @param wi - the workItem whose output catalogs should be resolved
  * @param frontendRoot - the root URL to use when producing Harmony permalinks
  * @param destinationBucket - the job's destinationUrl bucket name, or undefined
  * @returns the page of public file links plus paging (paging omitted for one page)
@@ -405,16 +397,16 @@ async function resolveOutputFiles(
 }
 
 /**
- * Resolve the requested kind (input or output) of files for the given work items
- * inline. Only invoked in resolve mode, which is scoped to a single work item, so
- * the S3 reads are bounded to that one work item's requested page.
+ * Resolve the requested kind (input or output) of files for the given workItems
+ * inline. Only invoked in resolve mode, which is scoped to a single workItem, so
+ * the S3 reads are bounded to that one workItem's requested page.
  *
  * @param req - the Express request
- * @param workItems - the work items to resolve (a single item in resolve mode)
+ * @param workItems - the workItems to resolve (a single item in resolve mode)
  * @param kind - whether to resolve input or output files
  * @param frontendRoot - the root URL to use when producing Harmony permalinks
  * @param destinationBucket - the job's destinationUrl bucket name, or undefined
- * @returns map of work item id to its resolved page of files
+ * @returns map of workItem id to its resolved page of files
  */
 async function resolveSelectedWorkItemFiles(
   req: HarmonyRequest,
@@ -437,12 +429,12 @@ async function resolveSelectedWorkItemFiles(
 }
 
 /**
- * Build the work item portion of the response.
+ * Build the workItem portion of the response.
  *
- * In overview mode (no `resolveFiles`) the work item carries `inputFilesUrl` /
+ * In overview mode (no `resolveFiles`) the workItem carries `inputFilesUrl` /
  * `outputFilesUrl` links back to this endpoint that resolve its files on demand,
- * doing no S3 reads here: `inputFilesUrl` is null when the work item has no STAC
- * input (e.g. query-cmr step 1) and `outputFilesUrl` is null until the work item
+ * doing no S3 reads here: `inputFilesUrl` is null when the workItem has no STAC
+ * input (e.g. query-cmr step 1) and `outputFilesUrl` is null until the workItem
  * completes.
  *
  * In resolve mode the requested kind's files are populated inline from the
@@ -451,10 +443,10 @@ async function resolveSelectedWorkItemFiles(
  * parameter) when there is more than one page.
  *
  * @param req - the Express request, used to build links
- * @param wi - the work item to serialize
+ * @param wi - the workItem to serialize
  * @param q - the parsed steps query (determines overview vs resolve mode)
  * @param resolved - the per-WI resolved files map (resolve mode only)
- * @returns the work item shaped for the steps response
+ * @returns the workItem shaped for the steps response
  */
 function buildWorkItem(
   req: HarmonyRequest,
@@ -481,7 +473,7 @@ function buildWorkItem(
 }
 
 
-// A workflow step, its page of work items and the pagination info.
+// A workflow step, its page of workItems and the pagination info.
 interface StepWorkItems {
   step: WorkflowStep;
   workItems: WorkItem[];
@@ -489,18 +481,18 @@ interface StepWorkItems {
 }
 
 /**
- * Build the full step list from each step's requested page of work items.
- * A step with more than one page of matching work items gets a `paging` block
+ * Build the full step list from each step's requested page of workItems.
+ * A step with more than one page of matching workItems gets a `paging` block
  * whose links page that step via its own `step<stepIndex>Page` query parameter.
- * When a status/workItem filter is active, steps with no matching work items are
+ * When a status/workItem filter is active, steps with no matching workItems are
  * omitted.
  *
  * @param req - the Express request, used to build per-step paging links
- * @param stepResults - each workflow step with its page of work items and pagination
- * @param statusCounts - per-step, per-status work item counts for the whole job
+ * @param stepResults - each workflow step with its page of workItems and pagination
+ * @param statusCounts - per-step, per-status workItem counts for the whole job
  * @param q - the parsed steps query, used to honor the status/workItem filters
  * @param resolved - per-WI resolved files map (resolve mode only)
- * @returns the steps with their work items, status summary, and any paging links
+ * @returns the steps with their workItems, status summary, and any paging links
  */
 function buildSteps(
   req: HarmonyRequest,
@@ -512,7 +504,7 @@ function buildSteps(
   const result: JobStep[] = [];
   const filtering = q.statuses !== undefined || q.workItems !== undefined;
   for (const { step, workItems, pagination } of stepResults) {
-    // Don't show steps having no matching work items.
+    // Don't show steps having no matching workItems.
     if (filtering && pagination.total === 0) continue;
 
     const jobStep: JobStep = {

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -27,28 +27,26 @@ import { getRequestRoot } from '../util/url';
 const DEFAULT_WORKITEMS_PER_PAGE = 50;
 const MAX_WORKITEMS_PER_PAGE = 1000;
 
-// Default number of a work item's input items / output catalogs resolved per page,
-// navigated with the per-work-item `workItem<id>InputPage` / `workItem<id>OutputPage`
-// parameters and overridable via the `wiLimit` query parameter. Bounds the S3 reads
-// each resolved page costs.
-const CATALOG_PAGE_SIZE = 50;
+// Default `wiLimit`: the number of a work item's input items / output catalogs
+// resolved per page. This confusingly will not always result in
+// DEFAULT_WI_LIMIT items in the output. For input catalogs we are reading
+// items inside a single catalog, a single item file with perhaps many
+// items. and for output catalogs, we're reading 1 batch catalog and all of
+// its files.
+const DEFAULT_WI_LIMIT = 50;
 // Upper bound on `wiLimit`: the largest page of input items / output catalogs that
-// may be resolved in a single request. A work item's input catalog can list a huge
-// number of items (e.g. an aggregating service), so this caps the per-page read cost.
-const MAX_WI_PAGE_SIZE = 100;
+// may be resolved in a single request.
+const MAX_WI_LIMIT = 100;
+
 const VALID_STATUSES = Object.values(WorkItemStatus);
 
-// Which side of a single work item's files a resolve request is asking for.
 type ResolveKind = 'input' | 'output';
 const VALID_RESOLVE_KINDS: ResolveKind[] = ['input', 'output'];
-
 
 interface StepsQueryParams {
   steps?: number[];
   statuses?: WorkItemStatus[];
   workItems?: number[];
-  // When set, the request resolves a single work item's input or output files
-  // inline (rather than returning the link-only overview).
   resolveFiles?: ResolveKind;
 }
 
@@ -57,7 +55,7 @@ interface StepWorkItem {
   status: WorkItemStatus;
   retryCount: number;
   // Overview mode: links back to the steps endpoint that resolve this work item's
-  // input / output files (null when the work item has no input / no outputs yet).
+  // input / output files
   inputFilesUrl?: string | null;
   outputFilesUrl?: string | null;
   // Resolve mode: the requested page of files for the requested kind, plus paging
@@ -307,7 +305,7 @@ async function getAllOutputCatalogFilenames(outputDir: string): Promise<string[]
  * @param requestedPage - the page requested via the work item's page parameter
  * @returns the pagination describing the (clamped) current page
  */
-function catalogPagination(total: number, requestedPage: number, perPage: number = CATALOG_PAGE_SIZE): ILengthAwarePagination {
+function catalogPagination(total: number, requestedPage: number, perPage: number): ILengthAwarePagination {
   const lastPage = Math.max(1, Math.ceil(total / perPage));
   const currentPage = Math.min(requestedPage, lastPage);
   const from = total === 0 ? 0 : (currentPage - 1) * perPage + 1;
@@ -322,7 +320,7 @@ function catalogPagination(total: number, requestedPage: number, perPage: number
 /**
  * Resolve one page of a work item's input files. The work item's single input
  * catalog can reference a huge number of items (e.g. an aggregating service), so
- * the catalog is enumerated once and only the requested page of items is read,
+ * the catalog is read once and only the requested page of items is read,
  * keeping the S3 reads bounded by `wiLimit`.
  *
  * @param req - the Express request, used to read the input page / wiLimit params
@@ -335,10 +333,10 @@ async function resolveInputFiles(
   req: HarmonyRequest, wi: WorkItem, frontendRoot: string, destinationBucket: string | undefined,
 ): Promise<WiResolvedFiles> {
   if (!wi.stacCatalogLocation) return { files: [] };
-  const perPage = parseIntegerParam(req, 'wilimit', CATALOG_PAGE_SIZE, 1, MAX_WI_PAGE_SIZE, true, true);
+  const perPage = parseIntegerParam(req, 'wilimit', DEFAULT_WI_LIMIT, 1, MAX_WI_LIMIT, true, true);
   const requestedPage = parseIntegerParam(req, `workitem${wi.id}inputpage`, 1, 1);
   try {
-    // Enumerate the catalog's item URLs once (one S3 read), then read only the
+    // Read the catalog's item URLs once, then read only the
     // requested page's slice of items.
     const itemUrls = await getCatalogItemUrls(wi.stacCatalogLocation);
     const pagination = catalogPagination(itemUrls.length, requestedPage, perPage);
@@ -354,8 +352,9 @@ async function resolveInputFiles(
 
 /**
  * Resolve one page of a work item's output files. A work item's outputs are a list
- * of catalog files; only the requested page of those catalogs is read (each fully)
- * so the S3 reads stay bounded by `wiLimit`.
+ * of catalog files; only the requested page of those catalogs is read completely
+ * so the S3 reads stay bounded by `wiLimit`, but the number of output files
+ * may exceed `wilimit`.
  *
  * @param req - the Express request, used to read the output page / wiLimit params
  * @param wi - the work item whose output catalogs should be resolved
@@ -367,7 +366,7 @@ async function resolveOutputFiles(
   req: HarmonyRequest, wi: WorkItem, frontendRoot: string, destinationBucket: string | undefined,
 ): Promise<WiResolvedFiles> {
   if (!COMPLETED_WORK_ITEM_STATUSES.includes(wi.status)) return { files: [] };
-  const perPage = parseIntegerParam(req, 'wilimit', CATALOG_PAGE_SIZE, 1, MAX_WI_PAGE_SIZE, true, true);
+  const perPage = parseIntegerParam(req, 'wilimit', DEFAULT_WI_LIMIT, 1, MAX_WI_LIMIT, true, true);
   const outputDir = getStacLocation({ id: wi.id, jobID: wi.jobID });
   const allCatalogUrls = await getAllOutputCatalogFilenames(outputDir);
   const requestedPage = parseIntegerParam(req, `workitem${wi.id}outputpage`, 1, 1);

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -28,9 +28,10 @@ import { getRequestRoot } from '../util/url';
 const DEFAULT_WORKITEMS_PER_PAGE = 50;
 const MAX_WORKITEMS_PER_PAGE = 1000;
 
-// Number of a work item's output catalogs resolved per page, navigated with the
-// per-work-item `workItem<id>Page` parameter. Bounds the S3 reads each page costs.
-const CATALOG_PAGE_SIZE = 2;
+// Default number of a work item's output catalogs resolved per page, navigated with the
+// per-work-item `workItem<id>Page` parameter and overridable via the `wiLimit` query
+// parameter. Bounds the S3 reads each page costs.
+const CATALOG_PAGE_SIZE = 10;
 // Upper bound on the number of items resolved from a single work item's input
 // catalog. A work item has one input catalog, but for an aggregating service that
 // catalog can list a huge number of items; this keeps the read bounded. Full
@@ -328,7 +329,7 @@ async function resolveAllCatalogs(
   await Promise.all(Array.from(inputUrls).map((url) => resolve(url, MAX_INPUT_CATALOG_ITEMS)));
 
   const durationMs = new Date().getTime() - startTime;
-  req.context.logger.info(`Finished steps:resolveAllCatalogs`, {durationMs});
+  req.context.logger.info('Finished steps:resolveAllCatalogs', { durationMs });
   return { catalogHrefs, wiOutputPages };
 }
 
@@ -506,7 +507,7 @@ export async function getJobSteps(
       steps: jobSteps,
     };
     const durationMs = new Date().getTime() - startTime;
-    req.context.logger.info(`Finished /steps for ${jobID}`, {durationMs});
+    req.context.logger.info(`Finished /steps for ${jobID}`, { durationMs });
     res.json(responseBody);
   } catch (e) {
     req.context.logger.error(e);

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -318,10 +318,48 @@ function catalogPagination(total: number, requestedPage: number, perPage: number
 }
 
 /**
+ * Resolve one page of a work item's files. The full list of paginated "units"
+ * (input item URLs within a single catalog, or output catalog URLs) is loaded,
+ * the requested page is sliced out, and only that slice is read into asset
+ * hrefs — keeping the S3 reads bounded by `wiLimit`. Validation errors on the
+ * `wilimit`/page parameters propagate (failing the request); I/O errors while
+ * loading or reading the page resolve to an empty file list.
+ *
+ * @param req - the Express request, used to read the page / wiLimit params
+ * @param pageParam - the per-work-item page query parameter for this kind
+ * @param loadUnits - loads the full ordered list of paginated units
+ * @param readPage - reads one page's slice of units into raw asset hrefs
+ * @param frontendRoot - the root URL to use when producing Harmony permalinks
+ * @param destinationBucket - the job's destinationUrl bucket name, or undefined
+ * @returns the page of public file links plus paging (paging omitted for one page)
+ */
+async function resolvePagedFiles(
+  req: HarmonyRequest,
+  pageParam: string,
+  loadUnits: () => Promise<string[]>,
+  readPage: (pageUnits: string[]) => Promise<string[]>,
+  frontendRoot: string,
+  destinationBucket: string | undefined,
+): Promise<WiResolvedFiles> {
+  const perPage = parseIntegerParam(req, 'wilimit', DEFAULT_WI_LIMIT, 1, MAX_WI_LIMIT, true, true);
+  const requestedPage = parseIntegerParam(req, pageParam, 1, 1);
+  try {
+    const units = await loadUnits();
+    const pagination = catalogPagination(units.length, requestedPage, perPage);
+    const start = (pagination.currentPage - 1) * perPage;
+    const hrefs = await readPage(units.slice(start, start + perPage));
+    const files = hrefs.map((h) => safePublicLink(h, frontendRoot, destinationBucket));
+    return { files, paging: buildFilesPaging(req, pagination, pageParam) };
+  } catch {
+    return { files: [] };
+  }
+}
+
+/**
  * Resolve one page of a work item's input files. The work item's single input
  * catalog can reference a huge number of items (e.g. an aggregating service), so
- * the catalog is read once and only the requested page of items is read,
- * keeping the S3 reads bounded by `wiLimit`.
+ * the catalog's item URLs are read once and only the requested page of items is
+ * read, keeping the S3 reads bounded by `wiLimit`.
  *
  * @param req - the Express request, used to read the input page / wiLimit params
  * @param wi - the work item whose input catalog should be resolved
@@ -333,21 +371,12 @@ async function resolveInputFiles(
   req: HarmonyRequest, wi: WorkItem, frontendRoot: string, destinationBucket: string | undefined,
 ): Promise<WiResolvedFiles> {
   if (!wi.stacCatalogLocation) return { files: [] };
-  const perPage = parseIntegerParam(req, 'wilimit', DEFAULT_WI_LIMIT, 1, MAX_WI_LIMIT, true, true);
-  const requestedPage = parseIntegerParam(req, `workitem${wi.id}inputpage`, 1, 1);
-  try {
-    // Read the catalog's item URLs once, then read only the
-    // requested page's slice of items.
-    const itemUrls = await getCatalogItemUrls(wi.stacCatalogLocation);
-    const pagination = catalogPagination(itemUrls.length, requestedPage, perPage);
-    const start = (pagination.currentPage - 1) * perPage;
-    const pageUrls = itemUrls.slice(start, start + perPage);
-    const items = await readItemsAtUrls(wi.stacCatalogLocation, pageUrls);
-    const files = getAllAssetHrefs(items).map((h) => safePublicLink(h, frontendRoot, destinationBucket));
-    return { files, paging: buildFilesPaging(req, pagination, `workitem${wi.id}inputpage`) };
-  } catch {
-    return { files: [] };
-  }
+  return resolvePagedFiles(
+    req, `workitem${wi.id}inputpage`,
+    () => getCatalogItemUrls(wi.stacCatalogLocation),
+    async (pageUrls) => getAllAssetHrefs(await readItemsAtUrls(wi.stacCatalogLocation, pageUrls)),
+    frontendRoot, destinationBucket,
+  );
 }
 
 /**
@@ -366,16 +395,13 @@ async function resolveOutputFiles(
   req: HarmonyRequest, wi: WorkItem, frontendRoot: string, destinationBucket: string | undefined,
 ): Promise<WiResolvedFiles> {
   if (!COMPLETED_WORK_ITEM_STATUSES.includes(wi.status)) return { files: [] };
-  const perPage = parseIntegerParam(req, 'wilimit', DEFAULT_WI_LIMIT, 1, MAX_WI_LIMIT, true, true);
   const outputDir = getStacLocation({ id: wi.id, jobID: wi.jobID });
-  const allCatalogUrls = await getAllOutputCatalogFilenames(outputDir);
-  const requestedPage = parseIntegerParam(req, `workitem${wi.id}outputpage`, 1, 1);
-  const pagination = catalogPagination(allCatalogUrls.length, requestedPage, perPage);
-  const start = (pagination.currentPage - 1) * perPage;
-  const pageUrls = allCatalogUrls.slice(start, start + perPage);
-  const hrefArrays = await Promise.all(pageUrls.map((url) => resolveDataHrefs(url)));
-  const files = hrefArrays.flat().map((h) => safePublicLink(h, frontendRoot, destinationBucket));
-  return { files, paging: buildFilesPaging(req, pagination, `workitem${wi.id}outputpage`) };
+  return resolvePagedFiles(
+    req, `workitem${wi.id}outputpage`,
+    () => getAllOutputCatalogFilenames(outputDir),
+    async (pageUrls) => (await Promise.all(pageUrls.map(resolveDataHrefs))).flat(),
+    frontendRoot, destinationBucket,
+  );
 }
 
 /**

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -1,5 +1,6 @@
 import { NextFunction, Response } from 'express';
 import { ILengthAwarePagination } from 'knex-paginate';
+import { Logger } from 'winston';
 
 import { sanitizeImage } from '@harmony/util/string';
 
@@ -29,7 +30,7 @@ const MAX_WORKITEMS_PER_PAGE = 1000;
 
 // Number of a work item's output catalogs resolved per page, navigated with the
 // per-work-item `workItem<id>Page` parameter. Bounds the S3 reads each page costs.
-const CATALOG_PAGE_SIZE = 10;
+const CATALOG_PAGE_SIZE = 2;
 // Upper bound on the number of items resolved from a single work item's input
 // catalog. A work item has one input catalog, but for an aggregating service that
 // catalog can list a huge number of items; this keeps the read bounded. Full
@@ -142,9 +143,11 @@ function getAllAssetHrefs(items: StacItem[]): string[] {
  *   cannot be read (e.g. the service failed before producing it, or the
  *   catalog has no assets)
  */
-async function resolveDataHrefs(catalogUrl: string, maxItems?: number): Promise<string[]> {
+async function resolveDataHrefs(catalogUrl: string, maxItems?: number, logger?: Logger): Promise<string[]> {
   try {
-    const items = await readCatalogItems(catalogUrl, maxItems);
+    // TODO [MHS, 06/16/2026]  this will need to be a paged read somehow..
+    // the catalogURL can point
+    const items = await readCatalogItems(catalogUrl, maxItems, logger);
     return getAllAssetHrefs(items);
   } catch {
     return [];
@@ -254,8 +257,7 @@ async function readOutputCatalogs(outputDir: string): Promise<string[]> {
  * @param requestedPage - the page requested via the work item's page parameter
  * @returns the pagination describing the (clamped) current page
  */
-function catalogPagination(total: number, requestedPage: number): ILengthAwarePagination {
-  const perPage = CATALOG_PAGE_SIZE;
+function catalogPagination(total: number, requestedPage: number, perPage: number = CATALOG_PAGE_SIZE): ILengthAwarePagination {
   const lastPage = Math.max(1, Math.ceil(total / perPage));
   const currentPage = Math.min(requestedPage, lastPage);
   const from = total === 0 ? 0 : (currentPage - 1) * perPage + 1;
@@ -291,21 +293,22 @@ async function resolveAllCatalogs(
   const completed_workitems = workItems.filter((wi) => COMPLETED_WORK_ITEM_STATUSES.includes(wi.status));
 
   // Determine each completed WI's current page of *output* catalog file URLs.
+  const wiPageSize = parseIntegerParam(req, 'wilimit', CATALOG_PAGE_SIZE, 1, MAX_INPUT_CATALOG_ITEMS, true, true);
   const wiOutputPages = new Map<number, WiOutputPage>();
   await Promise.all(completed_workitems.map(async (wi) => {
     const outputDir = getStacLocation({ id: wi.id, jobID: wi.jobID });
     const allUrls = await readOutputCatalogs(outputDir);
     const requestedPage = parseIntegerParam(req, `workitem${wi.id}page`, 1, 1);
-    const pagination = catalogPagination(allUrls.length, requestedPage);
-    const start = (pagination.currentPage - 1) * CATALOG_PAGE_SIZE;
-    const urls = allUrls.slice(start, start + CATALOG_PAGE_SIZE);
+    const pagination = catalogPagination(allUrls.length, requestedPage, wiPageSize);
+    const start = (pagination.currentPage - 1) * wiPageSize;
+    const urls = allUrls.slice(start, start + wiPageSize);
     wiOutputPages.set(wi.id, { urls, pagination });
   }));
 
   const catalogHrefs = new Map<string, string[]>();
   const resolve = async (url: string, maxItems?: number): Promise<void> => {
     if (catalogHrefs.has(url)) return;
-    const rawHrefs = await resolveDataHrefs(url, maxItems);
+    const rawHrefs = await resolveDataHrefs(url, maxItems, req.context.logger);
     catalogHrefs.set(url, rawHrefs.map((h) => safePublicLink(h, frontendRoot, destinationBucket)));
   };
 
@@ -361,7 +364,7 @@ function buildWorkItem(
         currentPage,
         lastPage,
         total,
-        links: getPagingLinks(req, outputPage.pagination, true, `workitem${wi.id}page`),
+        links: getPagingLinks(req, outputPage.pagination, true, `workitem${wi.id}page`, 'wilimit'),
       };
     }
   }

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -286,6 +286,7 @@ async function resolveAllCatalogs(
   frontendRoot: string,
   destinationBucket: string = undefined,
 ): Promise<ResolvedCatalogs> {
+  const startTime = new Date().getTime();
   const completed_workitems = workItems.filter((wi) => COMPLETED_WORK_ITEM_STATUSES.includes(wi.status));
 
   // Determine each completed WI's current page of *output* catalog file URLs.
@@ -322,6 +323,8 @@ async function resolveAllCatalogs(
   }
   await Promise.all(Array.from(inputUrls).map((url) => resolve(url, MAX_INPUT_CATALOG_ITEMS)));
 
+  const durationMs = new Date().getTime() - startTime;
+  req.context.logger.info(`Finished steps:resolveAllCatalogs`, {durationMs});
   return { catalogHrefs, wiOutputPages };
 }
 
@@ -445,6 +448,7 @@ function buildSteps(
 export async function getJobSteps(
   req: HarmonyRequest, res: Response, next: NextFunction,
 ): Promise<void> {
+  const startTime = new Date().getTime();
   const { jobID } = req.params;
   try {
     req.query = keysToLowerCase(req.query);
@@ -497,7 +501,8 @@ export async function getJobSteps(
       request: job.request,
       steps: jobSteps,
     };
-
+    const durationMs = new Date().getTime() - startTime;
+    req.context.logger.info(`Finished /steps for ${jobID}`, {durationMs});
     res.json(responseBody);
   } catch (e) {
     req.context.logger.error(e);

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -32,7 +32,7 @@ const MAX_WORKITEMS_PER_PAGE = 1000;
 // navigated with the per-work-item `workItem<id>InputPage` / `workItem<id>Page`
 // parameters and overridable via the `wiLimit` query parameter. Bounds the S3 reads
 // each resolved page costs.
-const CATALOG_PAGE_SIZE = 10;
+const CATALOG_PAGE_SIZE = 50;
 // Upper bound on `wiLimit`: the largest page of input items / output catalogs that
 // may be resolved in a single request. A work item's input catalog can list a huge
 // number of items (e.g. an aggregating service), so this caps the per-page read cost.
@@ -157,10 +157,11 @@ function getAllAssetHrefs(items: StacItem[]): string[] {
 }
 
 /**
- * Read a STAC catalog and return every asset href it references. Used to resolve
- * a single output catalog (one page of a work item's outputs); input catalogs,
- * which can list a huge number of items, are read a page at a time via
- * `resolveInputFiles` instead.
+ * Read a single STAC output catalog in full (all of its items) and return every
+ * asset href it references. A work item's outputs are a list of such catalogs;
+ * `resolveOutputFiles` calls this once per catalog on the requested page. Input
+ * catalogs, which can list a huge number of items, are instead read a page of
+ * items at a time via `resolveInputFiles`.
  *
  * @param catalogUrl - the location of the STAC catalog to read
  * @returns the asset hrefs from the catalog, or an empty array if the catalog
@@ -169,7 +170,7 @@ function getAllAssetHrefs(items: StacItem[]): string[] {
  */
 async function resolveDataHrefs(catalogUrl: string, logger?: Logger): Promise<string[]> {
   try {
-    const items = await readCatalogItems(catalogUrl, undefined, logger);
+    const items = await readCatalogItems(catalogUrl, logger);
     return getAllAssetHrefs(items);
   } catch {
     return [];
@@ -371,11 +372,11 @@ async function resolveOutputFiles(
   if (!COMPLETED_WORK_ITEM_STATUSES.includes(wi.status)) return { files: [] };
   const perPage = parseIntegerParam(req, 'wilimit', CATALOG_PAGE_SIZE, 1, MAX_WI_PAGE_SIZE, true, true);
   const outputDir = getStacLocation({ id: wi.id, jobID: wi.jobID });
-  const allUrls = await getAllOutputCatalogFilenames(outputDir);
+  const allCatalogUrls = await getAllOutputCatalogFilenames(outputDir);
   const requestedPage = parseIntegerParam(req, `workitem${wi.id}page`, 1, 1);
-  const pagination = catalogPagination(allUrls.length, requestedPage, perPage);
+  const pagination = catalogPagination(allCatalogUrls.length, requestedPage, perPage);
   const start = (pagination.currentPage - 1) * perPage;
-  const pageUrls = allUrls.slice(start, start + perPage);
+  const pageUrls = allCatalogUrls.slice(start, start + perPage);
   const hrefArrays = await Promise.all(pageUrls.map((url) => resolveDataHrefs(url, req.context.logger)));
   const files = hrefArrays.flat().map((h) => safePublicLink(h, frontendRoot, destinationBucket));
   return { files, paging: buildFilesPaging(req, pagination, `workitem${wi.id}page`) };

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -1,6 +1,5 @@
 import { NextFunction, Response } from 'express';
 import { ILengthAwarePagination } from 'knex-paginate';
-import { Logger } from 'winston';
 
 import { sanitizeImage } from '@harmony/util/string';
 

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -22,7 +22,7 @@ import { keysToLowerCase } from '../util/object';
 import { defaultObjectStore } from '../util/object-store';
 import { getPagingLinks, parseIntegerParam } from '../util/pagination';
 import { parseMultiValueParameter } from '../util/parameter-parsing-helpers';
-import { readCatalogItems, readCatalogItemsPage, StacItem } from '../util/stac';
+import { getCatalogItemUrls, readCatalogItems, readItemsAtUrls, StacItem } from '../util/stac';
 import { getRequestRoot } from '../util/url';
 
 const DEFAULT_WORKITEMS_PER_PAGE = 50;
@@ -168,9 +168,9 @@ function getAllAssetHrefs(items: StacItem[]): string[] {
  *   cannot be read (e.g. the service failed before producing it, or the
  *   catalog has no assets)
  */
-async function resolveDataHrefs(catalogUrl: string, logger?: Logger): Promise<string[]> {
+async function resolveDataHrefs(catalogUrl: string): Promise<string[]> {
   try {
-    const items = await readCatalogItems(catalogUrl, logger);
+    const items = await readCatalogItems(catalogUrl);
     return getAllAssetHrefs(items);
   } catch {
     return [];
@@ -339,15 +339,13 @@ async function resolveInputFiles(
   const perPage = parseIntegerParam(req, 'wilimit', CATALOG_PAGE_SIZE, 1, MAX_WI_PAGE_SIZE, true, true);
   const requestedPage = parseIntegerParam(req, `workitem${wi.id}inputpage`, 1, 1);
   try {
-    const first = await readCatalogItemsPage(
-      wi.stacCatalogLocation, (requestedPage - 1) * perPage, perPage, req.context.logger);
-    const pagination = catalogPagination(first.total, requestedPage, perPage);
-    // Re-read the clamped page when the requested page was beyond the last.
-    let { items } = first;
-    if (pagination.currentPage !== requestedPage) {
-      ({ items } = await readCatalogItemsPage(
-        wi.stacCatalogLocation, (pagination.currentPage - 1) * perPage, perPage, req.context.logger));
-    }
+    // Enumerate the catalog's item URLs once (one S3 read), then read only the
+    // requested page's slice of items.
+    const itemUrls = await getCatalogItemUrls(wi.stacCatalogLocation);
+    const pagination = catalogPagination(itemUrls.length, requestedPage, perPage);
+    const start = (pagination.currentPage - 1) * perPage;
+    const pageUrls = itemUrls.slice(start, start + perPage);
+    const items = await readItemsAtUrls(wi.stacCatalogLocation, pageUrls);
     const files = getAllAssetHrefs(items).map((h) => safePublicLink(h, frontendRoot, destinationBucket));
     return { files, paging: buildFilesPaging(req, pagination, `workitem${wi.id}inputpage`) };
   } catch {
@@ -377,7 +375,7 @@ async function resolveOutputFiles(
   const pagination = catalogPagination(allCatalogUrls.length, requestedPage, perPage);
   const start = (pagination.currentPage - 1) * perPage;
   const pageUrls = allCatalogUrls.slice(start, start + perPage);
-  const hrefArrays = await Promise.all(pageUrls.map((url) => resolveDataHrefs(url, req.context.logger)));
+  const hrefArrays = await Promise.all(pageUrls.map((url) => resolveDataHrefs(url)));
   const files = hrefArrays.flat().map((h) => safePublicLink(h, frontendRoot, destinationBucket));
   return { files, paging: buildFilesPaging(req, pagination, `workitem${wi.id}page`) };
 }
@@ -546,8 +544,7 @@ export async function getJobSteps(
       ? steps.filter((s) => q.steps.includes(s.stepIndex))
       : steps;
 
-    // Bound every page result by 'limit' and page each step independently
-    // via step<stepIndex>Page parameter.
+    // Bound workItems by 'limit' and page each step independently via step<stepIndex>Page parameter.
     const limit = parseIntegerParam(req, 'limit', DEFAULT_WORKITEMS_PER_PAGE, 1, MAX_WORKITEMS_PER_PAGE, true, true);
     const stepResults: StepWorkItems[] = await Promise.all(selectedSteps.map(async (step) => {
       const where: WorkItemQuery['where'] = { jobID, workflowStepIndex: step.stepIndex };
@@ -569,8 +566,6 @@ export async function getJobSteps(
     const frontendRoot = getRequestRoot(req);
     const allWorkItems = stepResults.flatMap((r) => r.workItems);
 
-    // Resolve mode resolves a single work item's files inline; the default
-    // overview does no S3 reads and returns links to resolve them on demand.
     let resolved: ResolvedFiles | undefined;
     if (q.resolveFiles !== undefined) {
       if (q.workItems === undefined || q.workItems.length !== 1) {
@@ -578,6 +573,7 @@ export async function getJobSteps(
       }
       resolved = await resolveSelectedWorkItemFiles(req, allWorkItems, q.resolveFiles, frontendRoot, destinationBucket);
     }
+
     const jobSteps = buildSteps(req, stepResults, statusCounts, q, resolved);
 
     const responseBody = {

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -323,7 +323,7 @@ function catalogPagination(total: number, requestedPage: number, perPage: number
  * @param readPage - reads one page's slice of source URLs into raw asset hrefs
  * @param frontendRoot - the root URL to use when producing Harmony permalinks
  * @param destinationBucket - the job's destinationUrl bucket name, or undefined
- * @returns the page of public file links plus paging (paging omitted for one page)
+ * @returns the page of public file links and paging if needed.
  */
 async function resolvePagedFiles(
   req: HarmonyRequest,
@@ -397,25 +397,23 @@ async function resolveOutputFiles(
 }
 
 /**
- * Resolve the requested kind (input or output) of files for the given workItems
- * inline. Only invoked in resolve mode, which is scoped to a single workItem, so
- * the S3 reads are bounded to that one workItem's requested page.
+ * Resolve the requested kind (input or output) of files for the given workItem
+ * inline.
  *
  * @param req - the Express request
- * @param workItems - the workItems to resolve (a single item in resolve mode)
- * @param kind - whether to resolve input or output files
+ * @param workItems - the workItems to resolve (a single item)
+ * @param kind - resolve input or output files
  * @param frontendRoot - the root URL to use when producing Harmony permalinks
  * @param destinationBucket - the job's destinationUrl bucket name, or undefined
  * @returns map of workItem id to its resolved page of files
  */
-async function resolveSelectedWorkItemFiles(
+async function resolveWorkItemFiles(
   req: HarmonyRequest,
   workItems: WorkItem[],
   kind: ResolveKind,
   frontendRoot: string,
   destinationBucket: string | undefined,
 ): Promise<ResolvedFiles> {
-  const startTime = new Date().getTime();
   const resolved: ResolvedFiles = new Map();
   await Promise.all(workItems.map(async (wi) => {
     const result = kind === 'input'
@@ -423,8 +421,6 @@ async function resolveSelectedWorkItemFiles(
       : await resolveOutputFiles(req, wi, frontendRoot, destinationBucket);
     resolved.set(wi.id, result);
   }));
-  const durationMs = new Date().getTime() - startTime;
-  req.context.logger.info('Finished steps:resolveSelectedWorkItemFiles', { durationMs });
   return resolved;
 }
 
@@ -587,7 +583,7 @@ export async function getJobSteps(
       if (q.workItems === undefined || q.workItems.length !== 1) {
         throw new RequestValidationError('resolveFiles requires exactly one workItem');
       }
-      resolved = await resolveSelectedWorkItemFiles(req, allWorkItems, q.resolveFiles, frontendRoot, destinationBucket);
+      resolved = await resolveWorkItemFiles(req, allWorkItems, q.resolveFiles, frontendRoot, destinationBucket);
     }
 
     const jobSteps = buildSteps(req, stepResults, statusCounts, q, resolved);
@@ -604,7 +600,7 @@ export async function getJobSteps(
       steps: jobSteps,
     };
     const durationMs = new Date().getTime() - startTime;
-    req.context.logger.info(`Finished /steps for ${jobID}`, { durationMs });
+    req.context.logger.info(`Finished steps endpoint for ${jobID}`, { durationMs });
     res.json(responseBody);
   } catch (e) {
     req.context.logger.error(e);

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -28,12 +28,17 @@ import { getRequestRoot } from '../util/url';
 const DEFAULT_WORKITEMS_PER_PAGE = 50;
 const MAX_WORKITEMS_PER_PAGE = 1000;
 
-// Default and max `wiLimit`: the number of a workitem's input items / output catalogs
-// resolved per page. This confusingly will not always result in
-// DEFAULT_WI_LIMIT items in the output. For input catalogs we are reading
-// items inside a single catalog, a single item file with perhaps many
-// items. and for output catalogs, we're reading 1 batch catalog and all of
-// its files.
+// Default and max `wiLimit`: the number of a workitem's input items / output
+// catalogs resolved per page. For input catalogs we are reading the items
+// inside a single catalog file, that in the case of aggregation catalogs can
+// contain many items.  For output catalogs, we're
+// reading 1 batch catalog, containing the list of all its catalogs.
+
+// Note: the resolved files may not be exactly the number set by `wiLimit`,
+// A catalog that contains both a data and opendap asset will provide
+// two both urls to the resolved url list.
+
+
 const DEFAULT_WI_LIMIT = 50;
 const MAX_WI_LIMIT = 100;
 
@@ -53,11 +58,10 @@ interface StepWorkItem {
   id: number;
   status: WorkItemStatus;
   retryCount: number;
-  // Overview mode: links back to the steps endpoint that resolve this workItem's
-  // input / output files
+  // Links back to this steps endpoint that resolve input / output files
   inputFilesUrl?: string | null;
   outputFilesUrl?: string | null;
-  // Resolve mode: the requested page of input or output files.
+  // The requested page of input or output files.
   inputFiles?: string[] | null;
   inputFilesPaging?: StepPaging;
   outputFiles?: string[] | null;

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -346,7 +346,8 @@ async function resolvePagedFiles(
     const hrefs = await readPage(sourceUrls.slice(start, start + perPage));
     const files = hrefs.map((h) => safePublicLink(h, frontendRoot, destinationBucket));
     return { files, paging: buildFilesPaging(req, pagination, pageParam) };
-  } catch {
+  } catch (e) {
+    req.context.logger.warn(`Failed to resolve paged files for ${pageParam}`, { error: e.message });
     return { files: [] };
   }
 }

--- a/services/harmony/app/markdown/steps.md
+++ b/services/harmony/app/markdown/steps.md
@@ -15,6 +15,8 @@ As with the jobs API, there are two sets of steps API endpoints with the same su
 
 Returns the workflow steps for the given job, along with the work items processed by each step. Each step's work items are paged independently: by default up to 50 are shown per step (configurable with `limit`), and each step is navigated with its own `step<stepIndex>Page` parameter. A step with more than one page of work items includes a `paging` object with links to the other pages.
 
+A single work item can produce a very large number of output files (for example a query-cmr step that fans out to thousands of granules). To keep the response responsive, each work item's output files are themselves paged — by STAC catalog — and navigated with that work item's own `workItem<id>Page` parameter. A work item with more than one page of output files includes an `outputFilesPaging` object with links to the other pages.
+
 ##### <a name="steps-query-parameters"></a> Query Parameters
 Parameter names are case-insensitive (e.g. `step2Page`, `Step2Page`, and `STEP2PAGE` are equivalent).
 
@@ -25,6 +27,7 @@ Parameter names are case-insensitive (e.g. `step2Page`, `Step2Page`, and `STEP2P
 | workItem            | Limit the work items shown to one or more IDs, comma-separated (e.g. `workItem=123,124`). Each a positive integer.                                                                            |
 | limit               | The number of work items to show per page for each step. Defaults to 50, maximum 1000.
 | step\<stepIndex\>Page | The page of work items to show for the step with the given stepIndex, e.g. `step2Page=3`. A positive integer that defaults to 1; a page beyond the last page returns the last page. Each step pages independently, so multiple may be supplied. |
+| workItem\<id\>Page    | The page of output files to show for the work item with the given id, e.g. `workItem123Page=2`. Output files are paged by STAC catalog (10 catalogs per page) so that even very large fan-out steps (e.g. query-cmr) stay responsive. A positive integer that defaults to 1; a page beyond the last page returns the last page. Each work item pages independently, so multiple may be supplied. |
 
 ---
 **Table {{tableCounter}}** - Harmony steps endpoint parameters
@@ -84,8 +87,8 @@ Each entry in a step's `workItems` list describes a single work item:
 | status      | Status of the work item                                                                                                                                                                   |
 | retryCount  | The number of times the work item has been retried                                                                                                                                        |
 | inputFiles  | A list of links to the input files for the work item, or `null` if the work item has no STAC input (e.g. the first query-cmr step).                                                       |
-| outputFiles | A list of links to the output files produced by the work item, or `null` if it produced no output. Files that cannot be turned into a public link are shown as `<private file location>`. |
-| warning     | Warning message displayed if the outputFiles array is incomplete.                                                                                                                          |
+| outputFiles | A list of links to the output files produced by the work item for the current output-file page, or `null` if it produced no output. Files that cannot be turned into a public link are shown as `<private file location>`. |
+| outputFilesPaging | Present when the work item has more than one page of output files. Navigate the pages with the `workItem<id>Page` parameter. Same shape as a step's `paging` object — see [paging fields](#step-paging-response) (here `total` is the work item's number of output STAC catalogs). |
 
 ---
 **Table {{tableCounter}}** - Harmony work item fields

--- a/services/harmony/app/markdown/steps.md
+++ b/services/harmony/app/markdown/steps.md
@@ -15,7 +15,25 @@ As with the jobs API, there are two sets of steps API endpoints with the same su
 
 Returns the workflow steps for the given job, along with the work items processed by each step. Each step's work items are paged independently: by default up to 50 are shown per step (configurable with `limit`), and each step is navigated with its own `step<stepIndex>Page` parameter. A step with more than one page of work items includes a `paging` object with links to the other pages.
 
-A single work item can produce a very large number of output files (for example a query-cmr step that fans out to thousands of granules). To keep the response responsive, each work item's output files are themselves paged — by STAC catalog — and navigated with that work item's own `workItem<id>Page` parameter. A work item with more than one page of output files includes an `outputFilesPaging` object with links to the other pages.
+A work item can reference or produce a very large number of files — for example a query-cmr step that fans out to thousands of granules, or an aggregating step whose single input catalog lists many items. To keep this overview responsive it does **not** read any files from storage: each work item instead carries `inputFilesUrl` and `outputFilesUrl` links (see [work item fields](#step-work-item-response)). The files themselves are resolved, and paged, only on demand by following those links — see [Resolving a work item's files](#steps-resolve-files).
+
+#### <a name="steps-resolve-files"></a> Resolving a work item's files
+
+The default steps response is link-only and reads nothing from storage. To see a single work item's actual input or output files, follow its `inputFilesUrl` / `outputFilesUrl`, which request the steps endpoint scoped to that one work item:
+
+```
+
+{{root}}/jobs/<job-id>/steps?workItem=<id>&resolveFiles=output
+
+```
+**Example {{exampleCounter}}** - Resolving a work item's output files
+
+When `resolveFiles` is supplied, exactly one `workItem` must be given (otherwise the request is rejected). The matching work item is returned with the requested kind of files resolved inline:
+
+- `resolveFiles=input` populates `inputFiles` (and `inputFilesPaging`), reading a page of the work item's input STAC catalog items.
+- `resolveFiles=output` populates `outputFiles` (and `outputFilesPaging`), reading a page of the work item's output STAC catalogs.
+
+Both are paged to bound the number of reads: at most `wiLimit` items/catalogs (default 50, maximum 100) are read per request. Input pages are navigated with the work item's `workItem<id>InputPage` parameter and output pages with its `workItem<id>OutputPage` parameter. A kind with more than one page includes an `inputFilesPaging` / `outputFilesPaging` object with links to the other pages.
 
 ##### <a name="steps-query-parameters"></a> Query Parameters
 Parameter names are case-insensitive (e.g. `step2Page`, `Step2Page`, and `STEP2PAGE` are equivalent).
@@ -26,8 +44,11 @@ Parameter names are case-insensitive (e.g. `step2Page`, `Step2Page`, and `STEP2P
 | status              | Filter the work items shown to one or more statuses, comma-separated (e.g. `status=failed,warning`). Each one of `ready`, `queued`, `running`, `successful`, `failed`, `canceled`, or `warning`. Steps with no matching work items are omitted. |
 | workItem            | Limit the work items shown to one or more IDs, comma-separated (e.g. `workItem=123,124`). Each a positive integer.                                                                            |
 | limit               | The number of work items to show per page for each step. Defaults to 50, maximum 1000.
+| resolveFiles        | Resolve a single work item's files inline instead of returning `inputFilesUrl` / `outputFilesUrl` links. One of `input` or `output`. Requires exactly one `workItem`; otherwise the request is rejected. See [Resolving a work item's files](#steps-resolve-files). |
+| wiLimit             | The page size used when resolving files: the number of input STAC items (for `resolveFiles=input`) or output STAC catalogs (for `resolveFiles=output`) read per page. Defaults to 50, maximum 100. |
 | step\<stepIndex\>Page | The page of work items to show for the step with the given stepIndex, e.g. `step2Page=3`. A positive integer that defaults to 1; a page beyond the last page returns the last page. Each step pages independently, so multiple may be supplied. |
-| workItem\<id\>Page    | The page of output files to show for the work item with the given id, e.g. `workItem123Page=2`. Output files are paged by STAC catalog (10 catalogs per page) so that even very large fan-out steps (e.g. query-cmr) stay responsive. A positive integer that defaults to 1; a page beyond the last page returns the last page. Each work item pages independently, so multiple may be supplied. |
+| workItem\<id\>OutputPage | The page of **output** files to show for the work item with the given id when `resolveFiles=output`, e.g. `workItem123OutputPage=2`. Output files are paged by STAC catalog (`wiLimit` per page). A positive integer that defaults to 1; a page beyond the last page returns the last page. |
+| workItem\<id\>InputPage | The page of **input** files to show for the work item with the given id when `resolveFiles=input`, e.g. `workItem123InputPage=2`. Input files are paged by STAC item (`wiLimit` per page). A positive integer that defaults to 1; a page beyond the last page returns the last page. |
 
 ---
 **Table {{tableCounter}}** - Harmony steps endpoint parameters
@@ -79,16 +100,19 @@ The `paging` object lets you navigate a step's work items one page at a time:
 **Table {{tableCounter}}** - Harmony step paging fields
 
 ###### <a name="step-work-item-response"></a> Work item fields
-Each entry in a step's `workItems` list describes a single work item:
+Each entry in a step's `workItems` list describes a single work item. The default (link-only) response carries `id`, `status`, `retryCount`, and the two `*Url` fields. The `inputFiles` / `outputFiles` fields and their paging appear only when [resolving a work item's files](#steps-resolve-files):
 
 | field       | description                                                                                                                                                                               |
 |-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | id          | ID of the work item in Harmony                                                                                                                                                            |
 | status      | Status of the work item                                                                                                                                                                   |
 | retryCount  | The number of times the work item has been retried                                                                                                                                        |
-| inputFiles  | A list of links to the input files for the work item, or `null` if the work item has no STAC input (e.g. the first query-cmr step).                                                       |
-| outputFiles | A list of links to the output files produced by the work item for the current output-file page, or `null` if it produced no output. Files that cannot be turned into a public link are shown as `<private file location>`. |
-| outputFilesPaging | Present when the work item has more than one page of output files. Navigate the pages with the `workItem<id>Page` parameter. Same shape as a step's `paging` object — see [paging fields](#step-paging-response) (here `total` is the work item's number of output STAC catalogs). |
+| inputFilesUrl  | (default response) A link that resolves this work item's input files, or `null` if the work item has no STAC input (e.g. the first query-cmr step). Follow it (equivalently, pass `workItem=<id>&resolveFiles=input`) to get the files. |
+| outputFilesUrl | (default response) A link that resolves this work item's output files, or `null` if the work item has not yet completed. Follow it (equivalently, pass `workItem=<id>&resolveFiles=output`) to get the files. |
+| inputFiles  | (resolve mode, `resolveFiles=input`) A list of links to the input files for the current input-file page. Files that cannot be turned into a public link are shown as `<private file location>`. |
+| inputFilesPaging | (resolve mode) Present when the work item has more than one page of input files. Navigate the pages with the `workItem<id>InputPage` parameter. Same shape as a step's `paging` object — see [paging fields](#step-paging-response) (here `total` is the work item's number of input STAC items). |
+| outputFiles | (resolve mode, `resolveFiles=output`) A list of links to the output files for the current output-file page, or empty if it produced no output. Files that cannot be turned into a public link are shown as `<private file location>`. |
+| outputFilesPaging | (resolve mode) Present when the work item has more than one page of output files. Navigate the pages with the `workItem<id>OutputPage` parameter. Same shape as a step's `paging` object — see [paging fields](#step-paging-response) (here `total` is the work item's number of output STAC catalogs). |
 
 ---
 **Table {{tableCounter}}** - Harmony work item fields

--- a/services/harmony/app/markdown/steps.md
+++ b/services/harmony/app/markdown/steps.md
@@ -15,11 +15,11 @@ As with the jobs API, there are two sets of steps API endpoints with the same su
 
 Returns the workflow steps for the given job, along with the work items processed by each step. Each step's work items are paged independently: by default up to 50 are shown per step (configurable with `limit`), and each step is navigated with its own `step<stepIndex>Page` parameter. A step with more than one page of work items includes a `paging` object with links to the other pages.
 
-A work item can reference or produce a very large number of files — for example a query-cmr step that fans out to thousands of granules, or an aggregating step whose single input catalog lists many items. To keep this overview responsive it does **not** read any files from storage: each work item instead carries `inputFilesUrl` and `outputFilesUrl` links (see [work item fields](#step-work-item-response)). The files themselves are resolved, and paged, only on demand by following those links — see [Resolving a work item's files](#steps-resolve-files).
+A work item can reference or produce a very large number of files - for example a query-cmr step that fans out to thousands of granules, or an aggregating step whose single input catalog lists many items. To keep the endpoint responsive, it does **not** read any files from storage. Instead, each work item has `inputFilesUrl` and `outputFilesUrl` links (see [work item fields](#step-work-item-response)). The files themselves are resolved, and paged, only on demand by following those links — see [Resolving a work item's files](#steps-resolve-files).
 
 #### <a name="steps-resolve-files"></a> Resolving a work item's files
 
-The default steps response is link-only and reads nothing from storage. To see a single work item's actual input or output files, follow its `inputFilesUrl` / `outputFilesUrl`, which request the steps endpoint scoped to that one work item:
+The default steps response is link-only and reads no stac catalogs thing from storage. To see a single work item's actual input or output files, follow its `inputFilesUrl` / `outputFilesUrl`, which make a request to the steps endpoint scoped to that one work item and sets the resolvedFiles parameter to either input or output as chosen:
 
 ```
 
@@ -28,7 +28,7 @@ The default steps response is link-only and reads nothing from storage. To see a
 ```
 **Example {{exampleCounter}}** - Resolving a work item's output files
 
-When `resolveFiles` is supplied, exactly one `workItem` must be given (otherwise the request is rejected). The matching work item is returned with the requested kind of files resolved inline:
+When `resolveFiles` is supplied and exactly one `workItem` is given, the work item is returned with the requested kind of files resolved inline:
 
 - `resolveFiles=input` populates `inputFiles` (and `inputFilesPaging`), reading a page of the work item's input STAC catalog items.
 - `resolveFiles=output` populates `outputFiles` (and `outputFilesPaging`), reading a page of the work item's output STAC catalogs.

--- a/services/harmony/app/markdown/steps.md
+++ b/services/harmony/app/markdown/steps.md
@@ -15,11 +15,11 @@ As with the jobs API, there are two sets of steps API endpoints with the same su
 
 Returns the workflow steps for the given job, along with the work items processed by each step. Each step's work items are paged independently: by default up to 50 are shown per step (configurable with `limit`), and each step is navigated with its own `step<stepIndex>Page` parameter. A step with more than one page of work items includes a `paging` object with links to the other pages.
 
-A work item can reference or produce a very large number of files - for example a query-cmr step that fans out to thousands of granules, or an aggregating step whose single input catalog lists many items. To keep the endpoint responsive, it does **not** read any files from storage. Instead, each work item has `inputFilesUrl` and `outputFilesUrl` links (see [work item fields](#step-work-item-response)). The files themselves are resolved, and paged, only on demand by following those links — see [Resolving a work item's files](#steps-resolve-files).
+A work item can reference or produce a very large number of files - for example a query-cmr step that fans out to thousands of granules, or an aggregating step whose single input catalog lists many items. To keep the endpoint responsive, it does **not** read any files from storage. Instead, each work item has `inputFilesUrl` and `outputFilesUrl` links (see [work item fields](#step-work-item-response)). The files themselves are resolved, and paged, only on demand by following those links - see [Resolving a work item's files](#steps-resolve-files).
 
 #### <a name="steps-resolve-files"></a> Resolving a work item's files
 
-The default steps response is link-only and reads no stac catalogs thing from storage. To see a single work item's actual input or output files, follow its `inputFilesUrl` / `outputFilesUrl`, which make a request to the steps endpoint scoped to that one work item and sets the resolvedFiles parameter to either input or output as chosen:
+To see a work item's actual input or output files, you need to follow its `inputFilesUrl` / `outputFilesUrl`, which is designed to make a request back to the steps endpoint scoped to that one work item and sets the resolvedFiles parameter to the chosen input or output value:
 
 ```
 
@@ -44,11 +44,11 @@ Parameter names are case-insensitive (e.g. `step2Page`, `Step2Page`, and `STEP2P
 | status              | Filter the work items shown to one or more statuses, comma-separated (e.g. `status=failed,warning`). Each one of `ready`, `queued`, `running`, `successful`, `failed`, `canceled`, or `warning`. Steps with no matching work items are omitted. |
 | workItem            | Limit the work items shown to one or more IDs, comma-separated (e.g. `workItem=123,124`). Each a positive integer.                                                                            |
 | limit               | The number of work items to show per page for each step. Defaults to 50, maximum 1000.
-| resolveFiles        | Resolve a single work item's files inline instead of returning `inputFilesUrl` / `outputFilesUrl` links. One of `input` or `output`. Requires exactly one `workItem`; otherwise the request is rejected. See [Resolving a work item's files](#steps-resolve-files). |
+| resolveFiles        | Resolves work item's files inline instead of returning `inputFilesUrl` / `outputFilesUrl` links. One of `input` or `output`. Requires exactly one `workItem`; otherwise the request is rejected. See [Resolving a work item's files](#steps-resolve-files). |
 | wiLimit             | The page size used when resolving files: the number of input STAC items (for `resolveFiles=input`) or output STAC catalogs (for `resolveFiles=output`) read per page. Defaults to 50, maximum 100. |
 | step\<stepIndex\>Page | The page of work items to show for the step with the given stepIndex, e.g. `step2Page=3`. A positive integer that defaults to 1; a page beyond the last page returns the last page. Each step pages independently, so multiple may be supplied. |
-| workItem\<id\>OutputPage | The page of **output** files to show for the work item with the given id when `resolveFiles=output`, e.g. `workItem123OutputPage=2`. Output files are paged by STAC catalog (`wiLimit` per page). A positive integer that defaults to 1; a page beyond the last page returns the last page. |
-| workItem\<id\>InputPage | The page of **input** files to show for the work item with the given id when `resolveFiles=input`, e.g. `workItem123InputPage=2`. Input files are paged by STAC item (`wiLimit` per page). A positive integer that defaults to 1; a page beyond the last page returns the last page. |
+| workItem\<id\>OutputPage | The page of output files to show for the work item with the given id when `resolveFiles=output`, e.g. `workItem123OutputPage=2`. Output files are paged by STAC catalog (`wiLimit` per page). A positive integer that defaults to 1; a page beyond the last page returns the last page. |
+| workItem\<id\>InputPage | The page of input files to show for the work item with the given id when `resolveFiles=input`, e.g. `workItem123InputPage=2`. Input files are paged by STAC item (`wiLimit` per page). A positive integer that defaults to 1; a page beyond the last page returns the last page. |
 
 ---
 **Table {{tableCounter}}** - Harmony steps endpoint parameters
@@ -107,12 +107,12 @@ Each entry in a step's `workItems` list describes a single work item. The defaul
 | id          | ID of the work item in Harmony                                                                                                                                                            |
 | status      | Status of the work item                                                                                                                                                                   |
 | retryCount  | The number of times the work item has been retried                                                                                                                                        |
-| inputFilesUrl  | (default response) A link that resolves this work item's input files, or `null` if the work item has no STAC input (e.g. the first query-cmr step). Follow it (equivalently, pass `workItem=<id>&resolveFiles=input`) to get the files. |
-| outputFilesUrl | (default response) A link that resolves this work item's output files, or `null` if the work item has not yet completed. Follow it (equivalently, pass `workItem=<id>&resolveFiles=output`) to get the files. |
-| inputFiles  | (resolve mode, `resolveFiles=input`) A list of links to the input files for the current input-file page. Files that cannot be turned into a public link are shown as `<private file location>`. |
-| inputFilesPaging | (resolve mode) Present when the work item has more than one page of input files. Navigate the pages with the `workItem<id>InputPage` parameter. Same shape as a step's `paging` object — see [paging fields](#step-paging-response) (here `total` is the work item's number of input STAC items). |
-| outputFiles | (resolve mode, `resolveFiles=output`) A list of links to the output files for the current output-file page, or empty if it produced no output. Files that cannot be turned into a public link are shown as `<private file location>`. |
-| outputFilesPaging | (resolve mode) Present when the work item has more than one page of output files. Navigate the pages with the `workItem<id>OutputPage` parameter. Same shape as a step's `paging` object — see [paging fields](#step-paging-response) (here `total` is the work item's number of output STAC catalogs). |
+| inputFilesUrl  | A link that resolves this work item's input files. Follow it (equivalently, pass `workItem=<id>&resolveFiles=input`) to get the files. |
+| outputFilesUrl | A link that resolves this work item's output files, or `null` if the work item has not yet completed. Follow it (equivalently, pass `workItem=<id>&resolveFiles=output`) to get the files. |
+| inputFiles  | A list of links to the input files for the current input-file page. Files unable be turned into a public link are shown as `<private file location>`. |
+| inputFilesPaging | Present when needed. Navigate the pages with the `workItem<id>InputPage` parameter. Same shape as a step's `paging` object — see [paging fields](#step-paging-response) (here `total` is the work item's number of input STAC items). |
+| outputFiles | A list of links to the output files for the current output-file page, or empty if it produced no output. Files unable be turned into a public link are shown as `<private file location>`. |
+| outputFilesPaging | Present when needed. Navigate the pages with the `workItem<id>OutputPage` parameter. Same shape as a step's `paging` object — see [paging fields](#step-paging-response) (here `total` is the work item's number of output STAC catalogs). |
 
 ---
 **Table {{tableCounter}}** - Harmony work item fields

--- a/services/harmony/app/markdown/steps.md
+++ b/services/harmony/app/markdown/steps.md
@@ -6,7 +6,7 @@ As with the jobs API, there are two sets of steps API endpoints with the same su
 
 #### Getting the steps for a job
 
-```
+```http
 
 {{root}}/jobs/<job-id>/steps
 
@@ -19,9 +19,9 @@ A work item can reference or produce a very large number of files - for example 
 
 #### <a name="steps-resolve-files"></a> Resolving a work item's files
 
-To see a work item's actual input or output files, you need to follow its `inputFilesUrl` / `outputFilesUrl`, which is designed to make a request back to the steps endpoint scoped to that one work item and sets the resolvedFiles parameter to the chosen input or output value:
+To see a work item's actual input or output files, you need to follow its `inputFilesUrl` / `outputFilesUrl`, which is designed to make a request back to the steps endpoint scoped to that one work item and sets the `resolveFiles` parameter to the chosen input or output value:
 
-```
+```http
 
 {{root}}/jobs/<job-id>/steps?workItem=<id>&resolveFiles=output
 

--- a/services/harmony/app/middleware/parameter-validation.ts
+++ b/services/harmony/app/middleware/parameter-validation.ts
@@ -236,7 +236,7 @@ function validateEdrParameterNames(req: HarmonyRequest): void {
  * @throws RequestValidationError - if disallowed parameters are detected
  */
 export function validateStepsParameterNames(req: HarmonyRequest): void {
-  const stepsAllowedParams = ['step', 'status', 'workItem', 'limit'];
+  const stepsAllowedParams = ['step', 'status', 'workItem', 'limit', 'wilimit'];
   const stepPageParamRegex = /^step\d+page$/;
   const workItemPageParamRegex = /^workitem\d+page$/;
 

--- a/services/harmony/app/middleware/parameter-validation.ts
+++ b/services/harmony/app/middleware/parameter-validation.ts
@@ -236,7 +236,7 @@ function validateEdrParameterNames(req: HarmonyRequest): void {
  * @throws RequestValidationError - if disallowed parameters are detected
  */
 export function validateStepsParameterNames(req: HarmonyRequest): void {
-  const stepsAllowedParams = ['step', 'status', 'workItem', 'limit', 'wilimit'];
+  const stepsAllowedParams = ['step', 'status', 'workItem', 'limit', 'wiLimit'];
   const stepPageParamRegex = /^step\d+page$/;
   const workItemPageParamRegex = /^workitem\d+page$/;
 

--- a/services/harmony/app/middleware/parameter-validation.ts
+++ b/services/harmony/app/middleware/parameter-validation.ts
@@ -229,16 +229,17 @@ function validateEdrParameterNames(req: HarmonyRequest): void {
 
 /**
  * Validate that the steps endpoint query parameter names are allowed. The
- * per-step `step<stepIndex>Page` and per-work-item `workItem<id>Page` paging
- * parameters are accepted alongside the fixed steps parameters.
+ * per-step `step<stepIndex>Page` and per-work-item `workItem<id>Page` /
+ * `workItem<id>InputPage` paging parameters are accepted alongside the fixed
+ * steps parameters.
  *
  * @param req - The client request
  * @throws RequestValidationError - if disallowed parameters are detected
  */
 export function validateStepsParameterNames(req: HarmonyRequest): void {
-  const stepsAllowedParams = ['step', 'status', 'workItem', 'limit', 'wiLimit'];
+  const stepsAllowedParams = ['step', 'status', 'workItem', 'limit', 'wiLimit', 'resolveFiles'];
   const stepPageParamRegex = /^step\d+page$/;
-  const workItemPageParamRegex = /^workitem\d+page$/;
+  const workItemPageParamRegex = /^workitem\d+(input)?page$/;
 
   const requestedParams = Object.keys(req.query)
     .filter((param) => !stepPageParamRegex.test(param.toLowerCase()))

--- a/services/harmony/app/middleware/parameter-validation.ts
+++ b/services/harmony/app/middleware/parameter-validation.ts
@@ -229,8 +229,8 @@ function validateEdrParameterNames(req: HarmonyRequest): void {
 
 /**
  * Validate that the steps endpoint query parameter names are allowed. The
- * per-step `step<stepIndex>Page` paging parameters are accepted alongside the
- * fixed steps parameters.
+ * per-step `step<stepIndex>Page` and per-work-item `workItem<id>Page` paging
+ * parameters are accepted alongside the fixed steps parameters.
  *
  * @param req - The client request
  * @throws RequestValidationError - if disallowed parameters are detected
@@ -238,9 +238,11 @@ function validateEdrParameterNames(req: HarmonyRequest): void {
 export function validateStepsParameterNames(req: HarmonyRequest): void {
   const stepsAllowedParams = ['step', 'status', 'workItem', 'limit'];
   const stepPageParamRegex = /^step\d+page$/;
+  const workItemPageParamRegex = /^workitem\d+page$/;
 
   const requestedParams = Object.keys(req.query)
-    .filter((param) => !stepPageParamRegex.test(param.toLowerCase()));
+    .filter((param) => !stepPageParamRegex.test(param.toLowerCase()))
+    .filter((param) => !workItemPageParamRegex.test(param.toLowerCase()));
   validateParameterNames(requestedParams, stepsAllowedParams);
 }
 

--- a/services/harmony/app/middleware/parameter-validation.ts
+++ b/services/harmony/app/middleware/parameter-validation.ts
@@ -229,8 +229,8 @@ function validateEdrParameterNames(req: HarmonyRequest): void {
 
 /**
  * Validate that the steps endpoint query parameter names are allowed. The
- * per-step `step<stepIndex>Page` and per-work-item `workItem<id>Page` /
- * `workItem<id>InputPage` paging parameters are accepted alongside the fixed
+ * per-step `step<stepIndex>Page` and per-work-item `workItem<id>InputPage` /
+ * `workItem<id>OutputPage` paging parameters are accepted alongside the fixed
  * steps parameters.
  *
  * @param req - The client request
@@ -239,7 +239,7 @@ function validateEdrParameterNames(req: HarmonyRequest): void {
 export function validateStepsParameterNames(req: HarmonyRequest): void {
   const stepsAllowedParams = ['step', 'status', 'workItem', 'limit', 'wiLimit', 'resolveFiles'];
   const stepPageParamRegex = /^step\d+page$/;
-  const workItemPageParamRegex = /^workitem\d+(input)?page$/;
+  const workItemPageParamRegex = /^workitem\d+(input|output)page$/;
 
   const requestedParams = Object.keys(req.query)
     .filter((param) => !stepPageParamRegex.test(param.toLowerCase()))

--- a/services/harmony/app/util/pagination.ts
+++ b/services/harmony/app/util/pagination.ts
@@ -107,6 +107,7 @@ export function getPagingParams(
  * @param rel - the name of the link relation
  * @param relName - the name of the link relation
  * @param pageParamName - the query parameter the link should set the page on
+ * @param pageParamLimit - the query parameter the link should set the page limit on
  * @returns the generated link
  */
 function getPagingLink(
@@ -116,12 +117,13 @@ function getPagingLink(
   rel: string,
   relName: string = rel,
   pageParamName = 'page',
+  pageParamLimit = 'limit',
 ): Link {
   const { lastPage, perPage } = pagination;
   const suffix = (lastPage <= 1 && page === 1) || perPage === 0 ? '' : ` (${page} of ${lastPage})`;
   return {
     title: `The ${relName} page${suffix}`,
-    href: getRequestUrl(req, true, { [pageParamName]: page, limit: perPage }),
+    href: getRequestUrl(req, true, { [pageParamName]: page, [pageParamLimit]: perPage }),
     rel,
     type: 'application/json',
   };
@@ -137,22 +139,25 @@ function getPagingLink(
  * @returns the links to paginate
  */
 export function getPagingLinks(
-  req: Request, pagination: ILengthAwarePagination, includeExtraneous = false, pageParamName = 'page',
+  req: Request, pagination: ILengthAwarePagination,
+  includeExtraneous = false,
+  pageParamName = 'page',
+  pageParamLimit = 'limit',
 ): Link[] {
   const result = [];
   const { currentPage, lastPage, perPage } = pagination;
   if (perPage > 0 && currentPage > lastPage && lastPage >= 1) {
     // this request was for a page beyond the last, just give them a first and last link.
-    if (lastPage > 1) result.push(getPagingLink(req, pagination, 1, 'first', 'first', pageParamName));
-    result.push(getPagingLink(req, pagination, currentPage, 'self', 'current', pageParamName));
-    result.push(getPagingLink(req, pagination, lastPage, 'last', 'last', pageParamName));
+    if (lastPage > 1) result.push(getPagingLink(req, pagination, 1, 'first', 'first', pageParamName, pageParamLimit));
+    result.push(getPagingLink(req, pagination, currentPage, 'self', 'current', pageParamName, pageParamLimit));
+    result.push(getPagingLink(req, pagination, lastPage, 'last', 'last', pageParamName, pageParamLimit));
     return result;
   }
-  if (perPage > 0 && currentPage > (includeExtraneous ? 1 : 2)) result.push(getPagingLink(req, pagination, 1, 'first', 'first', pageParamName));
-  if (perPage > 0 && currentPage > 1) result.push(getPagingLink(req, pagination, currentPage - 1, 'prev', 'previous', pageParamName));
-  result.push(getPagingLink(req, pagination, currentPage, 'self', 'current', pageParamName));
-  if (perPage > 0 && currentPage < lastPage) result.push(getPagingLink(req, pagination, currentPage + 1, 'next', 'next', pageParamName));
-  if (perPage > 0 && currentPage < (includeExtraneous ? lastPage : lastPage - 1)) result.push(getPagingLink(req, pagination, lastPage, 'last', 'last', pageParamName));
+  if (perPage > 0 && currentPage > (includeExtraneous ? 1 : 2)) result.push(getPagingLink(req, pagination, 1, 'first', 'first', pageParamName, pageParamLimit));
+  if (perPage > 0 && currentPage > 1) result.push(getPagingLink(req, pagination, currentPage - 1, 'prev', 'previous', pageParamName, pageParamLimit));
+  result.push(getPagingLink(req, pagination, currentPage, 'self', 'current', pageParamName, pageParamLimit));
+  if (perPage > 0 && currentPage < lastPage) result.push(getPagingLink(req, pagination, currentPage + 1, 'next', 'next', pageParamName, pageParamLimit));
+  if (perPage > 0 && currentPage < (includeExtraneous ? lastPage : lastPage - 1)) result.push(getPagingLink(req, pagination, lastPage, 'last', 'last', pageParamName, pageParamLimit));
   return result;
 }
 

--- a/services/harmony/app/util/stac.ts
+++ b/services/harmony/app/util/stac.ts
@@ -105,10 +105,13 @@ export async function getCatalogItemUrls(catalogUrl: string): Promise<string[]> 
 /**
  * Reads the content of the catalog and returns the catalog items
  * @param catalogUrl - the catalog s3 url
+ * @param maxItems - if provided, read at most this many items (bounds the number
+ *   of S3 reads for catalogs that reference a very large number of items)
  */
-export async function readCatalogItems(catalogUrl: string): Promise<StacItem[]> {
+export async function readCatalogItems(catalogUrl: string, maxItems?: number): Promise<StacItem[]> {
   const s3 = objectStoreForProtocol('s3');
-  const childLinks = await getCatalogItemUrls(catalogUrl);
+  const itemUrls = await getCatalogItemUrls(catalogUrl);
+  const childLinks = maxItems === undefined ? itemUrls : itemUrls.slice(0, maxItems);
 
   const items: StacItem[] = [];
   for (const link of childLinks) {

--- a/services/harmony/app/util/stac.ts
+++ b/services/harmony/app/util/stac.ts
@@ -1,5 +1,3 @@
-import { Logger } from 'winston';
-
 import { objectStoreForProtocol } from './object-store';
 import { resolve } from './url';
 import JobLink from '../models/job-link';
@@ -113,7 +111,7 @@ export async function getCatalogItemUrls(catalogUrl: string): Promise<string[]> 
  * @returns the items at the given URLs
  */
 export async function readItemsAtUrls(
-  catalogUrl: string, itemUrls: string[]
+  catalogUrl: string, itemUrls: string[],
 ): Promise<StacItem[]> {
   const s3 = objectStoreForProtocol('s3');
 
@@ -130,7 +128,6 @@ export async function readItemsAtUrls(
 /**
  * Reads the content of the catalog and returns all of its catalog items.
  * @param catalogUrl - the catalog s3 url
- * @param logger - optional logger
  */
 export async function readCatalogItems(catalogUrl: string): Promise<StacItem[]> {
   const childLinks = await getCatalogItemUrls(catalogUrl);

--- a/services/harmony/app/util/stac.ts
+++ b/services/harmony/app/util/stac.ts
@@ -1,5 +1,6 @@
-import { objectStoreForProtocol } from './object-store';
 import { Logger } from 'winston';
+
+import { objectStoreForProtocol } from './object-store';
 import { resolve } from './url';
 import JobLink from '../models/job-link';
 
@@ -112,8 +113,8 @@ export async function getCatalogItemUrls(catalogUrl: string): Promise<string[]> 
 export async function readCatalogItems(catalogUrl: string, maxItems?: number, logger?: Logger): Promise<StacItem[]> {
   const s3 = objectStoreForProtocol('s3');
   const itemUrls = await getCatalogItemUrls(catalogUrl);
-  logger.info(`readCatalogItems found ${itemUrls.length} items in CatalogUrl ${catalogUrl}.`);
-  logger.info(`readCatalogItems urls: ${JSON.stringify(itemUrls)}`);
+  logger?.info(`readCatalogItems found ${itemUrls.length} items in CatalogUrl ${catalogUrl}.`);
+  logger?.info(`readCatalogItems urls: ${JSON.stringify(itemUrls)}`);
   const childLinks = maxItems === undefined ? itemUrls : itemUrls.slice(0, maxItems);
 
   const items: StacItem[] = [];

--- a/services/harmony/app/util/stac.ts
+++ b/services/harmony/app/util/stac.ts
@@ -128,6 +128,37 @@ export async function readCatalogItems(catalogUrl: string, maxItems?: number, lo
 }
 
 /**
+ * Reads a single page of a STAC catalog's items. The catalog itself is read once
+ * to enumerate every item URL (cheap, a single S3 read), and only the requested
+ * `[offset, offset + limit)` slice of items is fetched. This keeps the number of
+ * S3 reads bounded for catalogs that reference a very large number of items.
+ *
+ * @param catalogUrl - the catalog s3 url
+ * @param offset - the index of the first item to read
+ * @param limit - the maximum number of items to read
+ * @param logger - optional logger
+ * @returns the page of items and the catalog's total item count
+ */
+export async function readCatalogItemsPage(
+  catalogUrl: string, offset: number, limit: number, logger?: Logger,
+): Promise<{ items: StacItem[]; total: number }> {
+  const s3 = objectStoreForProtocol('s3');
+  const itemUrls = await getCatalogItemUrls(catalogUrl);
+  const total = itemUrls.length;
+  const pageUrls = itemUrls.slice(offset, offset + limit);
+  logger?.info(`readCatalogItemsPage reading ${pageUrls.length} of ${total} items (offset ${offset}) in CatalogUrl ${catalogUrl}.`);
+
+  const items: StacItem[] = [];
+  for (const link of pageUrls) {
+    const itemUrl = resolve(catalogUrl, link); // link has a relative path "./itemFile.json"
+    const item = await s3.getObjectJson(itemUrl) as StacItem;
+    items.push(item);
+  }
+
+  return { items, total };
+}
+
+/**
  * Reads the content of the specified catalogs and returns an array of catalog items
  * combined from all catalogs.
  *

--- a/services/harmony/app/util/stac.ts
+++ b/services/harmony/app/util/stac.ts
@@ -110,12 +110,11 @@ export async function getCatalogItemUrls(catalogUrl: string): Promise<string[]> 
  * @param maxItems - if provided, read at most this many items (bounds the number
  *   of S3 reads for catalogs that reference a very large number of items)
  */
-export async function readCatalogItems(catalogUrl: string, maxItems?: number, logger?: Logger): Promise<StacItem[]> {
+export async function readCatalogItems(catalogUrl: string, logger?: Logger): Promise<StacItem[]> {
   const s3 = objectStoreForProtocol('s3');
-  const itemUrls = await getCatalogItemUrls(catalogUrl);
-  logger?.info(`readCatalogItems found ${itemUrls.length} items in CatalogUrl ${catalogUrl}.`);
-  logger?.info(`readCatalogItems urls: ${JSON.stringify(itemUrls)}`);
-  const childLinks = maxItems === undefined ? itemUrls : itemUrls.slice(0, maxItems);
+  const childLinks = await getCatalogItemUrls(catalogUrl);
+  logger?.info(`readCatalogItems found ${childLinks.length} items in CatalogUrl ${catalogUrl}.`);
+  logger?.info(`readCatalogItems urls: ${JSON.stringify(childLinks)}`);
 
   const items: StacItem[] = [];
   for (const link of childLinks) {

--- a/services/harmony/app/util/stac.ts
+++ b/services/harmony/app/util/stac.ts
@@ -1,4 +1,5 @@
 import { objectStoreForProtocol } from './object-store';
+import { Logger } from 'winston';
 import { resolve } from './url';
 import JobLink from '../models/job-link';
 
@@ -108,9 +109,11 @@ export async function getCatalogItemUrls(catalogUrl: string): Promise<string[]> 
  * @param maxItems - if provided, read at most this many items (bounds the number
  *   of S3 reads for catalogs that reference a very large number of items)
  */
-export async function readCatalogItems(catalogUrl: string, maxItems?: number): Promise<StacItem[]> {
+export async function readCatalogItems(catalogUrl: string, maxItems?: number, logger?: Logger): Promise<StacItem[]> {
   const s3 = objectStoreForProtocol('s3');
   const itemUrls = await getCatalogItemUrls(catalogUrl);
+  logger.info(`readCatalogItems found ${itemUrls.length} items in CatalogUrl ${catalogUrl}.`);
+  logger.info(`readCatalogItems urls: ${JSON.stringify(itemUrls)}`);
   const childLinks = maxItems === undefined ? itemUrls : itemUrls.slice(0, maxItems);
 
   const items: StacItem[] = [];

--- a/services/harmony/app/util/stac.ts
+++ b/services/harmony/app/util/stac.ts
@@ -105,19 +105,20 @@ export async function getCatalogItemUrls(catalogUrl: string): Promise<string[]> 
 }
 
 /**
- * Reads the content of the catalog and returns the catalog items
- * @param catalogUrl - the catalog s3 url
- * @param maxItems - if provided, read at most this many items (bounds the number
- *   of S3 reads for catalogs that reference a very large number of items)
+ * Reads the given STAC item URLs (each resolved relative to the catalog) and
+ * returns the items.
+ *
+ * @param catalogUrl - the catalog s3 url the item URLs are relative to
+ * @param itemUrls - the item URLs to read
+ * @returns the items at the given URLs
  */
-export async function readCatalogItems(catalogUrl: string, logger?: Logger): Promise<StacItem[]> {
+export async function readItemsAtUrls(
+  catalogUrl: string, itemUrls: string[]
+): Promise<StacItem[]> {
   const s3 = objectStoreForProtocol('s3');
-  const childLinks = await getCatalogItemUrls(catalogUrl);
-  logger?.info(`readCatalogItems found ${childLinks.length} items in CatalogUrl ${catalogUrl}.`);
-  logger?.info(`readCatalogItems urls: ${JSON.stringify(childLinks)}`);
 
   const items: StacItem[] = [];
-  for (const link of childLinks) {
+  for (const link of itemUrls) {
     const itemUrl = resolve(catalogUrl, link); // link has a relative path "./itemFile.json"
     const item = await s3.getObjectJson(itemUrl) as StacItem;
     items.push(item);
@@ -127,34 +128,14 @@ export async function readCatalogItems(catalogUrl: string, logger?: Logger): Pro
 }
 
 /**
- * Reads a single page of a STAC catalog's items. The catalog itself is read once
- * to enumerate every item URL (cheap, a single S3 read), and only the requested
- * `[offset, offset + limit)` slice of items is fetched. This keeps the number of
- * S3 reads bounded for catalogs that reference a very large number of items.
- *
+ * Reads the content of the catalog and returns all of its catalog items.
  * @param catalogUrl - the catalog s3 url
- * @param offset - the index of the first item to read
- * @param limit - the maximum number of items to read
  * @param logger - optional logger
- * @returns the page of items and the catalog's total item count
  */
-export async function readCatalogItemsPage(
-  catalogUrl: string, offset: number, limit: number, logger?: Logger,
-): Promise<{ items: StacItem[]; total: number }> {
-  const s3 = objectStoreForProtocol('s3');
-  const itemUrls = await getCatalogItemUrls(catalogUrl);
-  const total = itemUrls.length;
-  const pageUrls = itemUrls.slice(offset, offset + limit);
-  logger?.info(`readCatalogItemsPage reading ${pageUrls.length} of ${total} items (offset ${offset}) in CatalogUrl ${catalogUrl}.`);
+export async function readCatalogItems(catalogUrl: string): Promise<StacItem[]> {
+  const childLinks = await getCatalogItemUrls(catalogUrl);
 
-  const items: StacItem[] = [];
-  for (const link of pageUrls) {
-    const itemUrl = resolve(catalogUrl, link); // link has a relative path "./itemFile.json"
-    const item = await s3.getObjectJson(itemUrl) as StacItem;
-    items.push(item);
-  }
-
-  return { items, total };
+  return readItemsAtUrls(catalogUrl, childLinks);
 }
 
 /**

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -40,8 +40,8 @@ let inputPagedWiId: number;
 let destWiId: number;
 
 // Number of output catalogs staged for the paged-output work item, chosen to
-// span more than one page given the 10-catalog page size (ceil(25/10) = 3).
-const PAGED_OUTPUT_CATALOGS = 25;
+// span more than one page given the 50-catalog page size (ceil(60/50) = 2).
+const PAGED_OUTPUT_CATALOGS = 60;
 
 const joeJob = buildJob({
   username: 'joe',
@@ -75,8 +75,8 @@ const inputPagedJob = buildJob({
   request: 'https://harmony.example/input-paged',
 });
 // Number of items the input catalog references, chosen to span more than one page
-// given the 10-item page size (ceil(25/10) = 3).
-const INPUT_CATALOG_ITEMS = 25;
+// given the 50-item page size (ceil(60/50) = 2).
+const INPUT_CATALOG_ITEMS = 60;
 
 // Job written to a user-supplied destinationUrl bucket: its output catalog's
 // data asset is an s3:// href that createPublicPermalink can't sign (not under
@@ -632,14 +632,14 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const wi = body.steps[0].workItems[0];
-      // 25 catalogs over a 10-catalog page: page 1 resolves exactly 10 files
+      // 60 catalogs over a 50-catalog page: page 1 resolves exactly 50 files
       // (one data asset per catalog), proving the rest were not read.
-      expect(wi.outputFiles).to.have.lengthOf(10);
+      expect(wi.outputFiles).to.have.lengthOf(50);
       expect(wi.outputFiles[0]).to.equal('https://example.com/granule0.nc4');
-      expect(wi.outputFiles[9]).to.equal('https://example.com/granule9.nc4');
+      expect(wi.outputFiles[49]).to.equal('https://example.com/granule49.nc4');
       expect(wi.outputFilesPaging.currentPage).to.equal(1);
-      expect(wi.outputFilesPaging.lastPage).to.equal(3); // ceil(25 / 10)
-      expect(wi.outputFilesPaging.total).to.equal(25);
+      expect(wi.outputFilesPaging.lastPage).to.equal(2); // ceil(60 / 50)
+      expect(wi.outputFilesPaging.total).to.equal(60);
       const next = wi.outputFilesPaging.links.find((l) => l.rel === 'next');
       expect(next.href).to.include(`workitem${pagedOutputWiId}page=2`);
       expect(wi.outputFilesPaging.links.find((l) => l.rel === 'prev')).to.be.undefined;
@@ -658,13 +658,13 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const wi = body.steps[0].workItems[0];
-      // 25 catalogs over a 5-catalog page: page 1 resolves exactly 5 files.
+      // 60 catalogs over a 5-catalog page: page 1 resolves exactly 5 files.
       expect(wi.outputFiles).to.have.lengthOf(5);
       expect(wi.outputFiles[0]).to.equal('https://example.com/granule0.nc4');
       expect(wi.outputFiles[4]).to.equal('https://example.com/granule4.nc4');
       expect(wi.outputFilesPaging.currentPage).to.equal(1);
-      expect(wi.outputFilesPaging.lastPage).to.equal(5); // ceil(25 / 5)
-      expect(wi.outputFilesPaging.total).to.equal(25);
+      expect(wi.outputFilesPaging.lastPage).to.equal(12); // ceil(60 / 5)
+      expect(wi.outputFilesPaging.total).to.equal(60);
     });
 
   });
@@ -673,7 +673,7 @@ describe('GET /jobs/:jobID/steps', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
         jobID: pagedOutputJob.jobID,
-        query: { workItem: pagedOutputWiId, resolveFiles: 'output', [`workItem${pagedOutputWiId}Page`]: 3 },
+        query: { workItem: pagedOutputWiId, resolveFiles: 'output', [`workItem${pagedOutputWiId}Page`]: 2 },
       }).use(auth({ username: 'joe' }));
     });
     after(function () { delete this.res; });
@@ -682,11 +682,11 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const wi = body.steps[0].workItems[0];
-      expect(wi.outputFiles).to.have.lengthOf(5); // catalogs 20..24
-      expect(wi.outputFiles[0]).to.equal('https://example.com/granule20.nc4');
-      expect(wi.outputFilesPaging.currentPage).to.equal(3);
+      expect(wi.outputFiles).to.have.lengthOf(10); // catalogs 50..59
+      expect(wi.outputFiles[0]).to.equal('https://example.com/granule50.nc4');
+      expect(wi.outputFilesPaging.currentPage).to.equal(2);
       expect(wi.outputFilesPaging.links.find((l) => l.rel === 'prev').href)
-        .to.include(`workitem${pagedOutputWiId}page=2`);
+        .to.include(`workitem${pagedOutputWiId}page=1`);
       expect(wi.outputFilesPaging.links.find((l) => l.rel === 'next')).to.be.undefined;
     });
   });
@@ -704,9 +704,9 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const wi = body.steps[0].workItems[0];
-      expect(wi.outputFiles).to.have.lengthOf(5);
-      expect(wi.outputFilesPaging.currentPage).to.equal(3);
-      expect(wi.outputFilesPaging.lastPage).to.equal(3);
+      expect(wi.outputFiles).to.have.lengthOf(10);
+      expect(wi.outputFilesPaging.currentPage).to.equal(2);
+      expect(wi.outputFilesPaging.lastPage).to.equal(2);
     });
   });
 
@@ -722,14 +722,14 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const wi = body.steps[0].workItems[0];
-      // 25 items over a 10-item page: page 1 reads exactly 10 items, proving the
+      // 60 items over a 50-item page: page 1 reads exactly 50 items, proving the
       // rest were not read.
-      expect(wi.inputFiles).to.have.lengthOf(10);
+      expect(wi.inputFiles).to.have.lengthOf(50);
       expect(wi.inputFiles[0]).to.equal('https://example.com/input0.nc4');
-      expect(wi.inputFiles[9]).to.equal('https://example.com/input9.nc4');
+      expect(wi.inputFiles[49]).to.equal('https://example.com/input49.nc4');
       expect(wi.inputFilesPaging.currentPage).to.equal(1);
-      expect(wi.inputFilesPaging.lastPage).to.equal(3); // ceil(25 / 10)
-      expect(wi.inputFilesPaging.total).to.equal(25);
+      expect(wi.inputFilesPaging.lastPage).to.equal(2); // ceil(60 / 50)
+      expect(wi.inputFilesPaging.total).to.equal(60);
       const next = wi.inputFilesPaging.links.find((l) => l.rel === 'next');
       expect(next.href).to.include(`workitem${inputPagedWiId}inputpage=2`);
       expect(wi.inputFilesPaging.links.find((l) => l.rel === 'prev')).to.be.undefined;
@@ -740,7 +740,7 @@ describe('GET /jobs/:jobID/steps', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
         jobID: inputPagedJob.jobID,
-        query: { workItem: inputPagedWiId, resolveFiles: 'input', [`workItem${inputPagedWiId}InputPage`]: 3 },
+        query: { workItem: inputPagedWiId, resolveFiles: 'input', [`workItem${inputPagedWiId}InputPage`]: 2 },
       }).use(auth({ username: 'joe' }));
     });
     after(function () { delete this.res; });
@@ -749,11 +749,11 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const wi = body.steps[0].workItems[0];
-      expect(wi.inputFiles).to.have.lengthOf(5); // items 20..24
-      expect(wi.inputFiles[0]).to.equal('https://example.com/input20.nc4');
-      expect(wi.inputFilesPaging.currentPage).to.equal(3);
+      expect(wi.inputFiles).to.have.lengthOf(10); // items 50..59
+      expect(wi.inputFiles[0]).to.equal('https://example.com/input50.nc4');
+      expect(wi.inputFilesPaging.currentPage).to.equal(2);
       expect(wi.inputFilesPaging.links.find((l) => l.rel === 'prev').href)
-        .to.include(`workitem${inputPagedWiId}inputpage=2`);
+        .to.include(`workitem${inputPagedWiId}inputpage=1`);
       expect(wi.inputFilesPaging.links.find((l) => l.rel === 'next')).to.be.undefined;
     });
   });
@@ -771,9 +771,9 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const wi = body.steps[0].workItems[0];
-      expect(wi.inputFiles).to.have.lengthOf(5);
-      expect(wi.inputFilesPaging.currentPage).to.equal(3);
-      expect(wi.inputFilesPaging.lastPage).to.equal(3);
+      expect(wi.inputFiles).to.have.lengthOf(10);
+      expect(wi.inputFilesPaging.currentPage).to.equal(2);
+      expect(wi.inputFilesPaging.lastPage).to.equal(2);
     });
   });
 

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -86,7 +86,7 @@ const destBucketJob = buildJob({
   destination_url: 's3://user-bucket/out',
 });
 
-// Job whose single step has more work items than DEFAULT_PER_PAGE (50), to
+// Job whose single step has more work items than DEFAULT_WORKITEMS_PER_PAGE (50), to
 // exercise per-step paging and the paging links block.
 const pagedJob = buildJob({
   username: 'joe',
@@ -95,8 +95,8 @@ const pagedJob = buildJob({
   request: 'https://harmony.example/paged',
 });
 
-// Job whose single step holds one more work item than MAX_STEP_PAGE_SIZE, so a
-// limit above the max defaults to MAX_STEP_PAGE_SIZE (1000)
+// Job whose single step holds one more work item than MAX_WORKITEMS_PER_PAGE, so a
+// limit above the max defaults to MAX_WORKITEMS_PER_PAGE (1000)
 const BIG_STEP_WORKITEMS = 1001;
 const bigStepJob = buildJob({
   username: 'joe',
@@ -105,7 +105,7 @@ const bigStepJob = buildJob({
   request: 'https://harmony.example/big-step',
 });
 
-// Job with two steps each holding more than DEFAULT_PER_PAGE (50) work items, to
+// Job with two steps each holding more than DEFAULT_WORKITEMS_PER_PAGE (50) work items, to
 // exercise that each step pages independently via its own step<idx>Page param.
 const twoPagedJob = buildJob({
   username: 'joe',
@@ -300,7 +300,7 @@ describe('GET /jobs/:jobID/steps', function () {
     }), stacLoc('item0.json'), null, 'application/json');
 
     // A job whose single step holds 51 READY work items — one over
-    // DEFAULT_PER_PAGE (50). READY items are skipped by catalog resolution, so
+    // DEFAULT_WORKITEMS_PER_PAGE (50). READY items are skipped by catalog resolution, so
     // this stays cheap while still exercising the per-step bound + paging block.
     await pagedJob.save(this.trx);
     const pagedStep = buildWorkflowStep({
@@ -319,8 +319,8 @@ describe('GET /jobs/:jobID/steps', function () {
     }));
     await WorkItem.insertBatch(this.trx, pagedWorkItems);
 
-    // A job whose single step holds one more than MAX_STEP_PAGE_SIZE (1000) READY work
-    // items, used to show a limit above the MAX_STEP_PAGE_SIZE defaults to MAX_STEP_PAGE_SIZE.
+    // A job whose single step holds one more than MAX_WORKITEMS_PER_PAGE (1000) READY work
+    // items, used to show a limit above the MAX_WORKITEMS_PER_PAGE defaults to MAX_WORKITEMS_PER_PAGE.
     await bigStepJob.save(this.trx);
     const bigStep = buildWorkflowStep({
       jobID: bigStepJob.jobID,
@@ -717,7 +717,7 @@ describe('GET /jobs/:jobID/steps', function () {
   describe('For a step with more work items than the per-step limit', function () {
     hookJobSteps({ jobID: pagedJob.jobID, username: 'joe' });
 
-    it('caps the work items at DEFAULT_PER_PAGE and adds a paging block with links', function () {
+    it('caps the work items at DEFAULT_WORKITEMS_PER_PAGE and adds a paging block with links', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const step = body.steps[0];
@@ -764,7 +764,7 @@ describe('GET /jobs/:jobID/steps', function () {
   describe('When ?limit= exceeds the maximum page size', function () {
     hookJobSteps({ jobID: bigStepJob.jobID, username: 'joe', query: { limit: 99999 } });
 
-    it('defaults limit to MAX_STEP_PAGE_SIZE and pages', function () {
+    it('defaults limit to MAX_WORKITEMS_PER_PAGE and pages', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const step = body.steps[0];

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -210,17 +210,17 @@ describe('GET /jobs/:jobID/steps', function () {
     await pagedStore.upload(
       JSON.stringify(catalogList), pagedLoc('batch-catalogs.json'), null, 'application/json',
     );
-    for (let i = 0; i < PAGED_OUTPUT_CATALOGS; i++) {
-      await pagedStore.upload(JSON.stringify({
+    await Promise.all(Array.from({ length: PAGED_OUTPUT_CATALOGS }, (_, i) => Promise.all([
+      pagedStore.upload(JSON.stringify({
         stac_version: '1.0.0', id: `cat${i}`, description: 'c',
         links: [{ rel: 'item', href: `./item${i}.json` }],
-      }), pagedLoc(`catalog${i}.json`), null, 'application/json');
-      await pagedStore.upload(JSON.stringify({
+      }), pagedLoc(`catalog${i}.json`), null, 'application/json'),
+      pagedStore.upload(JSON.stringify({
         stac_version: '1.0.0', id: `item${i}`, type: 'Feature',
         geometry: null, properties: {}, links: [],
         assets: { data: { href: `https://example.com/granule${i}.nc4`, roles: ['data'] } },
-      }), pagedLoc(`item${i}.json`), null, 'application/json');
-    }
+      }), pagedLoc(`item${i}.json`), null, 'application/json'),
+    ])));
 
     // A job whose work item's input catalog references INPUT_CATALOG_ITEMS items,
     // spanning more than one input page. The catalog and every item file are staged

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -229,7 +229,7 @@ describe('GET /jobs/:jobID/steps', function () {
     const inputPagedStep = buildWorkflowStep({
       jobID: inputPagedJob.jobID,
       stepIndex: 1,
-      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      serviceID: 'nasa/batch-aggregator-service:2.4.1',
       workItemCount: 1,
       operation: validOperation,
     });
@@ -238,7 +238,7 @@ describe('GET /jobs/:jobID/steps', function () {
     const inputPagedWi = buildWorkItem({
       jobID: inputPagedJob.jobID,
       workflowStepIndex: 1,
-      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      serviceID: 'nasa/batch-aggregator-service:2.4.1',
       status: WorkItemStatus.SUCCESSFUL,
       stacCatalogLocation: inputCatalogUrl,
     });

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -641,7 +641,7 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(wi.outputFilesPaging.lastPage).to.equal(2); // ceil(60 / 50)
       expect(wi.outputFilesPaging.total).to.equal(60);
       const next = wi.outputFilesPaging.links.find((l) => l.rel === 'next');
-      expect(next.href).to.include(`workitem${pagedOutputWiId}page=2`);
+      expect(next.href).to.include(`workitem${pagedOutputWiId}outputpage=2`);
       expect(wi.outputFilesPaging.links.find((l) => l.rel === 'prev')).to.be.undefined;
     });
   });
@@ -673,7 +673,7 @@ describe('GET /jobs/:jobID/steps', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
         jobID: pagedOutputJob.jobID,
-        query: { workItem: pagedOutputWiId, resolveFiles: 'output', [`workItem${pagedOutputWiId}Page`]: 2 },
+        query: { workItem: pagedOutputWiId, resolveFiles: 'output', [`workItem${pagedOutputWiId}OutputPage`]: 2 },
       }).use(auth({ username: 'joe' }));
     });
     after(function () { delete this.res; });
@@ -686,7 +686,7 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(wi.outputFiles[0]).to.equal('https://example.com/granule50.nc4');
       expect(wi.outputFilesPaging.currentPage).to.equal(2);
       expect(wi.outputFilesPaging.links.find((l) => l.rel === 'prev').href)
-        .to.include(`workitem${pagedOutputWiId}page=1`);
+        .to.include(`workitem${pagedOutputWiId}outputpage=1`);
       expect(wi.outputFilesPaging.links.find((l) => l.rel === 'next')).to.be.undefined;
     });
   });
@@ -695,7 +695,7 @@ describe('GET /jobs/:jobID/steps', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
         jobID: pagedOutputJob.jobID,
-        query: { workItem: pagedOutputWiId, resolveFiles: 'output', [`workItem${pagedOutputWiId}Page`]: 9 },
+        query: { workItem: pagedOutputWiId, resolveFiles: 'output', [`workItem${pagedOutputWiId}OutputPage`]: 9 },
       }).use(auth({ username: 'joe' }));
     });
     after(function () { delete this.res; });

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -36,6 +36,8 @@ const hookAdminJobSteps = hookRequest.bind(this, adminJobSteps);
 let wi1Id: number;
 let wi2Id: number;
 let pagedOutputWiId: number;
+let inputPagedWiId: number;
+let destWiId: number;
 
 // Number of output catalogs staged for the paged-output work item, chosen to
 // span more than one page given the 10-catalog page size (ceil(25/10) = 3).
@@ -64,16 +66,17 @@ const pagedOutputJob = buildJob({
   request: 'https://harmony.example/paged-output',
 });
 
-// Job whose single work item has an input catalog referencing more items than
-// MAX_INPUT_CATALOG_ITEMS, to verify the input read is bounded.
-const inputBoundJob = buildJob({
+// Job whose single work item has an input catalog referencing more items than one
+// input page, to exercise per-work-item input-file paging in resolve mode.
+const inputPagedJob = buildJob({
   username: 'joe',
   status: JobStatus.SUCCESSFUL,
   service_name: 'harmony-best-service',
-  request: 'https://harmony.example/input-bound',
+  request: 'https://harmony.example/input-paged',
 });
-// Keep in sync with MAX_INPUT_CATALOG_ITEMS in app/frontends/steps.ts.
-const MAX_INPUT_CATALOG_ITEMS = 100;
+// Number of items the input catalog references, chosen to span more than one page
+// given the 10-item page size (ceil(25/10) = 3).
+const INPUT_CATALOG_ITEMS = 25;
 
 // Job written to a user-supplied destinationUrl bucket: its output catalog's
 // data asset is an s3:// href that createPublicPermalink can't sign (not under
@@ -219,40 +222,39 @@ describe('GET /jobs/:jobID/steps', function () {
       }), pagedLoc(`item${i}.json`), null, 'application/json');
     }
 
-    // A job whose work item's input catalog references more items than
-    // MAX_INPUT_CATALOG_ITEMS. Only the first MAX_INPUT_CATALOG_ITEMS item files
-    // are staged (the rest are sliced off before any read), so a correct bound
-    // resolves exactly that many input files.
-    await inputBoundJob.save(this.trx);
-    const inputBoundStep = buildWorkflowStep({
-      jobID: inputBoundJob.jobID,
+    // A job whose work item's input catalog references INPUT_CATALOG_ITEMS items,
+    // spanning more than one input page. The catalog and every item file are staged
+    // so input-file paging (resolve mode) resolves real hrefs across pages.
+    await inputPagedJob.save(this.trx);
+    const inputPagedStep = buildWorkflowStep({
+      jobID: inputPagedJob.jobID,
       stepIndex: 1,
       serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
       workItemCount: 1,
       operation: validOperation,
     });
-    await inputBoundStep.save(this.trx);
-    const inputCatalogUrl = `s3://artifacts/${inputBoundJob.jobID}/input/catalog.json`;
-    const inputBoundWi = buildWorkItem({
-      jobID: inputBoundJob.jobID,
+    await inputPagedStep.save(this.trx);
+    const inputCatalogUrl = `s3://artifacts/${inputPagedJob.jobID}/input/catalog.json`;
+    const inputPagedWi = buildWorkItem({
+      jobID: inputPagedJob.jobID,
       workflowStepIndex: 1,
       serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
       status: WorkItemStatus.SUCCESSFUL,
       stacCatalogLocation: inputCatalogUrl,
     });
-    await inputBoundWi.save(this.trx);
+    await inputPagedWi.save(this.trx);
+    inputPagedWiId = inputPagedWi.id;
     const inputStore = objectStoreForProtocol('s3');
-    const overCapItemCount = MAX_INPUT_CATALOG_ITEMS + 5;
     await inputStore.upload(JSON.stringify({
       stac_version: '1.0.0', id: 'input-cat', description: 'c',
-      links: Array.from({ length: overCapItemCount }, (_, i) => ({ rel: 'item', href: `./item${i}.json` })),
+      links: Array.from({ length: INPUT_CATALOG_ITEMS }, (_, i) => ({ rel: 'item', href: `./item${i}.json` })),
     }), inputCatalogUrl, null, 'application/json');
-    await Promise.all(Array.from({ length: MAX_INPUT_CATALOG_ITEMS }, (_, i) =>
+    await Promise.all(Array.from({ length: INPUT_CATALOG_ITEMS }, (_, i) =>
       inputStore.upload(JSON.stringify({
         stac_version: '1.0.0', id: `input-item${i}`, type: 'Feature',
         geometry: null, properties: {}, links: [],
         assets: { data: { href: `https://example.com/input${i}.nc4`, roles: ['data'] } },
-      }), `s3://artifacts/${inputBoundJob.jobID}/input/item${i}.json`, null, 'application/json')));
+      }), `s3://artifacts/${inputPagedJob.jobID}/input/item${i}.json`, null, 'application/json')));
 
     // A job with a destinationUrl with a data asset is an s3:// href in
     // the user's destination bucket. Its single step has both a successful and
@@ -273,6 +275,7 @@ describe('GET /jobs/:jobID/steps', function () {
       status: WorkItemStatus.SUCCESSFUL,
     });
     await destWi.save(this.trx);
+    destWiId = destWi.id;
     const destFailedWi = buildWorkItem({
       jobID: destBucketJob.jobID,
       workflowStepIndex: 1,
@@ -435,17 +438,22 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(body.steps[1].statuses).to.deep.equal({ failed: 1 });
     });
 
-    it('exposes inputFiles / outputFiles fields', function () {
+    it('exposes link-only inputFilesUrl / outputFilesUrl fields and no inline files', function () {
       const body = JSON.parse(this.res.text);
       const wi1 = body.steps[0].workItems[0];
       const wi2 = body.steps[1].workItems[0];
-      expect(wi1).to.have.property('inputFiles');
-      expect(wi1).to.have.property('outputFiles');
-      expect(wi1.inputFiles).to.be.null;
-      expect(wi1.outputFiles).to.be.an('array');
-      expect(wi2).to.have.property('inputFiles');
-      expect(wi2.inputFiles).to.be.an('array');
-      expect(wi2).to.have.property('outputFiles');
+      // The overview does no S3 reads: it never embeds inline files.
+      expect(wi1).to.not.have.property('inputFiles');
+      expect(wi1).to.not.have.property('outputFiles');
+      // wi1 (query-cmr, successful, no STAC input): no input link, output link present.
+      expect(wi1.inputFilesUrl).to.be.null;
+      expect(wi1.outputFilesUrl).to.include(`workitem=${wi1Id}`);
+      expect(wi1.outputFilesUrl).to.include('resolvefiles=output');
+      // wi2 (failed, has an input catalog): both links present (failed is completed).
+      expect(wi2.inputFilesUrl).to.include(`workitem=${wi2Id}`);
+      expect(wi2.inputFilesUrl).to.include('resolvefiles=input');
+      expect(wi2.outputFilesUrl).to.include(`workitem=${wi2Id}`);
+      expect(wi2.outputFilesUrl).to.include('resolvefiles=output');
     });
 
   });
@@ -531,13 +539,14 @@ describe('GET /jobs/:jobID/steps', function () {
 
   describe('For a job whose work item is still incomplete', function () {
     hookJobSteps({ jobID: runningJob.jobID, username: 'joe' });
-    it('leaves outputFiles as null and does not attempt resolution', function () {
+    it('leaves both file links null (no input, not yet completed)', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const wi = body.steps[0].workItems[0];
       expect(wi.status).to.equal('ready');
-      expect(wi.outputFiles).to.equal(null);
-      expect(wi.inputFiles).to.equal(null);
+      // Not completed -> no output link; no STAC input -> no input link.
+      expect(wi.outputFilesUrl).to.equal(null);
+      expect(wi.inputFilesUrl).to.equal(null);
     });
   });
 
@@ -611,8 +620,13 @@ describe('GET /jobs/:jobID/steps', function () {
     });
   });
 
-  describe('For a work item with more than one page of output catalogs', function () {
-    hookJobSteps({ jobID: pagedOutputJob.jobID, username: 'joe' });
+  describe('Resolving a work item with more than one page of output catalogs', function () {
+    before(async function () {
+      this.res = await jobSteps(this.frontend, {
+        jobID: pagedOutputJob.jobID, query: { workItem: pagedOutputWiId, resolveFiles: 'output' },
+      }).use(auth({ username: 'joe' }));
+    });
+    after(function () { delete this.res; });
 
     it('returns only the first page of output files and an outputFilesPaging block', function () {
       expect(this.res.statusCode).to.equal(200);
@@ -633,7 +647,12 @@ describe('GET /jobs/:jobID/steps', function () {
   });
 
   describe('When ?wiLimit= overrides the output-catalog page size', function () {
-    hookJobSteps({ jobID: pagedOutputJob.jobID, username: 'joe', query: { wiLimit: 5 } });
+    before(async function () {
+      this.res = await jobSteps(this.frontend, {
+        jobID: pagedOutputJob.jobID, query: { workItem: pagedOutputWiId, resolveFiles: 'output', wiLimit: 5 },
+      }).use(auth({ username: 'joe' }));
+    });
+    after(function () { delete this.res; });
 
     it('pages the output files using the requested size', function () {
       expect(this.res.statusCode).to.equal(200);
@@ -653,7 +672,8 @@ describe('GET /jobs/:jobID/steps', function () {
   describe('Requesting the last page of a work item\'s output files', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
-        jobID: pagedOutputJob.jobID, query: { [`workItem${pagedOutputWiId}Page`]: 3 },
+        jobID: pagedOutputJob.jobID,
+        query: { workItem: pagedOutputWiId, resolveFiles: 'output', [`workItem${pagedOutputWiId}Page`]: 3 },
       }).use(auth({ username: 'joe' }));
     });
     after(function () { delete this.res; });
@@ -674,7 +694,8 @@ describe('GET /jobs/:jobID/steps', function () {
   describe('Requesting an output-file page past the last page', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
-        jobID: pagedOutputJob.jobID, query: { [`workItem${pagedOutputWiId}Page`]: 9 },
+        jobID: pagedOutputJob.jobID,
+        query: { workItem: pagedOutputWiId, resolveFiles: 'output', [`workItem${pagedOutputWiId}Page`]: 9 },
       }).use(auth({ username: 'joe' }));
     });
     after(function () { delete this.res; });
@@ -689,20 +710,80 @@ describe('GET /jobs/:jobID/steps', function () {
     });
   });
 
-  describe('For a work item whose input catalog exceeds the input item bound', function () {
-    hookJobSteps({ jobID: inputBoundJob.jobID, username: 'joe' });
+  describe('Resolving a work item with more than one page of input items', function () {
+    before(async function () {
+      this.res = await jobSteps(this.frontend, {
+        jobID: inputPagedJob.jobID, query: { workItem: inputPagedWiId, resolveFiles: 'input' },
+      }).use(auth({ username: 'joe' }));
+    });
+    after(function () { delete this.res; });
 
-    it('resolves at most MAX_INPUT_CATALOG_ITEMS input files', function () {
+    it('returns only the first page of input files and an inputFilesPaging block', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const wi = body.steps[0].workItems[0];
-      expect(wi.inputFiles).to.have.lengthOf(MAX_INPUT_CATALOG_ITEMS);
+      // 25 items over a 10-item page: page 1 reads exactly 10 items, proving the
+      // rest were not read.
+      expect(wi.inputFiles).to.have.lengthOf(10);
       expect(wi.inputFiles[0]).to.equal('https://example.com/input0.nc4');
+      expect(wi.inputFiles[9]).to.equal('https://example.com/input9.nc4');
+      expect(wi.inputFilesPaging.currentPage).to.equal(1);
+      expect(wi.inputFilesPaging.lastPage).to.equal(3); // ceil(25 / 10)
+      expect(wi.inputFilesPaging.total).to.equal(25);
+      const next = wi.inputFilesPaging.links.find((l) => l.rel === 'next');
+      expect(next.href).to.include(`workitem${inputPagedWiId}inputpage=2`);
+      expect(wi.inputFilesPaging.links.find((l) => l.rel === 'prev')).to.be.undefined;
+    });
+  });
+
+  describe('Requesting the last page of a work item\'s input files', function () {
+    before(async function () {
+      this.res = await jobSteps(this.frontend, {
+        jobID: inputPagedJob.jobID,
+        query: { workItem: inputPagedWiId, resolveFiles: 'input', [`workItem${inputPagedWiId}InputPage`]: 3 },
+      }).use(auth({ username: 'joe' }));
+    });
+    after(function () { delete this.res; });
+
+    it('returns the remaining input files with a prev link and no next', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const wi = body.steps[0].workItems[0];
+      expect(wi.inputFiles).to.have.lengthOf(5); // items 20..24
+      expect(wi.inputFiles[0]).to.equal('https://example.com/input20.nc4');
+      expect(wi.inputFilesPaging.currentPage).to.equal(3);
+      expect(wi.inputFilesPaging.links.find((l) => l.rel === 'prev').href)
+        .to.include(`workitem${inputPagedWiId}inputpage=2`);
+      expect(wi.inputFilesPaging.links.find((l) => l.rel === 'next')).to.be.undefined;
+    });
+  });
+
+  describe('Requesting an input-file page past the last page', function () {
+    before(async function () {
+      this.res = await jobSteps(this.frontend, {
+        jobID: inputPagedJob.jobID,
+        query: { workItem: inputPagedWiId, resolveFiles: 'input', [`workItem${inputPagedWiId}InputPage`]: 9 },
+      }).use(auth({ username: 'joe' }));
+    });
+    after(function () { delete this.res; });
+
+    it('returns the last page instead of an empty page', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const wi = body.steps[0].workItems[0];
+      expect(wi.inputFiles).to.have.lengthOf(5);
+      expect(wi.inputFilesPaging.currentPage).to.equal(3);
+      expect(wi.inputFilesPaging.lastPage).to.equal(3);
     });
   });
 
   describe('For a job written to a user destinationUrl bucket', function () {
-    hookJobSteps({ jobID: destBucketJob.jobID, username: 'joe' });
+    before(async function () {
+      this.res = await jobSteps(this.frontend, {
+        jobID: destBucketJob.jobID, query: { workItem: destWiId, resolveFiles: 'output' },
+      }).use(auth({ username: 'joe' }));
+    });
+    after(function () { delete this.res; });
 
     it('displays a generic asset and passes the destination-bucket href through', function () {
       expect(this.res.statusCode).to.equal(200);
@@ -917,8 +998,45 @@ describe('GET /jobs/:jobID/steps', function () {
         const response = JSON.parse(this.res.text);
         expect(response).to.eql({
           code: 'harmony.RequestValidationError',
-          description: 'Error: Invalid parameter(s): staus. Allowed parameters are: step, status, workItem, limit, and wiLimit.',
+          description: 'Error: Invalid parameter(s): staus. Allowed parameters are: step, status, workItem, limit, wiLimit, and resolveFiles.',
         });
+      });
+    });
+
+    describe('?resolveFiles=bogus (invalid value)', function () {
+      hookJobSteps({
+        jobID: joeJob.jobID, username: 'joe', query: { workItem: 1, resolveFiles: 'bogus' },
+      });
+      it('returns 400', function () {
+        expect(this.res.statusCode).to.equal(400);
+      });
+    });
+
+    describe('?resolveFiles=input without a workItem filter', function () {
+      hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { resolveFiles: 'input' } });
+      it('returns 400', function () {
+        expect(this.res.statusCode).to.equal(400);
+      });
+
+      it('explains that exactly one workItem is required', function () {
+        const response = JSON.parse(this.res.text);
+        expect(response).to.eql({
+          code: 'harmony.RequestValidationError',
+          description: 'Error: resolveFiles requires exactly one workItem',
+        });
+      });
+    });
+
+    describe('?resolveFiles=input with more than one workItem', function () {
+      before(async function () {
+        this.res = await jobSteps(this.frontend, {
+          jobID: joeJob.jobID, query: { workItem: `${wi1Id},${wi2Id}`, resolveFiles: 'input' },
+        }).use(auth({ username: 'joe' }));
+      });
+      after(function () { delete this.res; });
+
+      it('returns 400', function () {
+        expect(this.res.statusCode).to.equal(400);
       });
     });
 

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -632,6 +632,24 @@ describe('GET /jobs/:jobID/steps', function () {
     });
   });
 
+  describe('When ?wiLimit= overrides the output-catalog page size', function () {
+    hookJobSteps({ jobID: pagedOutputJob.jobID, username: 'joe', query: { wiLimit: 5 } });
+
+    it('pages the output files using the requested size', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const wi = body.steps[0].workItems[0];
+      // 25 catalogs over a 5-catalog page: page 1 resolves exactly 5 files.
+      expect(wi.outputFiles).to.have.lengthOf(5);
+      expect(wi.outputFiles[0]).to.equal('https://example.com/granule0.nc4');
+      expect(wi.outputFiles[4]).to.equal('https://example.com/granule4.nc4');
+      expect(wi.outputFilesPaging.currentPage).to.equal(1);
+      expect(wi.outputFilesPaging.lastPage).to.equal(5); // ceil(25 / 5)
+      expect(wi.outputFilesPaging.total).to.equal(25);
+    });
+
+  });
+
   describe('Requesting the last page of a work item\'s output files', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
@@ -899,7 +917,7 @@ describe('GET /jobs/:jobID/steps', function () {
         const response = JSON.parse(this.res.text);
         expect(response).to.eql({
           code: 'harmony.RequestValidationError',
-          description: 'Error: Invalid parameter(s): staus. Allowed parameters are: step, status, workItem, and limit.',
+          description: 'Error: Invalid parameter(s): staus. Allowed parameters are: step, status, workItem, limit, and wiLimit.',
         });
       });
     });

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -35,6 +35,11 @@ const hookAdminJobSteps = hookRequest.bind(this, adminJobSteps);
 
 let wi1Id: number;
 let wi2Id: number;
+let pagedOutputWiId: number;
+
+// Number of output catalogs staged for the paged-output work item, chosen to
+// span more than one page given the 10-catalog page size (ceil(25/10) = 3).
+const PAGED_OUTPUT_CATALOGS = 25;
 
 const joeJob = buildJob({
   username: 'joe',
@@ -50,14 +55,25 @@ const runningJob = buildJob({
   request: 'https://harmony.example/running',
 });
 
-// Job exercising the batch-catalogs truncation path: a successful query-cmr WI
-// whose batch-catalogs.json lists more catalog files than MAX_BATCH_CATALOGS.
-const truncatedJob = buildJob({
+// Job exercising per-work-item output-file paging: a successful query-cmr WI
+// whose batch-catalogs.json lists more catalog files than one output page.
+const pagedOutputJob = buildJob({
   username: 'joe',
   status: JobStatus.SUCCESSFUL,
   service_name: 'harmony-best-service',
-  request: 'https://harmony.example/truncated',
+  request: 'https://harmony.example/paged-output',
 });
+
+// Job whose single work item has an input catalog referencing more items than
+// MAX_INPUT_CATALOG_ITEMS, to verify the input read is bounded.
+const inputBoundJob = buildJob({
+  username: 'joe',
+  status: JobStatus.SUCCESSFUL,
+  service_name: 'harmony-best-service',
+  request: 'https://harmony.example/input-bound',
+});
+// Keep in sync with MAX_INPUT_CATALOG_ITEMS in app/frontends/steps.ts.
+const MAX_INPUT_CATALOG_ITEMS = 100;
 
 // Job written to a user-supplied destinationUrl bucket: its output catalog's
 // data asset is an s3:// href that createPublicPermalink can't sign (not under
@@ -162,34 +178,81 @@ describe('GET /jobs/:jobID/steps', function () {
     });
     await runningWi.save(this.trx);
 
-    // A third job whose query-cmr WI has 105 catalog files listed in
-    // batch-catalogs.json — 5 over MAX_BATCH_CATALOGS (5). (The catalog
-    // files themselves are not staged.)
-    await truncatedJob.save(this.trx);
-    const truncatedStep = buildWorkflowStep({
-      jobID: truncatedJob.jobID,
+    // A third job whose query-cmr WI fans out to PAGED_OUTPUT_CATALOGS catalog
+    // files, each referencing one item with one data asset. Both the
+    // batch-catalogs.json index and every catalog/item file are staged so
+    // output-file paging resolves real hrefs across multiple pages.
+    await pagedOutputJob.save(this.trx);
+    const pagedOutputStep = buildWorkflowStep({
+      jobID: pagedOutputJob.jobID,
       stepIndex: 1,
       serviceID: 'harmonyservices/query-cmr:latest',
       workItemCount: 1,
       operation: validOperation,
     });
-    await truncatedStep.save(this.trx);
-    const truncatedWi = buildWorkItem({
-      jobID: truncatedJob.jobID,
+    await pagedOutputStep.save(this.trx);
+    const pagedOutputWi = buildWorkItem({
+      jobID: pagedOutputJob.jobID,
       workflowStepIndex: 1,
       serviceID: 'harmonyservices/query-cmr:latest',
       status: WorkItemStatus.SUCCESSFUL,
       scrollID: 'fake-scroll-key',
     });
-    await truncatedWi.save(this.trx);
-    const overCapCatalogList = Array.from({ length: 100 }, (_, i) => `catalog${i}.json`);
-    const batchUrl = getStacLocation(
-      { id: truncatedWi.id, jobID: truncatedJob.jobID },
-      'batch-catalogs.json',
+    await pagedOutputWi.save(this.trx);
+    pagedOutputWiId = pagedOutputWi.id;
+    const pagedStore = objectStoreForProtocol('s3');
+    const pagedLoc = (f: string): string =>
+      getStacLocation({ id: pagedOutputWi.id, jobID: pagedOutputJob.jobID }, f);
+    const catalogList = Array.from({ length: PAGED_OUTPUT_CATALOGS }, (_, i) => `catalog${i}.json`);
+    await pagedStore.upload(
+      JSON.stringify(catalogList), pagedLoc('batch-catalogs.json'), null, 'application/json',
     );
-    await objectStoreForProtocol('s3').upload(
-      JSON.stringify(overCapCatalogList), batchUrl, null, 'application/json',
-    );
+    for (let i = 0; i < PAGED_OUTPUT_CATALOGS; i++) {
+      await pagedStore.upload(JSON.stringify({
+        stac_version: '1.0.0', id: `cat${i}`, description: 'c',
+        links: [{ rel: 'item', href: `./item${i}.json` }],
+      }), pagedLoc(`catalog${i}.json`), null, 'application/json');
+      await pagedStore.upload(JSON.stringify({
+        stac_version: '1.0.0', id: `item${i}`, type: 'Feature',
+        geometry: null, properties: {}, links: [],
+        assets: { data: { href: `https://example.com/granule${i}.nc4`, roles: ['data'] } },
+      }), pagedLoc(`item${i}.json`), null, 'application/json');
+    }
+
+    // A job whose work item's input catalog references more items than
+    // MAX_INPUT_CATALOG_ITEMS. Only the first MAX_INPUT_CATALOG_ITEMS item files
+    // are staged (the rest are sliced off before any read), so a correct bound
+    // resolves exactly that many input files.
+    await inputBoundJob.save(this.trx);
+    const inputBoundStep = buildWorkflowStep({
+      jobID: inputBoundJob.jobID,
+      stepIndex: 1,
+      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      workItemCount: 1,
+      operation: validOperation,
+    });
+    await inputBoundStep.save(this.trx);
+    const inputCatalogUrl = `s3://artifacts/${inputBoundJob.jobID}/input/catalog.json`;
+    const inputBoundWi = buildWorkItem({
+      jobID: inputBoundJob.jobID,
+      workflowStepIndex: 1,
+      serviceID: 'nasa/harmony-opendap-subsetter:1.2.4',
+      status: WorkItemStatus.SUCCESSFUL,
+      stacCatalogLocation: inputCatalogUrl,
+    });
+    await inputBoundWi.save(this.trx);
+    const inputStore = objectStoreForProtocol('s3');
+    const overCapItemCount = MAX_INPUT_CATALOG_ITEMS + 5;
+    await inputStore.upload(JSON.stringify({
+      stac_version: '1.0.0', id: 'input-cat', description: 'c',
+      links: Array.from({ length: overCapItemCount }, (_, i) => ({ rel: 'item', href: `./item${i}.json` })),
+    }), inputCatalogUrl, null, 'application/json');
+    await Promise.all(Array.from({ length: MAX_INPUT_CATALOG_ITEMS }, (_, i) =>
+      inputStore.upload(JSON.stringify({
+        stac_version: '1.0.0', id: `input-item${i}`, type: 'Feature',
+        geometry: null, properties: {}, links: [],
+        assets: { data: { href: `https://example.com/input${i}.nc4`, roles: ['data'] } },
+      }), `s3://artifacts/${inputBoundJob.jobID}/input/item${i}.json`, null, 'application/json')));
 
     // A job with a destinationUrl with a data asset is an s3:// href in
     // the user's destination bucket. Its single step has both a successful and
@@ -548,16 +611,75 @@ describe('GET /jobs/:jobID/steps', function () {
     });
   });
 
-  describe('When batch-catalogs.json exceeds MAX_BATCH_CATALOGS', function () {
-    hookJobSteps({ jobID: truncatedJob.jobID, username: 'joe' });
+  describe('For a work item with more than one page of output catalogs', function () {
+    hookJobSteps({ jobID: pagedOutputJob.jobID, username: 'joe' });
 
-    it('includes a truncation warning when outputFiles in incomplete', function () {
+    it('returns only the first page of output files and an outputFilesPaging block', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
-      const { outputFiles, warning } = body.steps[0].workItems[0];
-      expect(outputFiles).to.be.an('array');
-      expect(warning).to.equal('Not all output files are included. Only the outputs from the first ' +
-        '5 STAC catalogs were resolved, there are 95 catalogs that were not resolved.');
+      const wi = body.steps[0].workItems[0];
+      // 25 catalogs over a 10-catalog page: page 1 resolves exactly 10 files
+      // (one data asset per catalog), proving the rest were not read.
+      expect(wi.outputFiles).to.have.lengthOf(10);
+      expect(wi.outputFiles[0]).to.equal('https://example.com/granule0.nc4');
+      expect(wi.outputFiles[9]).to.equal('https://example.com/granule9.nc4');
+      expect(wi.outputFilesPaging.currentPage).to.equal(1);
+      expect(wi.outputFilesPaging.lastPage).to.equal(3); // ceil(25 / 10)
+      expect(wi.outputFilesPaging.total).to.equal(25);
+      const next = wi.outputFilesPaging.links.find((l) => l.rel === 'next');
+      expect(next.href).to.include(`workitem${pagedOutputWiId}page=2`);
+      expect(wi.outputFilesPaging.links.find((l) => l.rel === 'prev')).to.be.undefined;
+    });
+  });
+
+  describe('Requesting the last page of a work item\'s output files', function () {
+    before(async function () {
+      this.res = await jobSteps(this.frontend, {
+        jobID: pagedOutputJob.jobID, query: { [`workItem${pagedOutputWiId}Page`]: 3 },
+      }).use(auth({ username: 'joe' }));
+    });
+    after(function () { delete this.res; });
+
+    it('returns the remaining output files with prev/first links and no next', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const wi = body.steps[0].workItems[0];
+      expect(wi.outputFiles).to.have.lengthOf(5); // catalogs 20..24
+      expect(wi.outputFiles[0]).to.equal('https://example.com/granule20.nc4');
+      expect(wi.outputFilesPaging.currentPage).to.equal(3);
+      expect(wi.outputFilesPaging.links.find((l) => l.rel === 'prev').href)
+        .to.include(`workitem${pagedOutputWiId}page=2`);
+      expect(wi.outputFilesPaging.links.find((l) => l.rel === 'next')).to.be.undefined;
+    });
+  });
+
+  describe('Requesting an output-file page past the last page', function () {
+    before(async function () {
+      this.res = await jobSteps(this.frontend, {
+        jobID: pagedOutputJob.jobID, query: { [`workItem${pagedOutputWiId}Page`]: 9 },
+      }).use(auth({ username: 'joe' }));
+    });
+    after(function () { delete this.res; });
+
+    it('returns the last page instead of an empty page', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const wi = body.steps[0].workItems[0];
+      expect(wi.outputFiles).to.have.lengthOf(5);
+      expect(wi.outputFilesPaging.currentPage).to.equal(3);
+      expect(wi.outputFilesPaging.lastPage).to.equal(3);
+    });
+  });
+
+  describe('For a work item whose input catalog exceeds the input item bound', function () {
+    hookJobSteps({ jobID: inputBoundJob.jobID, username: 'joe' });
+
+    it('resolves at most MAX_INPUT_CATALOG_ITEMS input files', function () {
+      expect(this.res.statusCode).to.equal(200);
+      const body = JSON.parse(this.res.text);
+      const wi = body.steps[0].workItems[0];
+      expect(wi.inputFiles).to.have.lengthOf(MAX_INPUT_CATALOG_ITEMS);
+      expect(wi.inputFiles[0]).to.equal('https://example.com/input0.nc4');
     });
   });
 
@@ -567,9 +689,10 @@ describe('GET /jobs/:jobID/steps', function () {
     it('displays a generic asset and passes the destination-bucket href through', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
-      const { outputFiles, warning } = body.steps[0].workItems[0];
-      expect(outputFiles).to.deep.equal(['s3://user-bucket/out/granule_reformatted.tif']);
-      expect(warning).not.to.exist;
+      const workItem = body.steps[0].workItems[0];
+      expect(workItem.outputFiles).to.deep.equal(['s3://user-bucket/out/granule_reformatted.tif']);
+      // A single output catalog means there is only one page, so no paging block.
+      expect(workItem).to.not.have.property('outputFilesPaging');
     });
 
     it('summarizes both statuses present in the step', function () {

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -211,10 +211,13 @@ describe('GET /jobs/:jobID/steps', function () {
       JSON.stringify(catalogList), pagedLoc('batch-catalogs.json'), null, 'application/json',
     );
     await Promise.all(Array.from({ length: PAGED_OUTPUT_CATALOGS }, (_, i) => Promise.all([
+      // create individual stac catalogs listed in the batch-catalogs pointing
+      // at the item[n].json files
       pagedStore.upload(JSON.stringify({
         stac_version: '1.0.0', id: `cat${i}`, description: 'c',
         links: [{ rel: 'item', href: `./item${i}.json` }],
       }), pagedLoc(`catalog${i}.json`), null, 'application/json'),
+      // create the item[n].json catalogs with the file's href in it.
       pagedStore.upload(JSON.stringify({
         stac_version: '1.0.0', id: `item${i}`, type: 'Feature',
         geometry: null, properties: {}, links: [],
@@ -234,7 +237,8 @@ describe('GET /jobs/:jobID/steps', function () {
       operation: validOperation,
     });
     await inputPagedStep.save(this.trx);
-    const inputCatalogUrl = `s3://artifacts/${inputPagedJob.jobID}/input/catalog.json`;
+    const inputLoc = (f: string): string => `s3://artifacts/${inputPagedJob.jobID}/input/${f}`;
+    const inputCatalogUrl = inputLoc('catalog.json');
     const inputPagedWi = buildWorkItem({
       jobID: inputPagedJob.jobID,
       workflowStepIndex: 1,
@@ -254,7 +258,7 @@ describe('GET /jobs/:jobID/steps', function () {
         stac_version: '1.0.0', id: `input-item${i}`, type: 'Feature',
         geometry: null, properties: {}, links: [],
         assets: { data: { href: `https://example.com/input${i}.nc4`, roles: ['data'] } },
-      }), `s3://artifacts/${inputPagedJob.jobID}/input/item${i}.json`, null, 'application/json')));
+      }), inputLoc(`item${i}.json`), null, 'application/json')));
 
     // A job with a destinationUrl with a data asset is an s3:// href in
     // the user's destination bucket. Its single step has both a successful and
@@ -442,14 +446,14 @@ describe('GET /jobs/:jobID/steps', function () {
       const body = JSON.parse(this.res.text);
       const wi1 = body.steps[0].workItems[0];
       const wi2 = body.steps[1].workItems[0];
-      // The overview does no S3 reads: it never embeds inline files.
+
       expect(wi1).to.not.have.property('inputFiles');
       expect(wi1).to.not.have.property('outputFiles');
-      // wi1 (query-cmr, successful, no STAC input): no input link, output link present.
+
       expect(wi1.inputFilesUrl).to.be.null;
       expect(wi1.outputFilesUrl).to.include(`workitem=${wi1Id}`);
       expect(wi1.outputFilesUrl).to.include('resolvefiles=output');
-      // wi2 (failed, has an input catalog): both links present (failed is completed).
+
       expect(wi2.inputFilesUrl).to.include(`workitem=${wi2Id}`);
       expect(wi2.inputFilesUrl).to.include('resolvefiles=input');
       expect(wi2.outputFilesUrl).to.include(`workitem=${wi2Id}`);
@@ -539,12 +543,12 @@ describe('GET /jobs/:jobID/steps', function () {
 
   describe('For a job whose work item is still incomplete', function () {
     hookJobSteps({ jobID: runningJob.jobID, username: 'joe' });
-    it('leaves both file links null (no input, not yet completed)', function () {
+    it('leaves both input and ouput file links as null', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const wi = body.steps[0].workItems[0];
       expect(wi.status).to.equal('ready');
-      // Not completed -> no output link; no STAC input -> no input link.
+
       expect(wi.outputFilesUrl).to.equal(null);
       expect(wi.inputFilesUrl).to.equal(null);
     });
@@ -633,7 +637,6 @@ describe('GET /jobs/:jobID/steps', function () {
       const body = JSON.parse(this.res.text);
       const wi = body.steps[0].workItems[0];
       // 60 catalogs over a 50-catalog page: page 1 resolves exactly 50 files
-      // (one data asset per catalog), proving the rest were not read.
       expect(wi.outputFiles).to.have.lengthOf(50);
       expect(wi.outputFiles[0]).to.equal('https://example.com/granule0.nc4');
       expect(wi.outputFiles[49]).to.equal('https://example.com/granule49.nc4');
@@ -722,8 +725,7 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const wi = body.steps[0].workItems[0];
-      // 60 items over a 50-item page: page 1 reads exactly 50 items, proving the
-      // rest were not read.
+      // 60 items over a 50-item page: page 1 reads exactly 50 items
       expect(wi.inputFiles).to.have.lengthOf(50);
       expect(wi.inputFiles[0]).to.equal('https://example.com/input0.nc4');
       expect(wi.inputFiles[49]).to.equal('https://example.com/input49.nc4');
@@ -790,7 +792,6 @@ describe('GET /jobs/:jobID/steps', function () {
       const body = JSON.parse(this.res.text);
       const workItem = body.steps[0].workItems[0];
       expect(workItem.outputFiles).to.deep.equal(['s3://user-bucket/out/granule_reformatted.tif']);
-      // A single output catalog means there is only one page, so no paging block.
       expect(workItem).to.not.have.property('outputFilesPaging');
     });
 


### PR DESCRIPTION
## Jira Issue ID

[HARMONY-2352](https://bugs.earthdata.nasa.gov/browse/HARMONY-2352)

## Description

This PR is follow on to allow harmony's step endpoint to handle and allow access to large numbers of input and output files.

To keep the service responsive, instead of resolving the data files for all the steps, we now provide links to a narrowed request that resolves only the input or output items/catalogs for a single workItem.  These files are themselves paged and the values I chose can be tweaked since I just guessed.

(describe the input/output catalog differences.)


## Local Test Steps

Pull this branch and deploy to Harmony-In-A-Box.

Run a request that will generate large output catalogs from query-cmr.

http://localhost:3000/C1234088182-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?format=image%2Ftiff&maxResults=60

Visit the steps endpoint for the job and see that the query-cmr step has a key outputFiles with a link back to the endpoint.
Follow that link and see that there is a paged set of input files.


If you want to see a batched input catalog you need to run batchee and narrow your page limit

http://localhost:3000/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-70%3A30)&subset=lon(-157.5%3A-10)&concatenate=true&maxResults=10&extend=true&serviceId=l2-subsetter-batchee-stitchee-concise

Browse to the batchee step and follow the inputFilesUrl link, see that all of the files are resolved.
add `&wilimit=3` to the end to see the paging for input files.



## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)
* [X] Harmony in a Box tested (if changes made to microservices or new dependencies added)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `resolveFiles` query parameter to the job steps endpoint to resolve per-work-item input/output files on demand.
  * Added `wiLimit` plus per-work-item paging for resolved files (`workItem<id>InputPage` / `workItem<id>OutputPage`), with sensible default/max bounds.

* **API Changes**
  * Default step responses return link-only fields (`inputFilesUrl` / `outputFilesUrl`).
  * Inline resolved `inputFiles` / `outputFiles` are returned only when `resolveFiles` is used with exactly one `workItem`.

* **Documentation**
  * Updated the steps API docs with the new query parameters and response shapes.

* **Tests**
  * Expanded steps endpoint coverage for resolved-file paging and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->