### PR TITLE
HARMONY-2373: Allows resolve files on multiple workItems.

### DIFF
--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -38,7 +38,6 @@ const MAX_WORKITEMS_PER_PAGE = 1000;
 // A catalog that contains both a data and opendap asset will provide
 // two both urls to the resolved url list.
 
-
 const DEFAULT_WI_LIMIT = 50;
 const MAX_WI_LIMIT = 100;
 
@@ -406,7 +405,7 @@ async function resolveOutputFiles(
  * inline.
  *
  * @param req - the Express request
- * @param workItems - the workItems to resolve (a single item)
+ * @param workItems - the workItems to resolve
  * @param kind - resolve input or output files
  * @param frontendRoot - the root URL to use when producing Harmony permalinks
  * @param destinationBucket - the job's destinationUrl bucket name, or undefined
@@ -581,8 +580,8 @@ export async function getJobSteps(
 
     let resolved: ResolvedFiles | undefined;
     if (q.resolveFiles !== undefined) {
-      if (q.workItems === undefined || q.workItems.length !== 1) {
-        throw new RequestValidationError('resolveFiles requires exactly one workItem');
+      if (q.workItems === undefined || q.workItems.length < 1) {
+        throw new RequestValidationError('resolveFiles requires one or more workItems');
       }
       resolved = await resolveWorkItemFiles(req, allWorkItems, q.resolveFiles, frontendRoot, destinationBucket);
     }

--- a/services/harmony/app/markdown/steps.md
+++ b/services/harmony/app/markdown/steps.md
@@ -28,7 +28,7 @@ To see a work item's actual input or output files, you need to follow its `input
 ```
 **Example {{exampleCounter}}** - Resolving a work item's output files
 
-When `resolveFiles` is supplied and exactly one `workItem` is given, the work item is returned with the requested kind of files resolved inline:
+When `resolveFiles` is supplied and one or more `workItem`s are given, each work item is returned with the requested kind of files resolved inline:
 
 - `resolveFiles=input` populates `inputFiles` (and `inputFilesPaging`), reading a page of the work item's input STAC catalog items.
 - `resolveFiles=output` populates `outputFiles` (and `outputFilesPaging`), reading a page of the work item's output STAC catalogs.
@@ -44,7 +44,7 @@ Parameter names are case-insensitive (e.g. `step2Page`, `Step2Page`, and `STEP2P
 | status              | Filter the work items shown to one or more statuses, comma-separated (e.g. `status=failed,warning`). Each one of `ready`, `queued`, `running`, `successful`, `failed`, `canceled`, or `warning`. Steps with no matching work items are omitted. |
 | workItem            | Limit the work items shown to one or more IDs, comma-separated (e.g. `workItem=123,124`). Each a positive integer.                                                                            |
 | limit               | The number of work items to show per page for each step. Defaults to 50, maximum 1000.
-| resolveFiles        | Resolves work item's files inline instead of returning `inputFilesUrl` / `outputFilesUrl` links. One of `input` or `output`. Requires exactly one `workItem`; otherwise the request is rejected. See [Resolving a work item's files](#steps-resolve-files). |
+| resolveFiles        | Resolves work item's files inline instead of returning `inputFilesUrl` / `outputFilesUrl` links. One of `input` or `output`. Requires one or more `workItem`s; otherwise the request is rejected. See [Resolving a work item's files](#steps-resolve-files). |
 | wiLimit             | The page size used when resolving files: the number of input STAC items (for `resolveFiles=input`) or output STAC catalogs (for `resolveFiles=output`) read per page. Defaults to 50, maximum 100. |
 | step\<stepIndex\>Page | The page of work items to show for the step with the given stepIndex, e.g. `step2Page=3`. A positive integer that defaults to 1; a page beyond the last page returns the last page. Each step pages independently, so multiple may be supplied. |
 | workItem\<id\>OutputPage | The page of output files to show for the work item with the given id when `resolveFiles=output`, e.g. `workItem123OutputPage=2`. Output files are paged by STAC catalog (`wiLimit` per page). A positive integer that defaults to 1; a page beyond the last page returns the last page. |

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -1019,11 +1019,11 @@ describe('GET /jobs/:jobID/steps', function () {
         expect(this.res.statusCode).to.equal(400);
       });
 
-      it('explains that exactly one workItem is required', function () {
+      it('explains that one or more workItems are required', function () {
         const response = JSON.parse(this.res.text);
         expect(response).to.eql({
           code: 'harmony.RequestValidationError',
-          description: 'Error: resolveFiles requires exactly one workItem',
+          description: 'Error: resolveFiles requires one or more workItems',
         });
       });
     });
@@ -1036,8 +1036,18 @@ describe('GET /jobs/:jobID/steps', function () {
       });
       after(function () { delete this.res; });
 
-      it('returns 400', function () {
-        expect(this.res.statusCode).to.equal(400);
+      it('returns 200', function () {
+        expect(this.res.statusCode).to.equal(200);
+      });
+
+      it('resolves files inline for each requested work item', function () {
+        const body = JSON.parse(this.res.text);
+        const workItems = body.steps.flatMap((s) => s.workItems);
+        expect(workItems.map((wi) => wi.id)).to.have.members([wi1Id, wi2Id]);
+        for (const wi of workItems) {
+          expect(wi).to.not.have.property('inputFilesUrl');
+          expect(wi.inputFiles).to.be.an('array');
+        }
       });
     });
 


### PR DESCRIPTION
## Jira Issue ID

[HARMONY-2373](https://bugs.earthdata.nasa.gov/browse/HARMONY-2373)

## Description

Relaxes the limit on number of workitems to resolve when selecting `resolveFiles` as a query param.
Previously it was limited to a single workItem, now it is limited to a comma separated list of workItems.
It is still constrained by that, and if a user requests the steps endpoint without a list of workItems and a resolveFiles as input or output, they will get a validation error.


## Local Test Steps

Pull and deploy this to your Harmony-In-A-Box 

Make a request with more than one workItem

http://localhost:3000/C1268429762-EEDTEST/ogc-api-coverages/1.0.0/collections/parameter_vars/coverage/rangeset?forceAsync=true&subset=lat(41.73504%3A43.2472)&subset=lon(5.0196%3A7.91089)&subset=time(%222015-03-31T17%3A06%3A00Z%22%3A%222015-03-31T17%3A10%3A00Z%22)&label=harmony-py&label=HARMONY-2254-verify&label=HARMONY-2254&format=image%2Ftiff&variable=Soil_Moisture_Retrieval_Data_1km%2Fretrieval_qual_flag_1km&variable=Soil_Moisture_Retrieval_Data_1km%2Fretrieval_qual_flag_apm_1km&variable=Soil_Moisture_Retrieval_Data_1km%2Fsoil_moisture_1km&variable=Soil_Moisture_Retrieval_Data_1km%2Fsoil_moisture_apm_1km

Follow the `inputFilesUrl` link and then add the workItem to the url to verify multiple workItems return resolved files.

add `?resolveFiles=output` to the steps endpoint without any workItems and verify you get an error `"Error: resolveFiles requires one or more workItems"`

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)
* [X] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `resolveFiles` parameter in the steps API now accepts one or more work items, enabling batch processing of file resolution requests. Each requested work item is returned with its resolved input or output files included inline.

* **Documentation**
  * Updated steps API documentation to reflect expanded support for `resolveFiles` with multiple work items. Validation error messages now accurately reflect the new requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->