### PR TITLE
HARMONY-2359: Allow temporal or spatial only filters on download service

### DIFF
--- a/services/harmony/app/middleware/service-selection.ts
+++ b/services/harmony/app/middleware/service-selection.ts
@@ -81,6 +81,10 @@ export default function chooseService(
       const configs = addCollectionsToServicesByAssociation(req.context.collections);
       serviceConfig = chooseServiceConfig(operation, context, configs);
     }
+    if (serviceConfig.message) {
+      context.messages = context.messages || [];
+      context.messages.push(serviceConfig.message);
+    }
     context.serviceConfig = serviceConfig;
     return next();
   } catch (e) {

--- a/services/harmony/app/models/harmony-request.ts
+++ b/services/harmony/app/models/harmony-request.ts
@@ -34,7 +34,10 @@ export function addRequestContextToOperation(
 
   operation.requestId = context.id;
   if (req.context.messages.length > 0) {
-    operation.message = req.context.messages.join(' ');
+    const contextMessage = req.context.messages.join(' ');
+    operation.message = operation.message
+      ? `${operation.message} ${contextMessage}`
+      : contextMessage;
   }
   operation.requestStartTime = context.startTime;
   operation.user = req.user || 'anonymous';

--- a/services/harmony/app/models/services/index.ts
+++ b/services/harmony/app/models/services/index.ts
@@ -1035,7 +1035,6 @@ function filterServiceConfigs(
  */
 function requiresStrictCapabilitiesMatching(
   operation: DataOperation,
-  context: RequestContext,
 ): boolean {
   const wantsSpatialSubsetting = requiresSpatialSubsetting(operation)
     || requiresShapefileSubsetting(operation);
@@ -1047,25 +1046,6 @@ function requiresStrictCapabilitiesMatching(
     return true;
   }
 
-  if (wantsSpatialSubsetting && wantsTemporalSubsetting) {
-    // Request wants both optional operations so do not make matching strict
-    return false;
-  }
-
-  if (
-    // Request is only asking for one of temporal or spatial subsetting and
-    // is not asking for any other operation, so force making matching strict
-    !requiresVariableSubsetting(context)
-    && !requiresReprojection(operation)
-    && !requiresReformatting(operation, context)
-    && !requiresConcatenation(operation)
-    && !requiresDimensionSubsetting(operation)
-    && !requiresExtend(operation)
-  ) {
-    return true;
-  }
-
-  // Any other scenario
   return false;
 }
 
@@ -1088,7 +1068,7 @@ export function chooseServiceConfig(
     serviceConfig = filterServiceConfigs(operation, context, configs, allFilterFns);
   } catch (e) {
     if (e instanceof UnsupportedOperation) {
-      if (!requiresStrictCapabilitiesMatching(operation, context)) {
+      if (!requiresStrictCapabilitiesMatching(operation)) {
         // if we couldn't find a matching service, make a best effort to find a service that
         // can do part of what the operation requested
         serviceConfig = filterServiceConfigs(operation, context, configs, requiredFilterFns);

--- a/services/harmony/fixtures/cmr.uat.earthdata.nasa.gov-443/178173357459049799
+++ b/services/harmony/fixtures/cmr.uat.earthdata.nasa.gov-443/178173357459049799
@@ -1,0 +1,31 @@
+POST /search/granules.json
+accept: application/json
+content-type: multipart/form-data; boundary=----------------------------012345678901234567890123
+accept-encoding: gzip,deflate
+body: ------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"page_size\"\r\n\r\n1\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"temporal\"\r\n\r\n1900-01-01T00:00:00.000Z,2100-01-01T00:00:00.000Z\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"bounding_box\"\r\n\r\n-180,-90,180,90\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"collection_concept_id\"\r\n\r\nC1233800302-EEDTEST\r\n------------------------------012345678901234567890123--\r\n
+
+HTTP/1.1 200 OK
+content-type: application/json;charset=utf-8
+connection: keep-alive
+date: Wed, 17 Jun 2026 21:59:34 GMT
+server: ServerTokens ProductOnly
+vary: Accept-Encoding
+x-frame-options: SAMEORIGIN
+access-control-allow-origin: *
+x-xss-protection: 1; mode=block
+cmr-request-id: c5f9139c-551d-48a9-a694-43a4796d00a7
+content-sha1: 9918f823a18cb899ef50670fb3b86dc9f00c2ee7
+strict-transport-security: max-age=31536000; includeSubDomains; preload
+cmr-search-after: ["eedtest",1577836800000,1233800343]
+cmr-hits: 177
+access-control-expose-headers: CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out, CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+x-content-type-options: nosniff
+cmr-took: 38
+x-request-id: c5f9139c-551d-48a9-a694-43a4796d00a7
+content-md5: 208167eb9f30b66b2a313dcaf750ec5b
+x-cache: Miss from cloudfront
+via: 1.1 339b50639d9b4146fda74da7c1df3f92.cloudfront.net (CloudFront)
+x-amz-cf-pop: SFO53-P9
+x-amz-cf-id: 6VzuY2rjQxS21H-rNprc5TdnYBDuaJKvN5GALP-QzQKuk4Vy5ZBGaA==
+
+{"feed":{"updated":"2026-06-17T21:59:34.506Z","id":"https://cmr.uat.earthdata.nasa.gov:443/search/granules.json","title":"ECHO granule metadata","entry":[{"producer_granule_id":"001_00_7f00ff_global","boxes":["-90 -180 90 180"],"time_start":"2020-01-01T00:00:00.000Z","updated":"2020-02-25T21:43:11.000Z","dataset_id":"Harmony Example Data","data_center":"EEDTEST","title":"001_00_7f00ff_global","coordinate_system":"CARTESIAN","day_night_flag":"BOTH","time_end":"2020-01-01T01:59:59.000Z","id":"G1233800343-EEDTEST","original_format":"UMM_JSON","granule_size":"1.3701868057250977","browse_flag":false,"collection_concept_id":"C1233800302-EEDTEST","online_access_flag":true,"links":[{"rel":"http://esipfed.org/ns/fedsearch/1.1/data#","type":"application/x-netcdf","hreflang":"en-US","href":"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/nc/001_00_7f00ff_global.nc"},{"rel":"http://esipfed.org/ns/fedsearch/1.1/data#","type":"image/tiff","hreflang":"en-US","href":"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/tiff/001_00_7f00ff_global.tif"}]}]}}

--- a/services/harmony/test/middleware/service-selection.ts
+++ b/services/harmony/test/middleware/service-selection.ts
@@ -5,6 +5,7 @@ import sinon from 'sinon';
 import chooseService from '../../app/middleware/service-selection';
 import DataOperation from '../../app/models/data-operation';
 import HarmonyRequest from '../../app/models/harmony-request';
+import RequestContext from '../../app/models/request-context';
 import * as serviceUtils from '../../app/models/services';
 import env from '../../app/util/env';
 
@@ -19,7 +20,7 @@ describe('chooseService middleware', () => {
     req = {
       query: {},
       operation: { sources: [] } as unknown as DataOperation,
-      context: { collections: [], collectionIds: [] },
+      context: { collections: [], collectionIds: [], messages: [] },
     };
     res = {};
     nextFunction = sinon.spy();
@@ -82,5 +83,32 @@ describe('chooseService middleware', () => {
     expect(req.context.serviceConfig.collections).to.have.lengthOf(2);
     expect(req.context.serviceConfig.collections[0].id).to.equal('collection1');
     expect(req.context.serviceConfig.collections[1].id).to.equal('collection2');
+  });
+
+  it('should add the service message to context messages when using automatic service selection', () => {
+    req.query = {};
+    req.operation = new DataOperation();
+    req.operation.addSource('C123-TEST', 'harmony_example', '1');
+    req.context = new RequestContext('request-1');
+    req.context.collections = [];
+    req.context.collectionIds = ['C123-TEST'];
+
+    const mockServiceConfig = {
+      name: 'best-effort-service',
+      collections: [{ id: 'C123-TEST' }],
+      message: 'Data in output files may extend outside the spatial and temporal bounds you requested.',
+    };
+
+    getServiceConfigsStub.returns([mockServiceConfig as never]);
+    const chooseConfigStub = sinon.stub(serviceUtils, 'chooseServiceConfig').returns(mockServiceConfig as never);
+
+    chooseService(req as HarmonyRequest, res as Response, nextFunction as NextFunction);
+
+    expect(req.context.messages).to.deep.equal([
+      'Data in output files may extend outside the spatial and temporal bounds you requested.',
+    ]);
+    expect(nextFunction.calledOnce).to.be.true;
+
+    chooseConfigStub.restore();
   });
 });

--- a/services/harmony/test/models/harmony-request.ts
+++ b/services/harmony/test/models/harmony-request.ts
@@ -1,0 +1,54 @@
+import { expect } from 'chai';
+import { NextFunction, Response } from 'express';
+import sinon from 'sinon';
+
+import DataOperation from '../../app/models/data-operation';
+import HarmonyRequest, { addRequestContextToOperation } from '../../app/models/harmony-request';
+import RequestContext from '../../app/models/request-context';
+
+describe('addRequestContextToOperation', function () {
+  it('appends context messages to an existing operation message', function () {
+    const operation = new DataOperation();
+    operation.message = 'Data in output files may extend outside the spatial and temporal bounds you requested.';
+
+    const context = new RequestContext('request-id-1');
+    context.messages.push('CMR query identified 48 granules, but the request has been limited to process only the first 1 granules because you requested 1 maxResults.');
+
+    const req = {
+      operation,
+      context,
+      user: 'test-user',
+      accessToken: 'test-token',
+    } as HarmonyRequest;
+
+    const next = sinon.spy();
+    addRequestContextToOperation(req, {} as Response, next as NextFunction);
+
+    expect(operation.message).to.equal(
+      'Data in output files may extend outside the spatial and temporal bounds you requested. CMR query identified 48 granules, but the request has been limited to process only the first 1 granules because you requested 1 maxResults.',
+    );
+    expect(next.calledOnce).to.be.true;
+  });
+
+  it('sets operation message from context messages when there is no existing message', function () {
+    const operation = new DataOperation();
+
+    const context = new RequestContext('request-id-2');
+    context.messages.push('CMR query identified 48 granules, but the request has been limited to process only the first 1 granules because you requested 1 maxResults.');
+
+    const req = {
+      operation,
+      context,
+      user: 'test-user',
+      accessToken: 'test-token',
+    } as HarmonyRequest;
+
+    const next = sinon.spy();
+    addRequestContextToOperation(req, {} as Response, next as NextFunction);
+
+    expect(operation.message).to.equal(
+      'CMR query identified 48 granules, but the request has been limited to process only the first 1 granules because you requested 1 maxResults.',
+    );
+    expect(next.calledOnce).to.be.true;
+  });
+});

--- a/services/harmony/test/models/services.ts
+++ b/services/harmony/test/models/services.ts
@@ -818,9 +818,10 @@ describe('services.chooseServiceConfig and services.buildService', function () {
         this.operation.boundingRectangle = [0, 0, 10, 10];
       });
 
-      it('throws an exception', function () {
-        expect(() => chooseServiceConfig(this.operation, defaultContext, this.config))
-          .to.throw(UnsupportedOperation, 'the requested combination of operations: spatial subsetting on C123-TEST is unsupported');
+      it('returns a service with a best-effort message', function () {
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
+        expect(serviceConfig.name).to.equal('a-service');
+        expect(serviceConfig.message).to.equal('Data in output files may extend outside the spatial and temporal bounds you requested.');
       });
     });
 
@@ -829,9 +830,10 @@ describe('services.chooseServiceConfig and services.buildService', function () {
         this.operation.geojson = 'some pretend geojson';
       });
 
-      it('throws an exception', function () {
-        expect(() => chooseServiceConfig(this.operation, defaultContext, this.config))
-          .to.throw(UnsupportedOperation, 'shapefile subsetting on C123-TEST is unsupported');
+      it('returns a service with a best-effort message', function () {
+        const serviceConfig = chooseServiceConfig(this.operation, defaultContext, this.config);
+        expect(serviceConfig.name).to.equal('a-service');
+        expect(serviceConfig.message).to.equal('Data in output files may extend outside the spatial and temporal bounds you requested.');
       });
     });
   });

--- a/services/harmony/test/ogc-api-coverages/get-coverage-rangeset.ts
+++ b/services/harmony/test/ogc-api-coverages/get-coverage-rangeset.ts
@@ -965,6 +965,49 @@ describe('OGC API Coverages - getCoverageRangeset', function () {
     });
   });
 
+  describe('when a request has spatial and temporal subsets but the selected service cannot subset either', function () {
+    const serviceConfigs: ServiceConfig<unknown>[] = [
+      {
+        name: 'no-subsetting-service',
+        collections: [{ id: collection }],
+        type: {
+          name: 'turbo',
+        },
+        steps: [{
+          image: 'harmonyservices/query-cmr:fake-test',
+          is_sequential: true,
+        }],
+        capabilities: {
+          subsetting: {
+            variable: true,
+          },
+        },
+      },
+    ];
+
+    hookServices(serviceConfigs);
+    StubService.hook({ params: { redirect: 'http://example.com' } });
+
+    hookRangesetRequest(version, collection, variableName, {
+      username: 'jdoe1',
+      query: {
+        subset: ['lat(-90:90)', 'lon(-180:180)', 'time("1900-01-01T00:00:00.000Z":"2100-01-01T00:00:00Z")'],
+        maxResults: 1,
+        forceAsync: true,
+      },
+    });
+
+    describe('retrieving its job status', function () {
+      hookRedirect('jdoe1');
+
+      it('includes both the best-effort warning and the results-limited warning', function () {
+        const job = JSON.parse(this.res.text);
+        expect(job.message).to.include('Data in output files may extend outside the spatial and temporal bounds you requested.');
+        expect(job.message).to.match(/CMR query identified \d+ granules, but the request has been limited to process only the first 1 granules because you requested 1 maxResults\.$/);
+      });
+    });
+  });
+
   describe('when requesting no data transformations', function () {
     StubService.hook({ params: { redirect: 'http://example.com' } });
     hookRangesetRequest(version, collection, 'all');

--- a/services/harmony/test/ogc-api-edr/get-data-for-area.ts
+++ b/services/harmony/test/ogc-api-edr/get-data-for-area.ts
@@ -14,6 +14,18 @@ import hookServersStartStop from '../helpers/servers';
 import StubService, { hookServices } from '../helpers/stub-service';
 
 const bigTriangleWKT = 'POLYGON ((-65.390625 -13.239945, -29.882813 -50.958427, 17.929688 30.145127, -65.390625 -13.239945))';
+const bestEffortMessage = 'Data in output files may extend outside the spatial and temporal bounds you requested.';
+
+/**
+ * Assert that a job message includes the standard best-effort prefix followed by
+ * a granule-limiting detail message.
+ *
+ * @param actual - The actual job message
+ * @param detailPattern - A regex fragment for the message detail that follows the prefix
+ */
+function expectBestEffortGranuleLimitMessage(actual: string, detailPattern: string): void {
+  expect(actual).to.match(new RegExp(`^${_.escapeRegExp(bestEffortMessage)} ${detailPattern}$`));
+}
 
 describe('OGC API EDR - getEdrArea', function () {
   const collection = 'C1233800302-EEDTEST';
@@ -474,7 +486,7 @@ describe('OGC API EDR - getEdrArea', function () {
         hookRedirect('jdoe1');
         it('returns a human-readable message field indicating the request has been limited to a subset of the granules determined by the collection configuration', function () {
           const job = JSON.parse(this.res.text);
-          expect(job.message).to.match(/^CMR query identified \d+ granules, but the request has been limited to process only the first 4 granules because the service nexus-service is limited to 4\.$/);
+          expectBestEffortGranuleLimitMessage(job.message, 'CMR query identified \\d+ granules, but the request has been limited to process only the first 4 granules because the service nexus-service is limited to 4\\.');
         });
 
         it('returns up to the granule limit configured for the collection', function () {
@@ -492,7 +504,7 @@ describe('OGC API EDR - getEdrArea', function () {
         hookRedirect('jdoe1');
         it('returns a human-readable message field indicating the request has been limited to a subset of the granules determined by the collection configuration', function () {
           const job = JSON.parse(this.res.text);
-          expect(job.message).to.match(/^CMR query identified \d+ granules, but the request has been limited to process only the first 4 granules because the service nexus-service is limited to 4\.$/);
+          expectBestEffortGranuleLimitMessage(job.message, 'CMR query identified \\d+ granules, but the request has been limited to process only the first 4 granules because the service nexus-service is limited to 4\\.');
         });
 
         it('returns up to the granule limit configured for the collection', function () {
@@ -510,7 +522,7 @@ describe('OGC API EDR - getEdrArea', function () {
         hookRedirect('jdoe1');
         it('returns a human-readable message field indicating the request has been limited to a subset of the granules determined by maxResults', function () {
           const job = JSON.parse(this.res.text);
-          expect(job.message).to.match(/^CMR query identified \d+ granules, but the request has been limited to process only the first 2 granules because you requested 2 maxResults\.$/);
+          expectBestEffortGranuleLimitMessage(job.message, 'CMR query identified \\d+ granules, but the request has been limited to process only the first 2 granules because you requested 2 maxResults\\.');
         });
 
         it('returns up to maxGraunules', function () {
@@ -533,7 +545,7 @@ describe('OGC API EDR - getEdrArea', function () {
 
       it('returns a warning message about maxResults limiting the number of results', function () {
         const job = JSON.parse(this.res.text);
-        expect(job.message).to.match(/^CMR query identified \d+ granules, but the request has been limited to process only the first 3 granules because of system constraints\.$/);
+        expectBestEffortGranuleLimitMessage(job.message, 'CMR query identified \\d+ granules, but the request has been limited to process only the first 3 granules because of system constraints\\.');
       });
 
       it('limits the input granules to the system limit', function () {
@@ -576,7 +588,7 @@ describe('OGC API EDR - getEdrArea', function () {
         hookRedirect('jdoe1');
         it('returns a human-readable message field indicating the request has been limited to a subset of the granules determined by the collection configuration', function () {
           const job = JSON.parse(this.res.text);
-          expect(job.message).to.match(/^CMR query identified \d+ granules, but the request has been limited to process only the first 5 granules because collection C1233800302-EEDTEST is limited to 5 for the nexus-service service\.$/);
+          expectBestEffortGranuleLimitMessage(job.message, 'CMR query identified \\d+ granules, but the request has been limited to process only the first 5 granules because collection C1233800302-EEDTEST is limited to 5 for the nexus-service service\\.');
         });
 
         it('returns up to the granule limit configured for the collection', function () {
@@ -594,7 +606,7 @@ describe('OGC API EDR - getEdrArea', function () {
         hookRedirect('jdoe1');
         it('returns a human-readable message field indicating the request has been limited to a subset of the granules determined by the collection configuration', function () {
           const job = JSON.parse(this.res.text);
-          expect(job.message).to.match(/^CMR query identified \d+ granules, but the request has been limited to process only the first 5 granules because collection C1233800302-EEDTEST is limited to 5 for the nexus-service service\.$/);
+          expectBestEffortGranuleLimitMessage(job.message, 'CMR query identified \\d+ granules, but the request has been limited to process only the first 5 granules because collection C1233800302-EEDTEST is limited to 5 for the nexus-service service\\.');
         });
 
         it('returns up to the granule limit configured for the collection', function () {
@@ -612,7 +624,7 @@ describe('OGC API EDR - getEdrArea', function () {
         hookRedirect('jdoe1');
         it('returns a human-readable message field indicating the request has been limited to a subset of the granules determined by maxResults', function () {
           const job = JSON.parse(this.res.text);
-          expect(job.message).to.match(/^CMR query identified \d+ granules, but the request has been limited to process only the first 2 granules because you requested 2 maxResults\.$/);
+          expectBestEffortGranuleLimitMessage(job.message, 'CMR query identified \\d+ granules, but the request has been limited to process only the first 2 granules because you requested 2 maxResults\\.');
         });
 
         it('returns up to maxGraunules', function () {
@@ -635,7 +647,7 @@ describe('OGC API EDR - getEdrArea', function () {
 
       it('returns a warning message about maxResults limiting the number of results', function () {
         const job = JSON.parse(this.res.text);
-        expect(job.message).to.match(/^CMR query identified \d+ granules, but the request has been limited to process only the first 3 granules because of system constraints\.$/);
+        expectBestEffortGranuleLimitMessage(job.message, 'CMR query identified \\d+ granules, but the request has been limited to process only the first 3 granules because of system constraints\\.');
       });
 
       it('limits the input granules to the system limit', function () {

--- a/services/harmony/test/ogc-api-edr/get-data-for-area.ts
+++ b/services/harmony/test/ogc-api-edr/get-data-for-area.ts
@@ -922,23 +922,6 @@ describe('OGC API EDR - getEdrArea', function () {
         description: 'Error: "all" cannot be specified alongside other variables',
       });
     });
-
-    // no subsetting other than shapefile (implied by 'area'), so we must fail since no service supports shapefile
-    // subsetting for this collection
-    it('returns an HTTP 422 "Unprocessable Content" error with explanatory message when only shapefile subsetting is specified for a collection that does not support it', async function () {
-      const res = await edrRequest(
-        'area',
-        this.frontend,
-        version,
-        collection,
-        { query: { coords: bigTriangleWKT, granuleId } },
-      );
-      expect(res.status).to.equal(422);
-      expect(res.body).to.eql({
-        code: 'harmony.UnsupportedOperation',
-        description: `Error: the requested combination of operations: shapefile subsetting on ${collection} is unsupported`,
-      });
-    });
   });
 
   describe('when using a collection with coordinate variables', function () {
@@ -993,29 +976,4 @@ describe('OGC API EDR - getEdrArea with the extend query parameter', async funct
   //   hookEdrRequest('1.1.0', 'C1233800302-EEDTEST', 'red_var', { query: { extend: 'lat,lon' }, username: 'joe' });
   //   itRedirectsToJobStatusUrl();
   // });
-});
-
-describe('OGC API EDR - getEdrArea with a collection not configured for services', function () {
-  const collection = 'C1243745256-EEDTEST';
-  const version = '1.1.0';
-
-  hookServersStartStop();
-
-  describe('when requesting an area subset', function () {
-    const query = { coords: bigTriangleWKT, 'parameter-name': 'all' };
-    hookEdrRequest('area', version, collection, { username: 'joe', query });
-
-    it('returns a 422 error response', function () {
-      expect(this.res.status).to.equal(422);
-    });
-
-    it('returns an error message indicating the transformation could not be performed', function () {
-      const body = JSON.parse(this.res.text);
-      expect(body).to.eql({
-        code: 'harmony.UnsupportedOperation',
-        description: 'Error: the requested combination of operations: shapefile subsetting on C1243745256-EEDTEST is unsupported',
-      });
-    });
-
-  });
 });

--- a/services/harmony/test/ogc-api-edr/get-data-for-point.ts
+++ b/services/harmony/test/ogc-api-edr/get-data-for-point.ts
@@ -70,7 +70,6 @@ describe('convertWktToPolygon', () => {
 });
 
 const pointWKT = 'POINT (-40 10)';
-const multipointWKT = 'MULTIPOINT ((30 10), (40 40), (20 20), (10 30))';
 
 describe('OGC API EDR - getEdrPosition', function () {
   const collection = 'C1233800302-EEDTEST';
@@ -978,23 +977,6 @@ describe('OGC API EDR - getEdrPosition', function () {
         description: 'Error: "all" cannot be specified alongside other variables',
       });
     });
-
-    // no subsetting other than shapefile (implied by 'position'), so we must fail since no service supports shapefile
-    // subsetting for this collection
-    it('returns an HTTP 422 "Unprocessable Content" error with explanatory message when only shapefile subsetting is specified for a collection that does not support it', async function () {
-      const res = await edrRequest(
-        'position',
-        this.frontend,
-        version,
-        collection,
-        { query: { coords: multipointWKT, granuleId } },
-      );
-      expect(res.status).to.equal(422);
-      expect(res.body).to.eql({
-        code: 'harmony.UnsupportedOperation',
-        description: `Error: the requested combination of operations: shapefile subsetting on ${collection} is unsupported`,
-      });
-    });
   });
 
   describe('when using a collection with coordinate variables', function () {
@@ -1049,29 +1031,4 @@ describe('OGC API EDR - getEdrPosition with the extend query parameter', async f
   //   hookEdrRequest('1.1.0', 'C1233800302-EEDTEST', 'red_var', { query: { extend: 'lat,lon' }, username: 'joe' });
   //   itRedirectsToJobStatusUrl();
   // });
-});
-
-describe('OGC API EDR - getEdrPosition with a collection not configured for services', function () {
-  const collection = 'C1243745256-EEDTEST';
-  const version = '1.1.0';
-
-  hookServersStartStop();
-
-  describe('when requesting position subset', function () {
-    const query = { coords: multipointWKT, 'parameter-name': 'all' };
-    hookEdrRequest('position', version, collection, { username: 'joe', query });
-
-    it('returns a 422 error response', function () {
-      expect(this.res.status).to.equal(422);
-    });
-
-    it('returns an error message indicating the transformation could not be performed', function () {
-      const body = JSON.parse(this.res.text);
-      expect(body).to.eql({
-        code: 'harmony.UnsupportedOperation',
-        description: 'Error: the requested combination of operations: shapefile subsetting on C1243745256-EEDTEST is unsupported',
-      });
-    });
-
-  });
 });

--- a/services/harmony/test/ogc-api-edr/get-data-for-trajectory.ts
+++ b/services/harmony/test/ogc-api-edr/get-data-for-trajectory.ts
@@ -508,23 +508,6 @@ describe('OGC API EDR - getEdrTrajectory', function () {
         description: 'Error: "all" cannot be specified alongside other variables',
       });
     });
-
-    // no subsetting other than shapefile (implied by 'trajectory'), so we must fail since no service supports shapefile
-    // subsetting for this collection
-    it('returns an HTTP 422 "Unprocessable Content" error with explanatory message when only shapefile subsetting is specified for a collection that does not support it', async function () {
-      const res = await edrRequest(
-        'trajectory',
-        this.frontend,
-        version,
-        collection,
-        { query: { coords: lineWKT, granuleId } },
-      );
-      expect(res.status).to.equal(422);
-      expect(res.body).to.eql({
-        code: 'harmony.UnsupportedOperation',
-        description: `Error: the requested combination of operations: shapefile subsetting on ${collection} is unsupported`,
-      });
-    });
   });
 
   describe('when using a collection with coordinate variables', function () {
@@ -565,30 +548,5 @@ describe('OGC API EDR - getEdrTrajectory with the extend query parameter', async
       code: 'harmony.UnsupportedOperation',
       description: 'Error: the requested combination of operations: extend on C1233800302-EEDTEST is unsupported',
     });
-  });
-});
-
-describe('OGC API EDR - getEdrTrajectory with a collection not configured for services', function () {
-  const collection = 'C1243745256-EEDTEST';
-  const version = '1.1.0';
-
-  hookServersStartStop();
-
-  describe('when requesting trajectory subset', function () {
-    const query = { coords: lineWKT, 'parameter-name': 'all' };
-    hookEdrRequest('trajectory', version, collection, { username: 'joe', query });
-
-    it('returns a 422 error response', function () {
-      expect(this.res.status).to.equal(422);
-    });
-
-    it('returns an error message indicating the transformation could not be performed', function () {
-      const body = JSON.parse(this.res.text);
-      expect(body).to.eql({
-        code: 'harmony.UnsupportedOperation',
-        description: 'Error: the requested combination of operations: shapefile subsetting on C1243745256-EEDTEST is unsupported',
-      });
-    });
-
   });
 });

--- a/services/harmony/test/work-items/fair-queueing.ts
+++ b/services/harmony/test/work-items/fair-queueing.ts
@@ -104,7 +104,8 @@ describe('Fair Queueing', function () {
       });
       it('returns the rest of the work items in fair queueing order', function () {
         const jobIds = results.slice(2, 5).map((result) => result.body.workItem?.jobID);
-        expect(jobIds).to.eql(['billOldest', 'bobOldest', 'billMiddle']);
+        expect(jobIds[0]).to.equal('billOldest');
+        expect(jobIds.slice(1)).to.have.members(['bobOldest', 'billMiddle']);
       });
       it('returns a 404 status when no work is available', function () {
         expect(results[5].status).to.equal(404);

--- a/services/harmony/test/work-items/fair-queueing.ts
+++ b/services/harmony/test/work-items/fair-queueing.ts
@@ -104,8 +104,7 @@ describe('Fair Queueing', function () {
       });
       it('returns the rest of the work items in fair queueing order', function () {
         const jobIds = results.slice(2, 5).map((result) => result.body.workItem?.jobID);
-        expect(jobIds[0]).to.equal('billOldest');
-        expect(jobIds.slice(1)).to.have.members(['bobOldest', 'billMiddle']);
+        expect(jobIds).to.eql(['billOldest', 'bobOldest', 'billMiddle']);
       });
       it('returns a 404 status when no work is available', function () {
         expect(results[5].status).to.equal(404);


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2359

## Description
Allow temporal or spatial only filters on download service and display best effort message on the job status message.

## Local Test Steps
Temporal only - http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?maxResults=1&subset=time(%222002-09-15T00%3A00%3A00.000Z%22%3A%222022-09-25T00%3A00%3A00Z%22)

Spatial only - http://localhost:3000/C1243745256-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)

Temporal and spatial - http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&maxResults=1&subset=time(%222002-09-15T00%3A00%3A00.000Z%22%3A%222022-09-25T00%3A00%3A00Z%22)

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service selection now includes contextual messages for better request transparency.

* **Bug Fixes**
  * Service requests gracefully fall back to best-effort processing with warnings instead of failing when strict capability requirements cannot be met.
  * Message context is preserved and appended rather than replaced during request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->