### PR TITLE
HARMONY-2372: resolve input and output files at once.

### DIFF
--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -20,7 +20,7 @@ import { Link } from '../util/links';
 import { keysToLowerCase } from '../util/object';
 import { defaultObjectStore } from '../util/object-store';
 import { getPagingLinks, parseIntegerParam } from '../util/pagination';
-import { parseMultiValueParameter } from '../util/parameter-parsing-helpers';
+import { parseBoolean, ParameterParseError, parseMultiValueParameter } from '../util/parameter-parsing-helpers';
 import { getCatalogItemUrls, readCatalogItems, readItemsAtUrls, StacItem } from '../util/stac';
 import { getRequestRoot } from '../util/url';
 
@@ -43,24 +43,20 @@ const MAX_WI_LIMIT = 100;
 
 const VALID_STATUSES = Object.values(WorkItemStatus);
 
-type ResolveKind = 'input' | 'output';
-const VALID_RESOLVE_KINDS: ResolveKind[] = ['input', 'output'];
-
 interface StepsQueryParams {
   steps?: number[];
   statuses?: WorkItemStatus[];
   workItems?: number[];
-  resolveFiles?: ResolveKind;
+  resolveFiles?: boolean;
 }
 
 interface StepWorkItem {
   id: number;
   status: WorkItemStatus;
   retryCount: number;
-  // Links back to this steps endpoint that resolve input / output files
-  inputFilesUrl?: string | null;
-  outputFilesUrl?: string | null;
-  // The requested page of input or output files.
+  // Link back to this steps endpoint that resolves intermediate files.
+  accessFilesUrl?: string | null;
+  // The requested page of input and output files.
   inputFiles?: string[] | null;
   inputFilesPaging?: StepPaging;
   outputFiles?: string[] | null;
@@ -127,11 +123,14 @@ function parseQuery(query: Record<string, unknown>): StepsQueryParams {
   }
 
   if (query.resolvefiles !== undefined) {
-    const kind = query.resolvefiles as ResolveKind;
-    if (!VALID_RESOLVE_KINDS.includes(kind)) {
-      throw new RequestValidationError(`resolveFiles must be one of: ${VALID_RESOLVE_KINDS.join(', ')}`);
+    try {
+      out.resolveFiles = parseBoolean(query.resolvefiles as string);
+    } catch (e) {
+      if (e instanceof ParameterParseError) {
+        throw new RequestValidationError('resolveFiles must be true or false');
+      }
+      throw e;
     }
-    out.resolveFiles = kind;
   }
 
   return out;
@@ -210,21 +209,26 @@ interface WiResolvedFiles {
   paging?: StepPaging;
 }
 
-// Map of workItem id -> its resolved page of files
-type ResolvedFiles = Map<number, WiResolvedFiles>;
+// A single workItem's resolved page of input and output files
+interface WiAccessFiles {
+  input: WiResolvedFiles;
+  output: WiResolvedFiles;
+}
+
+// Map of workItem id -> resolved page of files
+type ResolvedFiles = Map<number, WiAccessFiles>;
 
 /**
  * Build the link, back to this same steps endpoint, that resolves a single work
- * item's input or output files inline.
+ * item's input and output files inline.
  *
  * @param req - the Express request, used for the host and current path
  * @param wiId - the workItem id to scope the link to
- * @param kind - whether the link resolves input or output files
  * @returns the absolute URL that resolves that workItem's files
  */
-function workItemFilesUrl(req: HarmonyRequest, wiId: number, kind: ResolveKind): string {
+function workItemFilesUrl(req: HarmonyRequest, wiId: number): string {
   const path = req.originalUrl.split('?')[0];
-  return `${getRequestRoot(req)}${path}?workitem=${wiId}&resolvefiles=${kind}`;
+  return `${getRequestRoot(req)}${path}?workitem=${wiId}&resolvefiles=true`;
 }
 
 /**
@@ -401,29 +405,27 @@ async function resolveOutputFiles(
 }
 
 /**
- * Resolve the requested kind (input or output) of files for the given workItem
- * inline.
+ * Resolve both the input and output files for the given workItems.
  *
  * @param req - the Express request
  * @param workItems - the workItems to resolve
- * @param kind - resolve input or output files
  * @param frontendRoot - the root URL to use when producing Harmony permalinks
  * @param destinationBucket - the job's destinationUrl bucket name, or undefined
- * @returns map of workItem id to its resolved page of files
+ * @returns map of workItem id to its resolved page of input and output files
  */
 async function resolveWorkItemFiles(
   req: HarmonyRequest,
   workItems: WorkItem[],
-  kind: ResolveKind,
   frontendRoot: string,
   destinationBucket: string | undefined,
 ): Promise<ResolvedFiles> {
   const resolved: ResolvedFiles = new Map();
   await Promise.all(workItems.map(async (wi) => {
-    const result = kind === 'input'
-      ? await resolveInputFiles(req, wi, frontendRoot, destinationBucket)
-      : await resolveOutputFiles(req, wi, frontendRoot, destinationBucket);
-    resolved.set(wi.id, result);
+    const [input, output] = await Promise.all([
+      resolveInputFiles(req, wi, frontendRoot, destinationBucket),
+      resolveOutputFiles(req, wi, frontendRoot, destinationBucket),
+    ]);
+    resolved.set(wi.id, { input, output });
   }));
   return resolved;
 }
@@ -431,17 +433,17 @@ async function resolveWorkItemFiles(
 /**
  * Build the workItem portion of the response.
  *
- * In overview mode a workItem carries `inputFilesUrl` / `outputFilesUrl` links
- * doing no S3 reads here.
+ * When not resolving files, a workItem has a link `accessFilesUrl` back to
+ * revolve the files.
  *
- * In resolve mode either input or output files are populated inline from the
- * precomputed `resolved` map, with an `inputFilesPaging` / `outputFilesPaging`
+ * When resolving, both input and output files are populated inline from the
+ * precomputed `resolved` map, each with an `inputFilesPaging` / `outputFilesPaging`
  * block when necessary.
  *
  * @param req - the Express request, used to build links
  * @param wi - the workItem to serialize
- * @param q - the parsed steps query (determines overview vs resolve mode)
- * @param resolved - the per-WI resolved files map (resolve mode only)
+ * @param q - the parsed steps query (resolving or not mode)
+ * @param resolved - the per-WI resolved files map (resolving only)
  * @returns the workItem shaped for the steps response
  */
 function buildWorkItem(
@@ -452,20 +454,22 @@ function buildWorkItem(
 ): StepWorkItem {
   const base = { id: wi.id, status: wi.status, retryCount: wi.retryCount };
 
-  if (q.resolveFiles === undefined) {
+  if (!q.resolveFiles) {
+    const showFilesUrl = !!wi.stacCatalogLocation || COMPLETED_WORK_ITEM_STATUSES.includes(wi.status);
     return {
       ...base,
-      inputFilesUrl: wi.stacCatalogLocation ? workItemFilesUrl(req, wi.id, 'input') : null,
-      outputFilesUrl: COMPLETED_WORK_ITEM_STATUSES.includes(wi.status)
-        ? workItemFilesUrl(req, wi.id, 'output') : null,
+      accessFilesUrl: showFilesUrl ? workItemFilesUrl(req, wi.id) : null,
     };
   }
 
-  const { files, paging } = resolved?.get(wi.id) ?? { files: [] };
-  if (q.resolveFiles === 'input') {
-    return { ...base, inputFiles: files, ...(paging !== undefined && { inputFilesPaging: paging }) };
-  }
-  return { ...base, outputFiles: files, ...(paging !== undefined && { outputFilesPaging: paging }) };
+  const { input, output } = resolved?.get(wi.id) ?? { input: { files: [] }, output: { files: [] } };
+  return {
+    ...base,
+    inputFiles: input.files,
+    ...(input.paging !== undefined && { inputFilesPaging: input.paging }),
+    outputFiles: output.files,
+    ...(output.paging !== undefined && { outputFilesPaging: output.paging }),
+  };
 }
 
 
@@ -579,11 +583,11 @@ export async function getJobSteps(
     const allWorkItems = stepResults.flatMap((r) => r.workItems);
 
     let resolved: ResolvedFiles | undefined;
-    if (q.resolveFiles !== undefined) {
+    if (q.resolveFiles) {
       if (q.workItems === undefined || q.workItems.length < 1) {
         throw new RequestValidationError('resolveFiles requires one or more workItems');
       }
-      resolved = await resolveWorkItemFiles(req, allWorkItems, q.resolveFiles, frontendRoot, destinationBucket);
+      resolved = await resolveWorkItemFiles(req, allWorkItems, frontendRoot, destinationBucket);
     }
 
     const jobSteps = buildSteps(req, stepResults, statusCounts, q, resolved);

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -123,8 +123,12 @@ function parseQuery(query: Record<string, unknown>): StepsQueryParams {
   }
 
   if (query.resolvefiles !== undefined) {
+    const values = parseMultiValueParameter(query.resolvefiles as string | string[]);
+    if (values.length !== 1) {
+      throw new RequestValidationError('resolveFiles must be true or false');
+    }
     try {
-      out.resolveFiles = parseBoolean(query.resolvefiles as string);
+      out.resolveFiles = parseBoolean(values[0]);
     } catch (e) {
       if (e instanceof ParameterParseError) {
         throw new RequestValidationError('resolveFiles must be true or false');

--- a/services/harmony/app/frontends/steps.ts
+++ b/services/harmony/app/frontends/steps.ts
@@ -38,8 +38,8 @@ const MAX_WORKITEMS_PER_PAGE = 1000;
 // A catalog that contains both a data and opendap asset will provide
 // two both urls to the resolved url list.
 
-const DEFAULT_WI_LIMIT = 50;
-const MAX_WI_LIMIT = 100;
+const DEFAULT_WORKITEM_LIMIT = 50;
+const MAX_WORKITEM_LIMIT = 100;
 
 const VALID_STATUSES = Object.values(WorkItemStatus);
 
@@ -208,19 +208,19 @@ export function safePublicLink(href: string, frontendRoot: string, destinationBu
 }
 
 // A single workItem's resolved page of files plus its paging if needed
-interface WiResolvedFiles {
+interface WorkItemResolvedFiles {
   files: string[];
   paging?: StepPaging;
 }
 
 // A single workItem's resolved page of input and output files
-interface WiAccessFiles {
-  input: WiResolvedFiles;
-  output: WiResolvedFiles;
+interface WorkItemAccessFiles {
+  input: WorkItemResolvedFiles;
+  output: WorkItemResolvedFiles;
 }
 
 // Map of workItem id -> resolved page of files
-type ResolvedFiles = Map<number, WiAccessFiles>;
+type ResolvedFiles = Map<number, WorkItemAccessFiles>;
 
 /**
  * Build the link, back to this same steps endpoint, that resolves a single work
@@ -277,7 +277,7 @@ function catalogIndex(filename: string): number {
  *     several `catalogN.json` files without an index.
  * The full ordered list is returned.
  *
- * @param outputDir - the WI's outputs directory URL
+ * @param outputDir - the WorkItems's outputs directory URL
  * @returns the ordered output catalog URLs
  */
 async function getAllOutputCatalogFilenames(outputDir: string): Promise<string[]> {
@@ -343,8 +343,8 @@ async function resolvePagedFiles(
   readPage: (pageSourceUrls: string[]) => Promise<string[]>,
   frontendRoot: string,
   destinationBucket: string | undefined,
-): Promise<WiResolvedFiles> {
-  const perPage = parseIntegerParam(req, 'wilimit', DEFAULT_WI_LIMIT, 1, MAX_WI_LIMIT, true, true);
+): Promise<WorkItemResolvedFiles> {
+  const perPage = parseIntegerParam(req, 'wilimit', DEFAULT_WORKITEM_LIMIT, 1, MAX_WORKITEM_LIMIT, true, true);
   const requestedPage = parseIntegerParam(req, pageParam, 1, 1);
   try {
     const sourceUrls = await loadSourceUrls();
@@ -373,7 +373,7 @@ async function resolvePagedFiles(
  */
 async function resolveInputFiles(
   req: HarmonyRequest, wi: WorkItem, frontendRoot: string, destinationBucket: string | undefined,
-): Promise<WiResolvedFiles> {
+): Promise<WorkItemResolvedFiles> {
   if (!wi.stacCatalogLocation) return { files: [] };
   return resolvePagedFiles(
     req, `workitem${wi.id}inputpage`,
@@ -397,7 +397,7 @@ async function resolveInputFiles(
  */
 async function resolveOutputFiles(
   req: HarmonyRequest, wi: WorkItem, frontendRoot: string, destinationBucket: string | undefined,
-): Promise<WiResolvedFiles> {
+): Promise<WorkItemResolvedFiles> {
   if (!COMPLETED_WORK_ITEM_STATUSES.includes(wi.status)) return { files: [] };
   const outputDir = getStacLocation({ id: wi.id, jobID: wi.jobID });
   return resolvePagedFiles(
@@ -495,7 +495,7 @@ interface StepWorkItems {
  * @param stepResults - each workflow step with its page of workItems and pagination
  * @param statusCounts - per-step, per-status workItem counts for the whole job
  * @param q - the parsed steps query, used to honor the status/workItem filters
- * @param resolved - per-WI resolved files map (resolve mode only)
+ * @param resolved - per-WorkItem resolved files map (resolve mode only)
  * @returns the steps with their workItems, status summary, and any paging links
  */
 function buildSteps(

--- a/services/harmony/app/markdown/steps.md
+++ b/services/harmony/app/markdown/steps.md
@@ -15,25 +15,25 @@ As with the jobs API, there are two sets of steps API endpoints with the same su
 
 Returns the workflow steps for the given job, along with the work items processed by each step. Each step's work items are paged independently: by default up to 50 are shown per step (configurable with `limit`), and each step is navigated with its own `step<stepIndex>Page` parameter. A step with more than one page of work items includes a `paging` object with links to the other pages.
 
-A work item can reference or produce a very large number of files - for example a query-cmr step that fans out to thousands of granules, or an aggregating step whose single input catalog lists many items. To keep the endpoint responsive, it does **not** read any files from storage. Instead, each work item has `inputFilesUrl` and `outputFilesUrl` links (see [work item fields](#step-work-item-response)). The files themselves are resolved, and paged, only on demand by following those links - see [Resolving a work item's files](#steps-resolve-files).
+A work item can reference or produce a very large number of files - for example a query-cmr step that fans out to thousands of granules, or an aggregating step whose single input catalog lists many items. To keep the endpoint responsive, it does **not** read any files from storage. Instead, each work item has an `accessFilesUrl` link (see [work item fields](#step-work-item-response)). The files themselves are resolved, and paged, only on demand by following this link - see [Resolving a work item's files](#steps-resolve-files).
 
 #### <a name="steps-resolve-files"></a> Resolving a work item's files
 
-To see a work item's actual input or output files, you need to follow its `inputFilesUrl` / `outputFilesUrl`, which is designed to make a request back to the steps endpoint scoped to that one work item and sets the `resolveFiles` parameter to the chosen input or output value:
+To see a work item's actual input and output files, you need to follow its `accessFilesUrl`, which is designed to make a request back to the steps endpoint scoped to that one work item and sets the `resolveFiles` parameter to `true`:
 
 ```http
 
-{{root}}/jobs/<job-id>/steps?workItem=<id>&resolveFiles=output
+{{root}}/jobs/<job-id>/steps?workItem=<id>&resolveFiles=true
 
 ```
-**Example {{exampleCounter}}** - Resolving a work item's output files
+**Example {{exampleCounter}}** - Resolving a work item's files
 
-When `resolveFiles` is supplied and one or more `workItem`s are given, each work item is returned with the requested kind of files resolved inline:
+When `resolveFiles=true` is supplied and one or more `workItem`s are given, each work item is returned with both its input and output files resolved inline:
 
-- `resolveFiles=input` populates `inputFiles` (and `inputFilesPaging`), reading a page of the work item's input STAC catalog items.
-- `resolveFiles=output` populates `outputFiles` (and `outputFilesPaging`), reading a page of the work item's output STAC catalogs.
+- `inputFiles` (and `inputFilesPaging`) are populated by reading a page of the work item's input STAC catalog items.
+- `outputFiles` (and `outputFilesPaging`) are populated by reading a page of the work item's output STAC catalogs.
 
-Both are paged to bound the number of reads: at most `wiLimit` items/catalogs (default 50, maximum 100) are read per request. Input pages are navigated with the work item's `workItem<id>InputPage` parameter and output pages with its `workItem<id>OutputPage` parameter. A kind with more than one page includes an `inputFilesPaging` / `outputFilesPaging` object with links to the other pages.
+Each is paged independently to bound the number of reads: at most `wiLimit` items/catalogs (default 50, maximum 100) are read per request per input and output. Input pages are navigated with the work item's `workItem<id>InputPage` parameter and output pages with its `workItem<id>OutputPage` parameter, so the two catalogs can be paged independently. When necessary, an `inputFilesPaging` or `outputFilesPaging` object with links to the other pages is included.
 
 ##### <a name="steps-query-parameters"></a> Query Parameters
 Parameter names are case-insensitive (e.g. `step2Page`, `Step2Page`, and `STEP2PAGE` are equivalent).
@@ -44,11 +44,11 @@ Parameter names are case-insensitive (e.g. `step2Page`, `Step2Page`, and `STEP2P
 | status              | Filter the work items shown to one or more statuses, comma-separated (e.g. `status=failed,warning`). Each one of `ready`, `queued`, `running`, `successful`, `failed`, `canceled`, or `warning`. Steps with no matching work items are omitted. |
 | workItem            | Limit the work items shown to one or more IDs, comma-separated (e.g. `workItem=123,124`). Each a positive integer.                                                                            |
 | limit               | The number of work items to show per page for each step. Defaults to 50, maximum 1000.
-| resolveFiles        | Resolves work item's files inline instead of returning `inputFilesUrl` / `outputFilesUrl` links. One of `input` or `output`. Requires one or more `workItem`s; otherwise the request is rejected. See [Resolving a work item's files](#steps-resolve-files). |
-| wiLimit             | The page size used when resolving files: the number of input STAC items (for `resolveFiles=input`) or output STAC catalogs (for `resolveFiles=output`) read per page. Defaults to 50, maximum 100. |
+| resolveFiles        | Resolves a work item's input and output files inline instead of returning an `accessFilesUrl` link. Set to `true`. Requires one or more `workItem`s; otherwise the request is rejected. See [Resolving a work item's files](#steps-resolve-files). |
+| wiLimit             | The page size used when resolving files: the number of input STAC items and output STAC catalogs read per page (each paged independently). Defaults to 50, maximum 100. |
 | step\<stepIndex\>Page | The page of work items to show for the step with the given stepIndex, e.g. `step2Page=3`. A positive integer that defaults to 1; a page beyond the last page returns the last page. Each step pages independently, so multiple may be supplied. |
-| workItem\<id\>OutputPage | The page of output files to show for the work item with the given id when `resolveFiles=output`, e.g. `workItem123OutputPage=2`. Output files are paged by STAC catalog (`wiLimit` per page). A positive integer that defaults to 1; a page beyond the last page returns the last page. |
-| workItem\<id\>InputPage | The page of input files to show for the work item with the given id when `resolveFiles=input`, e.g. `workItem123InputPage=2`. Input files are paged by STAC item (`wiLimit` per page). A positive integer that defaults to 1; a page beyond the last page returns the last page. |
+| workItem\<id\>OutputPage | The page of output files to show for the work item with the given id when `resolveFiles=true`, e.g. `workItem123OutputPage=2`. Output files are paged by STAC catalog (`wiLimit` per page). A positive integer that defaults to 1; a page beyond the last page returns the last page. |
+| workItem\<id\>InputPage | The page of input files to show for the work item with the given id when `resolveFiles=true`, e.g. `workItem123InputPage=2`. Input files are paged by STAC item (`wiLimit` per page). A positive integer that defaults to 1; a page beyond the last page returns the last page. |
 
 ---
 **Table {{tableCounter}}** - Harmony steps endpoint parameters
@@ -100,15 +100,14 @@ The `paging` object lets you navigate a step's work items one page at a time:
 **Table {{tableCounter}}** - Harmony step paging fields
 
 ###### <a name="step-work-item-response"></a> Work item fields
-Each entry in a step's `workItems` list describes a single work item. The default (link-only) response carries `id`, `status`, `retryCount`, and the two `*Url` fields. The `inputFiles` / `outputFiles` fields and their paging appear only when [resolving a work item's files](#steps-resolve-files):
+Each entry in a step's `workItems` list describes a single work item. The default (link-only) response carries `id`, `status`, `retryCount`, and the `accessFilesUrl` field. The `inputFiles` / `outputFiles` fields and their paging appear only when [resolving a work item's files](#steps-resolve-files):
 
 | field       | description                                                                                                                                                                               |
 |-------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | id          | ID of the work item in Harmony                                                                                                                                                            |
 | status      | Status of the work item                                                                                                                                                                   |
 | retryCount  | The number of times the work item has been retried                                                                                                                                        |
-| inputFilesUrl  | A link that resolves this work item's input files. Follow it (equivalently, pass `workItem=<id>&resolveFiles=input`) to get the files. |
-| outputFilesUrl | A link that resolves this work item's output files, or `null` if the work item has not yet completed. Follow it (equivalently, pass `workItem=<id>&resolveFiles=output`) to get the files. |
+| accessFilesUrl | A link that resolves this work item's input and output files, or `null` if there is nothing to resolve (no input catalog and the work item has not yet completed). Follow it (equivalently, pass the query string `workItem=<id>&resolveFiles=true`) to get the files. |
 | inputFiles  | A list of links to the input files for the current input-file page. Files unable be turned into a public link are shown as `<private file location>`. |
 | inputFilesPaging | Present when needed. Navigate the pages with the `workItem<id>InputPage` parameter. Same shape as a step's `paging` object — see [paging fields](#step-paging-response) (here `total` is the work item's number of input STAC items). |
 | outputFiles | A list of links to the output files for the current output-file page, or empty if it produced no output. Files unable be turned into a public link are shown as `<private file location>`. |

--- a/services/harmony/test/jobs/jobs-steps.ts
+++ b/services/harmony/test/jobs/jobs-steps.ts
@@ -442,22 +442,20 @@ describe('GET /jobs/:jobID/steps', function () {
       expect(body.steps[1].statuses).to.deep.equal({ failed: 1 });
     });
 
-    it('exposes link-only inputFilesUrl / outputFilesUrl fields and no inline files', function () {
+    it('exposes a link-only accessFilesUrl field and no inline files', function () {
       const body = JSON.parse(this.res.text);
       const wi1 = body.steps[0].workItems[0];
       const wi2 = body.steps[1].workItems[0];
 
       expect(wi1).to.not.have.property('inputFiles');
       expect(wi1).to.not.have.property('outputFiles');
+      expect(wi1.accessFilesUrl).to.include(`workitem=${wi1Id}`);
+      expect(wi1.accessFilesUrl).to.include('resolvefiles=true');
 
-      expect(wi1.inputFilesUrl).to.be.null;
-      expect(wi1.outputFilesUrl).to.include(`workitem=${wi1Id}`);
-      expect(wi1.outputFilesUrl).to.include('resolvefiles=output');
-
-      expect(wi2.inputFilesUrl).to.include(`workitem=${wi2Id}`);
-      expect(wi2.inputFilesUrl).to.include('resolvefiles=input');
-      expect(wi2.outputFilesUrl).to.include(`workitem=${wi2Id}`);
-      expect(wi2.outputFilesUrl).to.include('resolvefiles=output');
+      expect(wi2).to.not.have.property('inputFiles');
+      expect(wi2).to.not.have.property('outputFiles');
+      expect(wi2.accessFilesUrl).to.include(`workitem=${wi2Id}`);
+      expect(wi2.accessFilesUrl).to.include('resolvefiles=true');
     });
 
   });
@@ -543,14 +541,13 @@ describe('GET /jobs/:jobID/steps', function () {
 
   describe('For a job whose work item is still incomplete', function () {
     hookJobSteps({ jobID: runningJob.jobID, username: 'joe' });
-    it('leaves both input and ouput file links as null', function () {
+    it('leaves the access file link as null', function () {
       expect(this.res.statusCode).to.equal(200);
       const body = JSON.parse(this.res.text);
       const wi = body.steps[0].workItems[0];
       expect(wi.status).to.equal('ready');
 
-      expect(wi.outputFilesUrl).to.equal(null);
-      expect(wi.inputFilesUrl).to.equal(null);
+      expect(wi.accessFilesUrl).to.equal(null);
     });
   });
 
@@ -627,7 +624,7 @@ describe('GET /jobs/:jobID/steps', function () {
   describe('Resolving a work item with more than one page of output catalogs', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
-        jobID: pagedOutputJob.jobID, query: { workItem: pagedOutputWiId, resolveFiles: 'output' },
+        jobID: pagedOutputJob.jobID, query: { workItem: pagedOutputWiId, resolveFiles: true },
       }).use(auth({ username: 'joe' }));
     });
     after(function () { delete this.res; });
@@ -652,7 +649,7 @@ describe('GET /jobs/:jobID/steps', function () {
   describe('When ?wiLimit= overrides the output-catalog page size', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
-        jobID: pagedOutputJob.jobID, query: { workItem: pagedOutputWiId, resolveFiles: 'output', wiLimit: 5 },
+        jobID: pagedOutputJob.jobID, query: { workItem: pagedOutputWiId, resolveFiles: true, wiLimit: 5 },
       }).use(auth({ username: 'joe' }));
     });
     after(function () { delete this.res; });
@@ -676,7 +673,7 @@ describe('GET /jobs/:jobID/steps', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
         jobID: pagedOutputJob.jobID,
-        query: { workItem: pagedOutputWiId, resolveFiles: 'output', [`workItem${pagedOutputWiId}OutputPage`]: 2 },
+        query: { workItem: pagedOutputWiId, resolveFiles: true, [`workItem${pagedOutputWiId}OutputPage`]: 2 },
       }).use(auth({ username: 'joe' }));
     });
     after(function () { delete this.res; });
@@ -698,7 +695,7 @@ describe('GET /jobs/:jobID/steps', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
         jobID: pagedOutputJob.jobID,
-        query: { workItem: pagedOutputWiId, resolveFiles: 'output', [`workItem${pagedOutputWiId}OutputPage`]: 9 },
+        query: { workItem: pagedOutputWiId, resolveFiles: true, [`workItem${pagedOutputWiId}OutputPage`]: 9 },
       }).use(auth({ username: 'joe' }));
     });
     after(function () { delete this.res; });
@@ -716,7 +713,7 @@ describe('GET /jobs/:jobID/steps', function () {
   describe('Resolving a work item with more than one page of input items', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
-        jobID: inputPagedJob.jobID, query: { workItem: inputPagedWiId, resolveFiles: 'input' },
+        jobID: inputPagedJob.jobID, query: { workItem: inputPagedWiId, resolveFiles: true },
       }).use(auth({ username: 'joe' }));
     });
     after(function () { delete this.res; });
@@ -742,7 +739,7 @@ describe('GET /jobs/:jobID/steps', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
         jobID: inputPagedJob.jobID,
-        query: { workItem: inputPagedWiId, resolveFiles: 'input', [`workItem${inputPagedWiId}InputPage`]: 2 },
+        query: { workItem: inputPagedWiId, resolveFiles: true, [`workItem${inputPagedWiId}InputPage`]: 2 },
       }).use(auth({ username: 'joe' }));
     });
     after(function () { delete this.res; });
@@ -764,7 +761,7 @@ describe('GET /jobs/:jobID/steps', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
         jobID: inputPagedJob.jobID,
-        query: { workItem: inputPagedWiId, resolveFiles: 'input', [`workItem${inputPagedWiId}InputPage`]: 9 },
+        query: { workItem: inputPagedWiId, resolveFiles: true, [`workItem${inputPagedWiId}InputPage`]: 9 },
       }).use(auth({ username: 'joe' }));
     });
     after(function () { delete this.res; });
@@ -782,7 +779,7 @@ describe('GET /jobs/:jobID/steps', function () {
   describe('For a job written to a user destinationUrl bucket', function () {
     before(async function () {
       this.res = await jobSteps(this.frontend, {
-        jobID: destBucketJob.jobID, query: { workItem: destWiId, resolveFiles: 'output' },
+        jobID: destBucketJob.jobID, query: { workItem: destWiId, resolveFiles: true },
       }).use(auth({ username: 'joe' }));
     });
     after(function () { delete this.res; });
@@ -1013,8 +1010,8 @@ describe('GET /jobs/:jobID/steps', function () {
       });
     });
 
-    describe('?resolveFiles=input without a workItem filter', function () {
-      hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { resolveFiles: 'input' } });
+    describe('?resolveFiles=true without a workItem filter', function () {
+      hookJobSteps({ jobID: joeJob.jobID, username: 'joe', query: { resolveFiles: true } });
       it('returns 400', function () {
         expect(this.res.statusCode).to.equal(400);
       });
@@ -1028,10 +1025,10 @@ describe('GET /jobs/:jobID/steps', function () {
       });
     });
 
-    describe('?resolveFiles=input with more than one workItem', function () {
+    describe('?resolveFiles=true with more than one workItem', function () {
       before(async function () {
         this.res = await jobSteps(this.frontend, {
-          jobID: joeJob.jobID, query: { workItem: `${wi1Id},${wi2Id}`, resolveFiles: 'input' },
+          jobID: joeJob.jobID, query: { workItem: `${wi1Id},${wi2Id}`, resolveFiles: true },
         }).use(auth({ username: 'joe' }));
       });
       after(function () { delete this.res; });
@@ -1040,13 +1037,14 @@ describe('GET /jobs/:jobID/steps', function () {
         expect(this.res.statusCode).to.equal(200);
       });
 
-      it('resolves files inline for each requested work item', function () {
+      it('resolves both input and output files inline for each requested work item', function () {
         const body = JSON.parse(this.res.text);
         const workItems = body.steps.flatMap((s) => s.workItems);
         expect(workItems.map((wi) => wi.id)).to.have.members([wi1Id, wi2Id]);
         for (const wi of workItems) {
-          expect(wi).to.not.have.property('inputFilesUrl');
+          expect(wi).to.not.have.property('accessFilesUrl');
           expect(wi.inputFiles).to.be.an('array');
+          expect(wi.outputFiles).to.be.an('array');
         }
       });
     });


### PR DESCRIPTION
## Jira Issue ID

[HARMONY-2372](https://bugs.earthdata.nasa.gov/browse/HARMONY-2372)

## Description

Combines inputFilesUrl and outputFilesUrl into a single accessFilesUrl link to resolve both input and output files.

Both sets of files are pageable independently (but to see it you'll probably need a batchee step and a `wilimit`


## Local Test Steps

Pull this branch, run the tests, and deploy to Harmony-In-A-Box.

Make some requests and examine the steps endoint output. 

Verify that there are single links now that are `accessFilesUrl` and that the links have `&resolvefiles=true` in them 

If you're feeling lucky you can deploy Harmony-In-A-Box with: "harmonyservices/query-cmr:latest","podaac/l2ss-py:sit","nasa/batchee:latest","nasa/stitchee:latest",podaac/concise:sit",

run this 20 element request.
http://localhost:3000/C1254854453-LARC_CLOUD/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?subset=lat(-70%3A30)&subset=lon(-157.5%3A-10)&concatenate=true&maxResults=20&extend=true&serviceId=l2-subsetter-batchee-stitchee-concise

Access the batchee files via the link `/steps?workitem={batchee}&resolvefiles=true`
check paging for in and output files works by adding a `wilimit`  `/steps?workitem={batchee}&resolvefiles=true&wilimit=3`
you can add another workitem to make sure more than one still works as well.  `/steps?workitem={querycmrWid},{batcheeWid}&resolvefiles=true&wilimit=3`



## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)
* [X] Harmony in a Box tested (if changes made to microservices or new dependencies added)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Steps API “resolve files” behavior to use a single `accessFilesUrl` link in overview mode.
  * When resolving is enabled, the API now inlines both `inputFiles` and `outputFiles` together, with updated paging included where applicable.
  * Updated query handling for `resolveFiles` to use `resolveFiles=true`, with stricter single-value validation.
* **Documentation**
  * Refreshed the Steps API documentation to reflect the new `accessFilesUrl` and `resolveFiles=true` flow.
* **Tests**
  * Updated job/steps test coverage and assertions for the new response shape and validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->