### PR TITLE
HARMONY-2374: Replace localstack container with ministack for local testing

### DIFF
--- a/bin/start-postgres-localstack
+++ b/bin/start-postgres-localstack
@@ -89,8 +89,8 @@ STAGING_BUCKET=${STAGING_BUCKET:-local-staging-bucket}
 ARTIFACT_BUCKET=${ARTIFACT_BUCKET:-local-artifact-bucket}
 UPLOAD_BUCKET=${UPLOAD_BUCKET:-local-upload-bucket}
 
-# Creates queue and buckets in localstack
-localstack_startup_script="
+# Creates queue and buckets in ministack
+ministack_startup_script="
 import boto3
 s3 = boto3.client('s3', endpoint_url='http://localhost:4566', region_name='us-west-2')
 s3.create_bucket(Bucket='${STAGING_BUCKET}', CreateBucketConfiguration={'LocationConstraint': 'us-west-2'})
@@ -109,7 +109,7 @@ kubectl -n harmony delete rolebinding default-admin 2>/dev/null || true
 kubectl -n harmony create rolebinding default-admin --clusterrole=admin --serviceaccount=harmony:default
 
 kubectl -n harmony delete configmap localstack-config 2>/dev/null || true
-kubectl -n harmony create configmap localstack-config --from-literal=startup.py="${localstack_startup_script}"
+kubectl -n harmony create configmap localstack-config --from-literal=startup.py="${ministack_startup_script}"
 
 . ./bin/create-k8s-config-maps-and-secrets
 
@@ -126,5 +126,5 @@ bin/port-forward start postgres ${POSTGRES_PORT}:5432
 DATABASE_TYPE=postgres DATABASE_URL="postgresql://postgres:password@localhost:${POSTGRES_PORT}/postgres" npx knex --cwd db migrate:latest || true
 
 echo ''
-echo 'Localstack has started at http://localhost:4566/'
+echo 'Ministack has started at http://localhost:4566/'
 echo "Postgres has started at localhost:${POSTGRES_PORT}"

--- a/config/local-postgres-localstack-deployment.yml
+++ b/config/local-postgres-localstack-deployment.yml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: localstack-pod
+  name: ministack-pod
   labels:
-    name: localstack-pod
+    name: ministack-pod
     app: localstack
 spec:
   containers:
-    - name: localstack
-      image: localstack/localstack:3.0.2
+    - name: ministack
+      image: ministackorg/ministack:1.3.63
       ports:
         - containerPort: 4566
       volumeMounts:
@@ -45,7 +45,7 @@ spec:
       port: 4592
       targetPort: 4566
   selector:
-    name: localstack-pod
+    name: ministack-pod
   type: ClusterIP
 ---
 apiVersion: v1

--- a/docs/guides/develop.md
+++ b/docs/guides/develop.md
@@ -19,13 +19,13 @@ Required:
   * Install [minikube](https://kubernetes.io/docs/tasks/tools/#minikube), a single-node Kubernetes cluster useful for local linux development.
   * Install [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl), a command line interface to Kubernetes.
 * [Docker compose](https://docs.docker.com/compose/) version 1.20.0 or greater; preferably the latest version, which is v1.26 or greater.
-* The [AWS CLI](https://aws.amazon.com/cli/) - Used to interact with both localstack and real AWS accounts
+* The [AWS CLI](https://aws.amazon.com/cli/) - Used to interact with both ministack and real AWS accounts
 * [SQLite3 commandline](https://sqlite.org/index.html) - Used to create the local development and test databases. Install using your OS package manager, or [download precompiled binaries from SQLite](https://www.sqlite.org/download.html)
 * PostgreSQL (required by the pg-native library) - `brew install postgresql` on OSX
 * [Earthdata Login application in UAT](../edl-application.md)
 * [envsubst](https://pypi.org/project/envsubst) - Used to substitute environment variable placeholders inside configuration files.
 * [openssl](https://www.openssl.org/) Read [this installation guide](https://github.com/openssl/openssl/blob/master/NOTES-WINDOWS.md) if you're a Windows user and openssl is not installed on your machine already.
-* [awscli-local](https://github.com/localstack/awscli-local) - CLI helpers for interacting with localstack
+* [awscli-local](https://github.com/localstack/awscli-local) - CLI helpers for interacting with localstack (or ministack).
 
 Highly Recommended:
 * An Amazon Web Services account - Used for testing Harmony against object stores and running Harmony in AWS
@@ -149,7 +149,7 @@ Harmony and the services can be run using the following:
 NOTE: You must set `LOCAL_DEV=true` before running these to prevent `bootstrap-harmony` from
 starting harmony and its support services in kubernetes.
 
-The provider services along with postgresql and localstack will now be running in kubernetes,
+The provider services along with postgresql and ministack will now be running in kubernetes,
 while Harmony and its support services will be running as local Node.js processes. Each process
 has a specific port and debug port as shown in the following table:
 
@@ -211,7 +211,7 @@ If you'd like to build and test a new service for Harmony see [this reference](.
 
 ### Deleting services and stopping Kubernetes
 
-To delete all resources associated with deployed services, postgres and localstack deployment, run:
+To delete all resources associated with deployed services, postgres and localstack/ministack deployment, run:
 
 ```bash
 kubectl delete namespaces harmony

--- a/packages/util/env.ts
+++ b/packages/util/env.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-import { IsInt, IsNotEmpty, IsNumber, IsUrl, Matches, Max, Min, ValidateIf, ValidationError, validateSync } from 'class-validator';
+import { IsBoolean, IsInt, IsNotEmpty, IsNumber, IsUrl, Matches, Max, Min, ValidateIf, ValidationError, validateSync } from 'class-validator';
 import * as dotenv from 'dotenv';
 import _ from 'lodash';
 import * as winston from 'winston';
@@ -166,6 +166,7 @@ export class HarmonyEnv {
   @Min(1)
   cmrMaxPageSize: number;
 
+  @IsBoolean()
   cmrAllowCompression: boolean;
 
   @IsNotEmpty()


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2374

## Description
Replaces the localstack container with a ministack container for local testing due to license and support changes going forward for LocalStack.

Note that in the code there are still many places localstack is referenced like queue names and Kubernetes services. Attempting to replace everything causes breakages. Ministack works as a drop in replacement for localstack so the simplest solution is to just replace the container for now, and treat the localstack references as the general name for the local emulation of an AWS stack.

## Local Test Steps
Test both local development and harmony in a box. After changing your .env run:
```
bin/stop-harmony-and-services && bin/bootstrap-harmony
```
Verify there is a ministack pod running:
```
k get pods -n harmony
```
should show a ministack-pod and no localstack-pod

```
k describe pods -n harmony ministack-pod
```
should show it is using the ministackorg/ministack:1.3.63 image.

Verify that requests continue to work as before (verifying S3 and SQS functionality):
http://localhost:3000/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=PNG&subset=time(%222002-09-15T00%3A00%3A00.000Z%22%3A%222022-09-25T00%3A00%3A00Z%22)

Verify the cloud access endpoint still works (verifying STS functionality):
http://localhost:3000/cloud-access

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [X] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the local PostgreSQL + cloud-mocking setup to use Ministack instead of Localstack, including the container image and matching Kubernetes pod/service configuration.
  * Refreshed the local startup messaging to reflect Ministack.
* **Documentation**
  * Updated the development guide to replace Localstack references with Ministack, including guidance around AWS CLI usage and related cleanup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->