### PR TITLE
HARMONY-2402: Lock version 3 updates to collection capabilities and version 1 updates to admin dashboard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @indiejames @chris-durbin @ygliuvt @flamingbear
+*       @indiejames @chris-durbin @ygliuvt

--- a/services/harmony/app/frontends/capabilities.ts
+++ b/services/harmony/app/frontends/capabilities.ts
@@ -16,8 +16,8 @@ import { NotFoundError, RequestValidationError } from '../util/errors';
 import { harmonyMimeTypeToName } from '../util/file-formats';
 import { keysToLowerCase } from '../util/object';
 
-export const stableApiVersion = '2';
-const supportedApiVersions = ['1', '2', '3-alpha'];
+export const stableApiVersion = '3';
+const supportedApiVersions = ['1', '2', '3'];
 
 interface Projection {
   crs: string;
@@ -486,7 +486,7 @@ async function getCollectionCapabilitiesV3(
   context: RequestContext,
   collection: CmrCollection,
 ): Promise<CollectionCapabilitiesV3> {
-  const capabilitiesVersion = '3-alpha';
+  const capabilitiesVersion = '3';
   const allServiceConfigs = addCollectionsToServicesByAssociation([collection]);
   const matchingServices = allServiceConfigs.filter((config) =>
     config.collections.map((c) => c.id).includes(collection.id));
@@ -552,7 +552,7 @@ function chooseCapabilitiesFunction(version: string)
     return getCollectionCapabilitiesV1;
   } else if (version === '2') {
     return getCollectionCapabilitiesV2;
-  } else if (version === '3' || version === '3-alpha') {
+  } else if (version === '3') {
     return getCollectionCapabilitiesV3;
   }
 

--- a/services/harmony/app/frontends/dashboard.ts
+++ b/services/harmony/app/frontends/dashboard.ts
@@ -14,8 +14,8 @@ import { getQueueForType, getWorkSchedulerQueue } from '../util/queue/queue-fact
 import { getImageToServiceMap, getServiceName } from '../util/service-images';
 import harmonyVersion from '../util/version';
 
-export const currentApiVersion = '1-alpha';
-const supportedApiVersions = ['1-alpha'];
+export const currentApiVersion = '1';
+const supportedApiVersions = ['1'];
 
 const TRACKED_STATUSES = ['successful', 'failed', 'canceled', 'warning'] as const;
 type TrackedStatus = typeof TRACKED_STATUSES[number];

--- a/services/harmony/app/markdown/capabilities.md
+++ b/services/harmony/app/markdown/capabilities.md
@@ -13,10 +13,10 @@ Either `collectionId` or `shortName` must be provided.
 **Table {{tableCounter}}** - Harmony capabilities endpoint parameters
 
 ##### <a name="response"></a> Response
-The returned JSON response will have the configured capabilities in Harmony for the given collection in terms of supported features (e.g. variable subsetting, bounding box subsetting, concatenation, reprojection, etc.), the output formats, the list of Harmony services that are applicable for the collection, the list of variables that are associated with the collection and the version of the capabilites result format.
+The returned JSON response will have the configured capabilities in Harmony for the given collection in terms of supported features (e.g. variable subsetting, bounding box subsetting, concatenation, reprojection, etc.), the output formats, the list of Harmony services that are applicable for the collection, the list of variables that are associated with the collection and the version of the capabilities result format.
 
 ###### <a name="response-v2"></a> Version 2
-See below for the root level fields in the capabilites response and their descriptions
+See below for the root level fields in the capabilities response and their descriptions
 
 | field               | description                                                                                               |
 |---------------------|-----------------------------------------------------------------------------------------------------------|
@@ -35,7 +35,7 @@ See below for the root level fields in the capabilites response and their descri
 **Table {{tableCounter}}** - Harmony capabilities endpoint response version 2 fields
 
 ###### <a name="response-v3"></a> Version 3
-See below for the root level fields in the capabilites response and their descriptions for version 3 which is the current stable version:
+See below for the root level fields in the capabilities response and their descriptions for version 3 which is the current stable version:
 
 | field               | description                                                                                               |
 |---------------------|-----------------------------------------------------------------------------------------------------------|

--- a/services/harmony/app/markdown/capabilities.md
+++ b/services/harmony/app/markdown/capabilities.md
@@ -4,49 +4,70 @@ Returns information related to what Harmony operations are supported for a given
 
 ##### <a name="query-parameters"></a> Query Parameters
 Either `collectionId` or `shortName` must be provided.
-| parameter    | description                                                                                    |
-|--------------|------------------------------------------------------------------------------------------------|
-| collectionId | Concept id of the collection to retrieve capabilities for                                      |
-| shortName    | Short name of the collection to retrieve capabilities for                                      |
-| version      | (optional) The version of the capabilities result format, currently 1, 2, and 3 are supported. |
+| parameter    | description |
+|--------------|-------------|
+| collectionId | Concept ID of the collection to retrieve capabilities for |
+| shortName    | Short name of the collection to retrieve capabilities for |
+| version      | (optional) The version of the capabilities result format. Currently 1, 2, and 3 are supported. Version 3 is the default. |
 ---
 **Table {{tableCounter}}** - Harmony capabilities endpoint parameters
 
 ##### <a name="response"></a> Response
-The returned JSON response will have the configured capabilities in Harmony for the given collection in terms of supported features (e.g. variable subsetting, bounding box subsetting, concatenation, reprojection, etc.), the output formats, the list of Harmony services that are applicable for the collection, the list of variables that are associated with the collection and the version of the capabilities result format.
+The returned JSON response will have the configured capabilities in Harmony for the given collection in terms of supported features (e.g. variable subsetting, bounding box subsetting, concatenation, reprojection, etc.), the output formats, the list of Harmony services that are applicable for the collection, the list of variables that are associated with the collection and the version of the capabilities result format. 
+
+###### <a name="response-v3"></a> Version 3
+See below for the root level fields in the capabilities response and their descriptions for version 3:
+
+| field               | description |
+|---------------------|-------------|
+| conceptId           | Concept ID of the collection. |
+| shortName           | Short name of the collection. |
+| summary             | A JSON object summarizing the Harmony capabilities available for the collection, including subsetting, reprojection, averaging, concatenation, and supported output formats. Some capabilities cannot be used together; see the `services` field to determine the capabilities supported by individual services and valid capability combinations. |
+| services            | A list of JSON objects describing the Harmony services applicable to the collection. Each service includes its name, reference URL, and the capabilities supported by that service. |
+| variables           | A list of JSON objects describing the variables associated with the collection. |
+| capabilitiesVersion | The version identifier for the capabilities response format. |
+---
+**Table {{tableCounter}}** - Harmony capabilities endpoint response version 3 fields
 
 ###### <a name="response-v2"></a> Version 2
-See below for the root level fields in the capabilities response and their descriptions
+See below for the root level fields in the capabilities response and their descriptions for version 2:
 
-| field               | description                                                                                               |
-|---------------------|-----------------------------------------------------------------------------------------------------------|
-| conceptId           | Concept id of the collection                                                                              |
-| shortName           | Short name of the collection                                                                              |
-| variableSubset      | (boolean) True if variable subsetting is supported by any of the Harmony services for the collection.     |
+| field               | description |
+|---------------------|-------------|
+| conceptId           | Concept ID of the collection. |
+| shortName           | Short name of the collection. |
+| variableSubset      | (boolean) True if variable subsetting is supported by any of the Harmony services for the collection. |
 | bboxSubset          | (boolean) True if bounding box subsetting is supported by any of the Harmony services for the collection. |
-| shapeSubset         | (boolean) True if shape file subsetting is supported by any of the Harmony services for the collection.   |
-| concatenate         | (boolean) True if concatenation is supported by any of the Harmony services for the collection.           |
-| reproject           | (boolean) True if reprojection is supported by any of the Harmony services for the collection.            |
-| outputFormats       | A list of supported output formats for the collection.                                                    |
-| services            | A list of JSON objects describing the supported Harmony services for the collection.                      |
-| variables           | A list of JSON objects describing the associated variables of the collection.                             |
-| capabilitiesVersion | The version of the capabilities result format.                                                            |
+| shapeSubset         | (boolean) True if shape subsetting is supported by any of the Harmony services for the collection. |
+| temporalSubset      | (boolean) True if temporal subsetting is supported by any of the Harmony services for the collection. |
+| concatenate         | (boolean) True if concatenation is supported by any of the Harmony services for the collection. |
+| reproject           | (boolean) True if reprojection is supported by any of the Harmony services for the collection. |
+| outputFormats       | A list of supported output format MIME types for the collection. |
+| services            | A list of JSON objects describing the Harmony services applicable to the collection and their supported capabilities. |
+| variables           | A list of JSON objects describing the variables associated with the collection. |
+| capabilitiesVersion | The version identifier for the capabilities response format. |
 ---
 **Table {{tableCounter}}** - Harmony capabilities endpoint response version 2 fields
 
-###### <a name="response-v3"></a> Version 3
-See below for the root level fields in the capabilities response and their descriptions for version 3 which is the current stable version:
+###### <a name="response-v1"></a> Version 1
+See below for the root level fields in the capabilities response and their descriptions for version 1:
 
-| field               | description                                                                                               |
-|---------------------|-----------------------------------------------------------------------------------------------------------|
-| conceptId           | Concept id of the collection                                                                              |
-| shortName           | Short name of the collection                                                                              |
-| summary             | A JSON object listing the available Harmony capabilities for the collection. **Note**: Some capabilities cannot be used together; check the `services` field to see which combinations are valid. |
-| services            | A list of JSON objects describing the supported Harmony services for the collection.                      |
-| variables           | A list of JSON objects describing the associated variables of the collection.                             |
-| capabilitiesVersion | The version of the capabilities result format.                                                            |
+| field               | description |
+|---------------------|-------------|
+| conceptId           | Concept ID of the collection. |
+| shortName           | Short name of the collection. |
+| variableSubset      | (boolean) True if variable subsetting is supported by any of the Harmony services for the collection. |
+| bboxSubset          | (boolean) True if bounding box subsetting is supported by any of the Harmony services for the collection. |
+| shapeSubset         | (boolean) True if shape subsetting is supported by any of the Harmony services for the collection. |
+| temporalSubset      | (boolean) True if temporal subsetting is supported by any of the Harmony services for the collection. |
+| concatenate         | (boolean) True if concatenation is supported by any of the Harmony services for the collection. |
+| reproject           | (boolean) True if reprojection is supported by any of the Harmony services for the collection. |
+| outputFormats       | A list of supported output format MIME types for the collection. |
+| services            | A list of JSON objects describing the Harmony services applicable to the collection and their supported capabilities. |
+| variables           | A list of variable names associated with the collection. |
+| capabilitiesVersion | The version identifier for the capabilities response format. |
 ---
-**Table {{tableCounter}}** - Harmony capabilities endpoint response version 3 fields
+**Table {{tableCounter}}** - Harmony capabilities endpoint response version 1 fields
 
 #### Getting Harmony capabilities for a given collection by collection concept id
 

--- a/services/harmony/app/markdown/capabilities.md
+++ b/services/harmony/app/markdown/capabilities.md
@@ -13,10 +13,10 @@ Either `collectionId` or `shortName` must be provided.
 **Table {{tableCounter}}** - Harmony capabilities endpoint parameters
 
 ##### <a name="response"></a> Response
-The returned JSON response will have the configured capabilities in Harmony for the given collection in terms of supported features (e.g. variable subsetting, boundingbox subsetting, concatenation, reprojection, etc.), the output formats, the list of Harmony services that are applicable for the collection, the list of variables that are associated with the collection and the version of the capabilites result format.
+The returned JSON response will have the configured capabilities in Harmony for the given collection in terms of supported features (e.g. variable subsetting, bounding box subsetting, concatenation, reprojection, etc.), the output formats, the list of Harmony services that are applicable for the collection, the list of variables that are associated with the collection and the version of the capabilites result format.
 
 ###### <a name="response-v2"></a> Version 2
-See below for the root level fields in the capabilites response and their descriptions with the current stable version (version 2)
+See below for the root level fields in the capabilites response and their descriptions
 
 | field               | description                                                                                               |
 |---------------------|-----------------------------------------------------------------------------------------------------------|
@@ -34,8 +34,8 @@ See below for the root level fields in the capabilites response and their descri
 ---
 **Table {{tableCounter}}** - Harmony capabilities endpoint response version 2 fields
 
-###### <a name="response-v3"></a> Version 3-alpha
-See below for the root level fields in the capabilites response and their descriptions for version 3-alpha (note the response format may change before finalizing version 3):
+###### <a name="response-v3"></a> Version 3
+See below for the root level fields in the capabilites response and their descriptions for version 3 which is the current stable version:
 
 | field               | description                                                                                               |
 |---------------------|-----------------------------------------------------------------------------------------------------------|
@@ -46,7 +46,7 @@ See below for the root level fields in the capabilites response and their descri
 | variables           | A list of JSON objects describing the associated variables of the collection.                             |
 | capabilitiesVersion | The version of the capabilities result format.                                                            |
 ---
-**Table {{tableCounter}}** - Harmony capabilities endpoint response version 3-alpha fields
+**Table {{tableCounter}}** - Harmony capabilities endpoint response version 3 fields
 
 #### Getting Harmony capabilities for a given collection by collection concept id
 

--- a/services/harmony/test/collection-capabilities.ts
+++ b/services/harmony/test/collection-capabilities.ts
@@ -11,6 +11,181 @@ import { stableApiVersion } from '../app/frontends/capabilities';
 // longer pass when regenerating CMR test fixtures.
 const collectionId = 'C1234088182-EEDTEST';
 
+/**
+ * Tests for the version 3 collection capabilities response. Pulled out into a separate function
+ * so that it can be reused for multiple test cases.
+ */
+function itBehaveLikeVersion3Capabilities(): void {
+  it('returns a 200 success status code', function () {
+    expect(this.res.status).to.equal(200);
+  });
+
+  it('includes all of the expected fields in the response according to version 3', function () {
+    const expectedFields = [
+      'conceptId', 'shortName', 'summary', 'services', 'variables', 'capabilitiesVersion',
+    ];
+    const capabilities = JSON.parse(this.res.text);
+    expect(Object.keys(capabilities)).to.eql(expectedFields);
+  });
+
+  it('sets the conceptId field correctly', function () {
+    const capabilities = JSON.parse(this.res.text);
+    expect(capabilities.conceptId).to.equal(collectionId);
+  });
+
+  it('sets the shortName field correctly', function () {
+    const capabilities = JSON.parse(this.res.text);
+    expect(capabilities.shortName).to.equal('harmony_example');
+  });
+
+  it('sets the summary.subsetting field correctly', function () {
+    const capabilities = JSON.parse(this.res.text);
+    const actualSubsetting = capabilities.summary.subsetting;
+
+    expect(actualSubsetting.bbox).to.be.true;
+    expect(actualSubsetting.dimension).to.be.false;
+    expect(actualSubsetting.shape).to.be.false;
+    expect(actualSubsetting.temporal).to.be.false;
+    expect(actualSubsetting.variable).to.be.true;
+  });
+
+  it('sets the summary.concatenation field correctly', function () {
+    const capabilities = JSON.parse(this.res.text);
+    expect(capabilities.summary.concatenation).to.equal(false);
+  });
+
+  it('sets the summary.reprojection field correctly', function () {
+    const capabilities = JSON.parse(this.res.text);
+    const actualReprojection = capabilities.summary.reprojection;
+
+    const expectedProjections = [{
+      name: 'Geographic',
+      crs: 'EPSG:4326',
+    }];
+
+    const expectedInterpolationMethods = ['Bilinear Interpolation', 'Nearest Neighbor'];
+
+    expect(actualReprojection.supported).to.be.true;
+    expect(actualReprojection.supportedProjections).to.eql(expectedProjections);
+    expect(actualReprojection.interpolationMethods).to.eql(expectedInterpolationMethods);
+
+  });
+
+  it('sets the summary.outputFormats field correctly', function () {
+    const capabilities = JSON.parse(this.res.text);
+    const expectedFormats = [
+      {
+        'mimeType': 'image/tiff',
+        'name': 'GEOTIFF',
+      },
+      {
+        'mimeType': 'image/gif',
+        'name': 'GIF',
+      },
+      {
+        'mimeType': 'application/netcdf',
+        'name': 'NETCDF-4',
+      },
+      {
+        'mimeType': 'image/png',
+        'name': 'PNG',
+      },
+    ];
+    expect(capabilities.summary.outputFormats).to.eql(expectedFormats);
+  });
+
+  it('includes the correct services', function () {
+    const capabilities = JSON.parse(this.res.text);
+    const services_name_href = capabilities.services.map((s) => _.pick(s, ['name', 'href']));
+    const expectedServices = [{
+      'name': 'sds/swath-projector',
+      'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/S1237974711-EEDTEST',
+    },
+    {
+      'name': 'harmony/service-example',
+      'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/S1257851197-EEDTEST',
+    }];
+    expect(services_name_href).to.eql(expectedServices);
+  });
+
+  it('includes the supported reprojections within the services', function () {
+    const capabilities = JSON.parse(this.res.text);
+    const { supportedProjections } = capabilities.services[0].capabilities.reprojection;
+    const expectedProjections = [{
+      'name': 'Geographic',
+      'crs': 'EPSG:4326',
+    }];
+    expect(supportedProjections).to.eql(expectedProjections);
+  });
+
+  it('includes the interpolation methods within the services', function () {
+    const capabilities = JSON.parse(this.res.text);
+    const { interpolationMethods } = capabilities.services[0].capabilities.reprojection;
+    const expectedInterpolationMethods = ['Bilinear Interpolation', 'Nearest Neighbor'];
+
+    expect(interpolationMethods).to.eql(expectedInterpolationMethods);
+  });
+
+  it('includes the complete v3 capability schema for every service', function () {
+    const capabilities = JSON.parse(this.res.text);
+
+    for (const service of capabilities.services) {
+      expect(Object.keys(service.capabilities)).to.include.members([
+        'subsetting',
+        'concatenation',
+        'reprojection',
+        'averaging',
+        'outputFormats',
+      ]);
+      expect(Object.keys(service.capabilities.subsetting)).to.include.members([
+        'bbox',
+        'dimension',
+        'shape',
+        'temporal',
+        'variable',
+      ]);
+      expect(Object.keys(service.capabilities.averaging)).to.include.members([
+        'time',
+        'area',
+      ]);
+    }
+  });
+
+  it('sets the variables field correctly', function () {
+    const capabilities = JSON.parse(this.res.text);
+    const expectedVariables = [{
+      'name': 'alpha_var',
+      'longName': 'Alpha Channel',
+      'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088190-EEDTEST',
+      'scienceKeywords': [],
+    },
+    {
+      'name': 'blue_var',
+      'longName': 'Blue Channel',
+      'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088189-EEDTEST',
+      'scienceKeywords': [],
+    },
+    {
+      'name': 'green_var',
+      'longName': 'Green Channel',
+      'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088188-EEDTEST',
+      'scienceKeywords': [],
+    },
+    {
+      'name': 'red_var',
+      'longName': 'Red Channel',
+      'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088187-EEDTEST',
+      'scienceKeywords': [],
+    }];
+    expect(capabilities.variables).to.eql(expectedVariables);
+  });
+
+  it('includes the correct capabilitiesVersion', function () {
+    const capabilities = JSON.parse(this.res.text);
+    expect(capabilities.capabilitiesVersion).to.equal('3');
+  });
+}
+
 describe('Testing collection capabilities', function () {
   hookServersStartStop();
   describe('requesting JSON format', function () {
@@ -30,107 +205,7 @@ describe('Testing collection capabilities', function () {
     for (const test of tests) {
       describe(test.description, function () {
         hookGetCollectionCapabilities(test.query);
-        it('returns a 200 success status code', function () {
-          expect(this.res.status).to.equal(200);
-        });
-
-        it('includes all of the expected fields in the response according to the default version', function () {
-          const expectedFields = [
-            'conceptId', 'shortName', 'variableSubset', 'bboxSubset', 'shapeSubset',
-            'temporalSubset', 'concatenate', 'reproject', 'outputFormats', 'services',
-            'variables', 'capabilitiesVersion',
-          ];
-          const capabilities = JSON.parse(this.res.text);
-          expect(Object.keys(capabilities)).to.eql(expectedFields);
-        });
-
-        it('sets the conceptId field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          expect(capabilities.conceptId).to.equal(collectionId);
-        });
-
-        it('sets the shortName field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          expect(capabilities.shortName).to.equal('harmony_example');
-        });
-
-        it('sets the variableSubset field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          expect(capabilities.variableSubset).to.equal(true);
-        });
-
-        it('sets the bboxSubset field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          expect(capabilities.bboxSubset).to.equal(true);
-        });
-
-        it('sets the shapeSubset field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          expect(capabilities.shapeSubset).to.equal(false);
-        });
-
-        it('sets the temporalSubset field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          expect(capabilities.temporalSubset).to.equal(false);
-        });
-
-        it('sets the concatenate field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          expect(capabilities.concatenate).to.equal(false);
-        });
-
-        it('sets the reproject field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          expect(capabilities.reproject).to.equal(true);
-        });
-
-        it('sets the outputFormats field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          const expectedFormats = [
-            'application/netcdf', 'image/tiff', 'image/png', 'image/gif',
-          ];
-          expect(capabilities.outputFormats).to.eql(expectedFormats);
-        });
-
-        it('includes the correct services', function () {
-          const capabilities = JSON.parse(this.res.text);
-          const services_name_href = capabilities.services.map((s) => _.pick(s, ['name', 'href']));
-          const expectedServices = [{
-            'name': 'sds/swath-projector',
-            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/S1237974711-EEDTEST',
-          },
-          {
-            'name': 'harmony/service-example',
-            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/S1257851197-EEDTEST',
-          }];
-          expect(services_name_href).to.eql(expectedServices);
-        });
-
-        it('sets the variables field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          const expectedVariables = [{
-            'name': 'alpha_var',
-            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088190-EEDTEST',
-          },
-          {
-            'name': 'blue_var',
-            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088189-EEDTEST',
-          },
-          {
-            'name': 'green_var',
-            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088188-EEDTEST',
-          },
-          {
-            'name': 'red_var',
-            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088187-EEDTEST',
-          }];
-          expect(capabilities.variables).to.eql(expectedVariables);
-        });
-
-        it('includes the correct capabilitiesVersion', function () {
-          const capabilities = JSON.parse(this.res.text);
-          expect(capabilities.capabilitiesVersion).to.equal(stableApiVersion);
-        });
+        itBehaveLikeVersion3Capabilities();
       });
     }
 
