### PR TITLE
HARMONY-2391: Do not allow redirects via a query parameter and ensure logout on Harmony forces a complete log out of EDL.

### DIFF
--- a/services/harmony/app/middleware/earthdata-login-oauth-authorizer.ts
+++ b/services/harmony/app/middleware/earthdata-login-oauth-authorizer.ts
@@ -82,19 +82,24 @@ async function handleLogout(oauth2: AuthorizationCode, req, res, _next): Promise
 
   if (token) {
     const oauthToken = oauth2.createToken(token);
-    await oauthToken.revokeAll();
+    try {
+      await oauthToken.revokeAll();
+    } catch (e) {
+      req.context.logger.error('Failed to revoke token during logout.');
+      req.context.logger.error(e.stack);
+    }
   }
 
   res.clearCookie('token');
   res.clearCookie('redirect');
 
-  const edlLogoutUrl = new URL('/logout', oauthOptions.auth.tokenHost);
-  edlLogoutUrl.searchParams.set(
+  const logoutUrl = new URL('/logout', oauthOptions.auth.tokenHost);
+  logoutUrl.searchParams.set(
     'post_logout_redirect_uri',
     new URL('/', process.env.OAUTH_REDIRECT_URI).origin,
   );
 
-  res.redirect(303, edlLogoutUrl.toString());
+  res.redirect(303, logoutUrl.toString());
 }
 
 /**

--- a/services/harmony/app/middleware/earthdata-login-oauth-authorizer.ts
+++ b/services/harmony/app/middleware/earthdata-login-oauth-authorizer.ts
@@ -78,15 +78,23 @@ async function handleCodeValidation(oauth2: AuthorizationCode, req, res, _next):
  * @param _next - The next function in the middleware chain
  */
 async function handleLogout(oauth2: AuthorizationCode, req, res, _next): Promise<void> {
-  const { redirect } = req.query;
-
   const { token } = req.signedCookies;
+
   if (token) {
     const oauthToken = oauth2.createToken(token);
     await oauthToken.revokeAll();
-    res.clearCookie('token', cookieOptions);
   }
-  res.redirect(307, redirect || '/');
+
+  res.clearCookie('token');
+  res.clearCookie('redirect');
+
+  const edlLogoutUrl = new URL('/logout', oauthOptions.auth.tokenHost);
+  edlLogoutUrl.searchParams.set(
+    'post_logout_redirect_uri',
+    new URL('/', process.env.OAUTH_REDIRECT_URI).origin,
+  );
+
+  res.redirect(303, edlLogoutUrl.toString());
 }
 
 /**

--- a/services/harmony/test/earthdata-login.ts
+++ b/services/harmony/test/earthdata-login.ts
@@ -14,6 +14,9 @@ const blankToken = /^token=s%3A\./; // The start of a signed empty token cookie
 const nonBlankToken = /^token=s%3A[^.]/; // The start of a signed non-empty token cookie
 const blankRedirect = /^redirect=s%3A\./; // The start of a signed empty redirect cookie
 const nonBlankRedirect = /^redirect=s%3A[^.]/; // The start of a signed non-empty redirect cookie
+
+// The start of a signed empty token cookie with an expiry date
+const noTokenWithExpiryDate = /^token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/;
 const fakeUsername = 'testy_mctestface';
 
 describe('Earthdata Login', function () {
@@ -303,8 +306,7 @@ describe('Earthdata Login', function () {
         });
 
         it('removes the token', function () {
-          expect(this.res.headers['set-cookie'][0]).to.match(
-            /^token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/,
+          expect(this.res.headers['set-cookie'][0]).to.match(noTokenWithExpiryDate,
           );
         });
 
@@ -329,9 +331,7 @@ describe('Earthdata Login', function () {
         });
 
         it('removes the token', function () {
-          expect(this.res.headers['set-cookie'][0]).to.match(
-            /^token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/,
-          );
+          expect(this.res.headers['set-cookie'][0]).to.match(noTokenWithExpiryDate);
         });
 
         it('redirects to EDL logout', function () {
@@ -346,6 +346,68 @@ describe('Earthdata Login', function () {
 
         it('makes a call to revoke the access and refresh tokens', function () {
           expect(this.revokeStub.called);
+        });
+      });
+
+      describe('and a "redirect" cookie has been set', function () {
+        beforeEach(async function () {
+          this.res = await this.req
+            .query({ redirect: '/tohere' })
+            .use(auth({ username: fakeUsername, extraCookies: { redirect: '/pending' } }));
+        });
+
+        it('removes the redirect cookie', function () {
+          const cookies = this.res.headers['set-cookie'];
+          expect(cookies.some((cookie) =>
+            /^redirect=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/.test(cookie),
+          )).to.equal(true);
+        });
+
+        it('removes the token', function () {
+          expect(this.res.headers['set-cookie'][0]).to.match(noTokenWithExpiryDate,
+          );
+        });
+
+        it('ignores the "redirect" query parameter and redirects to EDL logout', function () {
+          expect(this.res.statusCode).to.equal(303);
+
+          const location = new URL(this.res.headers.location);
+          expect(location.pathname).to.equal('/logout');
+          expect(location.searchParams.get('post_logout_redirect_uri')).to.equal(
+            new URL('/', process.env.OAUTH_REDIRECT_URI).origin,
+          );
+        });
+
+        it('makes a call to revoke the access and refresh tokens', function () {
+          expect(this.revokeStub.called);
+        });
+      });
+
+      describe('and token revocation fails', function () {
+        beforeEach(async function () {
+          this.revokeStub.rejects(new Error('Revocation failed'));
+
+          this.res = await this.req.use(auth({ username: fakeUsername }));
+        });
+
+        it('clears the token cookie', function () {
+          expect(this.res.headers['set-cookie'][0]).to.match(noTokenWithExpiryDate);
+        });
+
+        it('clears the redirect cookie', function () {
+          expect(this.res.headers['set-cookie'][1]).to.match(
+            /^redirect=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/,
+          );
+        });
+
+        it('redirects to EDL logout', function () {
+          expect(this.res.statusCode).to.equal(303);
+
+          const location = new URL(this.res.headers.location);
+          expect(location.pathname).to.equal('/logout');
+          expect(location.searchParams.get('post_logout_redirect_uri')).to.equal(
+            new URL('/', process.env.OAUTH_REDIRECT_URI).origin,
+          );
         });
       });
     });

--- a/services/harmony/test/earthdata-login.ts
+++ b/services/harmony/test/earthdata-login.ts
@@ -562,7 +562,7 @@ describe('Earthdata Login', function () {
 
   describe('When an EDL oauth endpoint fails', function () {
     before(async function () {
-      this.req = request(this.frontend).get('/oauth2/logout').use(auth({ username: fakeUsername }));
+      this.req = request(this.frontend).get('/oauth2/redirect').use(auth({ username: fakeUsername }));
       this.revokeStub = stubEdlError(
         '/oauth/revoke',
         undefined,

--- a/services/harmony/test/earthdata-login.ts
+++ b/services/harmony/test/earthdata-login.ts
@@ -295,18 +295,27 @@ describe('Earthdata Login', function () {
     });
 
     describe('When the client supplies a token', function () {
-      describe('and a "redirect" parameter has been set', function () {
+      describe('and a "redirect" query parameter has been set', function () {
         beforeEach(async function () {
-          this.res = await this.req.query({ redirect: '/tohere' }).use(auth({ username: fakeUsername }));
+          this.res = await this.req
+            .query({ redirect: '/tohere' })
+            .use(auth({ username: fakeUsername }));
         });
 
         it('removes the token', function () {
-          expect(this.res.headers['set-cookie'][0]).to.match(blankToken);
+          expect(this.res.headers['set-cookie'][0]).to.match(
+            /^token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/,
+          );
         });
 
-        it('redirects to the endpoint supplied in the "redirect" parameter', function () {
-          expect(this.res.statusCode).to.equal(307);
-          expect(this.res.headers.location).to.equal('/tohere');
+        it('ignores the "redirect" query parameter and redirects to EDL logout', function () {
+          expect(this.res.statusCode).to.equal(303);
+
+          const location = new URL(this.res.headers.location);
+          expect(location.pathname).to.equal('/logout');
+          expect(location.searchParams.get('post_logout_redirect_uri')).to.equal(
+            new URL('/', process.env.OAUTH_REDIRECT_URI).origin,
+          );
         });
 
         it('makes a call to revoke the access and refresh tokens', function () {
@@ -320,12 +329,19 @@ describe('Earthdata Login', function () {
         });
 
         it('removes the token', function () {
-          expect(this.res.headers['set-cookie'][0]).to.match(blankToken);
+          expect(this.res.headers['set-cookie'][0]).to.match(
+            /^token=; Path=\/; Expires=Thu, 01 Jan 1970 00:00:00 GMT/,
+          );
         });
 
-        it('redirects to the site root', function () {
-          expect(this.res.statusCode).to.equal(307);
-          expect(this.res.headers.location).to.equal('/');
+        it('redirects to EDL logout', function () {
+          expect(this.res.statusCode).to.equal(303);
+
+          const location = new URL(this.res.headers.location);
+          expect(location.pathname).to.equal('/logout');
+          expect(location.searchParams.get('post_logout_redirect_uri')).to.equal(
+            new URL('/', process.env.OAUTH_REDIRECT_URI).origin,
+          );
         });
 
         it('makes a call to revoke the access and refresh tokens', function () {
@@ -335,18 +351,23 @@ describe('Earthdata Login', function () {
     });
 
     describe('When the client does not supply a token', function () {
-      describe('and a "redirect" parameter has been set', function () {
+      describe('and a "redirect" query parameter has been set', function () {
         beforeEach(async function () {
           this.res = await this.req.query({ redirect: '/tohere' });
         });
 
-        it('redirects to the endpoint supplied in the "redirect" parameter', function () {
-          expect(this.res.statusCode).to.equal(307);
-          expect(this.res.headers.location).to.equal('/tohere');
+        it('ignores the "redirect" query parameter and redirects to EDL logout', function () {
+          expect(this.res.statusCode).to.equal(303);
+
+          const location = new URL(this.res.headers.location);
+          expect(location.pathname).to.equal('/logout');
+          expect(location.searchParams.get('post_logout_redirect_uri')).to.equal(
+            new URL('/', process.env.OAUTH_REDIRECT_URI).origin,
+          );
         });
 
-        it('makes a call to revoke the access and refresh tokens', function () {
-          expect(this.revokeStub.called);
+        it('does not make a call to revoke the access and refresh tokens', function () {
+          expect(this.revokeStub.called).to.equal(false);
         });
       });
 
@@ -355,13 +376,18 @@ describe('Earthdata Login', function () {
           this.res = await this.req;
         });
 
-        it('redirects to the site root', function () {
-          expect(this.res.statusCode).to.equal(307);
-          expect(this.res.headers.location).to.equal('/');
+        it('redirects to EDL logout', function () {
+          expect(this.res.statusCode).to.equal(303);
+
+          const location = new URL(this.res.headers.location);
+          expect(location.pathname).to.equal('/logout');
+          expect(location.searchParams.get('post_logout_redirect_uri')).to.equal(
+            new URL('/', process.env.OAUTH_REDIRECT_URI).origin,
+          );
         });
 
-        it('makes a call to revoke the access and refresh tokens', function () {
-          expect(this.revokeStub.called);
+        it('does not make a call to revoke the access and refresh tokens', function () {
+          expect(this.revokeStub.called).to.equal(false);
         });
       });
     });


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2391

## Description
Fixes the issue with allowing a query parameter to control a redirect URL when calling the logout endpoint. In addition log out was not invalidating the EDL session so navigating to another harmony page would just log the user right back in. This change forces the user to now log back in after intentionally logging out.

## Local Test Steps
In a browser make sure you log into harmony on http://localhost:3000/workflow-ui

Navigate to http://localhost:3000/oauth2/logout and ensure you are redirected to the EDL page and it shows you are logged out.

Navigate to http://localhost:3000/workflow-ui and verify it forces you to log back in.

Also verify `curl -v "http://localhost:3000/oauth2/logout?redirect=https%3A%2F%2Fexample.com%2Ffoo"` ignores your redirect parameter - the original ticket issue.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved logout handling by revoking active tokens when available.
  - Logout now completes even if token revocation encounters an error.
  - Ensured authentication and redirect cookies are cleared during logout.
  - Updated logout redirects to use Earthdata Login with a secure, configured return destination.
  - Ignored client-provided redirect parameters to prevent unexpected navigation.
  - Unauthenticated logout requests no longer attempt token revocation.
  - Updated logout responses to use the appropriate redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->