### PR TITLE
HARMONY-2375: Provide a way to disable compressed responses from the CMR

### DIFF
--- a/packages/util/env-defaults
+++ b/packages/util/env-defaults
@@ -142,6 +142,9 @@ DEFAULT_POD_GRACE_PERIOD_SECS=14400
 # page size to use with CMR calls
 CMR_MAX_PAGE_SIZE=2000
 
+# True if compressed CMR responses are allowed, in some environments compressed responses fail
+CMR_ALLOW_COMPRESSION=true
+
 # Prefix before "harmonyservices/task-name" for built-in tasks like query-cmr, e.g. an ECR location
 # If not blank, it should end in a slash if there is a slash before "harmony"
 BUILT_IN_TASK_PREFIX=

--- a/packages/util/env-defaults
+++ b/packages/util/env-defaults
@@ -143,7 +143,7 @@ DEFAULT_POD_GRACE_PERIOD_SECS=14400
 CMR_MAX_PAGE_SIZE=2000
 
 # True if compressed CMR responses are allowed, in some environments compressed responses fail
-CMR_ALLOW_COMPRESSION=true
+CMR_ALLOW_COMPRESSION=false
 
 # Prefix before "harmonyservices/task-name" for built-in tasks like query-cmr, e.g. an ECR location
 # If not blank, it should end in a slash if there is a slash before "harmony"

--- a/packages/util/env.ts
+++ b/packages/util/env.ts
@@ -166,6 +166,8 @@ export class HarmonyEnv {
   @Min(1)
   cmrMaxPageSize: number;
 
+  cmrAllowCompression: boolean;
+
   @IsNotEmpty()
   databaseType: string;
 

--- a/services/harmony/app/util/cmr.ts
+++ b/services/harmony/app/util/cmr.ts
@@ -441,6 +441,7 @@ export async function cmrGetBase(
     {
       method: 'GET',
       headers,
+      compress: env.cmrAllowCompression,
     });
   response.data = await response.json();
   return response;
@@ -488,6 +489,7 @@ export async function fetchPost(
     method: 'POST',
     body: formData,
     headers: fullHeaders,
+    compress: env.cmrAllowCompression,
   });
   response.data = await response.json();
 
@@ -682,6 +684,7 @@ async function _cmrPostBody(
     method: 'POST',
     body: JSON.stringify(body),
     headers,
+    compress: env.cmrAllowCompression,
   });
   _handleCmrErrors(response);
 
@@ -1463,7 +1466,10 @@ export function filterGranuleLinks(
  */
 export async function getCmrHealth(): Promise<{ healthy: boolean; message?: string }> {
   try {
-    const response: CmrResponse = await fetch(`${cmrApiConfig.baseURL}/search/health`);
+    const response: CmrResponse = await fetch(
+      `${cmrApiConfig.baseURL}/search/health`,
+      { compress: env.cmrAllowCompression },
+    );
 
     if (response.status === 200) {
       return { healthy: true };

--- a/services/harmony/test/helpers/env.ts
+++ b/services/harmony/test/helpers/env.ts
@@ -18,6 +18,7 @@ process.env.PREVIEW_THRESHOLD = '500';
 
 // prevent tests from using a different page size and creating many fixtures
 process.env.CMR_MAX_PAGE_SIZE = '100';
+process.env.CMR_ALLOW_COMPRESSION = 'true';
 
 // use reasonable aggregation batch sizes for tests
 process.env.MAX_BATCH_INPUTS = '3';


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2375

## Description
We started seeing an issue that compressed responses from the CMR were not being handled correctly - it seems related to a new AMI. We were seeing some working environments in sandbox and some failing initially. Today we see issues in both SIT and production (but not UAT).

## Local Test Steps
Here's a request that fails:
https://harmony.sit.earthdata.nasa.gov/C1234724470-POCLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-45%3A45)&subset=lon(0%3A180)&skipPreview=true&maxResults=2

Note other requests (I assume ones where CMR does not return a compressed response) succeed:
https://harmony.sit.earthdata.nasa.gov/C1233800302-EEDTEST/ogc-api-coverages/1.0.0/collections/blue_var/coverage/rangeset?subset=lat(20%3A60)&subset=lon(-140%3A-50)&granuleId=G1233800343-EEDTEST&outputCrs=EPSG%3A31975&format=PNG&subset=time(%222002-09-15T00%3A00%3A00.000Z%22%3A%222022-09-25T00%3A00%3A00Z%22)

I've tested in sandbox with these changes the first request now works for me.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added environment configuration option for CMR compression handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->