@@ -380,174 +455,7 @@ describe('Testing collection capabilities', function () {
 
       describe('specifying version 3', function () {
         hookGetCollectionCapabilities({ collectionId: 'C1234088182-EEDTEST', version: 3 });
-        it('returns a 200 success status code', function () {
-          expect(this.res.status).to.equal(200);
-        });
-
-        it('includes all of the expected fields in the response according to version 3', function () {
-          const expectedFields = [
-            'conceptId', 'shortName', 'summary', 'services', 'variables', 'capabilitiesVersion',
-          ];
-          const capabilities = JSON.parse(this.res.text);
-          expect(Object.keys(capabilities)).to.eql(expectedFields);
-        });
-
-        it('sets the conceptId field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          expect(capabilities.conceptId).to.equal(collectionId);
-        });
-
-        it('sets the shortName field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          expect(capabilities.shortName).to.equal('harmony_example');
-        });
-
-        it('sets the summary.subsetting field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          const actualSubsetting = capabilities.summary.subsetting;
-
-          expect(actualSubsetting.bbox).to.be.true;
-          expect(actualSubsetting.dimension).to.be.false;
-          expect(actualSubsetting.shape).to.be.false;
-          expect(actualSubsetting.temporal).to.be.false;
-          expect(actualSubsetting.variable).to.be.true;
-        });
-
-        it('sets the summary.concatenation field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          expect(capabilities.summary.concatenation).to.equal(false);
-        });
-
-        it('sets the summary.reprojection field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          const actualReprojection = capabilities.summary.reprojection;
-
-          const expectedProjections = [{
-            name: 'Geographic',
-            crs: 'EPSG:4326',
-          }];
-
-          const expectedInterpolationMethods = ['Bilinear Interpolation', 'Nearest Neighbor'];
-
-          expect(actualReprojection.supported).to.be.true;
-          expect(actualReprojection.supportedProjections).to.eql(expectedProjections);
-          expect(actualReprojection.interpolationMethods).to.eql(expectedInterpolationMethods);
-
-        });
-
-        it('sets the summary.outputFormats field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          const expectedFormats = [
-            {
-              'mimeType': 'image/tiff',
-              'name': 'GEOTIFF',
-            },
-            {
-              'mimeType': 'image/gif',
-              'name': 'GIF',
-            },
-            {
-              'mimeType': 'application/netcdf',
-              'name': 'NETCDF-4',
-            },
-            {
-              'mimeType': 'image/png',
-              'name': 'PNG',
-            },
-          ];
-          expect(capabilities.summary.outputFormats).to.eql(expectedFormats);
-        });
-
-        it('includes the correct services', function () {
-          const capabilities = JSON.parse(this.res.text);
-          const services_name_href = capabilities.services.map((s) => _.pick(s, ['name', 'href']));
-          const expectedServices = [{
-            'name': 'sds/swath-projector',
-            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/S1237974711-EEDTEST',
-          },
-          {
-            'name': 'harmony/service-example',
-            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/S1257851197-EEDTEST',
-          }];
-          expect(services_name_href).to.eql(expectedServices);
-        });
-
-        it('includes the supported reprojections within the services', function () {
-          const capabilities = JSON.parse(this.res.text);
-          const { supportedProjections } = capabilities.services[0].capabilities.reprojection;
-          const expectedProjections = [{
-            'name': 'Geographic',
-            'crs': 'EPSG:4326',
-          }];
-          expect(supportedProjections).to.eql(expectedProjections);
-        });
-
-        it('includes the interpolation methods within the services', function () {
-          const capabilities = JSON.parse(this.res.text);
-          const { interpolationMethods } = capabilities.services[0].capabilities.reprojection;
-          const expectedInterpolationMethods = ['Bilinear Interpolation', 'Nearest Neighbor'];
-
-          expect(interpolationMethods).to.eql(expectedInterpolationMethods);
-        });
-
-        it('includes the complete v3 capability schema for every service', function () {
-          const capabilities = JSON.parse(this.res.text);
-
-          for (const service of capabilities.services) {
-            expect(Object.keys(service.capabilities)).to.include.members([
-              'subsetting',
-              'concatenation',
-              'reprojection',
-              'averaging',
-              'outputFormats',
-            ]);
-            expect(Object.keys(service.capabilities.subsetting)).to.include.members([
-              'bbox',
-              'dimension',
-              'shape',
-              'temporal',
-              'variable',
-            ]);
-            expect(Object.keys(service.capabilities.averaging)).to.include.members([
-              'time',
-              'area',
-            ]);
-          }
-        });
-
-        it('sets the variables field correctly', function () {
-          const capabilities = JSON.parse(this.res.text);
-          const expectedVariables = [{
-            'name': 'alpha_var',
-            'longName': 'Alpha Channel',
-            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088190-EEDTEST',
-            'scienceKeywords': [],
-          },
-          {
-            'name': 'blue_var',
-            'longName': 'Blue Channel',
-            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088189-EEDTEST',
-            'scienceKeywords': [],
-          },
-          {
-            'name': 'green_var',
-            'longName': 'Green Channel',
-            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088188-EEDTEST',
-            'scienceKeywords': [],
-          },
-          {
-            'name': 'red_var',
-            'longName': 'Red Channel',
-            'href': 'https://cmr.uat.earthdata.nasa.gov/search/concepts/V1234088187-EEDTEST',
-            'scienceKeywords': [],
-          }];
-          expect(capabilities.variables).to.eql(expectedVariables);
-        });
-
-        it('includes the correct capabilitiesVersion', function () {
-          const capabilities = JSON.parse(this.res.text);
-          expect(capabilities.capabilitiesVersion).to.equal('3-alpha');
-        });
+        itBehaveLikeVersion3Capabilities();
 
         describe('for a collection with scienceKeywords and units in the variables', function () {
           hookGetCollectionCapabilities({ collectionId: 'C1238538022-EEDTEST', version: '3' });
@@ -628,8 +536,8 @@ describe('Testing collection capabilities', function () {
       });
 
 
-      describe('specifying version 3-alpha', function () {
-        hookGetCollectionCapabilities({ collectionId: 'C1234088182-EEDTEST', version: '3-alpha' });
+      describe('specifying version 3', function () {
+        hookGetCollectionCapabilities({ collectionId: 'C1234088182-EEDTEST', version: '3' });
         it('returns a 200 success status code', function () {
           expect(this.res.status).to.equal(200);
         });
@@ -644,7 +552,7 @@ describe('Testing collection capabilities', function () {
 
         it('includes the correct capabilitiesVersion', function () {
           const capabilities = JSON.parse(this.res.text);
-          expect(capabilities.capabilitiesVersion).to.equal('3-alpha');
+          expect(capabilities.capabilitiesVersion).to.equal('3');
         });
       });
 
@@ -657,7 +565,7 @@ describe('Testing collection capabilities', function () {
         it('returns an error message indicating the version was invalid', function () {
           expect(JSON.parse(this.res.text)).to.eql({
             code: 'harmony.RequestValidationError',
-            description: 'Error: Invalid API version bad_version, supported versions: 1, 2, and 3-alpha',
+            description: 'Error: Invalid API version bad_version, supported versions: 1, 2, and 3',
           });
         });
       });

--- a/services/harmony/test/dashboard.ts
+++ b/services/harmony/test/dashboard.ts
@@ -5,10 +5,10 @@ import sinon from 'sinon';
 import { getDashboard, THIRTY_YEARS_IN_MINUTES } from '../app/frontends/dashboard';
 import * as userWork from '../app/models/user-work';
 import * as workItemsStats from '../app/models/work-items-stats';
+import { RequestValidationError } from '../app/util/errors';
 import { WorkItemQueueType } from '../app/util/queue/queue';
 import * as qf from '../app/util/queue/queue-factory';
 import * as serviceImages from '../app/util/service-images';
-import { RequestValidationError } from 'app/util/errors';
 
 /**
  * Returns a fake getWorkItemsStatsSummary result with empty rows and fixed time boundaries.
@@ -87,18 +87,8 @@ describe('getDashboard', () => {
   // ---------------------------------------------------------------------------
 
   describe('version validation', () => {
-    it('succeeds when a valid version (1-alpha) is provided', async () => {
-      req.query.version = '1-alpha';
-      getCountsByServiceStub.resolves({});
-
-      await getDashboard(req, res, next);
-
-      expect(next.called).to.be.false;
-      expect(res.json.calledOnce).to.be.true;
-    });
-
-    it('is case-insensitive when validating the version parameter', async () => {
-      req.query.version = '1-ALPHA';
+    it('succeeds when a valid version 1 is provided', async () => {
+      req.query.version = '1';
       getCountsByServiceStub.resolves({});
 
       await getDashboard(req, res, next);
@@ -276,7 +266,7 @@ describe('getDashboard', () => {
       expect(res.json.calledOnce).to.be.true;
       const result = res.json.firstCall.args[0];
 
-      expect(result.version).to.equal('1-alpha');
+      expect(result.version).to.equal('1');
       expect(Object.keys(result.services)).to.deep.equal([
         'harmony-service-example',
         'podaac-l2-subsetter',

--- a/services/harmony/test/models/index.ts
+++ b/services/harmony/test/models/index.ts
@@ -23,13 +23,13 @@ describe('validateStepOperations', function () {
     const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, testServicesYmlFile);
     const testConfig = configs[0];
     testConfig.steps[1].operations = ['concatenate'];
-    describe('and the capabilites do not', function () {
+    describe('and the capabilities do not', function () {
       testConfig.capabilities = {};
       it('returns an error message', function () {
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-config step with image ghcr.io/podaac/l2ss-py:sit has operation \'concatenate\' which is not included in capabilities.');
       });
     });
-    describe('and the capabilites do as well', function () {
+    describe('and the capabilities do as well', function () {
       it('does not return an error message', function () {
         testConfig.capabilities.concatenation = true;
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
@@ -41,13 +41,13 @@ describe('validateStepOperations', function () {
     const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, testServicesYmlFile);
     const testConfig = configs[0];
     testConfig.steps[1].operations = ['dimensionSubset'];
-    describe('and the capabilites do not', function () {
+    describe('and the capabilities do not', function () {
       testConfig.capabilities = {};
       it('returns an error message', function () {
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-config step with image ghcr.io/podaac/l2ss-py:sit has operation \'dimensionSubset\' which is not included in capabilities.');
       });
     });
-    describe('and the capabilites do as well', function () {
+    describe('and the capabilities do as well', function () {
       it('does not return an error message', function () {
         testConfig.capabilities.subsetting = { dimension: true };
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
@@ -59,13 +59,13 @@ describe('validateStepOperations', function () {
     const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, testServicesYmlFile);
     const testConfig = configs[0];
     testConfig.steps[1].operations = ['extend'];
-    describe('and the capabilites do not', function () {
+    describe('and the capabilities do not', function () {
       testConfig.capabilities = {};
       it('returns an error message', function () {
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-config step with image ghcr.io/podaac/l2ss-py:sit has operation \'extend\' which is not included in capabilities.');
       });
     });
-    describe('and the capabilites do as well', function () {
+    describe('and the capabilities do as well', function () {
       it('does not return an error message', function () {
         testConfig.capabilities.extend = true;
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
@@ -77,13 +77,13 @@ describe('validateStepOperations', function () {
     const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, testServicesYmlFile);
     const testConfig = configs[0];
     testConfig.steps[1].operations = ['reproject'];
-    describe('and the capabilites do not', function () {
+    describe('and the capabilities do not', function () {
       testConfig.capabilities = {};
       it('returns an error message', function () {
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-config step with image ghcr.io/podaac/l2ss-py:sit has operation \'reproject\' which is not included in capabilities.');
       });
     });
-    describe('and the capabilites do as well', function () {
+    describe('and the capabilities do as well', function () {
       it('does not return an error message', function () {
         testConfig.capabilities.reprojection = true;
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
@@ -95,13 +95,13 @@ describe('validateStepOperations', function () {
     const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, testServicesYmlFile);
     const testConfig = configs[0];
     testConfig.steps[1].operations = ['shapefileSubset'];
-    describe('and the capabilites do not', function () {
+    describe('and the capabilities do not', function () {
       testConfig.capabilities = {};
       it('returns an error message', function () {
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-config step with image ghcr.io/podaac/l2ss-py:sit has operation \'shapefileSubset\' which is not included in capabilities.');
       });
     });
-    describe('and the capabilites do as well', function () {
+    describe('and the capabilities do as well', function () {
       it('does not return an error message', function () {
         testConfig.capabilities.subsetting = { shape: true };
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
@@ -113,13 +113,13 @@ describe('validateStepOperations', function () {
     const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, testServicesYmlFile);
     const testConfig = configs[0];
     testConfig.steps[1].operations = ['spatialSubset'];
-    describe('and the capabilites do not', function () {
+    describe('and the capabilities do not', function () {
       testConfig.capabilities = {};
       it('returns an error message', function () {
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-config step with image ghcr.io/podaac/l2ss-py:sit has operation \'spatialSubset\' which is not included in capabilities.');
       });
     });
-    describe('and the capabilites do as well', function () {
+    describe('and the capabilities do as well', function () {
       it('does not return an error message', function () {
         testConfig.capabilities.subsetting = { bbox: true };
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
@@ -131,13 +131,13 @@ describe('validateStepOperations', function () {
     const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, testServicesYmlFile);
     const testConfig = configs[0];
     testConfig.steps[1].operations = ['temporalSubset'];
-    describe('and the capabilites do not', function () {
+    describe('and the capabilities do not', function () {
       testConfig.capabilities = {};
       it('returns an error message', function () {
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-config step with image ghcr.io/podaac/l2ss-py:sit has operation \'temporalSubset\' which is not included in capabilities.');
       });
     });
-    describe('and the capabilites do as well', function () {
+    describe('and the capabilities do as well', function () {
       it('does not return an error message', function () {
         testConfig.capabilities.subsetting = { temporal: true };
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;
@@ -149,13 +149,13 @@ describe('validateStepOperations', function () {
     const configs = loadServiceConfigsFromFile(cmrEndpoints.prod, testServicesYmlFile);
     const testConfig = configs[0];
     testConfig.steps[1].operations = ['variableSubset'];
-    describe('and the capabilites do not', function () {
+    describe('and the capabilities do not', function () {
       testConfig.capabilities = {};
       it('returns an error message', function () {
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.equal('Service with-unsupported-config step with image ghcr.io/podaac/l2ss-py:sit has operation \'variableSubset\' which is not included in capabilities.');
       });
     });
-    describe('and the capabilites do as well', function () {
+    describe('and the capabilities do as well', function () {
       it('does not return an error message', function () {
         testConfig.capabilities.subsetting = { variable: true };
         expect(validateStepOperations(testConfig, testConfig.steps[1])).to.be.null;


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2402

## Description
All updates to version 3 of the collection capabilities and version 1 of the admin dashboard JSON response have been made and tested for the previous PI. Lock updates to both endpoints and update the default response returned for collection capabilities from version 2 to version 3.

## Local Test Steps
### Dashboard
```
curl -Ln -bj http://localhost:3000/admin/dashboard
```
Verify the response includes `"version" : "1"` rather than 1-alpha. Test passing in version=1 to make sure it works and any other version returns an appropriate error message.
### Collection capabilities
http://localhost:3000/capabilities?shortName=harmony_example

Verify the default response includes `"capabilitiesVersion": "3"`. Test with version=1, version=2, and version=3 and verify the correct versions are all returned. Test with another version like version=4 and verify an appropriate error message.

## PR Acceptance Checklist
* [X] Acceptance criteria met
* [X] Tests added/updated (if needed) and passing
* [X] Documentation updated (if needed)
* [ ] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capabilities API version 3 is now the stable default.
  * Dashboard API version 1 is now stable.
  * Version labels and validation now recognize `3` and `1` instead of their alpha equivalents.

* **Documentation**
  * Updated API documentation with schemas for capabilities versions 1, 2, and 3.
  * Clarified response formats, MIME types, terminology, and service details.
  * Corrected response-description typos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->