### PR TITLE
docs: fix cross-repo links in data-operation schema README

### DIFF
--- a/services/harmony/app/schemas/data-operation/README.md
+++ b/services/harmony/app/schemas/data-operation/README.md
@@ -14,11 +14,11 @@
 - [ ] Update all of the batch<n>-operation.json files in [test/resources/data-operation-samples](../../../test/resources/data-operation-samples)
 - [ ] Update [test/resources/data-operation-samples/multiple-collections-operation.json](../../../test/resources/data-operation-samples/multiple-collections-operation.json)
 - [ ] Update [example/service-operation.json](../../../example/service-operation.json) to reference the updated schema and have any required fields
-- [ ] Update [harmony-service-lib-py](../../../../../../harmony-service-lib-py/harmony_service_lib/message.py) to parse the new schema
-- [ ] Update [harmony-service-lib-py/tests/example_messages.py](../../../../../../harmony-service-lib-py/tests/example_messages.py) to use the new schema
-- [ ] Update [harmony-service-lib-py/tests/test_message.py](../../../../../../harmony-service-lib-py/tests/test_message.py) to use the new schema version and add / alter any necessary checks
-- [ ] Update [harmony-service-lib-py/example/example_message.json](../../../../../../harmony-service-lib-py/example/example_message.json) to use the new schema
-- [ ] Update [harmony-service-example/example/harmony-operation.json](../../../../../../harmony-service-example/example/harmony-operation.json) to use the new schema
+- [ ] Update [harmony-service-lib-py](https://github.com/nasa/harmony-service-lib-py/blob/main/harmony_service_lib/message.py) to parse the new schema
+- [ ] Update [harmony-service-lib-py/tests/example_messages.py](https://github.com/nasa/harmony-service-lib-py/blob/main/tests/example_messages.py) to use the new schema
+- [ ] Update [harmony-service-lib-py/tests/test_message.py](https://github.com/nasa/harmony-service-lib-py/blob/main/tests/test_message.py) to use the new schema version and add / alter any necessary checks
+- [ ] Update [harmony-service-lib-py/example/example_message.json](https://github.com/nasa/harmony-service-lib-py/blob/main/example/example_message.json) to use the new schema
+- [ ] Update [harmony-service-example/example/harmony-operation.json](https://github.com/nasa/harmony-service-example/blob/main/example/harmony-operation.json) to use the new schema
 - [ ] Update [config/services-uat.yml](../../../../../config/services-uat.yml) and [config/services-prod.yml](../../../../../config/services-prod.yml) to supply the new library version for any services that will be automatically or manually upgraded with the change
 - [ ] Update [docs/adapting-new-services.md](../../../../../docs/guides/adapting-new-services.md) to specify the updated version
 - [ ] Update any Harmony-owned services that need to use the new features or may be incompatible with the change


### PR DESCRIPTION
`services/harmony/app/schemas/data-operation/README.md` links five files in `harmony-service-lib-py` and `harmony-service-example` using `../../../../../../` relative paths — these escape the repository (they assume sibling checkouts) and 404 on GitHub's rendered view. Replaced with the canonical GitHub URLs; each target verified to exist via the GitHub API:

- `harmony_service_lib/message.py`, `tests/example_messages.py`, `tests/test_message.py`, `example/example_message.json` in [nasa/harmony-service-lib-py](https://github.com/nasa/harmony-service-lib-py)
- `example/harmony-operation.json` in [nasa/harmony-service-example](https://github.com/nasa/harmony-service-example)

Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the data operation schema checklist with direct links to relevant service library, parsing, test, and example JSON resources.
  * Improved documentation navigation for schema updates and related implementation tasks.
  * No changes were made to application functionality or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->