### PR TITLE
HARMONY-2349: Change timezone calculations to occur on the client browser instead of server side

### DIFF
--- a/services/harmony/app/frontends/dashboard.ts
+++ b/services/harmony/app/frontends/dashboard.ts
@@ -504,73 +504,6 @@ interface DashboardWindowView {
 }
 
 /**
- * Formats an ISO timestamp as a local-time HH:MM string.
- *
- * @param isoString - ISO timestamp
- * @param options - Intl.DateTimeFormatOptions to control formatting
- * @returns formatted local time
- */
-function formatLocalTime(
-  isoString: string,
-  options: Intl.DateTimeFormatOptions,
-): string {
-  return new Intl.DateTimeFormat([], options).format(new Date(isoString));
-}
-
-/**
- * Returns Intl.DateTimeFormatOptions appropriate for the given time range.
- *
- * @param startIso - The start of the time range (ISO string)
- * @param endIso - The end of the time range (ISO string)
- * @returns Intl.DateTimeFormatOptions for formatting the time range
- */
-function getTimeRangeFormatOptions(
-  startIso: string,
-  endIso: string,
-): Intl.DateTimeFormatOptions {
-  const start = new Date(startIso);
-  const end = new Date(endIso);
-  const now = new Date();
-
-  const sameDay = start.getFullYear() === now.getFullYear()
-    && start.getMonth() === now.getMonth()
-    && start.getDate() === now.getDate()
-    && end.getFullYear() === now.getFullYear()
-    && end.getMonth() === now.getMonth()
-    && end.getDate() === now.getDate();
-
-  if (sameDay) {
-    return {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: true,
-    };
-  }
-
-  const sameYear = start.getFullYear() === now.getFullYear()
-    && end.getFullYear() === now.getFullYear();
-
-  if (sameYear) {
-    return {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: true,
-    };
-  }
-
-  return {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: true,
-  };
-}
-
-/**
  * Transforms raw metrics into the format expected by the Mustache template
  * and renders the HTML response.
  *
@@ -597,15 +530,12 @@ function renderDashboardHtml(
   ): DashboardWindowView => {
     const rate = computeRate(counts);
     const range = timeRanges[label];
-    const options = range
-      ? getTimeRangeFormatOptions(range.start, range.end)
-      : undefined;
 
     return {
       label,
       displayName: camelCaseToSpacedTitleCase(label),
-      startTime: range ? formatLocalTime(range.start, options) : '',
-      endTime: range ? formatLocalTime(range.end, options) : '',
+      startTime: range ? new Date(range.start).toISOString() : '',
+      endTime: range ? new Date(range.end).toISOString() : '',
 
       successful: counts.successful,
       failed: counts.failed,

--- a/services/harmony/app/views/dashboard.mustache.html
+++ b/services/harmony/app/views/dashboard.mustache.html
@@ -465,16 +465,60 @@
       }
     }
 
+    /**
+     * Chooses Intl format options for a range, matching the old server-side logic:
+     * same-day → time only; same-year → month/day + time; otherwise + year.
+     * Evaluated against the viewer's local clock (the timezone fix).
+     */
+    function formatTimeRangeOptions(start, end) {
+      const now = new Date();
+
+      const sameDay = start.getFullYear() === now.getFullYear()
+        && start.getMonth() === now.getMonth()
+        && start.getDate() === now.getDate()
+        && end.getFullYear() === now.getFullYear()
+        && end.getMonth() === now.getMonth()
+        && end.getDate() === now.getDate();
+
+      if (sameDay) {
+        return { hour: '2-digit', minute: '2-digit', hour12: true };
+      }
+
+      const sameYear = start.getFullYear() === now.getFullYear()
+        && end.getFullYear() === now.getFullYear();
+
+      if (sameYear) {
+        return { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true };
+      }
+
+      return { year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hour12: true };
+    }
+
+    /**
+     * Reformats each window's start/end <time> pair into the viewer's local zone,
+     * using shared options derived from the pair (mirrors the old server behavior).
+     */
     function renderLocalTimes() {
-      const fmt = new Intl.DateTimeFormat(undefined, {
-        month: 'short', day: 'numeric',
-        hour: 'numeric', minute: '2-digit',
-      });
+      // Group the two <time> elements by their shared parent <span>, so each
+      // window's start and end are formatted with the same options.
+      const groups = new Map();
       document.querySelectorAll('time.local-time').forEach((el) => {
-        const iso = el.textContent.trim();
-        if (!iso) return;
-        const d = new Date(iso);
-        if (!Number.isNaN(d.getTime())) el.textContent = fmt.format(d);
+        const parent = el.parentNode;
+        if (!groups.has(parent)) groups.set(parent, []);
+        groups.get(parent).push(el);
+      });
+
+      groups.forEach((els) => {
+        const [startEl, endEl] = els;
+        if (!startEl || !endEl) return;
+
+        const start = new Date(startEl.textContent.trim());
+        const end = new Date(endEl.textContent.trim());
+        if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) return;
+
+        const fmt = new Intl.DateTimeFormat([], formatTimeRangeOptions(start, end));
+        startEl.textContent = fmt.format(start);
+        endEl.textContent = fmt.format(end);
       });
     }
 

--- a/services/harmony/app/views/dashboard.mustache.html
+++ b/services/harmony/app/views/dashboard.mustache.html
@@ -175,7 +175,7 @@
                     <div class="text-muted small text-uppercase mb-2">
                       {{displayName}}
                       <span class="fw-normal">
-                        ({{startTime}} - {{endTime}})
+                        (<time class="local-time">{{startTime}}</time> - <time class="local-time">{{endTime}}</time>)
                       </span>
                     </div>
                     <div class="row">
@@ -242,7 +242,7 @@
                 <th scope="col" colspan="5" class="text-center border-start">
                   {{displayName}}
                   <span class="text-muted fw-normal">
-                    ({{startTime}} - {{endTime}})
+                    (<time class="local-time">{{startTime}}</time> - <time class="local-time">{{endTime}}</time>)
                   </span>
                 </th>
                 {{/windows}}
@@ -464,6 +464,21 @@
           : "bi bi-sort-down sort-icon";
       }
     }
+
+    function renderLocalTimes() {
+      const fmt = new Intl.DateTimeFormat(undefined, {
+        month: 'short', day: 'numeric',
+        hour: 'numeric', minute: '2-digit',
+      });
+      document.querySelectorAll('time.local-time').forEach((el) => {
+        const iso = el.textContent.trim();
+        if (!iso) return;
+        const d = new Date(iso);
+        if (!Number.isNaN(d.getTime())) el.textContent = fmt.format(d);
+      });
+    }
+
+    renderLocalTimes();
   </script>
   <script>
     (function () {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2349

## Description
I saw a problem with the last 5 minutes and last 60 minutes showing times offset by 4 hours after HARMONY-2349 was deployed to SIT. This PR changes timezone calculations to occur on the client browser side instead of the server side due to Postgres timezone differences in live environments. This only changes the display on the browser to consistently be in local time for all places times are used. Queries were already correct.

## Local Test Steps
You cannot reproduce the problem locally (I guess our Postgres container setup doesn't match the timezone setup in deployed environments). I reproduced the problem in sandbox first and then verified the fix there.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard time ranges now display in each viewer’s local timezone.
  * Start and end times are formatted consistently across system summaries and service windows.
* **Bug Fixes**
  * Improved handling of time ranges spanning different days or years for clearer date and time display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->