### PR TITLE
limit concise to 3gb

### DIFF
--- a/config/services-uat.yml
+++ b/config/services-uat.yml
@@ -219,6 +219,7 @@ https://cmr.uat.earthdata.nasa.gov:
       - image: !Env ${PODAAC_CONCISE_IMAGE}
         always_wait_for_prior_step: true
         is_batched: true
+        max_batch_size_in_bytes: 3000000000
         operations: ['concatenate']
 
   - name: podaac/l2-subsetter-concise
@@ -265,6 +266,7 @@ https://cmr.uat.earthdata.nasa.gov:
       - image: !Env ${PODAAC_CONCISE_IMAGE}
         always_wait_for_prior_step: true
         is_batched: true
+        max_batch_size_in_bytes: 3000000000
         operations: ['concatenate']
         conditional:
           exists: ['concatenate']

--- a/services/harmony/test/aggregation-batching.ts
+++ b/services/harmony/test/aggregation-batching.ts
@@ -654,6 +654,30 @@ describe('when testing a batched aggregation service', function () {
     let pageStub;
     let batchSizeStub;
 
+    const serviceConfigs = [
+      {
+        name: 'podaac/concise',
+        data_operation_version: '0.22.0',
+        type: {
+          name: 'turbo',
+        },
+        collections: [{ id: collection }],
+        capabilities: {
+          concatenation: true,
+        },
+        steps: [{
+          image: 'harmonyservices/query-cmr:stable',
+          is_sequential: true,
+        }, {
+          image: 'ghcr.io/podaac/concise:sit',
+          is_batched: true,
+          operations: ['concatenate'],
+        }],
+      },
+    ];
+
+    hookServices(serviceConfigs);
+
     before(function () {
       pageStub = stub(env, 'cmrMaxPageSize').get(() => 2);
       batchSizeStub = stub(env, 'maxBatchInputs').get(() => 10000);


### PR DESCRIPTION
## Jira Issue ID


## Description

- Reduce max_batch_size_in_bytes for Concise and test it in UAT first. Large batches have been causing pods to run out of memory when concatenating files.

## Local Test Steps


## PR Acceptance Checklist
* [ ] Acceptance criteria met
* [ ] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased the maximum supported batch size for select PODAAC processing workflows in the UAT environment, enabling larger data batches to be processed.
* **Tests**
  * Updated the batching aggregation test to explicitly configure and register the PODAAC “concise” service chain for scenarios constrained to multiple batches.
* **Security**
  * Updated the Harmony security configuration to actively track a specific vulnerability until the scheduled fix date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->