### PR TITLE
HARMONY-2401: Admin dashboard updates

### DIFF
--- a/services/harmony/app/frontends/dashboard.ts
+++ b/services/harmony/app/frontends/dashboard.ts
@@ -413,14 +413,15 @@ function countClass(count: number, status: TrackedStatus): string {
 }
 
 /**
- * Computes a success rate from a set of status counts.
- * Warnings are included in the denominator while canceled items are excluded.
+ * Computes a success rate from a set of status counts. Only successful and failed
+ * items are considered; warned and canceled items are excluded from the
+ * denominator so that neither counts against the rate.
  *
  * @param counts - The status counts to evaluate
  * @returns Success rate between 0 and 1, or null if no applicable items exist
  */
 function computeRate(counts: StatusCounts): number | null {
-  const denominator = counts.successful + counts.failed + counts.warning;
+  const denominator = counts.successful + counts.failed;
 
   if (denominator === 0) {
     return null;
@@ -449,6 +450,17 @@ function rateClass(rate: number | null): string {
   }
 
   return 'rate-bad';
+}
+
+/**
+ * Formats a count for display in the HTML dashboard, grouping thousands with
+ * commas. Only used for the HTML view - the JSON response returns raw numbers.
+ *
+ * @param count - The count to format
+ * @returns The count as a string with thousands separators
+ */
+function formatCount(count: number): string {
+  return count.toLocaleString('en-US');
 }
 
 /**
@@ -484,10 +496,10 @@ interface DashboardWindowView {
   startTime: string;
   endTime: string;
 
-  successful: number;
-  failed: number;
-  canceled: number;
-  warning: number;
+  successful: string;
+  failed: string;
+  canceled: string;
+  warning: string;
 
   successfulClass: string;
   failedClass: string;
@@ -537,10 +549,10 @@ function renderDashboardHtml(
       startTime: range ? new Date(range.start).toISOString() : '',
       endTime: range ? new Date(range.end).toISOString() : '',
 
-      successful: counts.successful,
-      failed: counts.failed,
-      canceled: counts.canceled,
-      warning: counts.warning,
+      successful: formatCount(counts.successful),
+      failed: formatCount(counts.failed),
+      canceled: formatCount(counts.canceled),
+      warning: formatCount(counts.warning),
 
       successfulClass: countClass(counts.successful, 'successful'),
       failedClass: countClass(counts.failed, 'failed'),
@@ -589,7 +601,9 @@ function renderDashboardHtml(
 
     return {
       name,
-      queued: details.queued,
+      // queued for display has thousands separators, queuedCount is a raw number for sorting
+      queuedCount: details.queued,
+      queued: formatCount(details.queued),
       windows,
       trendIsUp,
       trendIsDown,
@@ -599,16 +613,16 @@ function renderDashboardHtml(
 
   const queuesArray = Object.entries(queues).map(([name, count]) => ({
     name: camelCaseToSpacedTitleCase(name),
-    count,
+    count: formatCount(count),
     isFailed: count === -1,
   }));
 
   // Sort by queued count descending for the primary dashboard view
-  servicesArray.sort((a, b) => b.queued - a.queued);
+  servicesArray.sort((a, b) => b.queuedCount - a.queuedCount);
 
   const windows = buildWindows(totals.windows);
   const summary = {
-    queued: totals.queued,
+    queued: formatCount(totals.queued),
     windows,
   };
 

--- a/services/harmony/app/views/dashboard.mustache.html
+++ b/services/harmony/app/views/dashboard.mustache.html
@@ -338,6 +338,17 @@
     }
 
     /**
+     * Parses a numeric cell ("1,234") to a sortable number, ignoring the
+     * thousands separators added for display.
+     *
+     * @param {string} text
+     * @returns {number}
+     */
+    function parseNumericCell(text) {
+      return parseInt(text.replace(/,/g, ''), 10);
+    }
+
+    /**
      * Returns the sortable column types based on the dynamic window count.
      *
      * @returns {{numericColumns: Set<number>, percentColumns: Set<number>}}
@@ -413,8 +424,8 @@
 
         if (isNumeric) {
           return (
-            parseInt(x, 10) -
-            parseInt(y, 10)
+            parseNumericCell(x) -
+            parseNumericCell(y)
           ) * direction;
         }
 

--- a/services/harmony/public/css/default.css
+++ b/services/harmony/public/css/default.css
@@ -98,12 +98,13 @@ a .badge-dark {
   z-index: 1;
 }
 
+/* An improving success rate is good news (green); a declining one is bad (red). */
 .trend-up {
-  color: #cf222e;
+  color: #1a7f37;
 }
 
 .trend-down {
-  color: #1a7f37;
+  color: #cf222e;
 }
 
 .trend-flat {

--- a/services/harmony/test/dashboard.ts
+++ b/services/harmony/test/dashboard.ts
@@ -677,7 +677,7 @@ describe('getDashboard', () => {
       const data = res.render.firstCall.args[1];
       expect(data.services).to.be.an('array');
       expect(data.services[0].name).to.equal('high-service');
-      expect(data.services[0].queued).to.equal(100);
+      expect(data.services[0].queued).to.equal('100');
     });
 
     it('transforms camelCase queue names into Title Case for the UI', async () => {
@@ -686,7 +686,7 @@ describe('getDashboard', () => {
       const data = res.render.firstCall.args[1];
       const smallUpdateQueue = data.queues.find(q => q.name === 'Small Work Item Updates');
       expect(smallUpdateQueue).to.exist;
-      expect(smallUpdateQueue.count).to.be.a('number');
+      expect(smallUpdateQueue.count).to.equal('20');
     });
 
     it('includes the harmony version in the rendered view', async () => {
@@ -706,7 +706,7 @@ describe('getDashboard', () => {
       const schedulerData = data.queues.find((q: any) => q.name === 'Work Item Scheduler');
 
       expect(schedulerData.isFailed).to.be.true;
-      expect(schedulerData.count).to.equal(-1);
+      expect(schedulerData.count).to.equal('-1');
     });
 
     it('sets isFailed to false when a queue count is valid', async () => {
@@ -716,7 +716,7 @@ describe('getDashboard', () => {
       const smallUpdateData = data.queues.find((q: any) => q.name === 'Small Work Item Updates');
 
       expect(smallUpdateData.isFailed).to.be.false;
-      expect(smallUpdateData.count).to.equal(20);
+      expect(smallUpdateData.count).to.equal('20');
     });
 
     it('sorts the services array by queued count descending for the initial view', async () => {
@@ -797,6 +797,170 @@ describe('getDashboard', () => {
         expect(window.warningClass).to.be.a('string');
         expect(window.rateClass).to.be.a('string');
       }
+    });
+
+    describe('success percentage', () => {
+      beforeEach(() => {
+        imageMapStub.returns({ 'some-image': 'some-service' });
+        getCountsByServiceStub.resolves({});
+      });
+
+      /**
+       * Stubs the 5-minute window with the given rows and returns the rendered
+       * success rate string for the first window of 'some-service'.
+       */
+      async function rateForRows(rows: workItemsStats.WorkItemsStatsRow[]): Promise<string> {
+        getWorkItemsStatsSummaryStub.callsFake((_trx: any, options: { lastMinutes: number }) => {
+          if (options.lastMinutes === 5) {
+            return Promise.resolve(makeStatsSummaryWithRows(5, rows));
+          }
+          return Promise.resolve(makeEmptyStatsSummary(options.lastMinutes));
+        });
+
+        await getDashboard(req, res, next);
+
+        const service = res.render.firstCall.args[1].services
+          .find((s: any) => s.name === 'some-service');
+        return service.windows[0].rate;
+      }
+
+      it('does not count warnings against the success percentage', async () => {
+        const rate = await rateForRows([
+          { service_id: 'some-image', status: 'successful', count: 90 },
+          { service_id: 'some-image', status: 'warning', count: 10 },
+        ]);
+
+        // Warnings are excluded from the denominator, so 90/90 is 100%
+        expect(rate).to.equal('100.0%');
+      });
+
+      it('excludes warnings from the denominator when failures are present', async () => {
+        const rate = await rateForRows([
+          { service_id: 'some-image', status: 'successful', count: 90 },
+          { service_id: 'some-image', status: 'failed', count: 10 },
+          { service_id: 'some-image', status: 'warning', count: 100 },
+        ]);
+
+        // 90 / (90 + 10), the 100 warnings are ignored entirely
+        expect(rate).to.equal('90.0%');
+      });
+
+      it('excludes canceled items from the success percentage', async () => {
+        const rate = await rateForRows([
+          { service_id: 'some-image', status: 'successful', count: 50 },
+          { service_id: 'some-image', status: 'canceled', count: 50 },
+        ]);
+
+        expect(rate).to.equal('100.0%');
+      });
+
+      it('reports no rate when a window has only warnings and cancellations', async () => {
+        const rate = await rateForRows([
+          { service_id: 'some-image', status: 'warning', count: 5 },
+          { service_id: 'some-image', status: 'canceled', count: 5 },
+        ]);
+
+        expect(rate).to.equal('—');
+      });
+
+      it('marks a rate of 100% with the good rate class', async () => {
+        getWorkItemsStatsSummaryStub.callsFake((_trx: any, options: { lastMinutes: number }) => {
+          if (options.lastMinutes === 5) {
+            return Promise.resolve(makeStatsSummaryWithRows(5, [
+              { service_id: 'some-image', status: 'successful', count: 10 },
+              { service_id: 'some-image', status: 'warning', count: 10 },
+            ]));
+          }
+          return Promise.resolve(makeEmptyStatsSummary(options.lastMinutes));
+        });
+
+        await getDashboard(req, res, next);
+
+        const service = res.render.firstCall.args[1].services
+          .find((s: any) => s.name === 'some-service');
+        expect(service.windows[0].rateClass).to.equal('rate-good');
+      });
+    });
+
+    describe('number formatting', () => {
+      it('formats large counts with commas for the HTML view', async () => {
+        imageMapStub.returns({ 'some-image': 'some-service' });
+        getCountsByServiceStub.resolves({ 'some-image': { queued: 1234567 } });
+
+        getWorkItemsStatsSummaryStub.callsFake((_trx: any, options: { lastMinutes: number }) => {
+          if (options.lastMinutes === 5) {
+            return Promise.resolve(makeStatsSummaryWithRows(5, [
+              { service_id: 'some-image', status: 'successful', count: 1000 },
+              { service_id: 'some-image', status: 'failed', count: 25000 },
+              { service_id: 'some-image', status: 'canceled', count: 100000 },
+              { service_id: 'some-image', status: 'warning', count: 9999 },
+            ]));
+          }
+          return Promise.resolve(makeEmptyStatsSummary(options.lastMinutes));
+        });
+
+        await getDashboard(req, res, next);
+
+        const service = res.render.firstCall.args[1].services
+          .find((s: any) => s.name === 'some-service');
+
+        expect(service.queued).to.equal('1,234,567');
+        expect(service.windows[0].successful).to.equal('1,000');
+        expect(service.windows[0].failed).to.equal('25,000');
+        expect(service.windows[0].canceled).to.equal('100,000');
+        expect(service.windows[0].warning).to.equal('9,999');
+      });
+
+      it('does not add separators to counts below one thousand', async () => {
+        imageMapStub.returns({ 'some-image': 'some-service' });
+        getCountsByServiceStub.resolves({ 'some-image': { queued: 999 } });
+
+        await getDashboard(req, res, next);
+
+        const service = res.render.firstCall.args[1].services
+          .find((s: any) => s.name === 'some-service');
+        expect(service.queued).to.equal('999');
+        expect(service.windows[0].successful).to.equal('0');
+      });
+
+      it('formats the system summary and queue counts with commas', async () => {
+        imageMapStub.returns({ 'some-image': 'some-service' });
+        getCountsByServiceStub.resolves({ 'some-image': { queued: 2500000 } });
+
+        const smallUpdateQueue = qf.getQueueForType(WorkItemQueueType.SMALL_ITEM_UPDATE);
+        (smallUpdateQueue.getApproximateNumberOfMessages as sinon.SinonStub).resolves(45000);
+
+        await getDashboard(req, res, next);
+
+        const data = res.render.firstCall.args[1];
+        expect(data.summary.queued).to.equal('2,500,000');
+
+        const queue = data.queues.find((q: any) => q.name === 'Small Work Item Updates');
+        expect(queue.count).to.equal('45,000');
+      });
+
+      it('returns raw numbers rather than formatted strings in the JSON response', async () => {
+        req.accepts.returns('json');
+        imageMapStub.returns({ 'some-image': 'some-service' });
+        getCountsByServiceStub.resolves({ 'some-image': { queued: 1234567 } });
+
+        getWorkItemsStatsSummaryStub.callsFake((_trx: any, options: { lastMinutes: number }) => {
+          if (options.lastMinutes === 5) {
+            return Promise.resolve(makeStatsSummaryWithRows(5, [
+              { service_id: 'some-image', status: 'successful', count: 250000 },
+            ]));
+          }
+          return Promise.resolve(makeEmptyStatsSummary(options.lastMinutes));
+        });
+
+        await getDashboard(req, res, next);
+
+        const result = res.json.firstCall.args[0];
+        expect(result.services['some-service'].queued).to.equal(1234567);
+        expect(result.services['some-service'].windows.last5Minutes.successful).to.equal(250000);
+        expect(result.totals.queued).to.equal(1234567);
+        expect(result.queues.smallWorkItemUpdates).to.be.a('number');
+      });
     });
 
     it('sets trendIsDown when 5-minute success rate is more than 2pp below the 60-minute rate', async () => {


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2401

## Description
Dashboard updates:

* Fix trend arrow color (it had the red and green colors flipped previously)
* Format large numbers with comma separators on the HTML dashboard view
* Ignore warnings when calculating success percentage

## Local Test Steps
Submit a request with more than 1000 granules and verify that the queued numbers are shown with comma separators on the HTML dashboard view and as raw numbers on the JSON view. http://localhost:3000/admin/dashboard

Submit successful and failing requests to verify the trend arrows. When comparing the first window to the second window if the success rate improves significantly in the first window the arrow should be up and green.

Submit requests that generate warnings and verify that the success rate does not consider warnings in the count (just like it does with canceled).

I deployed to sandbox and verified all 3 fixes there.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Success rates now exclude warning and canceled items for more accurate reporting.
  * Dashboard tables correctly sort counts that include thousands separators.
  * Queue failure indicators remain visible when metrics are unavailable.

* **Improvements**
  * Large dashboard counts now display with thousands separators.
  * Trend colors now consistently show improving rates in green and declining rates in red.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->